### PR TITLE
chore(tickets): mark TKT-0IGI4V unblocked after TKT-ZIRMGM merge

### DIFF
--- a/tickets/entities/tickets/TKT-0IGI4V.md
+++ b/tickets/entities/tickets/TKT-0IGI4V.md
@@ -35,5 +35,9 @@ tool differ).
 
 ## Depends on
 
-TKT-ZIRMGM's migration (`last_edited_by_*` columns) and `store.Attribution` ctx
-carrier being merged.
+**UNBLOCKED as of 2026-07-25.** TKT-ZIRMGM merged to develop (PR #1195, squash
+`6dea82af`), so both prerequisites are in place: migration 0006's
+`last_edited_by_*` columns and the `store.Attribution` ctx carrier
+(`internal/store/attribution.go`, populated at the entitymanager boundary by
+`withStoreAttribution`). This ticket is ready to move to `ready`/`planning`
+whenever prioritized.


### PR DESCRIPTION
TKT-ZIRMGM is `status: done` on develop (PR #1195, squash `6dea82af`), so both prerequisites for TKT-0IGI4V are in place:

- migration 0006's `last_edited_by_*` columns
- the `store.Attribution` ctx carrier (`internal/store/attribution.go`, populated at the entitymanager boundary by `withStoreAttribution`)

This replaces the stale "Depends on" note with an explicit unblocked marker. TKT-0IGI4V stays `status: backlog` — this is a bookkeeping correction, not a prioritization change.

Ticket-graph only; no code changes. `rela validate --check cardinality --check properties --check validations` passes.

Salvaged from a stale `develop`-tracking branch. The rest of that branch (the TKT-2VDVHF autosave-conflict plan and its 10 design-review findings) is deliberately **not** included — it fails the repo's own CI gates (`ci-no-planning-tickets`, `ci-no-open-review-responses`) because the plan is still mid-flight with 4 unaddressed critical findings.

https://claude.ai/code/session_01LeqEBvAixB2pbPp19RjfkR