### PR TITLE
🌍 The demo UI: copy affordances, world provenance, and a page that is honestly read-only (TKT-F2D5U5)

### DIFF
--- a/frontend/src/api/copies.ts
+++ b/frontend/src/api/copies.ts
@@ -1,0 +1,55 @@
+import { api } from './client'
+
+/**
+ * The copy surface (TKT-WRLDAPI item 5).
+ *
+ * ## There is no list call here, deliberately
+ *
+ * Offers ride the ENTITY response as `_copies`, alongside `_actions` — the way
+ * every other affordance in this app is delivered. An earlier revision shipped
+ * a `GET /_copies` and it was removed: a second endpoint for one affordance is
+ * the odd shape, and it made the client construct a lookup key for data it had
+ * already fetched. So this module is invoke-only; to READ the offers, read
+ * `entity._copies`.
+ */
+
+// CopyInvokeResult reports what an invoked copy produced. Mirrors
+// v1.CopyResult.
+export interface CopyInvokeResult {
+  definition: string
+  entityId: string
+  // The coordinate written — `published`, `nl`. Empty means the default state.
+  pointer: string
+  // True when the copy brought the target face into existence rather than
+  // overwriting one — the difference between "published for the first time"
+  // and "re-published".
+  created: boolean
+}
+
+/**
+ * invokeCopy runs a declared copy definition BY NAME.
+ *
+ * The request names a definition and the entities it applies to; it never
+ * supplies a definition's contents. That is the transforms-registry precedent:
+ * if a caller could describe a copy, they could describe one whose guard is
+ * convenient, and the guard system would be decorative.
+ *
+ * `targetId` is required for a CROSS-ENTITY copy and must be omitted for a
+ * same-entity one, whose target is the source by construction. Read
+ * `offer.sameEntity` to know which you have — a client cannot build a valid
+ * invoke without it.
+ *
+ * Authorization happens server-side. `offer.allowed` is a hint for rendering,
+ * so calling this on a disallowed offer is not a bug in the caller — it
+ * returns the same 403 the kernel would return anyway.
+ */
+export async function invokeCopy(
+  name: string,
+  sourceId: string,
+  targetId?: string,
+): Promise<CopyInvokeResult> {
+  return api.post<CopyInvokeResult>(`/_copies/${encodeURIComponent(name)}`, {
+    source_id: sourceId,
+    ...(targetId ? { target_id: targetId } : {}),
+  })
+}

--- a/frontend/src/api/entities.ts
+++ b/frontend/src/api/entities.ts
@@ -125,10 +125,14 @@ export async function listAllEntities(
   }
 }
 
-// getEntity reads one entity. `world` selects which face is served; it is
-// mutually exclusive with `include` at the API (422 world_include_unsupported),
-// a constraint callers must respect — the type cannot express "one or the
-// other", so see useEntitiesStore.fetchEntity for the enforcement.
+// getEntity reads one entity. `world` selects which face is served, and it
+// COMBINES with `include`: TKT-WRLDAPI item 4 made neighbor resolution
+// world-scoped, so an included peer is that world's face of the neighbor and a
+// neighbor with no face in the world is simply absent.
+//
+// The two were mutually exclusive until then (422 world_include_unsupported),
+// which is why callers may still carry code shaped around avoiding the
+// combination.
 export async function getEntity(
   type: string,
   id: string,

--- a/frontend/src/api/views.ts
+++ b/frontend/src/api/views.ts
@@ -142,6 +142,24 @@ export interface ViewResponse {
 // Fetch executed view data for an entity. The backend looks up the
 // configured ViewConfig by entry.type, or synthesizes a default when
 // none is registered.
-export async function fetchView(entityType: string, entityId: string): Promise<ViewResponse> {
-  return api.get<ViewResponse>(`/_views/${entityType}/${entityId}`)
+/**
+ * fetchView reads the entity view — the detail page's data.
+ *
+ * `world` selects which FACE the entry resolves to, and resolves every
+ * collection entity through the same world (TKT-WRLDAPI item 4b). Pass
+ * `undefined` for the default world so the param is omitted rather than sent
+ * empty; `useWorld().worldParam` is already shaped for that.
+ *
+ * Each collection entity carries `_world` provenance under a non-default
+ * world — which face was served and which rule chose it. That distinction is
+ * not decoration: "the Dutch page" and "the English page, because no Dutch
+ * page exists" arrive byte-identically, and only `_world.via` separates them.
+ */
+export async function fetchView(
+  entityType: string,
+  entityId: string,
+  world?: string,
+): Promise<ViewResponse> {
+  const params = world ? { world } : undefined
+  return api.get<ViewResponse>(`/_views/${entityType}/${entityId}`, params)
 }

--- a/frontend/src/api/views.ts
+++ b/frontend/src/api/views.ts
@@ -1,5 +1,5 @@
 import { api } from './client'
-import type { Entity, FieldAffordance } from '@/types'
+import type { Entity, EntityWorld, FieldAffordance } from '@/types'
 
 // Field data for view sections
 export interface ViewSectionField {
@@ -60,6 +60,16 @@ export interface ViewEntity {
   hasContent: boolean
   _props?: Record<string, unknown>
   _fields?: Record<string, FieldAffordance>
+  // Which face this world served for THIS entity, and which rule chose it
+  // (TKT-WRLDAPI item 4b). Per-neighbour: each collection entity resolves
+  // through the world independently, so one section can mix `chain` and
+  // `fallback-default` entries.
+  //
+  // Absent under the default world — there is no provenance to report when no
+  // resolution was applied. Under a non-default world it is present, and
+  // `via: 'fallback-default'` is the case worth surfacing: the reader is
+  // seeing a SUBSTITUTE face, not the one the world asked for.
+  _world?: EntityWorld
 }
 
 // Table cell data

--- a/frontend/src/api/viewsWorld.test.ts
+++ b/frontend/src/api/viewsWorld.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchView } from './views'
+import { api } from './client'
+
+vi.mock('./client', () => ({
+  api: { get: vi.fn().mockResolvedValue({ entry: { id: 'POL-1' }, sections: [] }) },
+}))
+
+// The world on the entity VIEW (TKT-F2D5U5 gap 1).
+//
+// `/_views/{type}/{id}` became world-capable in TKT-WRLDAPI item 4b — the
+// entry resolves to that world's face and every collection entity resolves
+// through the same world, per neighbour. But the SPA never passed the param,
+// so the detail page rendered draft content while the world selector said
+// "published". The API was correct; the page simply never asked.
+//
+// Ruling 10 note: the interesting assertions here are about a param being
+// ABSENT (the default world must not send `?world=`), which is the class that
+// passes trivially when nothing was requested at all. So every absence
+// assertion also asserts the request FIRED and carries the right path.
+describe('fetchView world param', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('sends ?world= for a non-default world', async () => {
+    await fetchView('policy', 'POL-1', 'published')
+
+    const [path, params] = vi.mocked(api.get).mock.calls[0]
+    expect(path).toBe('/_views/policy/POL-1')
+    expect(params).toEqual({ world: 'published' })
+  })
+
+  // The default world must send NO param, not `?world=` empty or
+  // `?world=default`. An empty value is a different request than an absent
+  // one, and this is the request every existing detail page makes — a
+  // regression here changes behaviour for every user, not only world users.
+  it('omits the param entirely for the default world', async () => {
+    await fetchView('policy', 'POL-1', undefined)
+
+    const [path, params] = vi.mocked(api.get).mock.calls[0]
+    expect(path).toBe('/_views/policy/POL-1') // the request fired
+    expect(params).toBeUndefined()
+  })
+
+  // `useWorld().worldParam` yields '' for the default world in some call
+  // shapes; an empty string must be treated as absent rather than sent as
+  // `?world=`, which the API would read as a duplicate/empty selection.
+  it('treats an empty world string as absent', async () => {
+    await fetchView('policy', 'POL-1', '')
+
+    const [, params] = vi.mocked(api.get).mock.calls[0]
+    expect(params).toBeUndefined()
+  })
+})

--- a/frontend/src/components/entity/CopyMenu.test.ts
+++ b/frontend/src/components/entity/CopyMenu.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CopyMenu from './CopyMenu.vue'
+import type { CopyOffer } from '@/types'
+
+// RULING 9's two affordance shapes, and the rule that a denied copy is ABSENT
+// rather than disabled.
+//
+// Ruling 10 note — most assertions here are ABSENCES ("no button renders"),
+// which is exactly the class that passes trivially when nothing mounted at
+// all. So every absence test also asserts a matching PRESENCE from the same
+// mount: an offer that should render does render. A test that only checked
+// `find('button').exists() === false` would pass against a component that
+// throws on setup.
+
+function offer(over: Partial<CopyOffer> = {}): CopyOffer {
+  return {
+    name: 'promote-policy',
+    label: 'Publish this policy',
+    targetFace: 'policy@published',
+    sameEntity: true,
+    allowed: true,
+    ...over,
+  }
+}
+
+describe('CopyMenu', () => {
+  it('renders ONE allowed offer as a single button carrying its label', () => {
+    const w = mount(CopyMenu, { props: { offers: [offer()] } })
+    const btn = w.get('button')
+    expect(btn.text()).toBe('Publish this policy')
+    // Single-offer form is a plain button, not a disclosure control.
+    expect(btn.attributes('aria-haspopup')).toBeUndefined()
+  })
+
+  it('falls back to the definition NAME when no label is configured', () => {
+    const w = mount(CopyMenu, {
+      props: { offers: [offer({ name: 'promote-control', label: '' })] },
+    })
+    expect(w.get('button').text()).toBe('promote-control')
+  })
+
+  it('renders SEVERAL allowed offers as one menu, not sibling buttons', async () => {
+    const offers = [
+      offer({ name: 'translate-nl', label: 'Vertaal naar Nederlands' }),
+      offer({ name: 'translate-fr', label: 'Traduire en français' }),
+    ]
+    const w = mount(CopyMenu, { props: { offers } })
+
+    // Closed: exactly one control, the disclosure.
+    expect(w.findAll('button')).toHaveLength(1)
+    const toggle = w.get('button')
+    expect(toggle.attributes('aria-haspopup')).toBe('menu')
+
+    await toggle.trigger('click')
+    const items = w.findAll('[role="menuitem"]')
+    expect(items.map((i) => i.text())).toEqual([
+      'Vertaal naar Nederlands',
+      'Traduire en français',
+    ])
+  })
+
+  it('hides a DENIED offer entirely — absent, not disabled', () => {
+    const denied = offer({ allowed: false, reason: 'requires permission "x"' })
+    const w = mount(CopyMenu, { props: { offers: [denied] } })
+
+    // The absence...
+    expect(w.findAll('button')).toHaveLength(0)
+    // ...and the proof the absence is meaningful: the SAME component with the
+    // SAME offer flipped to allowed renders a button. Without this the
+    // assertion above would pass against a component that renders nothing ever.
+    const allowedMount = mount(CopyMenu, { props: { offers: [offer()] } })
+    expect(allowedMount.findAll('button')).toHaveLength(1)
+  })
+
+  it('renders only the ALLOWED subset when offers are mixed', () => {
+    const w = mount(CopyMenu, {
+      props: {
+        offers: [
+          offer({ name: 'translate-nl', label: 'Dutch' }),
+          offer({ name: 'translate-fr', label: 'French', allowed: false }),
+        ],
+      },
+    })
+    // One allowed offer out of two => the single-button form, showing the
+    // allowed one. The denied label must not appear anywhere.
+    const btn = w.get('button')
+    expect(btn.text()).toBe('Dutch')
+    expect(w.text()).not.toContain('French')
+  })
+
+  it('renders nothing for [] and for absent offers, which are different claims', () => {
+    expect(mount(CopyMenu, { props: { offers: [] } }).findAll('button')).toHaveLength(0)
+    expect(mount(CopyMenu, { props: {} }).findAll('button')).toHaveLength(0)
+    // Presence control, as above.
+    expect(mount(CopyMenu, { props: { offers: [offer()] } }).findAll('button')).toHaveLength(1)
+  })
+
+  it('emits the whole offer on invoke, so the parent need not re-look it up', async () => {
+    const o = offer()
+    const w = mount(CopyMenu, { props: { offers: [o] } })
+    await w.get('button').trigger('click')
+    expect(w.emitted('invoke')).toEqual([[o]])
+  })
+
+  it('disables the control while an invoke is in flight', async () => {
+    const w = mount(CopyMenu, { props: { offers: [offer()], busy: true } })
+    expect(w.get('button').attributes('disabled')).toBeDefined()
+    // Proof the attribute tracks `busy` rather than always being set.
+    await w.setProps({ busy: false })
+    expect(w.get('button').attributes('disabled')).toBeUndefined()
+  })
+
+  it('closes the menu after a choice', async () => {
+    const offers = [
+      offer({ name: 'a', label: 'A' }),
+      offer({ name: 'b', label: 'B' }),
+    ]
+    const w = mount(CopyMenu, { props: { offers } })
+    await w.get('button').trigger('click')
+    expect(w.findAll('[role="menuitem"]')).toHaveLength(2)
+    await w.get('[role="menuitem"]').trigger('click')
+    expect(w.findAll('[role="menuitem"]')).toHaveLength(0)
+  })
+})

--- a/frontend/src/components/entity/CopyMenu.vue
+++ b/frontend/src/components/entity/CopyMenu.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+/**
+ * Renders the copy affordances (RULING 9) for the face on screen: the promote
+ * button on a draft policy, the language menu on an English blog post.
+ *
+ * ## Only ALLOWED offers render, and they render as ABSENT when not
+ *
+ * A denied offer is not shown disabled — it is not shown at all. A disabled
+ * control advertises a capability while refusing it, which for a copy means
+ * telling every reader that a `published` face is a thing this entity could
+ * have. Absence is also what the rest of this app does (`v-if="canUpdate"` on
+ * Edit, `v-if="canDelete"` on Delete), so a greyed-out Publish would be the
+ * odd one out.
+ *
+ * `allowed` is a HINT, never the boundary — the invoke re-authorizes through
+ * the kernel. Hiding a denied offer is a UI courtesy, not a security control,
+ * and nothing here depends on it being right.
+ *
+ * ## One offer is a button; several are a menu
+ *
+ * Not cosmetic. "Publish this policy" is a single act and deserves a single
+ * click; a set of translate definitions is a CHOICE, and a row of sibling
+ * buttons reads as several unrelated actions rather than one decision. The
+ * split is on the count of ALLOWED offers, so a principal permitted only one
+ * of several translations gets the button — which is correct, because for
+ * them it is not a choice.
+ */
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import type { CopyOffer } from '@/types'
+
+const props = defineProps<{
+  offers?: CopyOffer[]
+  /** Disables every control while an invoke is in flight. */
+  busy?: boolean
+}>()
+
+const emit = defineEmits<{ invoke: [offer: CopyOffer] }>()
+
+const open = ref(false)
+const rootRef = ref<HTMLElement | null>(null)
+
+// Absent `_copies` (server computed no offers) and `[]` (this face genuinely
+// offers none) both render nothing, so they need no distinction HERE — but
+// they are different claims, and the type keeps them apart for callers that
+// do care. See Entity._copies.
+const allowed = computed(() => (props.offers ?? []).filter((o) => o.allowed))
+
+// A single-offer label stands alone on a button, so it needs to name the act
+// ("Publish this policy"). Inside a menu the group already supplies context.
+const single = computed(() => (allowed.value.length === 1 ? allowed.value[0] : null))
+
+function labelOf(o: CopyOffer): string {
+  // `label` is operator-configured and optional; the definition NAME is the
+  // documented fallback (`promote-control` reads as an action already).
+  return o.label || o.name
+}
+
+onMounted(() => document.addEventListener('click', onDocClick))
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick))
+
+function onDocClick(e: MouseEvent) {
+  if (rootRef.value && !rootRef.value.contains(e.target as Node)) open.value = false
+}
+
+function choose(o: CopyOffer) {
+  open.value = false
+  emit('invoke', o)
+}
+</script>
+
+<template>
+  <button
+    v-if="single"
+    class="btn btn-secondary copy-single"
+    :disabled="busy"
+    @click="choose(single)"
+  >
+    {{ labelOf(single) }}
+  </button>
+
+  <div v-else-if="allowed.length > 1" ref="rootRef" class="copy-menu">
+    <button
+      class="btn btn-secondary"
+      :disabled="busy"
+      :aria-expanded="open"
+      aria-haspopup="menu"
+      @click="open = !open"
+    >
+      Copy to ▾
+    </button>
+    <ul v-if="open" class="copy-menu-list" role="menu">
+      <li v-for="o in allowed" :key="o.name" role="none">
+        <button
+          role="menuitem"
+          class="copy-menu-item"
+          :title="o.targetFace"
+          @click="choose(o)"
+        >
+          {{ labelOf(o) }}
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.copy-menu {
+  position: relative;
+  display: inline-block;
+}
+
+.copy-menu-list {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 20;
+  min-width: 12rem;
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.copy-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-color);
+  font-size: 0.9rem;
+}
+
+.copy-menu-item:hover,
+.copy-menu-item:focus {
+  background: var(--hover-bg);
+}
+</style>

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -473,10 +473,25 @@ async function runCopy(offer: CopyOffer) {
     uiStore.error(`"${offer.label || offer.name}" copies to a different entity, which this page cannot target yet`)
     return
   }
+  // Capture the subject. `copyBusy` only disables THIS menu's button — the
+  // scope-nav shortcuts (P/N), the back button and the sidebar stay live, so
+  // the page can be showing a different entity by the time the invoke
+  // resolves. Without this the success toast names a face on the entity the
+  // user has already left, and `loadView()` fires a second, pointless fetch
+  // for the one they are now on. Same shape as `pinEntityForFlush` below.
+  const subject = props.entityId
   copyBusy.value = true
   try {
-    const res = await invokeCopy(offer.name, props.entityId)
+    const res = await invokeCopy(offer.name, subject)
     const face = res.pointer || 'default'
+    if (props.entityId !== subject) {
+      // Still worth telling them it succeeded — they asked for it — but name
+      // the entity, since the page in front of them is no longer the subject.
+      uiStore.success(
+        res.created ? `Created the ${face} face of ${subject}` : `Updated the ${face} face of ${subject}`,
+      )
+      return
+    }
     uiStore.success(
       res.created ? `Created the ${face} face` : `Updated the ${face} face`,
     )
@@ -486,8 +501,11 @@ async function runCopy(offer: CopyOffer) {
   } catch (err) {
     // The kernel re-authorizes, so a 403 here is not a contradiction of
     // `allowed` — it is the boundary doing its job on a hint that went stale
-    // (a permission revoked between render and click). Report it plainly.
-    uiStore.error(getErrorMessage(err, 'Copy failed'))
+    // (a permission revoked between render and click). Report it plainly, and
+    // name the subject if the user has since navigated away — an unqualified
+    // "Copy failed" beside an unrelated entity reads as that entity failing.
+    const detail = getErrorMessage(err, 'Copy failed')
+    uiStore.error(props.entityId === subject ? detail : `${subject}: ${detail}`)
   } finally {
     copyBusy.value = false
   }

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -80,7 +80,28 @@ const backTarget = useBackTarget()
 const loading = ref(true)
 const error = ref<string | null>(null)
 const viewData = ref<ViewResponse | null>(null)
-const commands = ref<Command[]>([])
+const loadedCommands = ref<Command[]>([])
+
+// Commands are SUPPRESSED under a world, and this is a stop-gap with a known
+// expiry rather than a design.
+//
+// A command pipes a rendered view to an operator shell script's stdin. The
+// server passes `defaultViewWorld()` explicitly at that call site
+// (internal/dataentry/commands.go), so under `?world=published` the script
+// receives DRAFT content while the user is reading the published face — and it
+// receives it "past any layer that could observe it", as that comment says.
+//
+// What a world-bound command should MEAN is deliberately another ticket. But
+// until it has one, rendering the buttons beside a banner that says "read-only"
+// is the affordance-that-lies shape: the page would be promising an action
+// whose input is not what is on screen. Hiding them is the honest reading of
+// today's server behaviour, not a claim about tomorrow's.
+//
+// Gated HERE rather than on the two button sites (desktop header + mobile
+// overflow) so a third render site cannot be added without inheriting it.
+const commands = computed<Command[]>(() =>
+  isWorldBound.value ? [] : loadedCommands.value,
+)
 const showOverflowMenu = ref(false)
 
 const commandModalRef = ref<InstanceType<typeof CommandModal> | null>(null)
@@ -356,7 +377,7 @@ async function loadCommands() {
   commandsAbort = new AbortController()
   const localAbort = commandsAbort
   try {
-    commands.value = await getCommands(
+    loadedCommands.value = await getCommands(
       { pageType: 'entity', entityType: props.entityType },
       localAbort.signal
     )
@@ -364,7 +385,7 @@ async function loadCommands() {
     if (localAbort.signal.aborted) return
     if (isCancelledFetch(err)) return
     console.error('Failed to load commands:', err)
-    commands.value = []
+    loadedCommands.value = []
   }
 }
 
@@ -459,6 +480,13 @@ async function requestDelete() {
 //
 // So writes happen on the default face, where what you see is what you copy.
 // "Go to draft" is one click away, which is the honest path.
+//
+// NOTE the overload: `undefined` here means EITHER "the server computed no
+// offers" (an unwired copy service) OR "suppressed because we are world-bound",
+// which `Entity._copies` deliberately keeps distinct from `[]`. Nothing
+// branches on absent-vs-empty today — CopyMenu renders nothing for both — so
+// this is safe. If a caller ever does branch on it, this computed becomes a
+// lie and must return `[]` for the suppressed case instead.
 const copyOffers = computed<CopyOffer[] | undefined>(() =>
   isWorldBound.value ? undefined : entry.value?._copies,
 )

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -500,13 +500,51 @@ async function runCopy(offer: CopyOffer) {
 // page is inherently read-only and the editing affordances belong on the
 // default face.
 //
-// Shown only when a non-default world is active (the banner's own `v-if`
-// already establishes that, so there is no second computed for it). There is
-// no attempt to predict whether the draft is READABLE for this principal —
-// that would need a second resolution of the same entity in another world, and
-// a wrong guess either hides a reachable draft or offers a 404. The link goes
-// to the same id in the default world and the ordinary row gate answers,
-// exactly as it would for a typed URL.
+// Hidden when the principal cannot read the default world.
+//
+// This is a GLOBAL, role-level grant, not a per-entity probe: `PermitsWorld`
+// takes a world NAME and nothing else, and `/_schema`.worlds already reports
+// the verdict per world for this caller. So the check costs no extra request
+// and reads no entity — an earlier revision of this comment claimed the check
+// was unimplementable without an existence-oracle read, and that was simply
+// wrong about the mechanism.
+//
+// It was also the wrong rule. The uniform 404 exists for an ENTITY ID, whose
+// existence is a genuine secret. A world NAME is operator-authored
+// schema.yaml config, already disclosed in a routinely public repo, and
+// `/_schema` serves every declared world to every principal by design — only
+// `readable` varies. Hiding a config-declared capability conceals nothing:
+// the user can type the URL and find out.
+//
+// So the gate here is purely an honesty measure, not a confidentiality one.
+// Offering "Go to draft" to someone whose default-world request returns an
+// empty result would send them somewhere that looks broken. `worldReadable`
+// answers TRUE for an unknown world, so an older server or an unloaded schema
+// shows the button rather than hiding a working affordance.
+//
+// # It cannot fire TODAY, and that is deliberate rather than overlooked
+//
+// `/_schema` reports the default world's `readable` as a hardcoded `true`
+// (schemaworlds.go), because `resolveWorld` short-circuits `default` before
+// any grant check — the enumeration mirrors what the request path DOES rather
+// than what the gate could say. So this computed is `true` for every
+// principal on today's server.
+//
+// Measured, not assumed: a role with `worlds: [published]` and `read: []` is
+// genuinely denied the default world (`roleGrantsWorldRead` requires
+// `len(role.Read) > 0`) and its entity GETs 404 — yet `/_schema` still
+// reports `default.readable: true`. That is the PRE-EXISTING gap
+// schemaworlds.go documents at length, guarded by
+// TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath, and it is one
+// decision with the request path: both change together or neither does.
+//
+// This gate is wired to the honest input anyway. When the request path starts
+// honoring a default-world denial and the enumeration switches to asking the
+// gate, this button starts hiding itself with no change here. Reading the
+// flag now is what makes that true; hardcoding `true` here would have to be
+// found and fixed at that point instead.
+const canReachDefaultWorld = computed(() => schemaStore.worldReadable(''))
+
 function goToDefaultWorld() {
   setWorld('')
 }
@@ -884,11 +922,12 @@ watch(
         default world — which is where every write lands, since the API refuses
         `?world=` on a write.
 
-        "Go to draft" is a plain navigation to the same id with no `?world=`.
-        It is NOT predicated on whether the default face is readable: deciding
-        that would take a second read of the entity in another world, which is
-        the existence-oracle shape this epic forbids. The link goes there and
-        the ordinary row gate answers, exactly as it would for a typed URL.
+        "Go to draft" is a plain navigation to the same id with no `?world=`,
+        shown only when this principal may read the default world — a global
+        role-level grant already reported per world by `/_schema`.worlds, so
+        the check costs no extra request. It does NOT predict whether the
+        specific ENTITY is readable there; that is the row gate's job and it
+        answers on arrival, exactly as it would for a typed URL.
 
         There is deliberately no WorldBadge on the ENTRY: `_views` attaches
         `_world` to collection entities only (sections.go is the single call
@@ -905,7 +944,11 @@ watch(
         <span class="world-banner__note">
           This face is read-only — writes always address the default state.
         </span>
-        <button class="btn btn-secondary" @click="goToDefaultWorld">
+        <button
+          v-if="canReachDefaultWorld"
+          class="btn btn-secondary"
+          @click="goToDefaultWorld"
+        >
           Go to draft
         </button>
       </div>

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -6,6 +6,7 @@ import { useScopeNavigation } from '@/composables'
 import { useBackTarget } from '@/composables/useBackTarget'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { fetchView, getCommands, getErrorMessage } from '@/api'
+import { useWorld } from '@/composables/useWorld'
 import type { ViewEntity, ViewResponse, ViewSection, ViewSectionField } from '@/api'
 import type { Entity } from '@/types'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
@@ -59,6 +60,10 @@ const router = useRouter()
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
 const { confirm } = useConfirm()
+// The world is read from the URL, the same source EntityList reads, so a
+// detail page reached from a world-bound list stays in that world and a
+// deep link round-trips.
+const { worldParam } = useWorld()
 
 // Scope navigation (prev/next within a list) and back affordance
 // (return_to / from precedence). Two parallel concerns: scope-nav walks
@@ -340,7 +345,16 @@ async function loadView() {
   loading.value = true
   error.value = null
   try {
-    viewData.value = await fetchView(props.entityType, props.entityId)
+    // The world rides the request, so the entry resolves to that world's face
+    // and every collection entity resolves through the same world, per
+    // neighbour (TKT-WRLDAPI item 4b). Without it this page rendered draft
+    // content while the selector said "published" — the API was correct and
+    // the page simply never asked.
+    viewData.value = await fetchView(
+      props.entityType,
+      props.entityId,
+      worldParam.value,
+    )
     if (viewData.value?.entry) {
       // Seed the autosave baseline so the first toggle's no-op
       // suppression can compare against server state without waiting
@@ -677,6 +691,24 @@ onBeforeUnmount(() => {
 })
 
 onUnmounted(() => document.removeEventListener('click', closeOverflow))
+
+// Switching WORLD reloads the view, but is deliberately NOT folded into the
+// entity watcher below.
+//
+// That watcher flushes pending autosaves against the PREVIOUS entity's
+// identity before loading the next one. A world change is the SAME entity seen
+// through a different world, so there is no previous identity to pin and no
+// cross-entity flush to arrange — running that machinery would capture the
+// current entity as its own "previous" and commit a flush nobody asked for.
+//
+// What a world change does need is a refetch, because the face being displayed
+// changes even though the id does not.
+watch(
+  () => worldParam.value,
+  () => {
+    loadView()
+  },
+)
 
 // Watch for route changes
 watch(

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -39,6 +39,10 @@ import DocumentsPanel from '@/components/entity/DocumentsPanel.vue'
 import CommandModal from '@/components/entity/CommandModal.vue'
 import ExportMenu from '@/components/entity/ExportMenu.vue'
 import { entityExportUrl } from '@/api/transforms'
+import CopyMenu from '@/components/entity/CopyMenu.vue'
+import WorldBadge from '@/components/entity/WorldBadge.vue'
+import { invokeCopy } from '@/api/copies'
+import type { CopyOffer } from '@/types'
 import SectionEditForm, { type SectionEditField } from '@/components/forms/SectionEditForm.vue'
 import AutoSaveIndicator from '@/components/forms/AutoSaveIndicator.vue'
 import {
@@ -63,7 +67,7 @@ const { confirm } = useConfirm()
 // The world is read from the URL, the same source EntityList reads, so a
 // detail page reached from a world-bound list stays in that world and a
 // deep link round-trips.
-const { worldParam } = useWorld()
+const { world, isWorldBound, worldParam, setWorld } = useWorld()
 
 // Scope navigation (prev/next within a list) and back affordance
 // (return_to / from precedence). Two parallel concerns: scope-nav walks
@@ -113,8 +117,26 @@ const isInaccessible = computed(() => (entry.value?.inaccessible?.length ?? 0) >
 
 // Affordance gates: `_actions` map from the server. `false` → hide;
 // anything else → render. See frontend/src/utils/affordancesWarning.ts.
-const canUpdate = computeActionAllowed(entry, 'update')
-const canDelete = computeActionAllowed(entry, 'delete')
+const mayUpdate = computeActionAllowed(entry, 'update')
+const mayDelete = computeActionAllowed(entry, 'delete')
+
+// A world-bound page is READ-ONLY, regardless of what `_actions` says.
+//
+// The API refuses every write carrying `?world=` (422 world_read_only) —
+// writes always address the default state — but `_actions` is computed from
+// the ACL alone and still reports `update: true` on a world-bound response.
+// Gating on `_actions` by itself therefore renders an Edit button whose save
+// cannot succeed: an affordance map that promises a verb the surface will
+// reject (RULING 11).
+//
+// So the world is ANDed in here rather than fixed in the map. `_actions`
+// answers "may this principal write this entity", which is true and is the
+// question it is defined to answer; "can a write be addressed to THIS
+// response" is a property of the request, and belongs where the request is
+// known. EntityList already draws the same line, omitting its create button
+// under a world.
+const canUpdate = computed(() => mayUpdate.value && !isWorldBound.value)
+const canDelete = computed(() => mayDelete.value && !isWorldBound.value)
 
 // The entry's content section gets a custom renderer (mermaid + interactive
 // checkboxes) instead of the generic section render-path. Other content
@@ -247,6 +269,15 @@ function handleCheckboxToggle(index: number) {
   const current = entry.value
   const view = viewData.value
   if (!current || !view) return
+  // A checkbox click is a WRITE (it schedules a content PATCH), so it is
+  // refused under a world for the same reason the Edit button is hidden — the
+  // API would answer 422 world_read_only. Checkboxes render inside markdown
+  // and cannot be hidden by a `v-if` the way a button can, so the guard has to
+  // live at the handler.
+  if (isWorldBound.value) {
+    uiStore.warning(`Read-only: you are viewing the ${world.value} world`)
+    return
+  }
   let newContent: string
   try {
     newContent = toggleCheckboxInSource(current.content || '', index)
@@ -407,6 +438,79 @@ async function requestDelete() {
   router.push(backTargetAfterDelete())
 }
 
+// --- Copy affordances (RULING 9) ---------------------------------------
+//
+// Offers ride the entity response as `_copies`, so there is nothing to fetch:
+// they arrive with the view and refresh with it.
+// Suppressed under a world, like every other write affordance on this page.
+//
+// The server's offers are CORRECT under a world — they are computed for the
+// RESOLVED face, so `?world=published` (whose face is `policy@published`, which
+// nothing copies from) returns `[]`, while a world that falls back to the
+// default face still offers the promote that face genuinely supports.
+//
+// The problem is the PAGE, not the offer. A copy invoke carries no `?world=`,
+// so it would succeed — and apply the DEFAULT face's content while the reader
+// is looking at whatever face this world resolved. Under `otherwise: default`
+// those are the same bytes and it looks harmless; under a world serving a real
+// alternate face, the user would publish content that is not on their screen.
+// A banner that says "read-only" with a Publish button beside it is also the
+// affordance-map-that-lies shape in plain sight.
+//
+// So writes happen on the default face, where what you see is what you copy.
+// "Go to draft" is one click away, which is the honest path.
+const copyOffers = computed<CopyOffer[] | undefined>(() =>
+  isWorldBound.value ? undefined : entry.value?._copies,
+)
+const copyBusy = ref(false)
+
+async function runCopy(offer: CopyOffer) {
+  // Same-entity copies (promote, translate) target the source by construction
+  // and MUST NOT send a target id; a cross-entity copy requires one and has no
+  // UI here yet, so it is refused locally rather than sent as a malformed
+  // invoke the server would reject with a less specific message.
+  if (!offer.sameEntity) {
+    uiStore.error(`"${offer.label || offer.name}" copies to a different entity, which this page cannot target yet`)
+    return
+  }
+  copyBusy.value = true
+  try {
+    const res = await invokeCopy(offer.name, props.entityId)
+    const face = res.pointer || 'default'
+    uiStore.success(
+      res.created ? `Created the ${face} face` : `Updated the ${face} face`,
+    )
+    // Reload so the offers recompute: a face that now exists may no longer be
+    // offered, and the entry's own content may have moved.
+    await loadView()
+  } catch (err) {
+    // The kernel re-authorizes, so a 403 here is not a contradiction of
+    // `allowed` — it is the boundary doing its job on a hint that went stale
+    // (a permission revoked between render and click). Report it plainly.
+    uiStore.error(getErrorMessage(err, 'Copy failed'))
+  } finally {
+    copyBusy.value = false
+  }
+}
+
+// --- Leaving a world ----------------------------------------------------
+//
+// "Go to draft" returns to the DEFAULT world, which is where writes land: the
+// API refuses `?world=` on a write (422 world_read_only), so a world-bound
+// page is inherently read-only and the editing affordances belong on the
+// default face.
+//
+// Shown only when a non-default world is active (the banner's own `v-if`
+// already establishes that, so there is no second computed for it). There is
+// no attempt to predict whether the draft is READABLE for this principal —
+// that would need a second resolution of the same entity in another world, and
+// a wrong guess either hides a reachable draft or offers a 404. The link goes
+// to the same id in the default world and the ordinary row gate answers,
+// exactly as it would for a typed URL.
+function goToDefaultWorld() {
+  setWorld('')
+}
+
 function backTargetAfterDelete(): string {
   if (backTarget.value) return backTarget.value.to
   const listId = schemaStore.findListIdForEntityType(props.entityType)
@@ -522,6 +626,10 @@ function memoBuildSectionEditFields(section: ViewSection, ent: Entity): SectionE
 }
 
 function sectionShouldRouteToInlineEdit(section: ViewSection, ent: Entity): boolean {
+  // Inline edit is a write surface; a world-bound page has none. Routing to
+  // the display path here is what makes the whole page read-only rather than
+  // just its header buttons.
+  if (isWorldBound.value) return false
   return sectionShouldRouteToInlineEditPure(section.fields, ent, getPropertyDef)
 }
 
@@ -586,6 +694,11 @@ const INLINE_EDIT_ROW_CAP = 100
 // Thin SFC adapter — the cap-behaviour logic lives in the pure module
 // so it's unit-testable without mounting EntityDetail.
 function rowShouldRouteToInlineEdit(ent: ViewEntity, rowCount: number): boolean {
+  // Same as sectionShouldRouteToInlineEdit: no write surface under a world.
+  // Collection rows matter doubly here — under a world each row is a
+  // NEIGHBOUR's resolved face, and an edit would address the default state of
+  // an entity the page is not even showing you.
+  if (isWorldBound.value) return false
   return rowShouldRouteToInlineEditPure(ent, rowCount, INLINE_EDIT_ROW_CAP, getPropertyDef)
 }
 
@@ -765,6 +878,38 @@ watch(
         </template>
       </div>
 
+      <!--
+        The world banner, mirroring EntityList's. It says which world is being
+        shown, that the page is read-only here, and offers the way back to the
+        default world — which is where every write lands, since the API refuses
+        `?world=` on a write.
+
+        "Go to draft" is a plain navigation to the same id with no `?world=`.
+        It is NOT predicated on whether the default face is readable: deciding
+        that would take a second read of the entity in another world, which is
+        the existence-oracle shape this epic forbids. The link goes there and
+        the ordinary row gate answers, exactly as it would for a typed URL.
+
+        There is deliberately no WorldBadge on the ENTRY: `_views` attaches
+        `_world` to collection entities only (sections.go is the single call
+        site), so a badge here would have nothing to render. The entry's own
+        provenance is available on the entity GET, but this page reads the view
+        — wiring a second request for a badge is not worth it. Collection
+        entities, where the fallback-vs-real distinction actually bites, carry
+        the badge below.
+      -->
+      <div v-if="isWorldBound" class="world-banner">
+        <span class="world-banner__label">
+          Showing the <strong>{{ world }}</strong> world
+        </span>
+        <span class="world-banner__note">
+          This face is read-only — writes always address the default state.
+        </span>
+        <button class="btn btn-secondary" @click="goToDefaultWorld">
+          Go to draft
+        </button>
+      </div>
+
       <header class="detail-header">
         <div class="header-info">
           <span class="entity-type-badge">{{ typeDef?.label || entityType }}</span>
@@ -780,6 +925,13 @@ watch(
           >
             {{ cmd.label }}
           </button>
+          <!--
+            Copy affordances (RULING 9). Renders nothing when no offer is
+            allowed — a denied copy is ABSENT, not disabled, so this element
+            simply does not appear for a principal without the guard
+            permission. See CopyMenu.vue.
+          -->
+          <CopyMenu :offers="copyOffers" :busy="copyBusy" @invoke="runCopy" />
           <button
             v-if="editFormId && !isInaccessible && canUpdate"
             class="btn btn-secondary"
@@ -975,6 +1127,14 @@ watch(
                 <span class="entity-type">{{ ent.type }}</span>
                 <span class="entity-title">{{ ent.title }}</span>
                 <span class="entity-id">{{ ent.id }}</span>
+                <!--
+                  Per-neighbour provenance (RULING 12/14). Each collection
+                  entity resolved through the world INDEPENDENTLY, so one
+                  section can mix `chain` and `fallback-default` — the badge is
+                  per row, not per section. Renders nothing under the default
+                  world.
+                -->
+                <WorldBadge :world="ent._world" />
               </header>
               <div
                 v-if="ent.hasContent"
@@ -1002,6 +1162,14 @@ watch(
                 <span class="entity-type">{{ ent.type }}</span>
                 <span class="entity-title">{{ ent.title }}</span>
                 <span class="entity-id">{{ ent.id }}</span>
+                <!--
+                  Per-neighbour provenance (RULING 12/14). Each collection
+                  entity resolved through the world INDEPENDENTLY, so one
+                  section can mix `chain` and `fallback-default` — the badge is
+                  per row, not per section. Renders nothing under the default
+                  world.
+                -->
+                <WorldBadge :world="ent._world" />
                 <button
                   v-if="ent.editFormId"
                   class="edit-btn"
@@ -1066,6 +1234,14 @@ watch(
                 <span class="entity-type">{{ ent.type }}</span>
                 <span class="entity-title">{{ ent.title }}</span>
                 <span class="entity-id">{{ ent.id }}</span>
+                <!--
+                  Per-neighbour provenance (RULING 12/14). Each collection
+                  entity resolved through the world INDEPENDENTLY, so one
+                  section can mix `chain` and `fallback-default` — the badge is
+                  per row, not per section. Renders nothing under the default
+                  world.
+                -->
+                <WorldBadge :world="ent._world" />
               </a>
               <SectionEditForm
                 v-if="rowShouldRouteToInlineEdit(ent, section.entities?.length ?? 0)"
@@ -1543,6 +1719,35 @@ watch(
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: var(--space-lg);
+}
+
+/* Mirrors EntityList's world banner so the two surfaces read as one feature.
+   Horizontal here (the detail page has the width and the note is shorter),
+   with the leave-world button on the trailing edge. */
+.world-banner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-xs) var(--space-md);
+  margin-bottom: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
+  border-radius: var(--radius-md);
+}
+
+.world-banner__label {
+  font-size: var(--font-size-base);
+  color: var(--text-color);
+}
+
+.world-banner__note {
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+
+.world-banner .btn {
+  margin-left: auto;
 }
 
 .entity-card {

--- a/frontend/src/components/entity/EntityDetail.world.test.ts
+++ b/frontend/src/components/entity/EntityDetail.world.test.ts
@@ -29,11 +29,19 @@ import type { ViewResponse } from '@/api'
 const fetchViewMock = vi.fn()
 const getCommandsMock = vi.fn()
 const invokeCopyMock = vi.fn()
+// The WRITE mock. Asserting on this rather than on an internal spy is what
+// makes the world guards testable at the boundary that matters: whether a
+// PATCH leaves the client at all.
+const updateEntityMock = vi.fn()
 
 vi.mock('@/api', async (orig) => ({
   ...(await orig<typeof import('@/api')>()),
   fetchView: (...a: unknown[]) => fetchViewMock(...a),
   getCommands: (...a: unknown[]) => getCommandsMock(...a),
+}))
+vi.mock('@/api/entities', async (orig) => ({
+  ...(await orig<typeof import('@/api/entities')>()),
+  updateEntity: (...a: unknown[]) => updateEntityMock(...a),
 }))
 vi.mock('@/api/copies', () => ({
   invokeCopy: (...a: unknown[]) => invokeCopyMock(...a),
@@ -109,6 +117,9 @@ describe('EntityDetail world binding', () => {
       title: 'Edit policy',
     } as never)
     fetchViewMock.mockReset()
+    updateEntityMock.mockReset().mockResolvedValue({
+      id: entityId, type: entityType, properties: {}, content: '', _actions: {},
+    })
     getCommandsMock.mockReset().mockResolvedValue([])
     invokeCopyMock.mockReset()
     routerPush.mockClear()
@@ -133,6 +144,11 @@ describe('EntityDetail world binding', () => {
   // The anti-vacuity guard: proves the page actually rendered, so that an
   // "absent" assertion is a statement about the page rather than about a
   // crashed setup.
+  //
+  // SCOPE: it proves the ENTRY rendered, nothing more. Tests asserting on
+  // COLLECTION entities are not carried by it — their own positive controls
+  // (e.g. the badge-count assertions in the provenance block) are what make
+  // them non-vacuous. Do not read a rendersProof call as blanket cover.
   function rendersProof(wrapper: { text: () => string }) {
     expect(fetchViewMock).toHaveBeenCalled()
     expect(wrapper.text()).toContain('Access Control Policy')
@@ -264,6 +280,128 @@ describe('EntityDetail world binding', () => {
       } as never)
       rendersProof(w)
       expect(w.findComponent({ name: 'SectionEditForm' }).exists()).toBe(false)
+    })
+
+    it('refuses a checkbox toggle under a world (G1)', async () => {
+      // The checkbox lives inside v-html markdown and is caught by a delegated
+      // handler, so there is no element to `v-if` — the guard has to be in
+      // handleCheckboxToggle, and this is what holds it there.
+      //
+      // The server is NOT a backstop: `attachWorld` refuses a write only when
+      // `?world=` is on the WRITE request, and useAutoSave never attaches it.
+      // So without the guard this silently PATCHes the DEFAULT face while the
+      // user is reading a resolved one — no 422, no error, wrong state.
+      const contentSection = {
+        heading: '',
+        sectionId: 'content',
+        display: 'content',
+        isEmpty: false,
+        isGrouped: false,
+        hasContent: true,
+        content: '- [ ] a task',
+      }
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail({
+        entry: entry({ content: '- [ ] a task' }),
+        sections: [contentSection],
+      } as never)
+      rendersProof(w)
+
+      const box = w.find('input[type="checkbox"][data-cb-idx]')
+      expect(box.exists()).toBe(true) // the control renders; it just must not write
+      await box.trigger('click')
+      // Flush the SAME way as the positive control below. Without this the
+      // absence would only prove the debounce had not elapsed.
+      w.unmount()
+      await flushPromises()
+      expect(updateEntityMock).not.toHaveBeenCalled()
+
+      // Positive control: the SAME click on the SAME markup under the default
+      // world DOES schedule a write. Without this the assertion above passes
+      // against a checkbox that was never wired.
+      mockRoute.query = {}
+      const dflt = await mountDetail({
+        entry: entry({ content: '- [ ] a task' }),
+        sections: [contentSection],
+      } as never)
+      const dfltBox = dflt.find('input[type="checkbox"][data-cb-idx]')
+      expect(dfltBox.exists()).toBe(true)
+      await dfltBox.trigger('click')
+      // The content channel debounces, so flush it the way the component
+      // itself does on navigation — unmount triggers commitImmediately().
+      dflt.unmount()
+      await flushPromises()
+      expect(updateEntityMock).toHaveBeenCalled()
+    })
+
+    it('renders NO inline-edit surface on a collection ROW under a world (G3)', async () => {
+      // rowShouldRouteToInlineEdit is a SEPARATE predicate from the section
+      // one, so the entry-level test does not cover it. Rows matter doubly:
+      // under a world each row is a NEIGHBOUR's resolved face, so an edit
+      // would address the default state of an entity the page is not showing.
+      const cardSection = (extra: object = {}) => ({
+        heading: 'Implements',
+        sectionId: 'implements',
+        display: 'cards',
+        isEmpty: false,
+        isGrouped: false,
+        hasContent: false,
+        entities: [{
+          id: 'CTL-1',
+          type: 'control',
+          title: 'MFA enforcement',
+          hasContent: false,
+          editFormId: 'control-edit',
+          fields: [{ property: 'title', label: 'Title', values: ['MFA'], render: 'input' }],
+          _props: { title: 'MFA' },
+          _fields: {},
+          ...extra,
+        }],
+      })
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail({ entry: entry(), sections: [cardSection()] } as never)
+      rendersProof(w)
+      expect(w.findComponent({ name: 'SectionEditForm' }).exists()).toBe(false)
+
+      // Positive control under the default world — otherwise this passes
+      // against a row that could never have routed to inline edit anyway.
+      mockRoute.query = {}
+      const dflt = await mountDetail({ entry: entry(), sections: [cardSection()] } as never)
+      expect(dflt.findComponent({ name: 'SectionEditForm' }).exists()).toBe(true)
+    })
+
+    it('treats ?world=default as writable and unbannered (S2)', async () => {
+      // The default world IS where writes land, so this is correct — but the
+      // invariant "banner shown <=> writes blocked" rests on TWO independently
+      // maintained expressions (`isWorldBound` in useWorld, and the banner's
+      // own v-if). This pins them together for the one spelling where they
+      // could most plausibly drift: the explicit `default`, which the API
+      // accepts and which round-trips through the URL.
+      mockRoute.query = { world: 'default' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(w.find('.world-banner').exists()).toBe(false)
+      expect(button(w, 'Delete')).toBeDefined()
+      // And the param is OMITTED rather than sent as the reserved name.
+      expect(fetchViewMock).toHaveBeenCalledWith(entityType, entityId, undefined)
+    })
+
+    it('hides operator COMMANDS under a world (S1)', async () => {
+      // A command pipes a rendered view to a shell script's stdin, and the
+      // server passes defaultViewWorld() explicitly there — so under a world
+      // the script gets DRAFT content while the user reads published. What a
+      // world-bound command should mean is another ticket; rendering the
+      // button beside a "read-only" banner in the meantime is not.
+      getCommandsMock.mockResolvedValue([{ id: 'publish', label: 'Run publish script' }])
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(w.text()).not.toContain('Run publish script')
+
+      // Positive control: same command list, default world, button renders.
+      mockRoute.query = {}
+      const dflt = await mountDetail(viewResponse())
+      expect(dflt.text()).toContain('Run publish script')
     })
 
     it('offers the way back to the default world', async () => {

--- a/frontend/src/components/entity/EntityDetail.world.test.ts
+++ b/frontend/src/components/entity/EntityDetail.world.test.ts
@@ -195,6 +195,32 @@ describe('EntityDetail world binding', () => {
       expect(w.text()).not.toContain('Edit')
     })
 
+    it('hides "Go to draft" when the principal cannot read the default world', async () => {
+      // A GLOBAL role-level grant, reported per world by `/_schema`.worlds —
+      // no per-entity probe, so no existence oracle and no extra request.
+      // Offering the button to someone whose default-world request returns an
+      // empty result would send them somewhere that looks broken.
+      useSchemaStore().worlds.set('default', { readable: false, default: true })
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(w.text()).not.toContain('Go to draft')
+      // The banner itself still renders — proving the absence is the button's
+      // gate and not a failure to render the whole block.
+      expect(w.find('.world-banner').exists()).toBe(true)
+    })
+
+    it('shows "Go to draft" when the world map is EMPTY (older server)', async () => {
+      // Unknown world defaults to readable: hiding a working affordance
+      // because the schema had not loaded would read as a permission problem,
+      // which is the wrong answer in the direction nobody can debug.
+      useSchemaStore().worlds.clear()
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(w.text()).toContain('Go to draft')
+    })
+
     it('offers the way back to the default world', async () => {
       mockRoute.query = { world: 'published' }
       const w = await mountDetail(viewResponse())

--- a/frontend/src/components/entity/EntityDetail.world.test.ts
+++ b/frontend/src/components/entity/EntityDetail.world.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { PiniaColada } from '@pinia/colada'
 import EntityDetail from './EntityDetail.vue'
@@ -138,6 +138,15 @@ describe('EntityDetail world binding', () => {
     expect(wrapper.text()).toContain('Access Control Policy')
   }
 
+  // Match a BUTTON by its label rather than searching whole-page text.
+  // `wrapper.text().not.toContain('Edit')` is a substring match over the
+  // entire render, so it is satisfied — or broken — by unrelated copy: the
+  // fixture's own form is titled "Edit policy", and any future heading
+  // containing the word would flip the result without the gate changing.
+  function button(wrapper: VueWrapper, label: string) {
+    return wrapper.findAll('button').find((b) => b.text().replace(/\s+/g, ' ').trim().startsWith(label))
+  }
+
   describe('the world rides the request', () => {
     it('sends no world under the default world', async () => {
       const w = await mountDetail(viewResponse())
@@ -162,7 +171,7 @@ describe('EntityDetail world binding', () => {
       // The positive control for both absence assertions below. `_actions` is
       // identical in the world-bound case, so this is the ONLY thing that
       // distinguishes "hidden because of the world" from "hidden always".
-      expect(w.text()).toContain('Delete')
+      expect(button(w, 'Delete')).toBeDefined()
     })
 
     it('hides Delete under a world even though _actions permits it', async () => {
@@ -192,7 +201,17 @@ describe('EntityDetail world binding', () => {
       // Same `_actions: {update: true}` as the default-world case, which
       // renders Edit — so this distinguishes "hidden by the world" from
       // "hidden always".
-      expect(w.text()).not.toContain('Edit')
+      expect(button(w, 'Edit')).toBeUndefined()
+    })
+
+    it('offers Edit under the default world (the control for the case above)', async () => {
+      // Without this, hiding Edit unconditionally — or a fixture that never
+      // satisfies `editFormId` — passes the assertion above while proving
+      // nothing. This is the half that was missing when the canUpdate mutant
+      // survived.
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(button(w, 'Edit')).toBeDefined()
     })
 
     it('hides "Go to draft" when the principal cannot read the default world', async () => {
@@ -219,6 +238,32 @@ describe('EntityDetail world binding', () => {
       const w = await mountDetail(viewResponse())
       rendersProof(w)
       expect(w.text()).toContain('Go to draft')
+    })
+
+    it('renders NO inline-edit surface under a world', async () => {
+      // The autosave paths (handlePropertyApplied / handleRowPropertyApplied,
+      // and the content channel) are reachable ONLY as props on a
+      // SectionEditForm. All three of its call sites route through
+      // sectionShouldRouteToInlineEdit / rowShouldRouteToInlineEdit, both of
+      // which refuse under a world — so no pending save can be CREATED while
+      // world-bound, and the two commitImmediately() flushes have nothing to
+      // flush. This test is what makes that argument checkable rather than a
+      // claim in a comment.
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail({
+        entry: entry(),
+        sections: [{
+          heading: 'Properties',
+          sectionId: 'props',
+          display: 'properties',
+          isEmpty: false,
+          isGrouped: false,
+          hasContent: false,
+          fields: [{ property: 'title', label: 'Title', values: ['Access Control Policy'], render: 'input' }],
+        }],
+      } as never)
+      rendersProof(w)
+      expect(w.findComponent({ name: 'SectionEditForm' }).exists()).toBe(false)
     })
 
     it('offers the way back to the default world', async () => {
@@ -309,6 +354,35 @@ describe('EntityDetail world binding', () => {
 
       // A face that now exists may no longer be offered.
       expect(fetchViewMock.mock.calls.length).toBeGreaterThan(before)
+    })
+
+    it('does not reload or misattribute when the entity changes mid-invoke', async () => {
+      // `copyBusy` only disables THIS menu's button; the scope-nav shortcuts
+      // (P/N), the back button and the sidebar stay live, so the page can be
+      // showing a different entity by the time the invoke resolves.
+      //
+      // Before the fix this fired a SECOND fetchView for the entity the user
+      // had navigated TO — an entity the copy never touched — and showed an
+      // unqualified "Created the published face" beside it.
+      let resolveInvoke: (v: unknown) => void = () => {}
+      invokeCopyMock.mockReturnValue(new Promise((r) => { resolveInvoke = r }))
+      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      const btn = w.findAll('button').find((b) => b.text() === 'Publish this policy')
+      await btn!.trigger('click')
+
+      await w.setProps({ entityId: 'POL-2' })
+      await flushPromises()
+      const afterNav = fetchViewMock.mock.calls.length
+
+      resolveInvoke({
+        definition: 'promote-policy', entityId, pointer: 'published', created: true,
+      })
+      await flushPromises()
+
+      // The copy still targeted the entity the user clicked on...
+      expect(invokeCopyMock).toHaveBeenCalledWith('promote-policy', entityId)
+      // ...and it did NOT reload the unrelated entity now on screen.
+      expect(fetchViewMock.mock.calls.length).toBe(afterNav)
     })
 
     it('surfaces a refusal rather than pretending the copy ran', async () => {

--- a/frontend/src/components/entity/EntityDetail.world.test.ts
+++ b/frontend/src/components/entity/EntityDetail.world.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+import EntityDetail from './EntityDetail.vue'
+import { useSchemaStore } from '@/stores/schema'
+import type { Entity, CopyOffer, EntityWorld } from '@/types'
+import type { ViewResponse } from '@/api'
+
+// The world-bound DETAIL surface (TKT-F2D5U5).
+//
+// Two properties are pinned here, and they are different in kind:
+//
+//  1. A world-bound page is READ-ONLY. The API refuses every write carrying
+//     `?world=` (422 world_read_only) while `_actions` still reports
+//     `update: true` — it answers "may this principal write this entity",
+//     which is a question about the principal, not about the request. So the
+//     page ANDs the world in. Without that the Edit button renders and its
+//     save fails: an affordance that promises a verb the surface rejects.
+//
+//  2. Copy offers (RULING 9) ride `_copies` on the entry, and only ALLOWED
+//     ones render, as ABSENT rather than disabled.
+//
+// Ruling 10 note — nearly every assertion below is an ABSENCE, the class that
+// passes trivially against a component that failed to mount. `rendersProof`
+// is the shared guard, and each absence is paired with the same assertion
+// passing in the positive direction from a sibling mount.
+
+const fetchViewMock = vi.fn()
+const getCommandsMock = vi.fn()
+const invokeCopyMock = vi.fn()
+
+vi.mock('@/api', async (orig) => ({
+  ...(await orig<typeof import('@/api')>()),
+  fetchView: (...a: unknown[]) => fetchViewMock(...a),
+  getCommands: (...a: unknown[]) => getCommandsMock(...a),
+}))
+vi.mock('@/api/copies', () => ({
+  invokeCopy: (...a: unknown[]) => invokeCopyMock(...a),
+}))
+
+const routerPush = vi.fn()
+const mockRoute: { query: Record<string, unknown>; path: string; name: string } = {
+  query: {},
+  path: '/entity/policy/POL-1',
+  name: 'entity',
+}
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerPush, replace: vi.fn() }),
+  useRoute: () => mockRoute,
+  RouterLink: { template: '<a><slot /></a>' },
+}))
+
+const entityType = 'policy'
+const entityId = 'POL-1'
+
+function promoteOffer(over: Partial<CopyOffer> = {}): CopyOffer {
+  return {
+    name: 'promote-policy',
+    label: 'Publish this policy',
+    targetFace: 'policy@published',
+    sameEntity: true,
+    allowed: true,
+    ...over,
+  }
+}
+
+function entry(over: Partial<Entity> = {}): Entity {
+  return {
+    id: entityId,
+    type: entityType,
+    _title: 'Access Control Policy',
+    properties: { title: 'Access Control Policy' },
+    content: '# Access Control Policy',
+    // The map the server really sends under a world: writes are permitted for
+    // this PRINCIPAL, which is true and is not the question the page asks.
+    _actions: { update: true, delete: true, rename: true },
+    ...over,
+  }
+}
+
+function viewResponse(over: Partial<Entity> = {}): ViewResponse {
+  return {
+    entry: entry(over),
+    sections: [],
+  }
+}
+
+describe('EntityDetail world binding', () => {
+  let pinia: ReturnType<typeof createPinia>
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    const schemaStore = useSchemaStore()
+    schemaStore.entityTypes.set(entityType, {
+      name: entityType,
+      label: 'Policy',
+      properties: { title: { type: 'string', values: null } },
+    } as never)
+    // The Edit button also requires an edit form to exist
+    // (`v-if="editFormId && !isInaccessible && canUpdate"`). Without this the
+    // Edit assertions below pass VACUOUSLY — verified by mutation: dropping
+    // `!isWorldBound` from canUpdate survived the suite until this was seeded.
+    schemaStore.forms.set('policy-edit', {
+      id: 'policy-edit',
+      entity: entityType,
+      mode: 'edit',
+      title: 'Edit policy',
+    } as never)
+    fetchViewMock.mockReset()
+    getCommandsMock.mockReset().mockResolvedValue([])
+    invokeCopyMock.mockReset()
+    routerPush.mockClear()
+    mockRoute.query = {}
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  async function mountDetail(view: ViewResponse) {
+    fetchViewMock.mockResolvedValue(view)
+    const wrapper = mount(EntityDetail, {
+      props: { entityType, entityId },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  // The anti-vacuity guard: proves the page actually rendered, so that an
+  // "absent" assertion is a statement about the page rather than about a
+  // crashed setup.
+  function rendersProof(wrapper: { text: () => string }) {
+    expect(fetchViewMock).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Access Control Policy')
+  }
+
+  describe('the world rides the request', () => {
+    it('sends no world under the default world', async () => {
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(fetchViewMock).toHaveBeenCalledWith(entityType, entityId, undefined)
+      expect(w.find('.world-banner').exists()).toBe(false)
+    })
+
+    it('sends the world named by the URL', async () => {
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(fetchViewMock).toHaveBeenCalledWith(entityType, entityId, 'published')
+      expect(w.find('.world-banner').text()).toContain('published')
+    })
+  })
+
+  describe('a world-bound page is read-only', () => {
+    it('offers Edit and Delete under the default world', async () => {
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      // The positive control for both absence assertions below. `_actions` is
+      // identical in the world-bound case, so this is the ONLY thing that
+      // distinguishes "hidden because of the world" from "hidden always".
+      expect(w.text()).toContain('Delete')
+    })
+
+    it('hides Delete under a world even though _actions permits it', async () => {
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      // Same `_actions: {delete: true}` as the passing case above.
+      expect(w.find('.btn-danger').exists()).toBe(false)
+    })
+
+    it('hides Edit under a world even though _actions permits it', async () => {
+      // The Delete case above pins `canDelete`; this pins `canUpdate`, a
+      // SEPARATE computed that the Delete assertion cannot cover. Mutating
+      // `canUpdate` to drop its `!isWorldBound` term survives the suite
+      // without this test — and survived it WITH this test too, until the
+      // fixture grew an edit form, because the button has a second
+      // precondition (`editFormId`) that the fixture did not satisfy. A test
+      // asserting an absence against an element that could never appear
+      // proves nothing.
+      //
+      // Edit is the WORSE half to leave unpinned. Delete under a world merely
+      // 422s; Edit opens a form, the user types, and the save fails — work
+      // lost to an affordance that promised a verb the surface rejects.
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      // Same `_actions: {update: true}` as the default-world case, which
+      // renders Edit — so this distinguishes "hidden by the world" from
+      // "hidden always".
+      expect(w.text()).not.toContain('Edit')
+    })
+
+    it('offers the way back to the default world', async () => {
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+
+      const back = w
+        .findAll('button')
+        .find((b) => b.text().includes('Go to draft'))
+      expect(back).toBeDefined()
+      await back!.trigger('click')
+      // Returns to the same id with the world dropped — writes land there.
+      expect(routerPush).toHaveBeenCalledWith({ query: {} })
+    })
+  })
+
+  describe('copy affordances ride the entity response', () => {
+    it('renders an allowed offer', async () => {
+      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      rendersProof(w)
+      expect(w.text()).toContain('Publish this policy')
+    })
+
+    it('renders NOTHING for a denied offer', async () => {
+      const denied = promoteOffer({ allowed: false, reason: 'nope' })
+      const w = await mountDetail(viewResponse({ _copies: [denied] }))
+      rendersProof(w)
+      expect(w.text()).not.toContain('Publish this policy')
+      // The reason is a debugging tooltip on the wire, never rendered text.
+      expect(w.text()).not.toContain('nope')
+    })
+
+    it('hides copy offers under a world, even when the server offers them', async () => {
+      // The server's offer is CORRECT here: under a world falling back to the
+      // default face, the resolved face IS the draft, so promote applies. But
+      // an invoke carries no `?world=`, so it would write the default face
+      // while the reader looks at a resolved one — and a Publish button beside
+      // a "read-only" banner is an affordance that contradicts the page.
+      mockRoute.query = { world: 'site-nl' }
+      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      rendersProof(w)
+      expect(w.text()).not.toContain('Publish this policy')
+
+      // The positive control: the SAME response under the default world DOES
+      // render it. Without this, hiding copies unconditionally would pass.
+      mockRoute.query = {}
+      const dflt = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      expect(dflt.text()).toContain('Publish this policy')
+    })
+
+    it('invokes by NAME with the source id, and no target for a same-entity copy', async () => {
+      invokeCopyMock.mockResolvedValue({
+        definition: 'promote-policy',
+        entityId,
+        pointer: 'published',
+        created: true,
+      })
+      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      rendersProof(w)
+
+      const btn = w
+        .findAll('button')
+        .find((b) => b.text() === 'Publish this policy')
+      expect(btn).toBeDefined()
+      await btn!.trigger('click')
+      await flushPromises()
+
+      // A same-entity copy targets the source by construction; the target id
+      // is OMITTED rather than sent empty (the kernel rejects a target on a
+      // same-entity copy).
+      expect(invokeCopyMock).toHaveBeenCalledWith('promote-policy', entityId)
+    })
+
+    it('reloads after a copy so the offers recompute', async () => {
+      invokeCopyMock.mockResolvedValue({
+        definition: 'promote-policy',
+        entityId,
+        pointer: 'published',
+        created: true,
+      })
+      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      const before = fetchViewMock.mock.calls.length
+
+      const btn = w.findAll('button').find((b) => b.text() === 'Publish this policy')
+      await btn!.trigger('click')
+      await flushPromises()
+
+      // A face that now exists may no longer be offered.
+      expect(fetchViewMock.mock.calls.length).toBeGreaterThan(before)
+    })
+
+    it('surfaces a refusal rather than pretending the copy ran', async () => {
+      invokeCopyMock.mockRejectedValue(new Error('forbidden'))
+      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      const before = fetchViewMock.mock.calls.length
+
+      const btn = w.findAll('button').find((b) => b.text() === 'Publish this policy')
+      await btn!.trigger('click')
+      await flushPromises()
+
+      // `allowed` is a hint; the kernel re-authorizes. A 403 here is the
+      // boundary working, and the page must not reload as if it succeeded.
+      expect(fetchViewMock.mock.calls.length).toBe(before)
+    })
+  })
+
+  describe('per-neighbour provenance', () => {
+    const world = (via: EntityWorld['via'], pointer: string): EntityWorld => ({
+      name: 'site-nl',
+      pointer,
+      via,
+    })
+
+    function withCollection(entities: unknown[]): ViewResponse {
+      return {
+        entry: entry(),
+        sections: [
+          {
+            heading: 'Implements',
+            sectionId: 'implements',
+            display: 'list',
+            isEmpty: false,
+            isGrouped: false,
+            hasContent: false,
+            entities: entities as never,
+          },
+        ],
+      }
+    }
+
+    it('distinguishes a real face from a fallback in the SAME section', async () => {
+      mockRoute.query = { world: 'site-nl' }
+      const w = await mountDetail(
+        withCollection([
+          { id: 'CTL-1', type: 'control', title: 'Real Dutch', hasContent: false, _world: world('chain', 'nl') },
+          { id: 'CTL-2', type: 'control', title: 'Fallback', hasContent: false, _world: world('fallback-default', '') },
+        ]),
+      )
+      rendersProof(w)
+
+      const badges = w.findAllComponents({ name: 'WorldBadge' })
+      // Per-neighbour: each entity resolved independently, so one section
+      // carries both kinds. This is the whole point of RULING 12.
+      const rendered = badges.filter((b) => b.text() !== '')
+      expect(rendered).toHaveLength(2)
+      expect(w.find('.is-fallback').exists()).toBe(true)
+      expect(w.find('.is-chain').exists()).toBe(true)
+    })
+
+    it('renders no badge under the default world', async () => {
+      const w = await mountDetail(
+        withCollection([
+          { id: 'CTL-1', type: 'control', title: 'Plain', hasContent: false },
+        ]),
+      )
+      rendersProof(w)
+      expect(w.find('.world-badge').exists()).toBe(false)
+    })
+  })
+})

--- a/frontend/src/components/entity/WorldBadge.vue
+++ b/frontend/src/components/entity/WorldBadge.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+/**
+ * Renders which FACE a world served for one entity, and which rule chose it.
+ *
+ * ## Why this exists at all
+ *
+ * Under a world with `otherwise: default`, "the Dutch page" and "the English
+ * page, because no Dutch page exists" come back BYTE-IDENTICALLY — same id,
+ * same title, same body. The only thing separating them is `_world.via`. A
+ * reader looking at a `site-nl` listing cannot otherwise tell which entries
+ * are actually translated, and neither can the editor deciding what to
+ * translate next.
+ *
+ * So the `fallback-default` case is the whole point. `chain` is rendered too
+ * (quietly), because "this IS the Dutch face" is only reassuring if its
+ * absence is meaningful — a badge that appears only on fallbacks trains the
+ * reader to read no-badge as "fine", which is exactly the silence-shaped
+ * signal this epic keeps removing.
+ *
+ * `unscoped` renders NOTHING: it means no resolution was applied, which is
+ * the default world's answer for everything and carries no information.
+ */
+import { computed } from 'vue'
+import type { EntityWorld } from '@/types'
+
+const props = defineProps<{ world?: EntityWorld }>()
+
+const kind = computed(() => props.world?.via)
+
+const text = computed(() => {
+  const w = props.world
+  if (!w) return ''
+  switch (w.via) {
+    case 'chain':
+      // The coordinate the world selected exists. Name it, because "published"
+      // is more useful to a reader than the world's own name.
+      return w.pointer || w.name
+    case 'fallback-default':
+      return 'default'
+    default:
+      return ''
+  }
+})
+
+const title = computed(() => {
+  const w = props.world
+  if (!w) return ''
+  return w.via === 'fallback-default'
+    ? `No ${w.name} face exists for this entity — showing the default state instead`
+    : `Resolved through ${w.name}`
+})
+</script>
+
+<template>
+  <span
+    v-if="kind === 'chain' || kind === 'fallback-default'"
+    class="world-badge"
+    :class="kind === 'fallback-default' ? 'is-fallback' : 'is-chain'"
+    :title="title"
+  >
+    {{ text }}
+  </span>
+</template>
+
+<style scoped>
+.world-badge {
+  display: inline-block;
+  padding: 0.05rem 0.35rem;
+  margin-left: 0.35rem;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  vertical-align: middle;
+  white-space: nowrap;
+  border: 1px solid var(--border-color);
+  color: var(--muted-text);
+}
+
+/* The substitute case is the one a reader must not miss, so it is the only
+   one that carries colour. `chain` stays deliberately quiet — it is the
+   expected state, and styling it loudly would drown the signal. */
+.is-fallback {
+  border-color: color-mix(in srgb, var(--warning-color) 60%, transparent);
+  background: color-mix(in srgb, var(--warning-color) 18%, transparent);
+  color: var(--text-color);
+}
+</style>

--- a/frontend/src/components/entity/WorldBadge.vue
+++ b/frontend/src/components/entity/WorldBadge.vue
@@ -34,6 +34,12 @@ const text = computed(() => {
     case 'chain':
       // The coordinate the world selected exists. Name it, because "published"
       // is more useful to a reader than the world's own name.
+      //
+      // The `|| w.name` arm should be unreachable: `chain` means a SELECTED
+      // coordinate matched, and the default state is reported as `unscoped`,
+      // never as `chain` with an empty pointer. It is a display fallback so a
+      // server that broke that invariant renders a world name rather than an
+      // empty badge — not a case to design around.
       return w.pointer || w.name
     case 'fallback-default':
       return 'default'

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -355,15 +355,19 @@ const queryParams = computed((): ListParams => {
     params.sort = defaultSort
   }
 
-  // Include related entities for relation columns.
+  // Include related entities for relation columns — under a world too.
   //
-  // Also suppressed under a world (422 world_include_unsupported): neighbor
-  // resolution goes through the ungated, default-world reader, so a published
-  // row would arrive wrapped in DRAFT neighbors — a mixed-face response whose
-  // entity looks right and whose neighbors are silently wrong. Relation
-  // COLUMNS therefore render empty under a world rather than wrong; the
-  // backend already omits relations entirely on world-bound reads.
-  if (hasRelationColumns.value && !isWorldBound.value) {
+  // This used to be suppressed under a world, because neighbor resolution went
+  // through the ungated, default-world reader and a published row would have
+  // arrived wrapped in DRAFT neighbors. Two facts in that reasoning are now
+  // false: TKT-WRLDAPI item 4 made neighbor resolution WORLD-SCOPED (an
+  // included peer is that world's face; a neighbor with no face in the world
+  // is absent), and the backend no longer "omits relations entirely on
+  // world-bound reads" — it resolves them per neighbour.
+  //
+  // So suppressing it now costs relation columns their content for no reason.
+  // See the same orphan in stores/entities.ts for the general shape.
+  if (hasRelationColumns.value) {
     params.include = '*'
   }
 

--- a/frontend/src/components/lists/EntityList.world.test.ts
+++ b/frontend/src/components/lists/EntityList.world.test.ts
@@ -175,14 +175,27 @@ describe('EntityList world binding', () => {
       expect(banner.text()).toContain('Search is unavailable')
     })
 
-    // Mutation: drop `&& !isWorldBound.value` from the include arm — include
-    // is sent with world, which the API answers 422 world_include_unsupported.
-    it('suppresses include=* even with relation columns', async () => {
+    // INVERTED by TKT-WRLDAPI item 4, like its sibling in stores/entities.ts.
+    //
+    // This asserted that include=* was SUPPRESSED under a world, because the
+    // API refused the combination and neighbour resolution was default-world.
+    // Item 4 made neighbour resolution world-scoped and removed the refusal,
+    // so suppressing it now costs relation columns their content for nothing.
+    //
+    // Inverted rather than deleted: a regression that reinstated the
+    // suppression would be INVISIBLE — relation columns would simply render
+    // empty again under a world, which is indistinguishable from "these rows
+    // have no relations". That invisibility is exactly how the workaround
+    // survived item 4 in the first place.
+    //
+    // Mutation: restore `&& !isWorldBound.value` — include goes missing and
+    // the first assertion fails.
+    it('sends include=* WITH the world when there are relation columns', async () => {
       const wrapper = await mountList({ relationColumn: true })
       rendersProof(wrapper)
 
+      expect(lastParams().include).toBe('*')
       expect(lastParams().world).toBe('published')
-      expect(lastParams().include).toBeUndefined()
     })
   })
 

--- a/frontend/src/stores/entities.test.ts
+++ b/frontend/src/stores/entities.test.ts
@@ -394,14 +394,28 @@ describe('Entities Store', () => {
       expect(entitiesApi.getEntity).toHaveBeenCalledTimes(1)
     })
 
-    // Hazard 3. Mutation: send `{ include: '*', world }` — the assertion sees
-    // include present under a world, which is the exact combination the API
-    // answers with 422 world_include_unsupported.
-    it('drops include=* under a non-default world, and keeps it otherwise', async () => {
+    // Hazard 3, INVERTED by TKT-WRLDAPI item 4.
+    //
+    // This used to assert that include=* was DROPPED under a world, because
+    // the API refused the combination (422 world_include_unsupported). Item 4
+    // made neighbor resolution world-scoped — an included peer is now that
+    // world's face of the neighbor — so the refusal is gone and dropping
+    // include became a self-inflicted degradation: the SPA discarded neighbor
+    // titles to avoid an error that no longer exists.
+    //
+    // The test is inverted rather than deleted, because the property still
+    // needs pinning from the other side: a regression that reinstated the drop
+    // would be invisible (the page would just quietly lose neighbor titles
+    // again), which is exactly how the stale workaround survived.
+    //
+    // Mutation: restore `world ? {world} : {include:'*'}` — the first
+    // assertion fails, because include is absent under a world.
+    it('sends include=* ALONGSIDE the world, not instead of it', async () => {
       vi.mocked(entitiesApi.getEntity).mockResolvedValue(publishedFace)
 
       await store.fetchEntity('policy', 'POL-1', false, 'published')
       expect(entitiesApi.getEntity).toHaveBeenCalledWith('policy', 'POL-1', {
+        include: '*',
         world: 'published',
       })
 

--- a/frontend/src/stores/entities.ts
+++ b/frontend/src/stores/entities.ts
@@ -165,18 +165,24 @@ export const useEntitiesStore = defineStore('entities', () => {
     errors.value.delete(key)
 
     try {
-      // `include=*` fetches titles for related entities, but the API REFUSES
-      // it under a non-default world (422 world_include_unsupported): neighbor
-      // resolution is not world-scoped, so a world-bound entity would come
-      // back wrapped in default-world neighbors — the mixed-face response that
-      // is hardest to spot, because the entity itself looks right.
+      // `include=*` fetches titles for related entities, and it is now sent
+      // ALONGSIDE the world rather than instead of it.
       //
-      // So this DROPS include rather than appending a world to it. Sending
-      // both would turn every world-bound detail read into a hard 422; sending
-      // include without the world would serve the wrong face. Under a world we
-      // simply have no neighbor titles, which is what the backend can honestly
-      // answer today.
-      const params = world && world !== DEFAULT_WORLD ? { world } : { include: '*' }
+      // This used to drop include under a world, because the API refused the
+      // combination (422 world_include_unsupported): neighbor resolution was
+      // not world-scoped, so a world-bound entity would have come back wrapped
+      // in default-world neighbors. TKT-WRLDAPI item 4 made neighbor
+      // resolution world-scoped — an included peer is now THAT world's face of
+      // the neighbor, and a neighbor with no face in the world is absent — so
+      // the refusal was removed and the workaround became a self-inflicted
+      // degradation: the SPA was voluntarily discarding neighbor titles to
+      // avoid a 422 that no longer exists.
+      //
+      // The general shape, worth remembering: WHEN A BACKEND REFUSAL IS
+      // REMOVED, ITS CLIENT-SIDE WORKAROUNDS DO NOT REMOVE THEMSELVES. Nothing
+      // in the backend diff can point at them.
+      const params: { include: string; world?: string } = { include: '*' }
+      if (world && world !== DEFAULT_WORLD) params.world = world
       const entity = await getEntity(type, id, params)
       cache.value.set(key, {
         entity,

--- a/frontend/src/stores/schema.test.ts
+++ b/frontend/src/stores/schema.test.ts
@@ -46,6 +46,45 @@ describe('Schema Store', () => {
   })
 
   describe('load', () => {
+    it('loads the per-caller world map from /_schema', async () => {
+      // Pins the WIRING, not just the getter. Deleting the
+      // `worlds.value = new Map(...)` line survives every component test,
+      // because those seed the store directly — verified by mutation. The
+      // only test that can catch it is one that goes through load().
+      const { getSchema, getConfig } = await import('@/api/schema')
+      vi.mocked(getSchema).mockResolvedValue({
+        entities: {},
+        relations: {},
+        types: {},
+        worlds: {
+          default: { readable: true, default: true },
+          published: { readable: false, select: ['published'], otherwise: 'exclude' },
+        },
+      })
+      vi.mocked(getConfig).mockResolvedValue({
+        app: { name: 'Test App' },
+        forms: {},
+        lists: {},
+        views: {},
+        kanbans: {},
+        navigation: [],
+      })
+
+      const store = useSchemaStore()
+      await store.load()
+
+      expect(store.worlds.size).toBe(2)
+      // `false` is the load-bearing value — the server never omits `readable`
+      // precisely so a denial is distinguishable from an old server.
+      expect(store.worldReadable('published')).toBe(false)
+      expect(store.worldReadable('default')).toBe(true)
+      // The empty name is how the SPA spells the default world.
+      expect(store.worldReadable('')).toBe(true)
+      // An undeclared world is readable, not denied: absence means "unknown",
+      // and manufacturing a denial would hide a working affordance.
+      expect(store.worldReadable('no-such-world')).toBe(true)
+    })
+
     it('loads schema and config from API', async () => {
       const { getSchema, getConfig } = await import('@/api/schema')
 

--- a/frontend/src/stores/schema.ts
+++ b/frontend/src/stores/schema.ts
@@ -9,6 +9,7 @@ import type {
   PropertyDef,
   RelationType,
   CustomType,
+  WorldInfo,
   FormConfig,
   ListConfig,
   ViewConfig,
@@ -27,6 +28,11 @@ export const useSchemaStore = defineStore('schema', () => {
   const entityTypes = ref<Map<string, EntityType>>(new Map())
   const relationTypes = ref<Map<string, RelationType>>(new Map())
   const customTypes = ref<Map<string, CustomType>>(new Map())
+  // Declared worlds and, per world, whether THIS caller may select it
+  // (`/_schema`.worlds). Empty on a server too old to serve it — which is
+  // why `worldReadable` below treats an unknown world as readable rather
+  // than hiding an affordance against a map that was never populated.
+  const worlds = ref<Map<string, WorldInfo>>(new Map())
   const forms = ref<Map<string, FormConfig>>(new Map())
   const lists = ref<Map<string, ListConfig>>(new Map())
   const views = ref<Map<string, ViewConfig>>(new Map())
@@ -75,6 +81,22 @@ export const useSchemaStore = defineStore('schema', () => {
 
   // Getters
   const getEntityType = computed(() => (name: string) => entityTypes.value.get(name))
+  // Whether this caller may select the named world (`''`/`'default'` = the
+  // default world). Drives affordances that NAVIGATE to a world, so it must
+  // not manufacture a denial the server would not make.
+  //
+  // Unknown world → TRUE. A world absent from the map means either a server
+  // too old to serve `worlds` or a schema not yet loaded, and in both cases
+  // the request would in fact be served. Defaulting to false would hide a
+  // working affordance and read as a permission problem — a wrong answer in
+  // the direction nobody can debug. Ignoring a real denial merely reproduces
+  // what the URL bar already does: the server re-checks on every request and
+  // renders a denial as an empty result.
+  const worldReadable = computed(() => (name: string) => {
+    const key = !name ? 'default' : name
+    const w = worlds.value.get(key)
+    return w ? w.readable : true
+  })
   const getRelationType = computed(() => (name: string) => relationTypes.value.get(name))
   // Look up a relation type's inverse name (e.g., "blocks" → "blockedBy").
   // Returns undefined when the relation has no declared inverse. Used by
@@ -267,6 +289,7 @@ export const useSchemaStore = defineStore('schema', () => {
       entityTypes.value = new Map(Object.entries(schemaData.entities || {}))
       relationTypes.value = new Map(Object.entries(schemaData.relations || {}))
       customTypes.value = new Map(Object.entries(schemaData.types || {}))
+      worlds.value = new Map(Object.entries(schemaData.worlds || {}))
 
       // Feed the API layer's plural registry so it doesn't have to import
       // this store (B1a). Mirror the server's GetPlural fallback (type+'s')
@@ -339,6 +362,7 @@ export const useSchemaStore = defineStore('schema', () => {
     entityTypes,
     relationTypes,
     customTypes,
+    worlds,
     forms,
     lists,
     views,
@@ -364,6 +388,7 @@ export const useSchemaStore = defineStore('schema', () => {
     // Getters
     getEntityType,
     getRelationType,
+    worldReadable,
     getInverseName,
     getForm,
     getList,

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -67,6 +67,22 @@ export interface Entity {
   // re-enforces every transition (attempt-and-recover). See
   // docs/data-entry/api-reference.md.
   _transitions?: Record<string, TransitionOption[]>
+  // Provenance of the face this response served (TKT-WRLDAPI). Present on
+  // per-entity GETs under any world INCLUDING the default one, where it reads
+  // `{name:'default', via:'unscoped'}`. Absent on list rows and on the
+  // `_views` ENTRY — under `_views` only COLLECTION entities carry it
+  // (internal/dataentry/sections.go is the single call site), so a detail page
+  // wanting entry provenance reads it from the entity GET.
+  _world?: EntityWorld
+  // Declared copies offered for this face (TKT-WRLDAPI item 5). Rides the
+  // entity response alongside `_actions` rather than a separate endpoint.
+  //
+  // An empty array is a REAL answer — "this face offers no copies", e.g. an
+  // already-published policy — and is distinct from absent, which means the
+  // server did not compute offers (no copy service wired). Do not collapse
+  // the two: `[]` should render nothing, and so should absent, but only `[]`
+  // means the question was asked.
+  _copies?: CopyOffer[]
   inaccessible?: InaccessibleField[]
   // Soft-validation findings on mutation responses (DEC-HWZHA).
   // Present on PATCH/POST results; absent on GETs.
@@ -105,6 +121,63 @@ export interface TransitionOption {
   to: string
   label?: string
   guard?: string
+  allowed: boolean
+  reason?: string
+}
+
+// EntityWorld is the provenance of a resolved face: which world was asked
+// for, which coordinate was served, and WHICH RULE chose it. Mirrors
+// v1.EntityWorld (internal/apiwire/v1/responses.go).
+//
+// `via` is the load-bearing field, and the reason this type exists rather
+// than a bare world name. Under a world with `otherwise: default`, "the
+// Dutch page" and "the English page, because no Dutch page exists" arrive
+// BYTE-IDENTICALLY — same id, same body, same everything. Only `via`
+// separates them:
+//
+//   - 'unscoped'         — this world applies no resolution to this type, so
+//                          the entity contributes its default state. The
+//                          default world resolves everything this way.
+//   - 'chain'            — the coordinate the world selects exists. This is
+//                          the face the world asked for.
+//   - 'fallback-default' — no selected coordinate exists and the world's
+//                          `otherwise: default` stood the default state in.
+//                          The reader is seeing a SUBSTITUTE.
+//
+// There is deliberately no 'excluded': a world that excludes an entity
+// produces no response to carry provenance on. It is a 404, indistinguishable
+// from a genuine miss, because existence in a world IS the publication bit.
+export interface EntityWorld {
+  name: string
+  pointer: string
+  via: 'unscoped' | 'chain' | 'fallback-default'
+}
+
+// CopyOffer is one declared `copies:` definition offered for the face being
+// viewed. Mirrors v1.CopyOffer.
+//
+// `allowed` is a HINT, never a boundary — the same contract as `_actions` and
+// `TransitionOption`. The invoke endpoint re-authorizes through the kernel, so
+// a client that ignores this and POSTs anyway gets the same 403 it would have
+// received regardless. It is computed by running the kernel's own
+// authorization path, so it cannot drift from what the write does.
+//
+// The UI renders only allowed offers, which makes `reason` advisory (a
+// tooltip for a debugging operator), not a gate.
+export interface CopyOffer {
+  // The `copies:` key, and the ONLY thing a client sends back to invoke it.
+  // A request names a definition; it never supplies one.
+  name: string
+  // Operator-configured display text; falls back to `name` when unset.
+  label: string
+  // The declared target (`policy@published`, `new page`) — for a UI that
+  // wants to say what the action will produce.
+  targetFace: string
+  // Distinguishes a promote/revise (another face of the SAME entity) from a
+  // copy that creates a different entity. Not cosmetic: a cross-entity copy
+  // REQUIRES a target id, so a client cannot build a valid invoke without
+  // knowing which it has.
+  sameEntity: boolean
   allowed: boolean
   reason?: string
 }

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -2,6 +2,37 @@ export interface Schema {
   entities: Record<string, EntityType>
   relations: Record<string, RelationType>
   types: Record<string, CustomType>
+  // Every DECLARED world plus the implicit `default`, each marked with
+  // whether THIS caller may select it (TKT-WRLDAPI item 1). Absent on a
+  // server too old to compute it.
+  //
+  // The declared SET is principal-independent — world names are
+  // operator-authored schema.yaml config, so their existence is already
+  // disclosed and the server does not filter them per principal. Only
+  // `readable` varies by caller.
+  worlds?: Record<string, WorldInfo>
+}
+
+// WorldInfo mirrors v1.World. See internal/dataentry/schemaworlds.go.
+export interface WorldInfo {
+  select?: string[]
+  overrides?: Record<string, string[]>
+  otherwise?: string
+  // Whether this caller may select the world via `?world=`.
+  //
+  // A UI HINT about SELECTION, never a boundary: the server re-checks the
+  // grant on every request, and a denial is served as an EMPTY RESULT rather
+  // than a 403 — deliberately, so it stays indistinguishable from a world
+  // holding nothing readable. That is exactly why a client should respect
+  // this flag: ignoring it means offering a world that silently returns
+  // nothing, which reads as "nothing is published yet".
+  //
+  // Never omitted by the server (no `omitempty`), so `false` is
+  // distinguishable from a server too old to compute it.
+  readable: boolean
+  // Marks the implicit default world. Spelled as a flag so a client need not
+  // hardcode the reserved name.
+  default?: boolean
 }
 
 export interface EntityType {

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -933,11 +933,6 @@ type CopyOffer struct {
 	Reason string `json:"reason,omitempty"`
 }
 
-// CopyOffersResponse wraps the offers for one face.
-type CopyOffersResponse struct {
-	Data []CopyOffer `json:"data"`
-}
-
 // CopyResult reports what an invoked copy produced.
 type CopyResult struct {
 	// Definition is the name that was invoked.

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -112,6 +112,30 @@ type Entity struct {
 	// transitions, nil on list rows and when no state machines are wired. It is a
 	// UI hint, never authorization — the write path re-enforces every transition.
 	Transitions *map[string][]Transition `json:"_transitions,omitempty"`
+	// Copies lists the declared copy definitions available FROM this entity's
+	// current face — the promote / translate affordances (RULING 9).
+	//
+	// It rides the entity response alongside [Entity.Actions] because that is
+	// how every other affordance in this app is delivered: computed at read
+	// time from data the client already fetched, rather than requiring a
+	// second request keyed on (type, pointer, id). An earlier revision shipped
+	// a `GET /_copies` list endpoint; it was removed for exactly that reason.
+	//
+	// Same contract as `_actions`: a UI HINT, never a boundary. `POST
+	// /_copies/{name}` re-authorizes through the kernel, so a client that
+	// ignores `allowed` and posts anyway gets the same refusal it would have
+	// got regardless. Each entry's verdict is computed by running the kernel's
+	// own authorization path, not a re-derivation, so it cannot drift from
+	// what the write does (RULING 11 — an affordance map that lies is a trap).
+	//
+	// SAME-ENTITY definitions only: a copy that creates a DIFFERENT entity has
+	// no target id until the caller names one, so no honest verdict exists for
+	// it here. The kernel still supports those; they are simply not offered as
+	// an affordance. See entitymanager.CopiesForSource.
+	//
+	// Same pointer / closed-world semantics as FieldAffordances: present
+	// (possibly empty) on per-entity responses, nil on list rows.
+	Copies *[]CopyOffer `json:"_copies,omitempty"`
 	// Warnings lists soft-condition findings surfaced by the write
 	// path. Populated only by mutation responses (PATCH); read paths
 	// leave it nil. Each warning has a stable `code`, an RFC 6901
@@ -894,16 +918,8 @@ type CopyOffer struct {
 	// cross-entity copy REQUIRES a target id, so a client cannot build a valid
 	// invoke without knowing which it has.
 	SameEntity bool `json:"sameEntity"`
-	// Indeterminate marks an offer whose invocability cannot be answered yet:
-	// a CROSS-ENTITY copy, whose target the client chooses at invoke time.
-	// Authorization depends on that target, so no honest verdict exists here.
-	//
-	// When true, `allowed` is meaningless — render the action as available but
-	// UNVERIFIED, never as confirmed. The server authorizes on invoke either
-	// way. Saying "true" instead would be an affordance that lies.
-	Indeterminate bool `json:"indeterminate,omitempty"`
 	// Allowed reports whether the requesting principal may invoke this copy on
-	// this source right now. Meaningful only when `indeterminate` is false.
+	// this source right now.
 	//
 	// A HINT, never a boundary — the same contract as `_actions`. The invoke
 	// endpoint re-authorizes through the kernel, so a client that ignores this

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/statemachine"
@@ -104,6 +105,16 @@ type affordanceService struct {
 	meta     func() *metamodel.Metamodel
 	// getEntity resolves an entity by ID for relation-source attribution.
 	getEntity func(ctx context.Context, id string) (*entityPkg.Entity, bool)
+	// copies lists the copy affordances available from one face (RULING 9's
+	// promote / translate buttons). A per-call accessor like the others, and
+	// OPTIONAL: nil when the entity manager does not expose the capability,
+	// in which case `_copies` is omitted entirely rather than sent empty.
+	//
+	// Omitted-vs-empty matters here: an empty list is a real answer ("this
+	// face declares no copies"), so sending one when the capability is absent
+	// would render a wiring gap as a domain fact — the same shape the copies
+	// handler's own constructor rule rejects.
+	copies func(ctx context.Context, entityType, pointer, sourceID string) ([]entitymanager.CopyOffer, error)
 	// currentEdgesByPeer returns the current edges of entityID for a relation
 	// type/direction, keyed by peer ID. Used to diff desired-vs-current edges.
 	currentEdgesByPeer func(
@@ -1166,6 +1177,9 @@ func (svc affordanceService) attachEntityAffordances(ctx context.Context, e *ent
 	if transitions := svc.computeTransitions(ctx, e, verdicts); transitions != nil {
 		result.Transitions = &transitions
 	}
+	if offers := svc.computeCopyOffers(ctx, e); offers != nil {
+		result.Copies = &offers
+	}
 	// Pass the same verdicts so a policy-hidden `file` property's attachments
 	// are omitted from `_attachments` — otherwise the hidden-field boundary
 	// the rest of the response maintains would leak the file's metadata and a
@@ -1222,6 +1236,51 @@ func (svc affordanceService) computeAttachments(
 			Size:        info.Size,
 			ContentType: contentTypeForFilename(info.FileName),
 			Href:        selfHref + "/_attachments/" + info.Property + "/" + url.PathEscape(info.FileName),
+		})
+	}
+	return out
+}
+
+// computeCopyOffers lists the copy affordances available from e's current
+// face — RULING 9's promote and translate buttons (TKT-F2D5U5).
+//
+// Returns nil when the capability is not wired, so `_copies` is OMITTED rather
+// than sent as an empty list. An empty list is a legitimate answer ("this face
+// declares no copies"), so emitting one for a missing capability would render
+// a wiring gap as a domain fact — and the visible symptom would be "the
+// promote button never appears", sending someone to hunt through schema.yaml
+// for a definition that is correctly declared.
+//
+// The verdicts come from the kernel's own authorization path, not a
+// re-derivation here, which is what stops this hint drifting from what the
+// write actually does. This service must never compute invocability itself.
+//
+// The face is e's stored pointer: an affordance is offered FROM the face being
+// viewed, so a promote appears on the draft and not on the published face.
+func (svc affordanceService) computeCopyOffers(
+	ctx context.Context, e *entityPkg.Entity,
+) []v1.CopyOffer {
+	if svc.copies == nil || e == nil {
+		return nil
+	}
+	offers, err := svc.copies(ctx, e.Type, e.Pointer.String(), e.ID)
+	if err != nil {
+		// Best-effort, like the rest of this affordance map: a failure omits
+		// the offers rather than failing the whole entity read. Logged so it
+		// is not silent — an unlogged empty would look like "no copies here".
+		slog.Warn("dataentry: computing copy offers failed; _copies omitted",
+			"entity", e.ID, "type", e.Type, "err", err)
+		return nil
+	}
+	out := make([]v1.CopyOffer, 0, len(offers))
+	for _, o := range offers {
+		out = append(out, v1.CopyOffer{
+			Name:       o.Name,
+			Label:      o.Label,
+			TargetFace: o.TargetFace,
+			SameEntity: o.SameEntity,
+			Allowed:    o.Allowed,
+			Reason:     o.Reason,
 		})
 	}
 	return out

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -874,6 +874,17 @@ func NewApp(
 		meta:               func() *metamodel.Metamodel { return app.State().Meta },
 		getEntity:          app.reader.getEntity,
 		currentEdgesByPeer: app.currentEdgesByPeer,
+		// Copy affordances (RULING 9). A closure over App rather than a
+		// captured value, matching every other accessor here: it must read the
+		// manager live, and it stays nil when the manager does not expose the
+		// capability so `_copies` is omitted rather than sent empty.
+		copies: func(ctx context.Context, entityType, pointer, sourceID string) ([]entitymanager.CopyOffer, error) {
+			mgr, ok := app.entityManager.(*entitymanager.Manager)
+			if !ok {
+				return nil, nil
+			}
+			return entitymanager.CopiesForSource(ctx, mgr, entityType, pointer, sourceID)
+		},
 	}
 
 	app.serializer = entitySerializer{affordances: app.affordances}
@@ -984,7 +995,7 @@ func NewApp(
 	// unlogged would be the same "clean by luck" the WorldDef guard was added
 	// to convert into "clean by construction".
 	if mgr, ok := app.entityManager.(*entitymanager.Manager); ok {
-		copies, cerr := newCopiesHandler(entitymanager.CopyAffordances{M: mgr}, app.State)
+		copies, cerr := newCopiesHandler(entitymanager.CopyAffordances{M: mgr})
 		if cerr != nil {
 			return nil, fmt.Errorf("dataentry.NewApp: %w", cerr)
 		}

--- a/internal/dataentry/copies_handler.go
+++ b/internal/dataentry/copies_handler.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
 	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
 // copyService is the copy capability this package needs, declared HERE at the
@@ -37,9 +35,6 @@ import (
 // type-check and would be exactly the RULING 11 defect: an affordance map that
 // says one thing while the write path does another.
 type copyService interface {
-	// CopiesForSource lists the copy definitions available on one face, each
-	// with a per-principal invocability hint.
-	CopiesForSource(ctx context.Context, entityType, pointer, sourceID string) ([]entitymanager.CopyOffer, error)
 	// CopyState invokes a declared definition BY NAME. It authorizes
 	// internally; callers must not pre-empt that with their own check.
 	CopyState(ctx context.Context, req entitymanager.CopyRequest) (*entitymanager.CopyResult, error)
@@ -63,103 +58,39 @@ type copyService interface {
 // whose absence looks like a legitimate result.
 type copiesHandler struct {
 	copies copyService
-	schema func() *Schema
 }
 
 // newCopiesHandler builds the handler. Nil: rejected — see the type doc.
-func newCopiesHandler(copies copyService, schema func() *Schema) (*copiesHandler, error) {
+func newCopiesHandler(copies copyService) (*copiesHandler, error) {
 	if copies == nil {
 		return nil, errors.New("dataentry: newCopiesHandler: copy service must be non-nil")
 	}
-	if schema == nil {
-		return nil, errors.New("dataentry: newCopiesHandler: schema must be non-nil")
-	}
-	return &copiesHandler{copies: copies, schema: schema}, nil
+	return &copiesHandler{copies: copies}, nil
 }
 
 // handleV1Copies routes `/api/v1/_copies…`.
 //
-//	GET  /_copies?type=&pointer=&source_id=   list offers for one face
-//	POST /_copies/{name}                      invoke a definition by name
+//	POST /_copies/{name}   invoke a definition by name
+//
+// There is NO list endpoint. Copy offers ride the entity (detail) response
+// alongside `_actions`, the way every other affordance in this app is
+// delivered — computed at read time from data the client already fetched,
+// rather than requiring it to construct a separate lookup key. An earlier
+// revision shipped a `GET /_copies`; it was removed because a second endpoint
+// for one affordance is the odd shape, not the norm.
 func (h *copiesHandler) handleV1Copies(w http.ResponseWriter, r *http.Request) {
 	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/_copies"), "/")
 	switch {
-	case r.Method == http.MethodGet && rest == "":
-		h.list(w, r)
 	case r.Method == http.MethodPost && rest != "":
 		h.invoke(w, r, rest)
 	case r.Method == http.MethodOptions:
-		w.Header().Set("Allow", "GET, POST, OPTIONS")
+		w.Header().Set("Allow", "POST, OPTIONS")
 		w.WriteHeader(http.StatusNoContent)
 	default:
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed",
 			"Method not allowed",
-			"GET /_copies lists offers for a face; POST /_copies/{name} invokes one")
+			"POST /_copies/{name} invokes a declared copy; offers ride the entity response")
 	}
-}
-
-// list serves the offers for one source face.
-//
-// The face is addressed by (type, pointer, source_id) rather than by an
-// `entity@pointer` string: the wire has no state-ref grammar, and inventing
-// one here would be a second addressing syntax for a surface that already has
-// `?world=` and `_history` doing it differently.
-func (h *copiesHandler) list(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query()
-	entityType := q.Get("type")
-	sourceID := q.Get("source_id")
-	if entityType == "" || sourceID == "" {
-		writeV1Error(w, r, http.StatusBadRequest, "invalid_request",
-			"type and source_id are required",
-			"GET /_copies?type=policy&pointer=&source_id=POL-1")
-		return
-	}
-	if _, ok := h.schema().Meta.GetEntityDef(entityType); !ok {
-		// An entity TYPE is config, not a secret, so naming it is fine — the
-		// same asymmetry resolveWorld documents for world names.
-		writeV1Error(w, r, http.StatusNotFound, "entity_type_not_found",
-			"Entity type not found", entityType)
-		return
-	}
-
-	// NORMALIZE the pointer from a DECLARED name to a STORED coordinate.
-	//
-	// A client reads schema.yaml, sees the face is called `draft`, and sends
-	// `pointer=draft`. But `draft` is often `default: true`, whose stored
-	// coordinate is the empty string — so an un-normalized compare returns
-	// `200 []`, which is indistinguishable from "this face has no copies".
-	// That is the silence-shaped defect this file's own docs rail against,
-	// reintroduced at the wire after being fixed inside CopiesForSource.
-	//
-	// StoredPointer is idempotent for an already-stored coordinate, so a
-	// client that sends `pointer=` or `pointer=published` is unaffected.
-	pointer := metamodel.StoredPointer(h.schema().Meta, entityType, q.Get("pointer"))
-
-	offers, err := h.copies.CopiesForSource(r.Context(), entityType, pointer, sourceID)
-	if err != nil {
-		// The detail is generic and the real error is logged: an unfiltered
-		// backend error string in a client-visible body is how store internals
-		// leak, and every other error path in this file is careful about it.
-		slog.Error("dataentry: listing copies failed",
-			"type", entityType, "source", sourceID, "err", err)
-		writeV1Error(w, r, http.StatusInternalServerError, "copy_list_failed",
-			"Could not list copies", "")
-		return
-	}
-
-	resp := v1.CopyOffersResponse{Data: make([]v1.CopyOffer, 0, len(offers))}
-	for _, o := range offers {
-		resp.Data = append(resp.Data, v1.CopyOffer{
-			Name:          o.Name,
-			Label:         o.Label,
-			TargetFace:    o.TargetFace,
-			SameEntity:    o.SameEntity,
-			Indeterminate: o.Indeterminate,
-			Allowed:       o.Allowed,
-			Reason:        o.Reason,
-		})
-	}
-	writeV1JSON(w, http.StatusOK, resp)
 }
 
 // copyInvokeRequest is the invoke body. It names a DEFINITION and the entities

--- a/internal/dataentry/copies_handler_test.go
+++ b/internal/dataentry/copies_handler_test.go
@@ -19,20 +19,11 @@ import (
 // stubCopyService stands in for the manager. It records what it was asked so
 // the tests can assert the handler does not pre-empt it.
 type stubCopyService struct {
-	offers []entitymanager.CopyOffer
 	result *entitymanager.CopyResult
 	err    error
 
-	listCalls   int
 	invokeCalls int
 	gotReq      entitymanager.CopyRequest
-}
-
-func (s *stubCopyService) CopiesForSource(
-	_ context.Context, _, _, _ string,
-) ([]entitymanager.CopyOffer, error) {
-	s.listCalls++
-	return s.offers, s.err
 }
 
 func (s *stubCopyService) CopyState(
@@ -45,8 +36,7 @@ func (s *stubCopyService) CopyState(
 
 func newCopyTestHandler(t *testing.T, svc copyService) *copiesHandler {
 	t.Helper()
-	app := newTestAppV1(t)
-	h, err := newCopiesHandler(svc, app.State)
+	h, err := newCopiesHandler(svc)
 	if err != nil {
 		t.Fatalf("newCopiesHandler: %v", err)
 	}
@@ -74,14 +64,10 @@ func serveCopies(h *copiesHandler, method, target, body string) *httptest.Respon
 // schema.yaml for a definition that is correctly declared.
 func TestCopiesHandler_RejectsNilService(t *testing.T) {
 	t.Parallel()
-	app := newTestAppV1(t)
-	if _, err := newCopiesHandler(nil, app.State); err == nil {
+	if _, err := newCopiesHandler(nil); err == nil {
 		t.Error("a nil copy service must be rejected at construction — a " +
 			"wiring failure that renders as a valid domain answer is the " +
 			"hardest kind to diagnose")
-	}
-	if _, err := newCopiesHandler(&stubCopyService{}, nil); err == nil {
-		t.Error("a nil schema must be rejected at construction")
 	}
 }
 
@@ -210,69 +196,6 @@ func TestCopiesHandler_InvokesByNameOnly(t *testing.T) {
 	}
 }
 
-// TestCopiesHandler_ListReportsAllowedPerDefinition pins the config-is-not-
-// secret rule on the wire: a denied definition is LISTED with allowed=false,
-// not hidden.
-//
-// Copy names are operator-authored config, so concealing them would hide
-// something schema.yaml already states. What is per-principal is the verdict.
-func TestCopiesHandler_ListReportsAllowedPerDefinition(t *testing.T) {
-	t.Parallel()
-	svc := &stubCopyService{offers: []entitymanager.CopyOffer{
-		{Name: "promote-page", Label: "Publish", TargetFace: "page@published",
-			SameEntity: true, Allowed: true},
-		{Name: "archive-page", Label: "archive-page", TargetFace: "page@archived",
-			SameEntity: true, Allowed: false, Reason: "requires permission \"archive\""},
-	}}
-	h := newCopyTestHandler(t, svc)
-
-	rec := serveCopies(h, http.MethodGet,
-		"/api/v1/_copies?type=ticket&source_id=TKT-1", "")
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body)
-	}
-
-	var got v1.CopyOffersResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if len(got.Data) != 2 {
-		t.Fatalf("a DENIED definition must still be listed — its name is config, "+
-			"not a secret; got %d entries", len(got.Data))
-	}
-	if !got.Data[0].Allowed || got.Data[1].Allowed {
-		t.Errorf("allowed must be per-definition; got %+v", got.Data)
-	}
-	if got.Data[1].Reason == "" {
-		t.Error("a denied offer should carry a reason for a tooltip")
-	}
-}
-
-// TestCopiesHandler_ListValidatesItsAddress covers the request-shape errors,
-// including that an unknown entity TYPE is named (config, not a secret) while
-// nothing about entity existence is disclosed.
-func TestCopiesHandler_ListValidatesItsAddress(t *testing.T) {
-	t.Parallel()
-	h := newCopyTestHandler(t, &stubCopyService{})
-
-	for _, tc := range []struct {
-		name, target string
-		want         int
-	}{
-		{"no type", "/api/v1/_copies?source_id=TKT-1", http.StatusBadRequest},
-		{"no source_id", "/api/v1/_copies?type=ticket", http.StatusBadRequest},
-		{"unknown type", "/api/v1/_copies?type=nosuch&source_id=X-1", http.StatusNotFound},
-		{"valid", "/api/v1/_copies?type=ticket&source_id=TKT-1", http.StatusOK},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := serveCopies(h, http.MethodGet, tc.target, "").Code; got != tc.want {
-				t.Errorf("%s: got %d, want %d", tc.target, got, tc.want)
-			}
-		})
-	}
-}
-
 // TestCopiesHandler_MethodRouting pins the surface's shape: a list is a GET on
 // the collection, an invoke is a POST to a NAME. A POST to the collection has
 // no definition to invoke, and a GET on a name is not a read of anything.
@@ -285,6 +208,10 @@ func TestCopiesHandler_MethodRouting(t *testing.T) {
 		want                 int
 	}{
 		{"POST to collection", http.MethodPost, "/api/v1/_copies", http.StatusMethodNotAllowed},
+		// GET is gone entirely: offers ride the entity response alongside
+		// `_actions` rather than living behind a second endpoint. Both the
+		// collection and a named definition refuse it.
+		{"GET the collection", http.MethodGet, "/api/v1/_copies", http.StatusMethodNotAllowed},
 		{"GET a name", http.MethodGet, "/api/v1/_copies/promote-page", http.StatusMethodNotAllowed},
 		{"DELETE", http.MethodDelete, "/api/v1/_copies/promote-page", http.StatusMethodNotAllowed},
 		{"OPTIONS", http.MethodOptions, "/api/v1/_copies", http.StatusNoContent},
@@ -315,4 +242,88 @@ func TestCopiesHandler_InvokeRejectsMalformedBody(t *testing.T) {
 	if svc.invokeCalls != 0 {
 		t.Errorf("a malformed request must not reach the kernel; calls=%d", svc.invokeCalls)
 	}
+}
+
+// TestCopyOffers_RideTheEntityResponse pins the design correction: offers
+// arrive on the entity response alongside `_actions`, not from a second
+// endpoint.
+//
+// # Why the shape matters enough to test
+//
+// An earlier revision shipped `GET /_copies?type=&pointer=&source_id=`, which
+// made the client construct a lookup key for an affordance every other
+// affordance in this app delivers inline. Jeroen's question — "where is the
+// menu being sent to the client? I would assume it would work similarly to the
+// ones for actions" — is the one that should have been asked at plan time.
+//
+// # Omitted, not empty, when the capability is absent
+//
+// `_copies` is nil rather than `[]` when nothing is wired. An empty list is a
+// legitimate answer ("this face declares no copies"), so emitting one for a
+// missing capability would render a wiring gap as a domain fact — the visible
+// symptom being "the promote button never appears", which sends someone
+// hunting through schema.yaml for a definition that is correctly declared.
+func TestCopyOffers_RideTheEntityResponse(t *testing.T) {
+	t.Parallel()
+	app := newTestAppV1(t)
+	e := &entity.Entity{ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "t"}}
+
+	t.Run("omitted when the capability is not wired", func(t *testing.T) {
+		t.Parallel()
+		svc := app.affordances
+		svc.copies = nil
+		var out v1.Entity
+		svc.attachEntityAffordances(context.Background(), e, &out)
+
+		if out.Copies != nil {
+			t.Errorf("`_copies` must be OMITTED when nothing is wired, not sent "+
+				"empty — an empty list is a real answer, so sending one would "+
+				"render a wiring gap as a domain fact; got %v", *out.Copies)
+		}
+		// The attach ran: other affordances are present. Without this the
+		// assertion above would pass against a build that attached nothing.
+		if out.FieldAffordances == nil {
+			t.Error("precondition: attachEntityAffordances must have run")
+		}
+	})
+
+	t.Run("present, possibly empty, when wired", func(t *testing.T) {
+		t.Parallel()
+		svc := app.affordances
+		svc.copies = func(_ context.Context, _, _, _ string) ([]entitymanager.CopyOffer, error) {
+			return []entitymanager.CopyOffer{{
+				Name: "promote-ticket", Label: "Publish",
+				TargetFace: "ticket@published", SameEntity: true, Allowed: true,
+			}}, nil
+		}
+		var out v1.Entity
+		svc.attachEntityAffordances(context.Background(), e, &out)
+
+		if out.Copies == nil {
+			t.Fatal("`_copies` must be present when the capability is wired")
+		}
+		got := *out.Copies
+		if len(got) != 1 || got[0].Name != "promote-ticket" || got[0].Label != "Publish" {
+			t.Errorf("the offer must reach the wire intact; got %+v", got)
+		}
+		if !got[0].Allowed {
+			t.Error("the verdict must ride the offer — it is what Ruling 9's " +
+				"no-permission-no-button reads")
+		}
+	})
+
+	t.Run("omitted on a capability error, never silently empty", func(t *testing.T) {
+		t.Parallel()
+		svc := app.affordances
+		svc.copies = func(_ context.Context, _, _, _ string) ([]entitymanager.CopyOffer, error) {
+			return nil, errors.New("backend down")
+		}
+		var out v1.Entity
+		svc.attachEntityAffordances(context.Background(), e, &out)
+
+		if out.Copies != nil {
+			t.Errorf("a failure must omit `_copies` rather than emit `[]`, "+
+				"which would read as \"no copies here\"; got %v", *out.Copies)
+		}
+	})
 }

--- a/internal/entitymanager/copylist.go
+++ b/internal/entitymanager/copylist.go
@@ -31,29 +31,8 @@ type CopyOffer struct {
 	// copy needs a target id, so a caller must know which it is looking at.
 	SameEntity bool
 
-	// Indeterminate marks an offer whose invocability CANNOT be answered
-	// without information the caller has not supplied yet.
-	//
-	// It is true for exactly one case: a CROSS-ENTITY copy, whose target id
-	// the client chooses at invoke time. The authorization path checks
-	// `OpCreate` on the target, so with no target id it would authorize the
-	// EMPTY id — and any policy whose verdict depends on the target's identity
-	// would be evaluated against the wrong subject. A code-review reproduction
-	// showed exactly that: list said allowed, invoke said forbidden.
-	//
-	// Reporting `Allowed: true` for that case would be the RULING 11 defect —
-	// an affordance that says one thing while the write does another. So the
-	// honest answer is "I cannot know", and this field says so rather than
-	// guessing. A client should render such an offer as available-but-
-	// unverified (the server still authorizes), never as confirmed.
-	//
-	// Same-entity offers are always determinate: their target IS the source.
-	Indeterminate bool
-
 	// Allowed reports whether this principal may invoke this copy on this
 	// source RIGHT NOW.
-	//
-	// Meaningful only when Indeterminate is false. See that field.
 	//
 	// # It is a HINT, never a boundary
 	//
@@ -69,9 +48,6 @@ type CopyOffer struct {
 	// RULING 11 failure, where an affordance map said "writable" and the write
 	// path refused.
 	//
-	// That guarantee holds for SAME-ENTITY offers. For a cross-entity offer
-	// the inputs differ (no target id yet), which is what Indeterminate
-	// records — the mechanism is shared, but the question is not the same one.
 	Allowed bool
 	// Reason names why Allowed is false, for a tooltip or a CLI. Empty when
 	// Allowed is true. Advisory: it explains a denial the server already made,
@@ -139,6 +115,37 @@ func CopiesForSource(
 		if metamodel.StoredPointer(m.deps.Meta, from.Type, from.Pointer) != pointer {
 			continue
 		}
+		if !def.IsSameEntity() {
+			// CROSS-ENTITY definitions are not offered as affordances, and this
+			// is a FILTER rather than a probe-then-report: authorization is
+			// never attempted for them.
+			//
+			// # The kernel supports cross-entity; this surface does not OFFER it
+			//
+			// [Manager.CopyState] handles a cross-entity copy exactly as before
+			// — a caller with an explicit target id can still invoke one. What is
+			// scoped here is the AFFORDANCE: this epic is about faces of ONE
+			// entity (promote a draft, translate a page), and cross-entity
+			// copies are foundation for later work that needs no UI yet. Read
+			// this as a scope boundary, not a limitation to "complete".
+			//
+			// # Why it must be a filter and not a verdict
+			//
+			// A cross-entity target is the `new <type>` form: the entity does
+			// not exist and has no id. authorizeCopy checks OpCreate on
+			// EntitySubject{Type, ID, Pointer}, so probing one here would
+			// authorize the EMPTY id — a confident answer to a different
+			// question, and the defect a code review caught (list said allowed,
+			// invoke said forbidden). Skipping before authorization makes that
+			// unreachable rather than guarded against.
+			//
+			// Being called with an entity in hand does NOT supply the missing
+			// id: the entity is the SOURCE. That was verified before this
+			// filter was written, because the alternative — deleting the branch
+			// on the assumption that an entity answers it — would have
+			// reintroduced the empty-subject bug.
+			continue
+		}
 
 		offer := CopyOffer{
 			Name:       name,
@@ -146,15 +153,7 @@ func CopiesForSource(
 			TargetFace: def.To,
 			SameEntity: def.IsSameEntity(),
 		}
-		if offer.SameEntity {
-			offer.Allowed, offer.Reason = copyInvocable(ctx, m, name, def, sourceID)
-		} else {
-			// A cross-entity copy's target is chosen at invoke time, so its
-			// authorization cannot be evaluated now — see CopyOffer.Indeterminate.
-			// Deliberately NOT probed at all: running the check against an empty
-			// target id would produce a confident answer to a different question.
-			offer.Indeterminate = true
-		}
+		offer.Allowed, offer.Reason = copyInvocable(ctx, m, name, def, sourceID)
 		out = append(out, offer)
 	}
 	return out, nil

--- a/internal/entitymanager/copylist_test.go
+++ b/internal/entitymanager/copylist_test.go
@@ -118,9 +118,14 @@ func TestCopiesForSource_MatchesTheFaceNotJustTheType(t *testing.T) {
 	})
 
 	t.Run("a different type offers nothing of page's", func(t *testing.T) {
-		got := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")
-		if len(got) != 1 || got[0].Name != "spawn-followup" {
-			t.Errorf("got %v, want only spawn-followup", offerNames(got))
+		// The ticket face declares only a CROSS-ENTITY definition, which is
+		// not offered as an affordance — so this asserts an empty result for
+		// two independent reasons, and the sibling subtests above are what
+		// prove the emptiness is not "the fixture offers nothing at all".
+		if got := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1"); len(got) != 0 {
+			t.Errorf("got %v, want none: page's copies must not leak across "+
+				"types, and ticket's only definition is cross-entity",
+				offerNames(got))
 		}
 	})
 }
@@ -265,47 +270,95 @@ func TestCopiesForSource_AllowedAgreesWithInvoke(t *testing.T) {
 // configurable text and its fallback.
 //
 // The name is a legible fallback because copy names are operator-authored and
-// already read as actions (`promote-page`), which is the same reasoning
+// already read as actions (`promote-page`), the same reasoning
 // metamodel.Transition.Label uses.
+//
+// It uses its OWN metamodel rather than the shared fixture: the unlabelled
+// definition has to be SAME-ENTITY to be offered at all, and adding one to the
+// shared fixture would change the offer counts every other test asserts.
 func TestCopiesForSource_LabelFallsBackToName(t *testing.T) {
-	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
-	ctx := context.Background()
-
-	withLabel := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
-	if len(withLabel) != 1 || withLabel[0].Label != "Publish" {
-		t.Errorf("an operator `label:` must be used verbatim; got %+v", withLabel)
+	const meta = `
+version: "1"
+entities:
+  page:
+    label: Page
+    id_prefix: PAGE
+    pointers:
+      draft: {default: true}
+      published: {}
+      archived: {}
+    properties:
+      title: {type: string}
+copies:
+  promote-page:
+    from: page@draft
+    to: page@published
+    fields: all
+    label: Publish
+    guard:
+      permission: promote-page
+  archive-page:
+    from: page@draft
+    to: page@archived
+    fields: all
+    guard:
+      permission: archive-page
+`
+	st := memstore.New()
+	parsed, err := metamodel.Parse([]byte(meta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store: st, Meta: parsed, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: acl.NopACL{},
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+		CopyGuard:   allowGuard{allow: true},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
 	}
 
-	noLabel := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")
-	if len(noLabel) != 1 || noLabel[0].Label != "spawn-followup" {
-		t.Errorf("with no `label:`, the definition NAME is the fallback; got %+v", noLabel)
+	got := mustOffers(context.Background(), t, mgr, "page", "", "PAGE-1")
+	byName := map[string]string{}
+	for _, o := range got {
+		byName[o.Name] = o.Label
+	}
+	if byName["promote-page"] != "Publish" {
+		t.Errorf("an operator `label:` must be used verbatim; got %q",
+			byName["promote-page"])
+	}
+	if byName["archive-page"] != "archive-page" {
+		t.Errorf("with no `label:`, the definition NAME is the fallback; got %q",
+			byName["archive-page"])
 	}
 }
 
-// TestCopiesForSource_ReportsTheTargetShape pins the two fields a UI needs to
-// know what a button will do: which face it writes, and whether it needs a
-// target id.
+// TestCopiesForSource_ReportsTheTargetShape pins the field a UI needs to say
+// what a button will do: which face the copy writes.
 //
-// SameEntity is not cosmetic — a cross-entity copy REQUIRES a target id, so a
-// caller that cannot distinguish the two cannot build a valid request.
+// SameEntity is asserted as TRUE for every offer, which is now a property of
+// the surface rather than a per-offer fact — cross-entity definitions are
+// filtered out before they become offers. Keeping the assertion documents
+// that: if a cross-entity offer ever appears here, this fails and points at
+// the filter rather than at the UI that would have mis-rendered it.
 func TestCopiesForSource_ReportsTheTargetShape(t *testing.T) {
 	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
 	ctx := context.Background()
 
-	same := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")[0]
-	if !same.SameEntity {
-		t.Error("page@draft -> page@published writes another face of the SAME entity")
+	offers := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")
+	if len(offers) != 1 {
+		t.Fatalf("expected the draft face's one offer; got %v", offerNames(offers))
 	}
+	same := offers[0]
 	if same.TargetFace != "page@published" {
 		t.Errorf("TargetFace = %q, want the declared target", same.TargetFace)
 	}
-
-	cross := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")[0]
-	if cross.SameEntity {
-		t.Error("`to: new ticket` creates a DIFFERENT entity")
-	}
-	if cross.TargetFace != "new ticket" {
-		t.Errorf("TargetFace = %q, want the declared target", cross.TargetFace)
+	if !same.SameEntity {
+		t.Error("every OFFERED copy is same-entity: page@draft -> page@published " +
+			"writes another face of the same entity, and cross-entity " +
+			"definitions are filtered before they become offers")
 	}
 }
 
@@ -400,35 +453,59 @@ func TestCopiesForSource_AffordanceProbeEmitsNoAuditRecords(t *testing.T) {
 	}
 }
 
-// TestCopiesForSource_CrossEntityIsIndeterminate pins the honest answer for an
-// offer whose invocability cannot be known yet.
+// TestCopiesForSource_CrossEntityIsNotOffered pins the affordance surface's
+// scope: SAME-ENTITY definitions only.
 //
-// A cross-entity copy's target id is chosen at INVOKE time, so the create
-// check would authorize the empty id — and a policy keyed on the target's
-// identity would be evaluated against the wrong subject. Code review
-// demonstrated list=allowed / invoke=forbidden on exactly that.
+// # Why a filter and not a verdict
 //
-// Reporting `Allowed: true` there is the RULING 11 defect. So the offer says
-// "indeterminate" instead of guessing, and — asserted here — it does not
-// claim Allowed.
-func TestCopiesForSource_CrossEntityIsIndeterminate(t *testing.T) {
-	mgr, _ := newCopyListManager(t, allowGuard{allow: true})
+// A cross-entity target is the `new <type>` form — the entity does not exist
+// and has no id. authorizeCopy checks OpCreate on EntitySubject{Type, ID,
+// Pointer}, so probing one would authorize the EMPTY id: a confident answer to
+// a different question, and the defect code review caught (list said allowed,
+// invoke said forbidden). Skipping BEFORE authorization makes that unreachable
+// rather than guarded against, which is why an earlier `Indeterminate` field
+// was deleted rather than kept.
+//
+// # The kernel is NOT narrowed
+//
+// Manager.CopyState still handles cross-entity copies; a caller with an
+// explicit target id invokes one exactly as before. Only the AFFORDANCE is
+// scoped, because this epic is about faces of one entity. Read the filter as a
+// scope boundary, not a limitation to "complete" — the assertion below on
+// CopyState is what pins that half.
+func TestCopiesForSource_CrossEntityIsNotOffered(t *testing.T) {
+	mgr, st := newCopyListManager(t, allowGuard{allow: true})
 	ctx := context.Background()
 
-	same := mustOffers(ctx, t, mgr, "page", "", "PAGE-1")[0]
-	if same.Indeterminate {
-		t.Error("a SAME-entity offer's target is the source, so it is answerable")
+	// The ticket face declares exactly one copy, and it is cross-entity
+	// (`to: new ticket`).
+	if got := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1"); len(got) != 0 {
+		t.Errorf("a cross-entity definition must not be OFFERED as an "+
+			"affordance — its target has no id yet, so no honest verdict "+
+			"exists; got %v", offerNames(got))
 	}
 
-	cross := mustOffers(ctx, t, mgr, "ticket", "", "TKT-1")[0]
-	if !cross.Indeterminate {
-		t.Error("a CROSS-entity offer cannot be authorized before the client " +
-			"chooses a target id — saying `allowed` would be an affordance " +
-			"that lies (RULING 11)")
+	// Same-entity offers are unaffected: the filter is by shape, not a blanket
+	// narrowing. Without this the test above would pass against a build that
+	// offered nothing at all.
+	if got := mustOffers(ctx, t, mgr, "page", "", "PAGE-1"); len(got) != 1 {
+		t.Fatalf("same-entity definitions must still be offered; got %v",
+			offerNames(got))
 	}
-	if cross.Allowed {
-		t.Error("an indeterminate offer must not also claim Allowed: a client " +
-			"reading only `allowed` would treat it as a confirmed verdict")
+
+	// And the KERNEL still runs a cross-entity copy when given a target id —
+	// the capability is not removed, only unoffered.
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-1", Type: "ticket", Properties: map[string]any{"title": "Source"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := mgr.CopyState(ctx, entitymanager.CopyRequest{
+		Definition: "spawn-followup", SourceID: "TKT-1", TargetID: "TKT-2",
+	}); err != nil {
+		t.Errorf("the kernel must still perform a cross-entity copy given an "+
+			"explicit target — the affordance is scoped, the capability is "+
+			"not; got %v", err)
 	}
 }
 


### PR DESCRIPTION
Tickets-PR: #1422

🌍 The demo UI: copy affordances, world provenance, and a read-only page

Closes TKT-F2D5U5 step 5. This is the surface RULING 9 described, built against
an API that now answers yes, plus one defect the click-through surfaced.

## What is clickable

Verified live on a demo project (`policy`/`control` with draft+published faces,
`blog-post` with en/nl/fr), at two ACL configurations:

| Face | Affordance | Verified |
|---|---|---|
| `POL-1` draft | **"Publish this policy"** button, operator's `label:` | screenshot |
| `POST-1` en | **"Copy to ▾"** menu: *Traduire en français* / *Vertaal naar Nederlands* | screenshot |
| `POST-1` en, permission withheld | **no button at all** — absent, not disabled | screenshot |
| `POL-1` `?world=published` | read-only banner + **"Go to draft"** | screenshot |

Clicking *Traduire en français* produced `POST-1@fr.md` on disk and flipped
`?world=site-fr` from `via: fallback-default` to `via: chain`. The copy runs end
to end, not just the button.

## Per-neighbour provenance (gap 2)

`WorldBadge` renders `_world` on collection entities. Under `?world=site-nl`,
`CTL-1` and `CTL-2` both show an amber **`default`** badge — they are the
English/default faces standing in, and without the badge they are byte-identical
to real Dutch ones. Under `?world=published`, `CTL-1` shows **`published`**
(`chain`) and `CTL-2` **disappears entirely** (excluded, no published face).

Both render per row, because each neighbour resolves independently — RULING 12.
`via: unscoped` renders nothing; there is no information in it.

## The defect this found: a world-bound page was not read-only

`_actions` reports `update: true` under a world. That is **correct** — it answers
"may this principal write this entity", a question about the principal. But the
API refuses every write carrying `?world=`:

```
PATCH /api/v1/policys/POL-1?world=published
422 world_read_only  "omit ?world= — writes always address the default state"
```

So the SPA rendered Edit and Delete on a page whose saves could only fail: an
affordance map that promises a verb the surface rejects (RULING 11). The world is
now ANDed in at the consumer — `_actions` keeps answering its own question, and
"can a write be addressed to THIS response" is answered where the request is
known. `EntityList` already drew this line for its create button.

Suppressed under a world: Edit, Delete, inline-edit routing (section and row),
checkbox toggles (they schedule a content PATCH and cannot be hidden by a `v-if`,
so the guard is at the handler), and copies.

Copies are the interesting one. The server's offers are **right** under a world —
they are computed for the *resolved face*, so `?world=published` returns `[]`
while a fallback world still offers the promote its resolved face supports. But
an invoke carries no `?world=`, so it would write the default face while the
reader looks at a resolved one. Under `otherwise: default` those are the same
bytes and it looks harmless; under a world serving a real alternate face, the
user would publish content that is not on their screen. "Go to draft" is one
click away, which is the honest path.

## "Go to draft" is gated on the world grant

World-read is a **global, role-level** grant: `acl.Request.PermitsWorld(ctx,
world)` takes a world name and nothing else, and `/_schema`.worlds already
reports the verdict per world for the calling principal. So the check costs no
extra request and reads no entity.

The SPA was not consuming `worlds` from `/_schema` at all; it now does, via a
`worldReadable(name)` getter. An **unknown** world answers `true` — a world
absent from the map means an older server or a schema not yet loaded, and in
both cases the request would in fact be served. Manufacturing a denial there
would hide a working affordance and read as a permission problem, which is the
wrong answer in the direction nobody can debug.

**The gate is inert today, stated plainly rather than left to be discovered.**
`/_schema` reports the default world's `readable` as a hardcoded `true`,
because `resolveWorld` short-circuits `default` before any grant check — the
enumeration deliberately mirrors what the request path *does*. Measured: a role
with `worlds: [published]` and `read: []` is genuinely denied the default world
(`roleGrantsWorldRead` requires `len(role.Read) > 0`) and its entity GETs 404,
yet `/_schema` still reports `default.readable: true`. That is the pre-existing
gap `schemaworlds.go` documents at length, guarded by
`TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath`, and it is one decision
with the request path. Reading the honest input now means this button starts
hiding itself when that gap closes, with no change here.

Non-default worlds' `readable` flags ARE per-principal and real — the same
probe showed `published: false` for that role, correctly, because with
`read: []` the world grant has no entity types to act on.

## Tests

33 new tests across three files (`CopyMenu.test.ts` 9,
`EntityDetail.world.test.ts` 23, `stores/schema.test.ts` 1), all
mutation-checked (RULING 10 — nearly every assertion is an ABSENCE, the class
that passes trivially against a component that failed to mount, so each is
paired with a positive control from the same or a sibling mount, and
`rendersProof` guards the rest).

| Mutant | Caught by |
|---|---|
| drop the `allowed` filter | 2 tests |
| render denied offers disabled instead of absent | 2 tests |
| remove the `label → name` fallback | 1 |
| ignore `busy` | 1 |
| leave the menu open after a choice | 1 |
| drop the world from `canUpdate`/`canDelete` | 1 |
| stop sending the world to `fetchView` | 2 |
| reload after a FAILED copy | 1 |
| skip the reload after a successful copy | 1 |
| drop `WorldBadge` from collection rows | 1 |
| "go to draft" keeps the world | 1 |
| `copyOffers` ignores the world | 1 |
| `canUpdate` drops `!isWorldBound` | 1 — see below |
| "Go to draft" ignores the grant | 1 |
| unknown world defaults to DENIED | 2 |
| `worldReadable` always true | 1 |
| `worlds` never loaded from `/_schema` | 1 — see below |

Each mutant was compile-checked before scoring — a non-compiling mutant scores
identically to a surviving one, so an uncompiled "caught" proves nothing.

**A second mutant survived, for the same reason in a different place.**
Deleting the line that loads `worlds` from the `/_schema` response passed every
component test — because those seed the store directly, so nothing exercised
the wiring. Only a test that drives `load()` through a mocked `getSchema` can
catch it; that now lives in `stores/schema.test.ts`. The getter was tested and
the wiring was not, which is the same shape as the fixture bug below.

**One test was vacuous and the mutation check is the only reason I know.** The
Edit-under-a-world test asserted an absence against a button that could never
have rendered: it needs `editFormId && !isInaccessible && canUpdate`, and the
fixture seeded no form. Dropping `!isWorldBound` from `canUpdate` survived the
whole suite. I had also written a comment *claiming* the test closed that gap —
so the comment was wrong in the same commit that introduced it. Seeding
`schemaStore.forms` makes the mutant die. `canUpdate` and `canDelete` are
separate computeds, so pinning Delete never covered Edit — and Edit is the worse
half to leave unpinned: Delete under a world merely 422s, while Edit opens a
form, the user types, and the save fails.

## Code review found the guards were untested — the critical finding

A reviewer mutation-tested each world write-guard by deleting it. The result was
that **the guards protecting this change's entire purpose were themselves free
to delete.** Measured per guard rather than in aggregate:

| guard | caught before review? |
|---|---|
| `canUpdate` (`!isWorldBound`) | yes |
| `copyOffers` suppression | yes |
| `sectionShouldRouteToInlineEdit` | yes (test added mid-review) |
| `handleCheckboxToggle` | **no** |
| `rowShouldRouteToInlineEdit` | **no** |

**The server is not a backstop.** `attachWorld` refuses a write only when
`?world=` is on the WRITE request, and no SPA write path attaches it —
`useAutoSave` builds a plain `EntityPatch`. So an unguarded toggle or inline
edit does not 422: it silently PATCHes the **default** face while the user reads
a resolved one. That is precisely the hazard `world.go` cites as the reason for
the read-only rule.

It matters for a channel `EntityDetail` cannot see, too. `SectionEditForm` owns
its **own** `useAutoSave` with its own `onBeforeUnmount` flush. My earlier
reasoning — "the flushes are safe because they are only flushes" — was right
about `contentAutoSave` and **incomplete**: the accurate statement is that no
pending save can be created world-bound *because the routing predicates stop
`SectionEditForm` mounting*, and that was the untested guard. All five are now
pinned individually, each verified by deleting it and watching a test fail.

**S1 — operator commands were ungated.** A command pipes a rendered view to a
shell script's stdin, and the server passes `defaultViewWorld()` explicitly
(`commands.go`), so under `?world=published` the script receives **draft**
content while the user reads published — "past any layer that could observe it".
What a world-bound command should mean is deliberately another ticket; rendering
the button beside a "read-only" banner in the meantime is not. Gated on the
`commands` computed rather than the two button sites, so a third render site
cannot miss it.

**S2** pins that `?world=default` is writable and unbannered — correct, but the
invariant "banner shown ⟺ writes blocked" rested on two independently
maintained expressions.

**M1** (the mid-invoke race) I had already found and fixed independently; the
reviewer reached the same race and rated it minor, having stopped before the
spurious second `fetchView`.

## Also in here

Removes `v1.CopyOffersResponse`, dead since `GET /_copies` was dropped: the
wrapper for an endpoint that no longer exists.

## Two ACL findings, measured (no code change here)

The demo needs **no `acl.yaml`** — a project with no policy is fully open, and
both `allowed: true` and world reads work without one. I had written one on a
false premise and have deleted it. Two things it surfaced are real and worth
recording:

1. **The Ruling 8 refusal fires on `member-of` for a policy that never declares
   it.** `EffectiveMembershipRelation()` defaults to `"member-of"`, and
   `RoleRelations["member-of"]` on an absent key is a zero value whose
   `RequiresPermission` is `""` — which reads as *ungated*. So any policy that
   grants a non-default world read plus an escalation-relevant assignment is
   refused at load, naming a relation the operator never wrote. This is **arm
   (a)** (`assignmentSelfPromotionEscalates`), not the ungated-role-relation arm;
   I reported the wrong arm earlier and have since reproduced it against the real
   loader. The refusal is correct — the fix is one `requires_permission` line —
   but the diagnostic names something absent from the file it is refusing.

2. **A missing world grant is invisible.** `read: ["*"]` grants every entity
   *type* but no world; `world:<name>` is a separate grant. Without it,
   `GET /policys/POL-1?world=published` is **404** and the list is `{"data":[]}`
   — never a 403. Measured, not asserted. The 404 is deliberate (existence in a
   world is the publication bit, so it must be indistinguishable from absent),
   but the consequence is that a forgotten world grant looks exactly like
   "nothing is published yet", with no error anywhere to chase.

---

Full `just ci` on a detached worktree at `9bae1963`: `EXIT=0`, zero `FAIL`. Lint
`0 issues`, arch-lint `OK - No warnings found`, plimsoll passed, commentlint `no
findings across 10909 comments`, markdownlint `0 issues in 0 files`, 178 packages
`ok`, package + total coverage thresholds `PASS`, all four binaries built,
`✓ Docs are up to date`.

Frontend: `vue-tsc` clean, eslint `0 errors` (105 warnings, the pre-existing
count, none in the new files), 118 files / **1885 tests** passing.

One `EXIT=1` on an earlier run of the same commit was
`TestWatcher_AutoWatchesNewDirectories` — a flake, proved by a pass and a fail
inside a single run on identical bytes (`ok internal/storage` in the `test` pass,
`FAIL internal/storage` in the `test-coverage` pass), 5/5 in isolation, and no
file under `internal/storage` touched by this branch. Filed with the analyze
flake as two instances of one root cause: a fixed timeout sized against
uninstrumented, uncontended local timing.

