### PR TITLE
Derive PostgreSQL indexes for pushed queries (TKT-03HCWT)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -92,6 +92,7 @@ components:
   sync:             { in: internal/sync }
   frontmatter:      { in: internal/frontmatter }
   filter:           { in: internal/filter }
+  queryplan:        { in: internal/queryplan }
   propmatch:        { in: internal/propmatch }
   userstate:        { in: internal/userstate }
   nextaction:       { in: internal/nextaction }
@@ -308,6 +309,7 @@ deps:
       - principal
       - project
       - projectsetup
+      - queryplan
       - renametype
       - scheduler
       - schema
@@ -376,6 +378,7 @@ deps:
       - migration
       - openapi
       - project
+      - queryplan
       - script
       - search
       - searchparser
@@ -507,6 +510,7 @@ deps:
       - metamodel
       - pgstore
       - project
+      - queryplan
       - script
       - search
       - state
@@ -895,6 +899,13 @@ deps:
   searchparser:
     mayDependOn:
       - filter
+  queryplan:
+    mayDependOn:
+      - dataentryconfig
+      - filter
+      - metamodel
+      - searchparser
+      - store
   store:
     mayDependOn:
       - metamodel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,6 +539,14 @@ Rules when touching this:
   `--database-url` flag, so the credential never lands in `ps`/shell history.
   `appbuild.Discover` reads the env into `appbuild.Config.DatabaseURL`; the
   `db` commands read the env directly. Don't add a DSN flag.
+- **Derived static-query indexes are all-or-nothing desired state.** The
+  PostgreSQL reconciler owns only `rela_derived_query__*` and derives those
+  indexes from validated static dashboard/next-action query shapes. Never
+  reconcile a partial set after a `data-entry.yaml` read/parse/validation
+  failure: an absent desired object means DROP, so partial input is destructive.
+  Runtime/ad-hoc queries never issue DDL. Pushdown and index inference must use
+  the same `internal/queryplan` eligibility decision, and an EXPLAIN test must
+  prove each newly supported SQL shape actually uses its generated index.
 - **Migrations** are embedded SQL (`pgstore/migrations/*.sql`), applied by
   `pgstore.Migrate` in one transaction under a `pg_advisory_xact_lock`
   (concurrent-start safe; forward-only). Auto-applied on first store open;

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -88,7 +88,7 @@ rela's tables are created in the connection's default schema (typically
 `public`). Point rela at a database it owns; if you share a schema with
 another application, rela's tables sit alongside it.
 
-## Derived schema (unique constraints)
+## Derived schema (constraints and query indexes)
 
 Some things you declare in the metamodel are enforced not only in the
 application but by the **database itself** on the PostgreSQL backend. Today
@@ -105,6 +105,21 @@ against the indexes actually present and creates the missing ones, dropping
 any it previously created for a rule you have since removed. This is
 idempotent and self-correcting — a hand-dropped index is recreated on the
 next start — and in the steady state (nothing changed) it does no work.
+
+PostgreSQL also derives ordinary B-tree indexes from eligible static queries in
+`data-entry.yaml`. Dashboard cards, global next-action queries, and `pick_one`
+option queries qualify when they target exactly one entity type and all pushed
+filters are non-empty equality checks on declared, scalar string properties.
+rela creates one composite `rela_derived_query__…` index for the complete set
+of properties in each query shape. Equivalent queries share an index even when
+their literal values or filter order differ.
+
+Runtime and URL queries are not observed. Free text, relations, sorting, glob,
+not-equal, empty-value, list-valued, and non-string filters do not produce an
+index. Query indexes are recalculated only at startup or by `rela db reconcile`,
+so restart or reconcile after changing static query configuration. A missing
+`data-entry.yaml` is valid; an invalid or unreadable file aborts reconciliation
+without dropping existing rela-owned query indexes.
 
 ### When a constraint can't be enforced
 
@@ -129,7 +144,7 @@ rela db reconcile --dry-run # show what WOULD change; non-zero exit if anything 
 ```
 
 `rela db reconcile --dry-run` is the pre-flight: run it against your live
-database before shipping a schema change to see exactly which constraints
+database before shipping a configuration change to see exactly which constraints
 would be created, dropped, or left unenforced (and, with `--show-values`, a
 sample of the blocking values — this prints entity data, so it is opt-in and
 operator-only). Because the dry-run and the real startup reconcile share one

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -82,7 +82,7 @@ rela's tables are created in the connection's default schema (typically
 `public`). Point rela at a database it owns; if you share a schema with
 another application, rela's tables sit alongside it.
 
-## Derived schema (unique constraints)
+## Derived schema (constraints and query indexes)
 
 Some things you declare in the metamodel are enforced not only in the
 application but by the **database itself** on the PostgreSQL backend. Today
@@ -99,6 +99,21 @@ against the indexes actually present and creates the missing ones, dropping
 any it previously created for a rule you have since removed. This is
 idempotent and self-correcting — a hand-dropped index is recreated on the
 next start — and in the steady state (nothing changed) it does no work.
+
+PostgreSQL also derives ordinary B-tree indexes from eligible static queries in
+`data-entry.yaml`. Dashboard cards, global next-action queries, and `pick_one`
+option queries qualify when they target exactly one entity type and all pushed
+filters are non-empty equality checks on declared, scalar string properties.
+rela creates one composite `rela_derived_query__…` index for the complete set
+of properties in each query shape. Equivalent queries share an index even when
+their literal values or filter order differ.
+
+Runtime and URL queries are not observed. Free text, relations, sorting, glob,
+not-equal, empty-value, list-valued, and non-string filters do not produce an
+index. Query indexes are recalculated only at startup or by `rela db reconcile`,
+so restart or reconcile after changing static query configuration. A missing
+`data-entry.yaml` is valid; an invalid or unreadable file aborts reconciliation
+without dropping existing rela-owned query indexes.
 
 ### When a constraint can't be enforced
 
@@ -123,7 +138,7 @@ rela db reconcile --dry-run # show what WOULD change; non-zero exit if anything 
 ```
 
 `rela db reconcile --dry-run` is the pre-flight: run it against your live
-database before shipping a schema change to see exactly which constraints
+database before shipping a configuration change to see exactly which constraints
 would be created, dropped, or left unenforced (and, with `--show-values`, a
 sample of the blocking values — this prints entity data, so it is opt-in and
 operator-only). Because the dry-run and the real startup reconcile share one

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1407,7 +1407,7 @@ func assemble(
 	// indexes so uniqueness is enforced atomically, and publish the current
 	// unique pairs so a violation can be attributed to a property (TKT-3Q0GP1).
 	// Failures degrade to warnings — a derived-schema problem never fails boot.
-	reconcileDerivedSchemaIfSupported(context.Background(), st, base.meta)
+	reconcileDerivedSchemaIfSupported(context.Background(), st, base)
 
 	// Evaluate the data-migration gate (adopt compatible schema-shape
 	// changes, warn on incompatible ones) and start the drift GC sweep

--- a/internal/appbuild/derivedschema_nosweep.go
+++ b/internal/appbuild/derivedschema_nosweep.go
@@ -5,7 +5,6 @@ package appbuild
 import (
 	"context"
 
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -14,4 +13,4 @@ import (
 // the metamodel. fsstore/memstore enforce `unique: true` with the
 // application-level check-then-write scan, which is correct for their
 // single-process nature (TKT-3Q0GP1).
-func reconcileDerivedSchemaIfSupported(_ context.Context, _ store.Store, _ *metamodel.Metamodel) {}
+func reconcileDerivedSchemaIfSupported(_ context.Context, _ store.Store, _ *SharedBase) {}

--- a/internal/appbuild/derivedschema_postgres.go
+++ b/internal/appbuild/derivedschema_postgres.go
@@ -6,8 +6,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
 
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/queryplan"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
 )
@@ -28,24 +32,36 @@ type derivedSchemaReconciler interface {
 	) ([]store.DerivedObjectOutcome, error)
 }
 
-// reconcileDerivedSchemaIfSupported converges the derived schema at store-open
-// and publishes the metamodel's unique (type, property) pairs so the write path
-// can attribute a unique-index violation to a property (TKT-3Q0GP1). A store
-// without the capability (should not happen in this build) is skipped. Reconcile
-// failures are logged and swallowed: a derived-schema problem — most often
-// pre-existing duplicate values blocking an index — must NEVER fail store-open.
-// An operator inspects/repairs drift via `rela db status` / `rela db reconcile`.
-func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, meta *metamodel.Metamodel) {
+// reconcileDerivedSchemaIfSupported converges unique constraints and eligible
+// static-query indexes at store-open. It also publishes unique pairs so the
+// write path can attribute a unique-index violation to a property. A store
+// without the capability is skipped. Reconcile failures are logged and
+// swallowed: a derived-schema problem must never fail store-open. An operator
+// inspects or repairs drift via `rela db status` / `rela db reconcile`.
+func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, base *SharedBase) {
 	s, ok := st.(derivedSchemaReconciler)
 	if !ok {
 		return
 	}
 
-	specs := uniqueSpecsFromMetamodel(meta)
-
-	// Publish the pairs first so that even if the reconcile below degrades, a
-	// violation of an already-present index still maps to its property.
-	s.SetUniqueSpecProvider(specs)
+	uniqueSpecs := uniqueSpecsFromMetamodel(base.meta)
+	// Publish unique pairs even when data-entry config later prevents DDL. An
+	// already-present unique index may still reject a concurrent write, and the
+	// error must remain attributable to its property.
+	s.SetUniqueSpecProvider(uniqueSpecs)
+	specs := append([]store.DerivedObjectSpec(nil), uniqueSpecs...)
+	configPath := filepath.Join(base.cfg.Paths.Root, dataentryconfig.ConfigFile)
+	if data, err := base.cfg.FS.ReadFile(configPath); err == nil {
+		querySpecs, err := queryplan.LoadStaticIndexSpecs(data, base.meta)
+		if err != nil {
+			slog.Warn("appbuild: derived-schema reconcile skipped; invalid data-entry config", "error", err)
+			return
+		}
+		specs = append(specs, querySpecs...)
+	} else if !os.IsNotExist(err) {
+		slog.Warn("appbuild: derived-schema reconcile skipped; data-entry config unreadable", "error", err)
+		return
+	}
 
 	outcomes, err := s.Reconcile(ctx, specs, store.ReconcileOptions{})
 	switch {
@@ -56,19 +72,29 @@ func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, meta
 		slog.Debug("appbuild: derived-schema reconcile skipped; a peer holds the lock")
 		return
 	case err != nil:
-		slog.Warn("appbuild: derived-schema reconcile failed; uniqueness may be "+
-			"enforced only by the application-level check until repaired", "error", err)
+		slog.Warn("appbuild: derived-schema reconcile failed; database constraints or query indexes may be stale",
+			"error", err)
 		return
 	}
 	for _, o := range outcomes {
 		switch o.State {
 		case store.DerivedUnenforced:
-			slog.Warn("appbuild: derived unique constraint NOT enforced",
-				"type", o.Spec.Type, "property", o.Spec.Property,
-				"blocking_value_groups", o.BlockingCount, "reason", o.Reason)
+			if o.Spec.Kind == store.DerivedQueryIndex {
+				slog.Warn("appbuild: derived static-query index NOT created",
+					"type", o.Spec.Type, "properties", o.Spec.Properties, "reason", o.Reason)
+			} else {
+				slog.Warn("appbuild: derived unique constraint NOT enforced",
+					"type", o.Spec.Type, "property", o.Spec.Property,
+					"blocking_value_groups", o.BlockingCount, "reason", o.Reason)
+			}
 		case store.DerivedCreated:
-			slog.Info("appbuild: derived unique constraint created",
-				"type", o.Spec.Type, "property", o.Spec.Property)
+			if o.Spec.Kind == store.DerivedQueryIndex {
+				slog.Info("appbuild: derived static-query index created",
+					"type", o.Spec.Type, "properties", o.Spec.Properties)
+			} else {
+				slog.Info("appbuild: derived unique constraint created",
+					"type", o.Spec.Type, "property", o.Spec.Property)
+			}
 		case store.DerivedDropped:
 			slog.Info("appbuild: derived schema object dropped (no longer declared)",
 				"reason", o.Reason)

--- a/internal/appbuild/widen_assertions_postgres_test.go
+++ b/internal/appbuild/widen_assertions_postgres_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
@@ -39,6 +41,15 @@ func newFakeStore(t *testing.T) fakeStore {
 	return fakeStore{Store: m}
 }
 
+func derivedTestBase(meta *metamodel.Metamodel) *SharedBase {
+	fs := storage.NewMemFS()
+	_ = fs.MkdirAll("/project", 0o700)
+	return &SharedBase{
+		cfg:  Config{FS: fs, Paths: &project.Context{Root: "/project"}},
+		meta: meta,
+	}
+}
+
 type fakeUserStateStore struct {
 	fakeStore
 	called bool
@@ -58,6 +69,7 @@ func (f *fakeUserStateStore) UserState() (userstate.Store, error) {
 type fakeReconciler struct {
 	fakeStore
 	specsPublished []store.DerivedObjectSpec
+	desired        []store.DerivedObjectSpec
 	reconcileCalls int
 	reconcileErr   error
 
@@ -76,6 +88,7 @@ func (f *fakeReconciler) Reconcile(
 	_ context.Context, desired []store.DerivedObjectSpec, _ store.ReconcileOptions,
 ) ([]store.DerivedObjectOutcome, error) {
 	f.reconcileCalls++
+	f.desired = append([]store.DerivedObjectSpec(nil), desired...)
 	f.calls = append(f.calls, "Reconcile")
 	if f.reconcileErr != nil {
 		return nil, f.reconcileErr
@@ -130,7 +143,7 @@ func TestCapabilitiesDiscoveredByInterface_NotConcreteType(t *testing.T) {
 
 	t.Run("derived schema reconciler", func(t *testing.T) {
 		f := &fakeReconciler{fakeStore: newFakeStore(t)}
-		reconcileDerivedSchemaIfSupported(t.Context(), f, meta)
+		reconcileDerivedSchemaIfSupported(t.Context(), f, derivedTestBase(meta))
 		if f.reconcileCalls != 1 {
 			t.Fatalf("Reconcile called %d times, want 1", f.reconcileCalls)
 		}
@@ -154,7 +167,7 @@ func TestDerivedSchemaPublishesSpecsBeforeReconciling(t *testing.T) {
 		fakeStore:    newFakeStore(t),
 		reconcileErr: errors.New("reconcile unavailable"),
 	}
-	reconcileDerivedSchemaIfSupported(t.Context(), f, nil)
+	reconcileDerivedSchemaIfSupported(t.Context(), f, derivedTestBase(nil))
 
 	// Order is the assertion. An earlier draft tested
 	// `specsPublished == nil && len(specsPublished) != 0`, which is
@@ -165,6 +178,55 @@ func TestDerivedSchemaPublishesSpecsBeforeReconciling(t *testing.T) {
 		t.Errorf("call order = %v, want %v (specs must be published before "+
 			"reconciling, so a violation of an existing index still maps to a "+
 			"property when reconcile degrades)", f.calls, want)
+	}
+}
+
+func TestDerivedSchemaIncludesValidatedStaticQueryIndexes(t *testing.T) {
+	meta := &metamodel.Metamodel{Entities: map[string]metamodel.EntityDef{
+		"task": {Properties: map[string]metamodel.PropertyDef{
+			"status": {Type: metamodel.PropertyTypeString},
+		}},
+	}}
+	base := derivedTestBase(meta)
+	data := []byte(`version: "1.0"
+app: {name: Test}
+dashboard:
+  title: Test
+  cards:
+    - title: Open
+      query: "type:task prop:status=open"
+      display: count
+`)
+	if err := base.cfg.FS.WriteFile("/project/data-entry.yaml", data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeReconciler{fakeStore: newFakeStore(t)}
+	reconcileDerivedSchemaIfSupported(t.Context(), f, base)
+
+	want := store.DerivedObjectSpec{
+		Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"status"},
+	}
+	if !slices.ContainsFunc(f.desired, func(got store.DerivedObjectSpec) bool {
+		return got.Kind == want.Kind && got.Type == want.Type && slices.Equal(got.Properties, want.Properties)
+	}) {
+		t.Fatalf("desired = %#v, missing %#v", f.desired, want)
+	}
+	if slices.ContainsFunc(f.specsPublished, func(got store.DerivedObjectSpec) bool {
+		return got.Kind == store.DerivedQueryIndex
+	}) {
+		t.Fatalf("query specs leaked into unique-violation provider: %#v", f.specsPublished)
+	}
+}
+
+func TestDerivedSchemaInvalidConfigDoesNotReconcilePartialSet(t *testing.T) {
+	base := derivedTestBase(&metamodel.Metamodel{})
+	if err := base.cfg.FS.WriteFile("/project/data-entry.yaml", []byte("dashboard: ["), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeReconciler{fakeStore: newFakeStore(t)}
+	reconcileDerivedSchemaIfSupported(t.Context(), f, base)
+	if f.reconcileCalls != 0 {
+		t.Fatal("invalid config reconciled a partial desired set")
 	}
 }
 
@@ -193,7 +255,7 @@ func TestResolversReturnUntypedNilWithoutCapability(t *testing.T) {
 
 	// Must not panic, and must not start a sweep.
 	startVersionSweepIfSupported(plain, nil)
-	reconcileDerivedSchemaIfSupported(t.Context(), plain, nil)
+	reconcileDerivedSchemaIfSupported(t.Context(), plain, derivedTestBase(nil))
 }
 
 // TestCapabilityPresentButHandleNilYieldsUntypedNil is the branch the

--- a/internal/cli/db_postgres.go
+++ b/internal/cli/db_postgres.go
@@ -7,9 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/queryplan"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
@@ -71,7 +74,7 @@ func runDBStatus() error {
 	// is INFORMATIONAL: it never changes the exit code (a config edit against
 	// dirty data must not brick a health check). The strict gate lives on
 	// `rela db reconcile --dry-run`.
-	if specs, _, ok := loadUniqueSpecs(); ok {
+	if specs, _, ok := loadDerivedSpecs(); ok {
 		outcomes, err := pgstore.ReconcileDSN(
 			context.Background(), resolved, specs, store.ReconcileOptions{DryRun: true})
 		switch {
@@ -96,9 +99,9 @@ func runDBReconcile(dryRun, showValues bool) error {
 	if err != nil {
 		return err
 	}
-	specs, schemaPath, ok := loadUniqueSpecs()
+	specs, schemaPath, ok := loadDerivedSpecs()
 	if !ok {
-		return errors.New("could not load the metamodel to derive unique constraints; " +
+		return errors.New("could not load project configuration to derive database indexes; " +
 			"run this from a project directory")
 	}
 	// Echo which schema the constraints are derived from: reconcile mutates the
@@ -136,7 +139,11 @@ func printDerivedDrift(outcomes []store.DerivedObjectOutcome, dryRun bool) (drif
 			if dryRun {
 				verb = "would create"
 			}
-			fmt.Printf("  + %s unique constraint on %s.%s\n", verb, o.Spec.Type, o.Spec.Property)
+			if o.Spec.Kind == store.DerivedQueryIndex {
+				fmt.Printf("  + %s query index on %s.%v\n", verb, o.Spec.Type, o.Spec.Properties)
+			} else {
+				fmt.Printf("  + %s unique constraint on %s.%s\n", verb, o.Spec.Type, o.Spec.Property)
+			}
 		case store.DerivedDropped:
 			drift = true
 			verb := "dropped"
@@ -146,25 +153,29 @@ func printDerivedDrift(outcomes []store.DerivedObjectOutcome, dryRun bool) (drif
 			fmt.Printf("  - %s %s\n", verb, o.Reason)
 		case store.DerivedUnenforced:
 			drift = true
-			fmt.Printf("  ! NOT enforced: unique on %s.%s — %s (%d duplicate value group(s))\n",
-				o.Spec.Type, o.Spec.Property, o.Reason, o.BlockingCount)
+			if o.Spec.Kind == store.DerivedQueryIndex {
+				fmt.Printf("  ! NOT created: query index on %s.%v — %s\n",
+					o.Spec.Type, o.Spec.Properties, o.Reason)
+			} else {
+				fmt.Printf("  ! NOT enforced: unique on %s.%s — %s (%d duplicate value group(s))\n",
+					o.Spec.Type, o.Spec.Property, o.Reason, o.BlockingCount)
+			}
 			for _, v := range o.SampleValues {
 				fmt.Printf("      duplicate value: %s\n", v)
 			}
 		}
 	}
 	if !drift {
-		fmt.Printf("Derived schema: up to date (%d unique constraint(s) enforced).\n", enforced)
+		fmt.Printf("Derived schema: up to date (%d object(s) enforced).\n", enforced)
 	}
 	return drift
 }
 
-// loadUniqueSpecs discovers the project at the current directory, loads the
-// metamodel, and returns its `unique: true` (type, property) pairs as reconciler
-// specs plus the resolved schema path (so the caller can show the operator which
-// schema is driving the reconcile). ok is false when the project/metamodel could
-// not be loaded (the caller treats that as "cannot check").
-func loadUniqueSpecs() (specs []store.DerivedObjectSpec, schemaPath string, ok bool) {
+// loadDerivedSpecs discovers the project and returns unique constraints plus
+// indexes derived from valid static data-entry queries. ok is false when the
+// complete desired set cannot be loaded; callers must not reconcile a partial
+// set because that could drop still-desired owned indexes.
+func loadDerivedSpecs() (specs []store.DerivedObjectSpec, schemaPath string, ok bool) {
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	startDir, err := os.Getwd()
 	if err != nil {
@@ -191,5 +202,18 @@ func loadUniqueSpecs() (specs []store.DerivedObjectSpec, schemaPath string, ok b
 			}
 		}
 	}
+	configPath := filepath.Join(paths.Root, dataentryconfig.ConfigFile)
+	data, err := fs.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return specs, paths.SchemaPath, true
+		}
+		return nil, "", false
+	}
+	querySpecs, err := queryplan.LoadStaticIndexSpecs(data, meta)
+	if err != nil {
+		return nil, "", false
+	}
+	specs = append(specs, querySpecs...)
 	return specs, paths.SchemaPath, true
 }

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/htmlutil"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/queryplan"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -824,52 +825,7 @@ func relationDirection(d dataentryconfig.Direction) store.Direction {
 func pushdownPrefilters(
 	filters []*filter.Filter, meta *metamodel.Metamodel, types []string,
 ) []store.PropPredicate {
-	if len(types) == 0 || meta == nil {
-		return nil // no declared type to check against — push nothing
-	}
-	var pushed []store.PropPredicate
-	for _, f := range filters {
-		// A glob (`status=in-*`) rides on OpEqual but means pattern-match, so
-		// it must NOT become a literal string comparison in the store.
-		if f.IsGlob || f.Operator != filter.OpEqual {
-			continue
-		}
-		if !stringComparableOnEveryType(meta, types, f.Property) {
-			continue
-		}
-		pushed = append(pushed, store.PropPredicate{
-			Property: f.Property, Op: store.PropEqual, Value: f.Value,
-		})
-	}
-	return pushed
-}
-
-// stringComparableOnEveryType reports whether `prop` compares identically as a
-// string on every named type — the precondition for pushing it down.
-//
-// Conservative by construction: an unknown type, an undeclared property, or
-// any non-string declared type all return false, so the filter simply stays in
-// the Go pass. The cost of a false negative is a slower query; the cost of a
-// false positive is a wrong result.
-func stringComparableOnEveryType(meta *metamodel.Metamodel, types []string, prop string) bool {
-	for _, typ := range types {
-		def, ok := meta.GetEntityDef(typ)
-		if !ok {
-			return false
-		}
-		pd, ok := def.Properties[prop]
-		if !ok {
-			return false
-		}
-		// Enums are excluded too: filter.matchEnum ERRORS on a value that is
-		// not declared, which surfaces an operator typo. Pushed down, the same
-		// typo silently matches nothing and the source goes quiet with no
-		// diagnostic.
-		if pd.Type != metamodel.PropertyTypeString {
-			return false
-		}
-	}
-	return true
+	return queryplan.PushdownPrefilters(filters, meta, types)
 }
 
 func (a *App) matchesPropertyFilters(e *entity.Entity, filters []*filter.Filter) bool {

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -1085,6 +1085,9 @@ func TestPushdownPrefilters(t *testing.T) {
 			if pushed[0].Property != tc.in.Property || pushed[0].Value != tc.in.Value {
 				t.Errorf("predicate = %+v, want property/value from %+v", pushed[0], tc.in)
 			}
+			if pushed[0].Scalar != (tc.in.Value != "") {
+				t.Errorf("Scalar = %v, want %v", pushed[0].Scalar, tc.in.Value != "")
+			}
 		})
 	}
 }

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -1,0 +1,118 @@
+// Package queryplan compiles the safe store-side subset of data-entry search
+// queries. Runtime pushdown and static index planning share this package.
+package queryplan
+
+import (
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// LoadStaticIndexSpecs parses and validates a complete data-entry config before
+// deriving specs. An error yields no partial desired set: reconciliation treats
+// absence as permission to drop owned indexes.
+func LoadStaticIndexSpecs(data []byte, meta *metamodel.Metamodel) ([]store.DerivedObjectSpec, error) {
+	var cfg dataentryconfig.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	if err := dataentryconfig.ValidateConfig(data, &cfg, meta); err != nil {
+		return nil, err
+	}
+	return StaticIndexSpecs(&cfg, meta), nil
+}
+
+// PushdownPrefilters returns the store-evaluable pre-filter subset. The caller
+// must still run every filter through the metamodel-aware evaluator.
+func PushdownPrefilters(filters []*filter.Filter, meta *metamodel.Metamodel, types []string) []store.PropPredicate {
+	if len(types) == 0 || meta == nil {
+		return nil
+	}
+	var pushed []store.PropPredicate
+	for _, f := range filters {
+		if f.IsGlob || f.Operator != filter.OpEqual || !stringComparableOnEveryType(meta, types, f.Property) {
+			continue
+		}
+		pushed = append(pushed, store.PropPredicate{
+			Property: f.Property, Op: store.PropEqual, Value: f.Value, Scalar: f.Value != "",
+		})
+	}
+	return pushed
+}
+
+func stringComparableOnEveryType(meta *metamodel.Metamodel, types []string, prop string) bool {
+	for _, typ := range types {
+		def, ok := meta.GetEntityDef(typ)
+		if !ok {
+			return false
+		}
+		pd, ok := def.Properties[prop]
+		if !ok || pd.List || pd.Type != metamodel.PropertyTypeString {
+			return false
+		}
+	}
+	return true
+}
+
+// StaticIndexSpecs derives one composite index per canonical static query
+// shape. Query literal values are deliberately absent from the spec.
+func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []store.DerivedObjectSpec {
+	if cfg == nil || meta == nil {
+		return nil
+	}
+	var queries []string
+	if cfg.Dashboard != nil {
+		for _, card := range cfg.Dashboard.Cards {
+			queries = append(queries, card.Query)
+		}
+	}
+	for _, src := range cfg.NextActions {
+		if src.Query != "" {
+			queries = append(queries, src.Query)
+		}
+		for _, offer := range src.Actions {
+			if offer.PickOne != nil {
+				queries = append(queries, offer.PickOne.Query)
+			}
+		}
+	}
+
+	byKey := make(map[string]store.DerivedObjectSpec)
+	for _, raw := range queries {
+		sq := searchparser.ParseQuery(raw)
+		if len(sq.ParseErrors) != 0 || len(sq.EntityTypes) != 1 || sq.HasFreeText() {
+			continue
+		}
+		pushed := PushdownPrefilters(sq.PropertyFilters, meta, sq.EntityTypes)
+		props := make([]string, 0, len(pushed))
+		for _, p := range pushed {
+			if p.Scalar {
+				props = append(props, p.Property)
+			}
+		}
+		slices.Sort(props)
+		props = slices.Compact(props)
+		if len(props) == 0 {
+			continue
+		}
+		spec := store.DerivedObjectSpec{Kind: store.DerivedQueryIndex, Type: sq.EntityTypes[0], Properties: props}
+		byKey[spec.Type+"\x00"+strings.Join(props, "\x00")] = spec
+	}
+	keys := make([]string, 0, len(byKey))
+	for key := range byKey {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	out := make([]store.DerivedObjectSpec, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, byKey[key])
+	}
+	return out
+}

--- a/internal/queryplan/queryplan_test.go
+++ b/internal/queryplan/queryplan_test.go
@@ -1,0 +1,76 @@
+package queryplan
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+func testMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{Entities: map[string]metamodel.EntityDef{
+		"task": {Properties: map[string]metamodel.PropertyDef{
+			"status": {Type: metamodel.PropertyTypeString},
+			"owner":  {Type: metamodel.PropertyTypeString},
+			"tags":   {Type: metamodel.PropertyTypeString, List: true},
+			"count":  {Type: metamodel.PropertyTypeInteger},
+		}},
+	}}
+}
+
+func TestStaticIndexSpecsCollectsAndCanonicalizesStaticQueries(t *testing.T) {
+	t.Parallel()
+	cfg := &dataentryconfig.Config{
+		Dashboard: &dataentryconfig.DashboardConfig{Cards: []dataentryconfig.DashboardCard{
+			{Query: "type:task prop:status=open prop:owner=alice"},
+			{Query: "type:task prop:owner=bob prop:status=done"},
+		}},
+		NextActions: map[string]dataentryconfig.NextActionSource{
+			"stale": {
+				Query: "type:task prop:status=stale",
+				Actions: []dataentryconfig.NextActionOffer{{PickOne: &dataentryconfig.NextActionPickOne{
+					Query: "type:task prop:owner=alice", Action: "open",
+				}}},
+			},
+		},
+	}
+	want := []store.DerivedObjectSpec{
+		{Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"owner"}},
+		{Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"owner", "status"}},
+		{Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"status"}},
+	}
+	if got := StaticIndexSpecs(cfg, testMeta()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("StaticIndexSpecs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestStaticIndexSpecsSkipsUnsupportedShapes(t *testing.T) {
+	t.Parallel()
+	queries := []string{
+		"prop:status=open",                 // no type
+		"type:task,other prop:status=open", // multiple types
+		"type:task prop:status=",           // empty semantics
+		"type:task prop:status!=open",      // not equal
+		"type:task prop:status=op*",        // glob
+		"type:task prop:tags=x",            // list
+		"type:task prop:count=3",           // typed
+		"type:task prop:missing=x",         // undeclared
+		"type:task prop:status=open words", // free text
+	}
+	cfg := &dataentryconfig.Config{Dashboard: &dataentryconfig.DashboardConfig{}}
+	for _, query := range queries {
+		cfg.Dashboard.Cards = append(cfg.Dashboard.Cards, dataentryconfig.DashboardCard{Query: query})
+	}
+	if got := StaticIndexSpecs(cfg, testMeta()); len(got) != 0 {
+		t.Fatalf("StaticIndexSpecs() = %#v, want none", got)
+	}
+}
+
+func TestLoadStaticIndexSpecsRejectsIncompleteConfig(t *testing.T) {
+	t.Parallel()
+	if got, err := LoadStaticIndexSpecs([]byte("dashboard: ["), testMeta()); err == nil || got != nil {
+		t.Fatalf("LoadStaticIndexSpecs() = %#v, %v; want nil specs and an error", got, err)
+	}
+}

--- a/internal/store/derivedschema.go
+++ b/internal/store/derivedschema.go
@@ -25,23 +25,26 @@ import (
 // DerivedObjectKind identifies which reconciler RULE produced a spec. Each rule
 // owns a disjoint name sub-namespace in the backend catalog so rules never
 // clobber one another's objects (the unique rule only ever drops its own
-// indexes, an enum rule only its own checks, etc.). Today there is one rule.
+// indexes, a static-query rule only its own indexes, etc.).
 type DerivedObjectKind string
 
 const (
 	// DerivedUnique is the `unique: true` rule: a partial unique index over a
 	// single scalar property value, per entity type.
 	DerivedUnique DerivedObjectKind = "unique"
+	// DerivedQueryIndex accelerates one static scalar-equality query shape.
+	DerivedQueryIndex DerivedObjectKind = "query-index"
 )
 
-// DerivedObjectSpec is one desired derived object, derived from the metamodel.
-// It is backend-agnostic: the backend translates it into concrete DDL. For
-// DerivedUnique, (Type, Property) names the entity type and the unique scalar
-// property.
+// DerivedObjectSpec is one desired derived object, derived from validated
+// project configuration. It is backend-agnostic: the backend translates it
+// into concrete DDL. DerivedUnique uses Property; DerivedQueryIndex uses the
+// canonical sorted Properties query shape.
 type DerivedObjectSpec struct {
-	Kind     DerivedObjectKind
-	Type     string
-	Property string
+	Kind       DerivedObjectKind
+	Type       string
+	Property   string
+	Properties []string
 }
 
 // DerivedObjectState is the outcome of reconciling one spec (or one discovered

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -67,6 +67,10 @@ type PropPredicate struct {
 	Property string
 	Op       PropOp
 	Value    string
+	// Scalar restricts a non-empty equality predicate to a scalar string and
+	// lets SQL backends emit an indexable ->> comparison. It is ignored for
+	// empty values and other operators.
+	Scalar bool
 }
 
 // RelationPredicate restricts which relations the surrounding

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -155,6 +155,13 @@ func matches(ctx context.Context, r Reader, e *entity.Entity, q store.GraphQuery
 // exactly with internal/filter and with the pgstore pushdown.
 func matchesProps(e *entity.Entity, props []store.PropPredicate) bool {
 	for _, p := range props {
+		if p.Scalar && p.Op == store.PropEqual && p.Value != "" {
+			value, ok := e.Properties[p.Property].(string)
+			if !ok || value != p.Value {
+				return false
+			}
+			continue
+		}
 		op := propmatch.OpEqual
 		if p.Op == store.PropNotEqual {
 			op = propmatch.OpNotEqual

--- a/internal/store/pgstore/derivedschema.go
+++ b/internal/store/pgstore/derivedschema.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -33,10 +34,9 @@ func safeDDLName(name string) bool {
 
 // Derived-schema reconciliation (TKT-3Q0GP1). pgstore implements the optional
 // [store.DerivedSchemaReconciler] capability: it synthesizes Postgres objects
-// from the metamodel that enforce declarations atomically which the application
-// otherwise checks non-atomically. Today the one rule is `unique: true`, which
-// becomes a partial unique EXPRESSION index over `properties->>'<prop>'` scoped
-// to `type = '<type>'`.
+// from validated project configuration. `unique: true` becomes a partial
+// unique expression index; eligible static query shapes become partial
+// composite expression indexes over their scalar string properties.
 //
 // Reconciliation is STATELESS: the metamodel is the desired set, the live
 // catalog (pg_indexes) is the actual set, and a name prefix marks ownership.
@@ -60,6 +60,9 @@ const reconcileAdvisoryLockKey = 0x52_45_4c_44 // "RELD"
 // It is also the discriminator the write path matches on (see mapUniqueViolation).
 const derivedUniquePrefix = "rela_derived_uniq__"
 
+// derivedQueryPrefix is owned exclusively by the static-query index rule.
+const derivedQueryPrefix = "rela_derived_query__"
+
 // uniqueIndexName is the deterministic index name for a (type, property) unique
 // rule. Deterministic across processes and versions (no per-run entropy) so the
 // drop side of reconcile is safe: an index whose name is not recomputed from the
@@ -70,6 +73,16 @@ const derivedUniquePrefix = "rela_derived_uniq__"
 func uniqueIndexName(entityType, property string) string {
 	sum := sha256.Sum256([]byte(entityType + "\x00" + property))
 	return derivedUniquePrefix + hex.EncodeToString(sum[:16])
+}
+
+func queryIndexName(entityType string, properties []string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(entityType))
+	for _, property := range properties {
+		_, _ = h.Write([]byte{'\x00'})
+		_, _ = h.Write([]byte(property))
+	}
+	return derivedQueryPrefix + hex.EncodeToString(h.Sum(nil)[:16])
 }
 
 // Reconcile implements store.DerivedSchemaReconciler. It converges the derived
@@ -168,8 +181,8 @@ func (s *Store) Reconcile(
 			})
 			continue
 		}
-		if _, err := conn.Exec(ctx, `DROP INDEX IF EXISTS `+quoteIdent(name)); err != nil {
-			return nil, fmt.Errorf("pgstore: reconcile: drop %s: %w", name, err)
+		if _, dropErr := conn.Exec(ctx, `DROP INDEX IF EXISTS `+quoteIdent(name)); dropErr != nil {
+			return nil, fmt.Errorf("pgstore: reconcile: drop %s: %w", name, dropErr)
 		}
 		outcomes = append(outcomes, store.DerivedObjectOutcome{
 			Spec:   store.DerivedObjectSpec{Kind: store.DerivedUnique},
@@ -194,7 +207,111 @@ func (s *Store) Reconcile(
 		outcomes = append(outcomes, createUniqueIndex(ctx, conn, spec, name, opts.ShowValues))
 	}
 
+	queryOutcomes, err := reconcileQueryIndexes(ctx, conn, desired, opts)
+	if err != nil {
+		return nil, err
+	}
+	return append(outcomes, queryOutcomes...), nil
+}
+
+func reconcileQueryIndexes(
+	ctx context.Context, conn *pgxpool.Conn, desired []store.DerivedObjectSpec, opts store.ReconcileOptions,
+) ([]store.DerivedObjectOutcome, error) {
+	desiredByName := make(map[string]store.DerivedObjectSpec)
+	var outcomes []store.DerivedObjectOutcome
+	for _, spec := range desired {
+		if spec.Kind != store.DerivedQueryIndex {
+			continue
+		}
+		spec.Properties = slices.Clone(spec.Properties)
+		slices.Sort(spec.Properties)
+		spec.Properties = slices.Compact(spec.Properties)
+		if !safeDDLName(spec.Type) || len(spec.Properties) == 0 {
+			outcomes = append(outcomes, unenforced(spec, "invalid static query index shape"))
+			continue
+		}
+		valid := true
+		for _, property := range spec.Properties {
+			if !safeDDLName(property) {
+				valid = false
+				break
+			}
+		}
+		if !valid {
+			outcomes = append(outcomes, unenforced(spec, "unsafe property name for DDL"))
+			continue
+		}
+		desiredByName[queryIndexName(spec.Type, spec.Properties)] = spec
+	}
+
+	actual, err := listOwnedIndexes(ctx, conn, derivedQueryPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: reconcile: list query indexes: %w", err)
+	}
+	for name := range actual {
+		if _, ok := desiredByName[name]; ok {
+			continue
+		}
+		out := store.DerivedObjectOutcome{
+			Spec: store.DerivedObjectSpec{Kind: store.DerivedQueryIndex}, State: store.DerivedDropped,
+			Reason: "index " + name + " no longer declared", WouldChange: opts.DryRun,
+		}
+		if !opts.DryRun {
+			if _, dropErr := conn.Exec(ctx, `DROP INDEX IF EXISTS `+quoteIdent(name)); dropErr != nil {
+				return nil, fmt.Errorf("pgstore: reconcile: drop %s: %w", name, dropErr)
+			}
+		}
+		outcomes = append(outcomes, out)
+	}
+	for _, name := range sortedNames(desiredByName) {
+		spec := desiredByName[name]
+		if _, ok := actual[name]; ok {
+			outcomes = append(outcomes, store.DerivedObjectOutcome{Spec: spec, State: store.DerivedEnforced})
+			continue
+		}
+		if opts.DryRun {
+			outcomes = append(outcomes, store.DerivedObjectOutcome{
+				Spec: spec, State: store.DerivedCreated, WouldChange: true,
+			})
+			continue
+		}
+		if _, createErr := conn.Exec(ctx, createQueryIndexDDL(name, spec)); createErr != nil {
+			outcomes = append(outcomes, unenforced(spec, "index could not be created: "+createErr.Error()))
+			continue
+		}
+		outcomes = append(outcomes, store.DerivedObjectOutcome{Spec: spec, State: store.DerivedCreated})
+	}
 	return outcomes, nil
+}
+
+func listOwnedIndexes(ctx context.Context, conn *pgxpool.Conn, prefix string) (map[string]struct{}, error) {
+	rows, err := conn.Query(ctx, `SELECT indexname FROM pg_indexes
+		WHERE schemaname = current_schema() AND indexname LIKE $1`, prefix+`%`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+func createQueryIndexDDL(name string, spec store.DerivedObjectSpec) string {
+	expressions := make([]string, 0, len(spec.Properties))
+	guards := make([]string, 0, len(spec.Properties)+1)
+	guards = append(guards, "type = "+quoteLiteral(spec.Type))
+	for _, property := range spec.Properties {
+		expressions = append(expressions, "(properties->>"+quoteLiteral(property)+")")
+		guards = append(guards, "jsonb_typeof(properties->"+quoteLiteral(property)+") = 'string'")
+	}
+	return "CREATE INDEX IF NOT EXISTS " + quoteIdent(name) + " ON entities (" +
+		strings.Join(expressions, ", ") + ") WHERE " + strings.Join(guards, " AND ")
 }
 
 // listOwnedUniqueIndexes returns the set of this schema's unique-rule indexes.

--- a/internal/store/pgstore/derivedschema_db_test.go
+++ b/internal/store/pgstore/derivedschema_db_test.go
@@ -20,6 +20,46 @@ var personSpec = []store.DerivedObjectSpec{
 	{Kind: store.DerivedUnique, Type: "person", Property: "email"},
 }
 
+var taskQuerySpec = []store.DerivedObjectSpec{
+	{Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"owner", "status"}},
+}
+
+func TestDerivedQueryIndex_ReconcileLifecycleAndIsolation(t *testing.T) {
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	out, err := s.Reconcile(ctx, taskQuerySpec, store.ReconcileOptions{DryRun: true})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedCreated, out[0].State)
+	require.True(t, out[0].WouldChange)
+
+	out, err = s.Reconcile(ctx, taskQuerySpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedCreated, out[0].State)
+
+	out, err = s.Reconcile(ctx, taskQuerySpec, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedEnforced, out[0].State)
+
+	_, err = pool.Exec(ctx, `CREATE INDEX operator_owned_task_idx ON entities (type)`)
+	require.NoError(t, err)
+	out, err = s.Reconcile(ctx, nil, store.ReconcileOptions{})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, store.DerivedDropped, out[0].State)
+
+	var operatorExists bool
+	require.NoError(t, pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM pg_indexes WHERE schemaname=current_schema() AND indexname='operator_owned_task_idx'
+	)`).Scan(&operatorExists))
+	require.True(t, operatorExists, "reconcile must not drop operator-owned indexes")
+}
+
 // newReconciledStore builds a store on a fresh migrated schema, reconciles the
 // person.email unique rule, publishes the specs, and returns the store. It
 // asserts the index was created (no pre-existing dupes).

--- a/internal/store/pgstore/derivedschema_unit_test.go
+++ b/internal/store/pgstore/derivedschema_unit_test.go
@@ -61,6 +61,30 @@ func TestUniqueIndexName_NoSeparatorCollision(t *testing.T) {
 	}
 }
 
+func TestQueryIndexNameAndDDL(t *testing.T) {
+	props := []string{"owner", "status"}
+	name := queryIndexName("task", props)
+	if !strings.HasPrefix(name, derivedQueryPrefix) || len(name) > 63 {
+		t.Fatalf("query index name = %q", name)
+	}
+	if name == queryIndexName("task", []string{"owner"}) {
+		t.Fatal("different query shapes collided")
+	}
+	dll := createQueryIndexDDL(name, store.DerivedObjectSpec{
+		Kind: store.DerivedQueryIndex, Type: "task", Properties: props,
+	})
+	for _, want := range []string{
+		`CREATE INDEX IF NOT EXISTS "rela_derived_query__`,
+		`(properties->>'owner'), (properties->>'status')`,
+		`type = 'task'`,
+		`jsonb_typeof(properties->'owner') = 'string'`,
+	} {
+		if !strings.Contains(dll, want) {
+			t.Errorf("DDL %q missing %q", dll, want)
+		}
+	}
+}
+
 func TestMapUniqueViolation(t *testing.T) {
 	pairs := []store.DerivedObjectSpec{
 		{Kind: store.DerivedUnique, Type: "persoon", Property: "email"},

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -175,6 +175,10 @@ func propCond(b *sqlBuilder, p store.PropPredicate) string {
 	propArg := b.arg(p.Property)
 	txt := fmt.Sprintf("(e.properties ->> %s)", propArg)
 	jsn := fmt.Sprintf("(e.properties -> %s)", propArg)
+	if p.Scalar && p.Op == store.PropEqual && p.Value != "" {
+		valArg := b.arg(p.Value)
+		return fmt.Sprintf("(jsonb_typeof(%s) = 'string' AND %s = %s)", jsn, txt, valArg)
+	}
 
 	// isEmpty covers: missing key, JSON null, empty string, empty array.
 	isEmpty := fmt.Sprintf(

--- a/internal/store/pgstore/graphquery_explain_test.go
+++ b/internal/store/pgstore/graphquery_explain_test.go
@@ -85,6 +85,42 @@ func TestGraphQueryExplainUsesIndex(t *testing.T) {
 	}
 }
 
+func TestGraphQueryExplainUsesDerivedStaticQueryIndex(t *testing.T) {
+	const n = 5000
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	spec := []store.DerivedObjectSpec{{
+		Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"status"},
+	}}
+	_, err = s.Reconcile(ctx, spec, store.ReconcileOptions{})
+	require.NoError(t, err)
+
+	for i := range n {
+		status := "closed"
+		if i == n-1 {
+			status = "open"
+		}
+		e := entity.New(fmt.Sprintf("TASK-%06d", i), "task")
+		e.Properties["status"] = status
+		require.NoError(t, s.CreateEntity(ctx, e))
+	}
+	_, err = pool.Exec(ctx, "ANALYZE entities")
+	require.NoError(t, err)
+
+	plan := explainGraphQuery(t, pool, store.GraphQuery{
+		EntityType: "task",
+		Props: []store.PropPredicate{{
+			Property: "status", Op: store.PropEqual, Value: "open", Scalar: true,
+		}},
+	})
+	t.Logf("plan:\n%s", plan)
+	if !strings.Contains(plan, "rela_derived_query__") {
+		t.Fatalf("derived static-query index is not used:\n%s", plan)
+	}
+}
+
 // explainGraphQuery runs EXPLAIN (no ANALYZE — we only need the plan
 // shape) against the SQL pgstore would build for q, and returns the
 // formatted plan as a single string.

--- a/internal/store/storetest/graphquery.go
+++ b/internal/store/storetest/graphquery.go
@@ -171,6 +171,11 @@ func RunGraphQueryTests(t *testing.T, f Factory) {
 				want: []string{"D-list", "D-str"},
 			},
 			{
+				name: "scalar equality excludes list and non-string shapes",
+				pred: store.PropPredicate{Property: "p", Op: store.PropEqual, Value: "a", Scalar: true},
+				want: []string{"D-str"},
+			},
+			{
 				// Exclusion must not sweep in the empty rows.
 				name: "exclusion excludes matches and empties",
 				pred: store.PropPredicate{Property: "p", Op: store.PropNotEqual, Value: "a"},

--- a/tickets/entities/docs-checklists/DOCS-690VPK.md
+++ b/tickets/entities/docs-checklists/DOCS-690VPK.md
@@ -1,0 +1,16 @@
+---
+id: DOCS-690VPK
+type: docs-checklist
+title: 'Docs: static PostgreSQL query indexes'
+status: done
+---
+
+## Code Documentation
+
+- [x] Derived query-index specs and scalar predicate contract documented in Go comments
+- [x] Reconciler ownership, naming, and all-or-nothing safety invariant documented
+
+## Project Documentation
+
+- [x] PostgreSQL backend guide documents eligible static queries, generated composite indexes, lifecycle, and exclusions
+- [x] Root CLAUDE.md records reconciliation and runtime-DDL invariants

--- a/tickets/entities/implementation-checklists/IMPL-GHHUGZ.md
+++ b/tickets/entities/implementation-checklists/IMPL-GHHUGZ.md
@@ -1,0 +1,60 @@
+---
+id: IMPL-GHHUGZ
+type: implementation-checklist
+title: 'Implementation: Derive PostgreSQL indexes from static pushed-down query predicates'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] ~~Interpolated values constructed from objects, not hardcoded~~ (N/A: no interpolation feature or generated expected strings)
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+- `queryplan.StaticIndexSpecs` was exercised with dashboard, next-action and
+`pick_one` queries. Equivalent reordered/literal-varied queries deduplicated;
+unsupported and runtime-only shapes produced no specs.
+- Live PostgreSQL 15 lifecycle test passed: dry-run create, create, idempotent
+enforced result, orphan drop, and survival of an operator-owned index.
+- Live PostgreSQL EXPLAIN over 5,000 task rows reported
+`Index Scan using rela_derived_query__361f58cb59417f5a10164251fa9681a6` with an
+index condition on `properties->>'status'`.
+- Scalar predicate conformance covers scalar, list, absent, blank, integer and
+boolean storage shapes across mem/fs/PostgreSQL implementations.
+- Invalid `data-entry.yaml` test proves appbuild performs zero reconciliation
+rather than passing a partial desired set; unique violation specs remain
+published independently.
+- `RELA_TEST_DATABASE_URL='postgres:///postgres?host=/tmp'
+RELA_TEST_DATABASE_REQUIRED=1 just test-postgres`: PASS under race detector.
+- `just arch-lint`: PASS. `just lint`: PASS with zero issues.
+- Full `just ci`: final pass recorded after the implementation stabilized.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-D99KGA.md
+++ b/tickets/entities/planning-checklists/PLAN-D99KGA.md
@@ -1,0 +1,253 @@
+---
+id: PLAN-D99KGA
+type: planning-checklist
+title: 'Planning: Derive PostgreSQL indexes from static pushed-down query predicates'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+In scope: statically declared query strings in `data-entry.yaml` that execute
+through `dataentry.executeQuery`: dashboard cards, global next-action sources,
+and `pick_one` option queries. Extract their already push-eligible, non-empty
+scalar string equality predicates, group them by entity type and complete query
+shape, and reconcile matching PostgreSQL expression indexes at boot and through
+`rela db status|reconcile`. Keep fsstore/memstore behavior unchanged.
+
+Also in scope is making the pushed store predicate explicitly scalar. The
+current generic equality SQL contains a scalar/list `CASE`; a normal expression
+index cannot reliably serve that shape. The scalar contract is safe here because
+the pushdown eligibility check already requires a non-list string declaration on
+every queried type, while the authoritative Go filter remains in place.
+
+Out of scope: runtime/ad-hoc query observation, indexes for request URL filters,
+automatic computed/hidden properties, relation predicates, full text, sorting,
+ordered/not-equal/glob/empty predicates, cost-based decisions, hot-reload DDL,
+and indexes for predicate `condition:` expressions.
+
+**Acceptance Criteria:**
+
+1. A static single-type query with one non-empty, declared scalar string
+equality produces one deterministic `DerivedQueryIndex` specification; a unit
+test covers dashboard, next-action, and `pick_one` sources.
+2. Equivalent query shapes deduplicate regardless of source, map order, filter
+order, or literal value; distinct property sets/types remain distinct.
+3. Only filters the existing pushdown can safely execute are indexed. Tests
+reject missing/multiple types, undeclared/list/typed properties, glob,
+not-equal, empty-value and free-text queries.
+4. pgstore reconciliation creates, preserves, dry-run reports, and drops only
+its `rela_derived_query__*` indexes, without touching unique-rule or
+operator-owned indexes.
+5. The scalar GraphQuery predicate remains backend-parity correct for scalar,
+absent, empty, JSON-null and invalid list-shaped stored values.
+6. A live PostgreSQL EXPLAIN test with realistic cardinality names the generated
+index for a representative `type + property equality` GraphQuery.
+7. Store-open and `rela db status|reconcile` derive the same desired set from
+`schema.yaml` plus valid `data-entry.yaml`; missing config yields only unique
+specs, while invalid config is reported rather than silently dropping owned
+indexes.
+8. `just arch-lint`, targeted tests, `just test-postgres`, and `just ci` pass.
+
+## Research
+
+- [x] ~~For larger features: run `/research` to create a structured research doc~~ (N/A: direct extension of two existing in-tree mechanisms)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A; this is a bounded composition of TKT-F4TIS6's GraphQuery
+property pushdown and TKT-3Q0GP1's derived-schema reconciler.
+
+**Existing Solutions:**
+
+- `internal/dataentry/helpers.go` owns the conservative pushdown eligibility
+rules and keeps `filter.MatchAll` authoritative.
+- `internal/store/pgstore/graphquery.go` currently emits a `CASE` supporting
+both scalar and list shapes. That general expression is not the same shape as a
+scalar `properties->>'key'` B-tree expression index.
+- `internal/store/derivedschema.go` and
+`internal/store/pgstore/derivedschema.go` already provide stateless,
+advisory-locked, prefix-owned desired-vs-actual reconciliation. Extend this
+mechanism instead of introducing migrations or an index registry table.
+- PostgreSQL expression and partial indexes are the native solution; no new Go
+library is needed. PostgreSQL's leftmost B-tree matching and predicate
+implication will be verified by EXPLAIN rather than assumed.
+- TKT-F4TIS6 and FEAT-79DTF9 establish backend parity and the static
+next-action query use case. TKT-3Q0GP1 establishes ownership, dry-run and
+boot-only reconciliation conventions.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. Extract the safe filter-to-store-predicate compilation from `dataentry` into
+a small shared query-planning package. It returns GraphQuery predicates plus
+static index shapes from the same decision, preventing eligibility drift.
+2. Add an explicit scalar-string equality representation to
+`store.PropPredicate`. pgstore lowers it to a direct `->>` comparison with a
+scalar-shape guard; graphquerynaive mirrors that contract. The existing generic
+equality operator stays unchanged for other callers.
+3. Collect validated static queries from dashboard cards, global next-action
+sources, and `pick_one`. Canonicalize each desired index as entity type plus
+sorted unique property names; literal values are deliberately excluded so
+queries differing only in values share an index. Create one composite index per
+complete shape, not one index per individual clause.
+4. Add `DerivedQueryIndex` and a property-list field to
+`store.DerivedObjectSpec`. Generate a deterministic SHA-256-derived name in a
+disjoint `rela_derived_query__` namespace.
+5. Extend pgstore's existing reconciler with a per-kind plan: catalog only the
+query prefix, drop only orphaned query indexes, and create partial expression
+indexes scoped by literal validated entity type. DDL identifiers/literals go
+through the existing defensive quoting/validation.
+6. Centralize loading of all derived specs (unique plus static query specs) so
+appbuild boot and `rela db status|reconcile` cannot disagree. Missing
+`data-entry.yaml` is valid. A present invalid file must surface an error and
+must not run reconciliation with an incomplete desired set, which would
+otherwise drop valid indexes.
+7. Keep reconciliation boot/manual-only. Document restart or `rela db
+reconcile` after static query configuration changes.
+
+Alternatives rejected: a GIN index over all `properties` is broad, larger and
+does not directly serve the current `CASE`; one index per property loses the
+compound query shape and multiplies indexes; runtime `auto_explain`/statistics
+is explicitly out of scope; silently reconciling only parsable queries can
+destructively misclassify desired indexes as orphans.
+
+**Files to modify:**
+
+- `internal/store/graphquery.go`, `internal/store/graphquerynaive/naive.go`
+- `internal/store/derivedschema.go`
+- `internal/store/pgstore/graphquery.go`, `derivedschema.go` and tests
+- `internal/dataentry/helpers.go` and pushdown tests
+- new shared static-query planning/derived-spec collector package and tests
+- `internal/appbuild/derivedschema_postgres.go` and assertions
+- `internal/cli/db_postgres.go` and tests
+- `docs/postgres-backend.md`; root `CLAUDE.md` only if a durable invariant is
+introduced
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+Inputs are operator-authored `schema.yaml` and `data-entry.yaml`. The normal
+metamodel/config validators run first. Only allowlisted query shapes already
+accepted for scalar pushdown produce specs. Entity/property names receive the
+existing DDL safety validation as defense in depth. Query literal values never
+enter index definitions.
+
+**Security-Sensitive Operations:**
+
+DDL remains PostgreSQL-build-only, serialized by the existing schema-scoped
+advisory lock, uses deterministic Rela-owned name prefixes, and never drops
+outside the query-index sub-prefix. A parse/validation failure aborts
+desired-set calculation before DDL, preventing accidental drop-on-partial-input.
+Index contents are entity data, but status/log output reports only
+config-declared type/property names, never values.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+AC1-3: table-driven collector/compiler unit tests using parsed real config and
+metamodel fixtures. AC4: pgstore reconciler unit SQL-shape tests plus DB-gated
+create/idempotence/dry-run/drop/prefix-isolation tests. AC5: extend storetest
+GraphQuery conformance and run mem/fs/pg implementations. AC6: DB-gated seeded
+EXPLAIN test after ANALYZE, asserting the deterministic index name. AC7:
+appbuild/CLI tests feed missing, valid and invalid configs and compare specs and
+failure behavior. AC8: project commands.
+
+**Edge Cases:**
+
+No static queries means no query indexes. Duplicate sources and reordered
+filters deduplicate. Empty equality stays unindexed because its semantics span
+missing/null/blank/empty-list. Invalid list-shaped storage under a declared
+scalar field is excluded by the scalar prefilter and therefore cannot widen the
+authoritative result. Unsafe/control-character schema names are reported
+unenforced. Concurrent reconcilers retain the existing non-blocking advisory
+lock behavior. A maximum of one index per unique static query shape prevents
+literal-value cardinality from multiplying indexes.
+
+**Negative Tests:**
+
+Malformed/invalid config returns a load error and performs no query-index DDL.
+Unsupported/free-text/dynamic query shapes produce no spec, not an error.
+Infrastructure/catalog failures return the existing reconcile error. An unsafe
+spec is `DerivedUnenforced`, never interpolated. A hand-created/operator index
+and derived unique index survive query-index removal.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **Unused indexes:** exact SQL/index compatibility is proven with EXPLAIN;
+unsupported shapes are skipped.
+- **Semantic narrowing/widening:** one compiler produces both the pushed
+predicate and index shape; Go remains authoritative; conformance covers
+malformed stored shapes.
+- **Destructive reconciliation from bad config:** fail before reconciliation,
+use a disjoint owned prefix, and test prefix isolation.
+- **Index explosion/write amplification:** deduplicate by complete canonical
+shape and ignore literal values; runtime queries are excluded.
+- **Boot latency/locking:** retain boot-only, non-blocking advisory-lock
+reconciliation. Effort remains `m`.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/postgres-backend.md` — which static queries receive indexes,
+reconciliation lifecycle, and limitations.
+- [x] `docs/cli-reference.md` only if `db status/reconcile` output wording
+changes materially.
+- [x] Root `CLAUDE.md` only if needed to pin the derived query-index ownership
+and no-partial-desired-set invariant.
+- [x] ~~`docs/data-entry.md`~~ (N/A: query syntax and UI do not change).
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** [[RR-CJ9PG6]], [[RR-YEKG49]], [[RR-PXW1PF]]
+
+- Significant: generic scalar/list `CASE` SQL would make the proposed B-tree
+index unusable. Addressed by explicit scalar predicate semantics and an EXPLAIN
+acceptance gate.
+- Significant: parsing invalid config as an empty/partial desired set could
+drop still-desired indexes. Addressed by all-or-nothing desired-set loading.
+- Minor: one index per query clause would multiply write cost and ignore
+compound selectivity. Addressed by one canonical composite index per complete
+static query shape.

--- a/tickets/entities/review-checklists/REV-RXQLWQ.md
+++ b/tickets/entities/review-checklists/REV-RXQLWQ.md
@@ -1,0 +1,93 @@
+---
+id: REV-RXQLWQ
+type: review-checklist
+title: 'Review: Derive PostgreSQL indexes from static pushed-down query predicates'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (performed equivalent full-diff review in this task)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** [[RR-CJ9PG6]], [[RR-YEKG49]], [[RR-PXW1PF]]. All are
+addressed in the implementation; the final full-diff review found no additional
+critical or significant findings.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+1. PASS — dashboard, next-action and `pick_one` collection unit tests.
+2. PASS — canonical type/property-shape deduplication tests.
+3. PASS — unsupported predicate, type, property and free-text negative tests.
+4. PASS — live PostgreSQL create/idempotence/dry-run/drop/isolation lifecycle test.
+5. PASS — scalar-shape store conformance across naive and PostgreSQL backends.
+6. PASS — live PostgreSQL EXPLAIN names the generated B-tree index.
+7. PASS — appbuild and CLI share validated static-index derivation; invalid
+app config proves zero reconciliation.
+8. PASS — `just ci` with required local PostgreSQL exited 0; total coverage 78.0%.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** [[DOCS-690VPK]]
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-CJ9PG6.md
+++ b/tickets/entities/review-responses/RR-CJ9PG6.md
@@ -1,0 +1,9 @@
+---
+id: RR-CJ9PG6
+type: review-response
+title: Generic predicate SQL cannot use the proposed expression index
+finding: The current scalar/list CASE in pgstore equality does not match a scalar properties expression index. Reconciliation could create indexes that the pushed query never uses.
+severity: significant
+resolution: Plan now introduces an explicit scalar string equality predicate shared by pushdown and index planning with a live EXPLAIN acceptance test.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PXW1PF.md
+++ b/tickets/entities/review-responses/RR-PXW1PF.md
@@ -1,0 +1,9 @@
+---
+id: RR-PXW1PF
+type: review-response
+title: Per-clause indexes multiply write cost
+finding: Creating one index for every query clause ignores compound query shape and can multiply indexes across static sources.
+severity: minor
+resolution: Plan canonicalizes one composite index per full entity-type and property-set query shape and deduplicates literal values.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YEKG49.md
+++ b/tickets/entities/review-responses/RR-YEKG49.md
@@ -1,0 +1,9 @@
+---
+id: RR-YEKG49
+type: review-response
+title: Invalid config could trigger destructive orphan drops
+finding: Treating an unreadable or partly invalid data-entry config as an empty desired query-index set would classify still-desired owned indexes as orphans and drop them.
+severity: significant
+resolution: Plan requires all-or-nothing desired-set loading. Present invalid config aborts reconciliation before DDL.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-03HCWT.md
+++ b/tickets/entities/tickets/TKT-03HCWT.md
@@ -1,0 +1,22 @@
+---
+id: TKT-03HCWT
+type: ticket
+title: Derive PostgreSQL indexes from static pushed-down query predicates
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+## Description
+
+Extend the existing static property-filter pushdown so PostgreSQL derived-schema
+reconciliation creates indexes matching the pushed GraphQuery predicate shapes.
+Scope is limited to statically configured queries already compiled by the
+data-entry/next-action path. Runtime/ad-hoc query observation, automatic
+computed-property synthesis, and general cost-based indexing are out of scope.
+
+The implementation must derive deterministic index specifications from validated
+configuration, reconcile only Rela-owned indexes, preserve fs/mem behavior, and
+prove with EXPLAIN-backed PostgreSQL tests that representative
+type-plus-property queries use the generated index.

--- a/tickets/relations/TKT-03HCWT--affects--store-backends.md
+++ b/tickets/relations/TKT-03HCWT--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-03HCWT--has-docs--DOCS-690VPK.md
+++ b/tickets/relations/TKT-03HCWT--has-docs--DOCS-690VPK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: has-docs
+to: DOCS-690VPK
+---

--- a/tickets/relations/TKT-03HCWT--has-implementation--IMPL-GHHUGZ.md
+++ b/tickets/relations/TKT-03HCWT--has-implementation--IMPL-GHHUGZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: has-implementation
+to: IMPL-GHHUGZ
+---

--- a/tickets/relations/TKT-03HCWT--has-planning--PLAN-D99KGA.md
+++ b/tickets/relations/TKT-03HCWT--has-planning--PLAN-D99KGA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: has-planning
+to: PLAN-D99KGA
+---

--- a/tickets/relations/TKT-03HCWT--has-review--REV-RXQLWQ.md
+++ b/tickets/relations/TKT-03HCWT--has-review--REV-RXQLWQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: has-review
+to: REV-RXQLWQ
+---

--- a/tickets/relations/TKT-03HCWT--has-review-response--RR-CJ9PG6.md
+++ b/tickets/relations/TKT-03HCWT--has-review-response--RR-CJ9PG6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: has-review-response
+to: RR-CJ9PG6
+---

--- a/tickets/relations/TKT-03HCWT--has-review-response--RR-PXW1PF.md
+++ b/tickets/relations/TKT-03HCWT--has-review-response--RR-PXW1PF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: has-review-response
+to: RR-PXW1PF
+---

--- a/tickets/relations/TKT-03HCWT--has-review-response--RR-YEKG49.md
+++ b/tickets/relations/TKT-03HCWT--has-review-response--RR-YEKG49.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: has-review-response
+to: RR-YEKG49
+---

--- a/tickets/relations/TKT-03HCWT--implements--FEAT-79DTF9.md
+++ b/tickets/relations/TKT-03HCWT--implements--FEAT-79DTF9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-03HCWT
+relation: implements
+to: FEAT-79DTF9
+---


### PR DESCRIPTION
Static data-entry queries already expose safe scalar equality predicates. Reuse that planning decision to reconcile deterministic composite indexes, while keeping invalid configuration all-or-nothing so existing owned indexes are never dropped from a partial desired set.
