### PR TITLE
feat(tenant): org_id -> DSN resolution with fail-closed routing (TKT-TNT9RS)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -51,6 +51,7 @@ components:
   appbuild:         { in: internal/appbuild }
   appbuildtest:     { in: internal/appbuild/appbuildtest }
   backendtest:      { in: internal/appbuild/backendtest }
+  tenant:           { in: internal/tenant }
 
   # Domain services
   analysis:         { in: internal/analysis }
@@ -555,6 +556,22 @@ deps:
       - appbuild
     canUse:
       - pgx
+  # tenant resolves a verified org to the store it may reach (RES-D54281). It
+  # sits ABOVE appbuild — it assembles per-tenant Services over one shared
+  # configuration — so appbuild must never depend on it: a tenant map is a
+  # deployment concern, and appbuild is the wiring facade the single-store
+  # binaries and the desktop app also use.
+  #
+  # pgx is confined to the postgres-tagged dsn file, which the default build
+  # does not compile — the same arrangement pgstore and backendtest use, and
+  # the reason CI's "default build must not link pgx" assertion keeps holding
+  # once a host wires this package.
+  tenant:
+    mayDependOn:
+      - appbuild
+    canUse:
+      - pgx
+      - yaml
   appbuildtest:
     mayDependOn:
       - acl

--- a/internal/tenant/config.go
+++ b/internal/tenant/config.go
@@ -1,0 +1,125 @@
+package tenant
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFileName is the operator-authored tenant map, read from the project
+// root alongside `acl.yaml` and `metamodel.yaml`.
+const ConfigFileName = "tenants.yaml"
+
+// Config is the parsed `tenants.yaml`.
+//
+// # Why the map is a file
+//
+// RES-D54281 decided the tenant map is rela-owned — not a JWT claim, not the
+// identity provider's — and left the storage open. It is a file because the map
+// cannot live inside the thing it shards: a table in a tenant schema is
+// circular, and a table in a control schema means the process needs a DSN in
+// order to find DSNs, so there is always a bootstrap-config layer underneath.
+// A file *is* that layer. Backing the map with a database does not remove the
+// file; it adds a database and keeps the file.
+//
+// It also matches the deployment this design is built around, where the
+// operator already authors exactly one config — one metamodel, one `acl.yaml`,
+// one `data-entry.yaml` — and every tenant arrives through an operator action
+// because self-serve provisioning (TKT-TNPRV8) does not exist yet. A
+// control-schema table today would be infrastructure built for a writer that
+// has not been designed, which is the wrong order.
+//
+// What makes this reversible is [Resolver], not this type: when provisioning
+// needs to add a tenant without a deploy, a DB-backed resolver replaces this
+// one behind the same single-method seam.
+type Config struct {
+	// BaseDSN connects to the cluster holding the shared-tier tenants. Each
+	// tenant's own DSN is derived from it by pinning `search_path`.
+	//
+	// Left empty when every tenant carries an explicit DSN, which is the
+	// fully-sharded arrangement.
+	BaseDSN string `yaml:"base_dsn"`
+
+	// Tenants is the map itself.
+	Tenants []ConfigTenant `yaml:"tenants"`
+}
+
+// ConfigTenant is one entry in the tenant map.
+type ConfigTenant struct {
+	// OrgID is the verified `org_id` claim.
+	OrgID string `yaml:"org_id"`
+
+	// Schema is the PostgreSQL schema holding this org's data.
+	Schema string `yaml:"schema"`
+
+	// DSN overrides the derivation from BaseDSN, placing this tenant on another
+	// database or another cluster.
+	//
+	// This field is the sharding story in its entirety. RES-D54281 chose
+	// schema-per-tenant partly because `(tenant) -> DSN` composes with it:
+	// shard to a cluster, then pick a schema within it. Promoting a tenant that
+	// outgrew the shared tier — or one whose contract requires isolation — is
+	// then this one line, with no code path that only the promoted tenant
+	// takes.
+	DSN string `yaml:"dsn"`
+}
+
+// LoadConfig reads and parses a tenant map from path.
+//
+// A parse failure is an error rather than an empty map, for the reason
+// `acl.yaml` loading gives: silently degrading to "no tenants" on a typo would
+// boot a multi-tenant deployment that serves nobody, and the operator would
+// learn about it from users rather than from the process that read the file.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("tenant: read %s: %w", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("tenant: parse %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// Resolver turns the parsed config into a live lookup, deriving each tenant's
+// DSN and validating the whole table.
+//
+// An empty tenant list is refused. A multi-tenant host with no tenants can
+// serve no request, so booting it would only defer the same failure to every
+// request — and would do so as a per-request denial, which reads like a
+// permissions problem rather than a deployment one.
+func (c *Config) Resolver() (*MapResolver, error) {
+	if len(c.Tenants) == 0 {
+		return nil, errors.New("tenant: no tenants configured")
+	}
+	tenants := make([]Tenant, 0, len(c.Tenants))
+	for i, ct := range c.Tenants {
+		dsn := ct.DSN
+		if dsn == "" {
+			if c.BaseDSN == "" {
+				return nil, fmt.Errorf(
+					"tenant %d (org_id %q): no dsn and no base_dsn to derive one from",
+					i, ct.OrgID)
+			}
+			// Validate the schema before it reaches DSN construction: the
+			// derivation interpolates it into a connection string, so an
+			// unchecked name would be building a credential out of unvalidated
+			// input. NewMapResolver checks it again — this is the earlier of
+			// the two, not a substitute for it.
+			if !schemaNamePattern.MatchString(ct.Schema) {
+				return nil, fmt.Errorf(
+					"tenant %d (org_id %q): schema %q must match %s",
+					i, ct.OrgID, ct.Schema, schemaNamePattern)
+			}
+			var err error
+			if dsn, err = dsnForSchema(c.BaseDSN, ct.Schema); err != nil {
+				return nil, fmt.Errorf("tenant %d (org_id %q): %w", i, ct.OrgID, err)
+			}
+		}
+		tenants = append(tenants, Tenant{OrgID: ct.OrgID, Schema: ct.Schema, DSN: dsn})
+	}
+	return NewMapResolver(tenants)
+}

--- a/internal/tenant/dsn_nopostgres.go
+++ b/internal/tenant/dsn_nopostgres.go
@@ -1,0 +1,28 @@
+//go:build !postgres
+
+package tenant
+
+import "errors"
+
+// dsnForSchema refuses to derive a per-tenant DSN on a build with no PostgreSQL.
+//
+// Split from the postgres implementation for the reason `pgstore` is:
+// deriving a DSN needs `pgx.ParseConfig` to handle both DSN dialects safely,
+// and importing pgx here unconditionally would link it into the default and
+// memory builds. CI asserts it is absent from those binaries, and the isolation
+// is worth keeping even while nothing wires this package yet — the alternative
+// is a violation that only appears once a host does.
+//
+// It errors rather than returning the base DSN unchanged, which is the
+// fail-closed choice: an unpinned DSN would put every tenant on the same
+// `search_path` and hand them each other's data. Refusing to boot is the only
+// safe way to be wrong here.
+//
+// A deployment on these builds is single-store by construction (fsstore or
+// memstore), so a tenant map is meaningless rather than merely unsupported. A
+// tenant carrying an explicit DSN never reaches this function.
+func dsnForSchema(_, _ string) (string, error) {
+	return "", errors.New(
+		"tenant: deriving a per-tenant DSN requires the postgres build; " +
+			"schema-per-tenant has no meaning for the filesystem or memory stores")
+}

--- a/internal/tenant/dsn_postgres.go
+++ b/internal/tenant/dsn_postgres.go
@@ -1,0 +1,59 @@
+//go:build postgres
+
+package tenant
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// dsnForSchema returns base with `search_path` pinned to schema, which is what
+// scopes a tenant to its own data.
+//
+// This is the entire isolation mechanism, so it is worth being precise about
+// why it is enough. rela's PostgreSQL SQL is unqualified — `FROM entities`, not
+// `FROM tenant_a.entities` — so every table reference resolves through the
+// connection's `search_path`. Pinning it in the DSN means a store opened for
+// tenant A cannot name tenant B's tables even in principle: the attempt is a
+// "relation does not exist" error from PostgreSQL, not a row-filtering decision
+// rela could get wrong. It is also why `pgstore` needs no changes for
+// multi-tenancy — it never learns it is multi-tenant.
+//
+// Built by re-serializing the parsed config rather than appending
+// "?search_path=" to the caller's string: pgx accepts both URL and key/value
+// ("host=x dbname=y") DSNs, and query-string surgery silently produces garbage
+// for the latter — a DSN that still parses, still connects, and lands the
+// tenant on the wrong `search_path`. That failure is a cross-tenant leak that
+// looks like a working deployment, which is why this mirrors
+// `backendtest.dsnWithSearchPath` rather than reinventing it.
+//
+// `public` stays on the path because the search backend's `pg_trgm` operators
+// live there. It holds no rela tables, so it is not a tenant-visible surface.
+//
+// Only the postgres build has a DSN to derive; see the stub in
+// dsn_nopostgres.go.
+func dsnForSchema(base, schema string) (string, error) {
+	cfg, err := pgx.ParseConfig(base)
+	if err != nil {
+		// pgx redacts the password in parse errors, so this is safe to wrap.
+		return "", fmt.Errorf("parse base_dsn: %w", err)
+	}
+	kv := []string{
+		"host=" + cfg.Host,
+		fmt.Sprintf("port=%d", cfg.Port),
+		"user=" + cfg.User,
+		"dbname=" + cfg.Database,
+		"search_path=" + schema + ",public",
+	}
+	if cfg.Password != "" {
+		kv = append(kv, "password="+cfg.Password)
+	}
+	// TLSConfig is nil exactly when the DSN disabled it; preserve that rather
+	// than defaulting to on, which would make a plaintext cluster unreachable.
+	if cfg.TLSConfig == nil {
+		kv = append(kv, "sslmode=disable")
+	}
+	return strings.Join(kv, " "), nil
+}

--- a/internal/tenant/isolation_postgres_test.go
+++ b/internal/tenant/isolation_postgres_test.go
@@ -1,0 +1,307 @@
+//go:build postgres
+
+// Package tenant_test's isolation suite proves the property the whole design
+// rests on, against a real PostgreSQL rather than in prose: a principal
+// resolved to one tenant cannot read another tenant's rows.
+//
+// It is the centrepiece of TKT-TNT9RS. Every other test in this package checks
+// bookkeeping — that a lookup fails closed, that eviction closes the right
+// store. Those matter, but they would all pass on a design that leaked, because
+// the leak would be in the SQL and not in the Go. Only this test looks at the
+// database.
+package tenant_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/backendtest"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/script"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/tenant"
+)
+
+const isolationMetamodel = `version: "1.0"
+entities:
+  ticket:
+    label: Ticket
+    plural: tickets
+    id_prefix: "TKT-"
+    id_type: sequential
+    properties:
+      title:
+        type: string
+        required: true
+relations: {}
+`
+
+// TestTenantIsolation_OneTenantCannotReadAnother is acceptance criterion 7 of
+// TKT-TNT9RS.
+//
+// Two tenants, two schemas, one database, one process, one shared
+// configuration. An entity written through tenant A's store must be invisible
+// through tenant B's, and vice versa — and the reason it is invisible is worth
+// stating: rela's SQL is unqualified (`FROM entities`), so it resolves through
+// the connection's `search_path`. Tenant B's connection names only tenant B's
+// schema, so tenant A's rows are not filtered out, they are unaddressable.
+//
+// A leak here would not be a missing WHERE clause. It would mean the DSN
+// derivation failed to pin `search_path` and both tenants landed on the same
+// schema — which is exactly the failure mode that looks like a working
+// deployment, and exactly why this assertion is executed rather than asserted.
+func TestTenantIsolation_OneTenantCannotReadAnother(t *testing.T) {
+	root := writeIsolationProject(t)
+
+	// Two private, migrated schemas on one database. backendtest hands back a
+	// DSN per call with search_path pinned, which is the same construction the
+	// tenant config derives — so this exercises the real mechanism rather than
+	// a test-only shortcut.
+	dsnA, dsnB := backendtest.DSN(t), backendtest.DSN(t)
+	if dsnA == "" || dsnB == "" {
+		t.Fatal("backendtest returned no DSN")
+	}
+	if dsnA == dsnB {
+		t.Fatal("both tenants received the same DSN; the test cannot prove isolation")
+	}
+
+	resolver, err := tenant.NewMapResolver([]tenant.Tenant{
+		{OrgID: "org-a", Schema: "tenant_a", DSN: dsnA},
+		{OrgID: "org-b", Schema: "tenant_b", DSN: dsnB},
+	})
+	if err != nil {
+		t.Fatalf("NewMapResolver: %v", err)
+	}
+
+	reg, err := tenant.NewRegistry(resolver, tenant.AppBuildOpener(isolationConfig(t, root)), 4)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	ctx := t.Context()
+	leaseA, err := reg.Acquire(ctx, "org-a")
+	if err != nil {
+		t.Fatalf("Acquire(org-a): %v", err)
+	}
+	defer leaseA.Release()
+	leaseB, err := reg.Acquire(ctx, "org-b")
+	if err != nil {
+		t.Fatalf("Acquire(org-b): %v", err)
+	}
+	defer leaseB.Release()
+
+	if leaseA.Services() == leaseB.Services() {
+		t.Fatal("both tenants were handed the same Services")
+	}
+
+	// Write one entity into each tenant, through that tenant's store only.
+	secretOfA := &entity.Entity{
+		ID:         "TKT-A1",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "tenant A confidential"},
+	}
+	secretOfB := &entity.Entity{
+		ID:         "TKT-B1",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "tenant B confidential"},
+	}
+	if err := leaseA.Services().Store().CreateEntity(ctx, secretOfA); err != nil {
+		t.Fatalf("create in tenant A: %v", err)
+	}
+	if err := leaseB.Services().Store().CreateEntity(ctx, secretOfB); err != nil {
+		t.Fatalf("create in tenant B: %v", err)
+	}
+
+	// The property: each tenant sees its own row and only its own row.
+	assertVisible(t, ctx, leaseA.Services(), "TKT-A1", "tenant A confidential")
+	assertVisible(t, ctx, leaseB.Services(), "TKT-B1", "tenant B confidential")
+	assertInvisible(t, ctx, leaseA.Services(), "TKT-B1", "A")
+	assertInvisible(t, ctx, leaseB.Services(), "TKT-A1", "B")
+
+	// A listing must not leak either. A direct GetEntity could conceivably be
+	// gated while a list query still returned foreign rows, so check the bulk
+	// read path too — it is the one that would carry a whole tenant's data.
+	assertOnlyOwnEntities(t, ctx, leaseA.Services(), "TKT-A1")
+	assertOnlyOwnEntities(t, ctx, leaseB.Services(), "TKT-B1")
+}
+
+// TestTenantIsolation_UnknownOrgReachesNoDatabase pins the fail-closed rule on
+// the path that matters: with a live database configured and reachable, an
+// unknown org must still get nothing.
+//
+// The database-backed version of the same assertion the unit tests make. It is
+// worth having separately because the unit tests use a fake opener, so they
+// cannot distinguish "denied" from "opened nothing because there was nothing to
+// open".
+func TestTenantIsolation_UnknownOrgReachesNoDatabase(t *testing.T) {
+	root := writeIsolationProject(t)
+	dsn := backendtest.DSN(t)
+
+	resolver, err := tenant.NewMapResolver([]tenant.Tenant{
+		{OrgID: "org-a", Schema: "tenant_a", DSN: dsn},
+	})
+	if err != nil {
+		t.Fatalf("NewMapResolver: %v", err)
+	}
+	reg, err := tenant.NewRegistry(resolver, tenant.AppBuildOpener(isolationConfig(t, root)), 4)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	for _, orgID := range []string{"", "org-b", "org-a-but-not-quite"} {
+		lease, err := reg.Acquire(t.Context(), orgID)
+		if !errors.Is(err, tenant.ErrUnknownTenant) {
+			if lease != nil {
+				lease.Release()
+			}
+			t.Fatalf("Acquire(%q) error = %v, want ErrUnknownTenant", orgID, err)
+		}
+		if lease != nil {
+			t.Fatalf("Acquire(%q) returned a lease for an unknown org", orgID)
+		}
+	}
+	if reg.Resident() != 0 {
+		t.Errorf("Resident() = %d; an unknown org must not open a store", reg.Resident())
+	}
+}
+
+// TestTenantIsolation_EvictionDoesNotDisturbSiblings runs eviction against real
+// stores.
+//
+// The unit test proves the bookkeeping; this proves the consequence. Closing
+// one tenant's Services must tear down only that tenant's pool and search
+// closer — if it ever reached something shared, the surviving tenant's reads
+// would start failing, which is what this checks.
+func TestTenantIsolation_EvictionDoesNotDisturbSiblings(t *testing.T) {
+	root := writeIsolationProject(t)
+
+	resolver, err := tenant.NewMapResolver([]tenant.Tenant{
+		{OrgID: "org-a", Schema: "tenant_a", DSN: backendtest.DSN(t)},
+		{OrgID: "org-b", Schema: "tenant_b", DSN: backendtest.DSN(t)},
+	})
+	if err != nil {
+		t.Fatalf("NewMapResolver: %v", err)
+	}
+	// A bound of one, so acquiring the second tenant evicts and closes the first.
+	reg, err := tenant.NewRegistry(resolver, tenant.AppBuildOpener(isolationConfig(t, root)), 1)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	ctx := t.Context()
+	leaseA, err := reg.Acquire(ctx, "org-a")
+	if err != nil {
+		t.Fatalf("Acquire(org-a): %v", err)
+	}
+	if err := leaseA.Services().Store().CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-A1", Type: "ticket", Properties: map[string]any{"title": "a"},
+	}); err != nil {
+		t.Fatalf("create in tenant A: %v", err)
+	}
+	leaseA.Release() // now evictable
+
+	leaseB, err := reg.Acquire(ctx, "org-b")
+	if err != nil {
+		t.Fatalf("Acquire(org-b) after eviction: %v", err)
+	}
+	defer leaseB.Release()
+
+	if err := leaseB.Services().Store().CreateEntity(ctx, &entity.Entity{
+		ID: "TKT-B1", Type: "ticket", Properties: map[string]any{"title": "b"},
+	}); err != nil {
+		t.Fatalf("tenant B unusable after tenant A was evicted and closed: %v", err)
+	}
+	assertInvisible(t, ctx, leaseB.Services(), "TKT-A1", "B")
+
+	// Re-acquiring the evicted tenant must reopen it and find its data intact —
+	// eviction closes a connection, it does not destroy anything.
+	leaseA2, err := reg.Acquire(ctx, "org-a")
+	if err != nil {
+		t.Fatalf("re-Acquire(org-a): %v", err)
+	}
+	defer leaseA2.Release()
+	assertVisible(t, ctx, leaseA2.Services(), "TKT-A1", "a")
+	assertInvisible(t, ctx, leaseA2.Services(), "TKT-B1", "A")
+}
+
+// --- helpers ---
+
+func assertVisible(t *testing.T, ctx context.Context, svc *appbuild.Services, id, wantTitle string) {
+	t.Helper()
+	got, err := svc.Store().GetEntity(ctx, id)
+	if err != nil {
+		t.Fatalf("tenant cannot read its own entity %s: %v", id, err)
+	}
+	if title, _ := got.Properties["title"].(string); title != wantTitle {
+		t.Errorf("entity %s title = %q, want %q", id, title, wantTitle)
+	}
+}
+
+// assertInvisible is the leak assertion. A foreign id must not resolve — and
+// the failure message says what a failure means, because a green run here is
+// the only thing standing between this design and a cross-tenant disclosure.
+func assertInvisible(t *testing.T, ctx context.Context, svc *appbuild.Services, id, asTenant string) {
+	t.Helper()
+	got, err := svc.Store().GetEntity(ctx, id)
+	if err == nil {
+		t.Fatalf("CROSS-TENANT LEAK: tenant %s read foreign entity %s (%+v); "+
+			"search_path is not isolating these tenants", asTenant, id, got.Properties)
+	}
+}
+
+func assertOnlyOwnEntities(t *testing.T, ctx context.Context, svc *appbuild.Services, wantID string) {
+	t.Helper()
+	var ids []string
+	for e, err := range svc.Store().ListEntities(ctx, store.EntityQuery{Type: "ticket"}) {
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids = append(ids, e.ID)
+	}
+	if len(ids) != 1 || ids[0] != wantID {
+		t.Fatalf("CROSS-TENANT LEAK: list returned %v, want only [%s]", ids, wantID)
+	}
+}
+
+// isolationConfig is the shared, tenant-independent half of construction: one
+// project root, one metamodel, one script engine, for every tenant. Only
+// DatabaseURL differs per tenant, and AppBuildOpener sets it.
+func isolationConfig(t *testing.T, root string) appbuild.Config {
+	t.Helper()
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	paths, err := project.Discover(root, fs)
+	if err != nil {
+		t.Fatalf("project.Discover: %v", err)
+	}
+	return appbuild.Config{
+		FS:           fs,
+		Paths:        paths,
+		ScriptEngine: script.NewEngine(),
+		Audit:        audit.Nop{},
+	}
+}
+
+func writeIsolationProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, dir := range []string{"entities", "relations", filepath.Join(".rela", "audit")} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, "metamodel.yaml"), []byte(isolationMetamodel), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}

--- a/internal/tenant/registry.go
+++ b/internal/tenant/registry.go
@@ -1,0 +1,348 @@
+package tenant
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+)
+
+// DefaultMaxResident is the resident-set bound applied when an operator sets
+// none.
+//
+// Small on purpose, because an open store is expensive in the one resource that
+// runs out first. `pgstore.Open` builds a pgx pool with no MaxConns — so
+// max(4, numCPU) — plus one dedicated non-pooled connection for LISTEN, plus
+// the version sweep's own. RES-S8CH9C measured that at roughly 17 connections
+// per open store on a 16-core box, and against a typical max_connections=100
+// that is about five resident tenants, not five hundred.
+//
+// A default that quietly exceeded the cluster's connection budget would fail as
+// "too many connections" under load — an outage affecting every tenant,
+// triggered by traffic to any of them. Failing instead by evicting is a latency
+// cost paid by one tenant.
+const DefaultMaxResident = 4
+
+// Opener opens the backing store for one tenant.
+//
+// Injected rather than calling `appbuild.New` directly, because the store a
+// build opens is build-tag-dependent (PostgreSQL, filesystem, memory) while
+// this package is not. It is also the seam the tests use to count opens and
+// closes without a database.
+//
+// Implementations must return a usable [appbuild.Services] or an error, never
+// both — the fail-closed rule from the package doc, applied one level down.
+type Opener func(ctx context.Context, t Tenant) (*appbuild.Services, error)
+
+// AppBuildOpener opens a tenant's store through appbuild, using base for
+// everything that is tenant-independent.
+//
+// Note that it sets Config.DatabaseURL rather than passing
+// appbuild.WithDatabaseURL: the option is consumed by appbuild.Discover, while
+// appbuild.New — which is what a caller assembling a Config by hand reaches —
+// reads the field. Passing the option here would compile, do nothing, and open
+// every tenant against whichever DSN the config already held. That is precisely
+// the cross-tenant failure this package exists to prevent, and it would be
+// invisible until two tenants were resident at once.
+func AppBuildOpener(base appbuild.Config) Opener {
+	return func(_ context.Context, t Tenant) (*appbuild.Services, error) {
+		cfg := base
+		cfg.DatabaseURL = t.DSN
+		//nolint:contextcheck // appbuild.New takes no ctx; it opens its own on the
+		// build recipe's behalf. Opening a tenant's store must also outlive the
+		// request that triggered it — a cancelled request must not leave a
+		// half-migrated schema behind.
+		return appbuild.New(cfg)
+	}
+}
+
+// Lease is a borrowed reference to one tenant's services.
+//
+// It exists because eviction and use overlap. The resident set is bounded, so
+// acquiring tenant F may evict tenant A — and if a request is still reading
+// through A's store, closing it is a use-after-close, which in a pgx pool is a
+// panic rather than an error. Counting references is the only way to know, and
+// hoping request lifetimes are shorter than eviction pressure is not knowing.
+//
+// Every successful [Registry.Acquire] must be matched by exactly one
+// [Lease.Release], conventionally deferred.
+type Lease struct {
+	// Tenant is the resolved tenant this lease serves, carried so a caller can
+	// log or audit the tenant it acted as without a second lookup.
+	Tenant Tenant
+
+	svc      *appbuild.Services
+	registry *Registry
+	released bool
+}
+
+// Services returns the tenant-scoped services this lease borrows.
+//
+// The returned value is valid only until [Lease.Release]. It is scoped to
+// exactly one tenant's schema: this is where the isolation guarantee is
+// actually delivered, since every query issued through it resolves through a
+// `search_path` that names one tenant's schema and no other's.
+func (l *Lease) Services() *appbuild.Services { return l.svc }
+
+// Release returns the lease. Safe to call more than once so a handler can
+// defer it unconditionally; only the first call counts, because a double
+// release would drop another caller's reference and re-open the
+// use-after-close it exists to prevent.
+func (l *Lease) Release() {
+	if l == nil || l.released {
+		return
+	}
+	l.released = true
+	l.registry.release(l.Tenant.OrgID)
+}
+
+// resident is one tenant's open store and its bookkeeping.
+type resident struct {
+	tenant   Tenant
+	svc      *appbuild.Services
+	refs     int
+	element  *list.Element // position in the registry's recency list
+	evicting bool
+}
+
+// Registry hands out per-tenant services over one shared configuration.
+//
+// It is the multi-store host `appbuild.SharedBase` was built for: one parsed
+// metamodel and one parsed ACL policy, assembled against N stores. Which is
+// also the reason it is cheap to serve many tenants — under this design the
+// tenants differ only in content, so the expensive half of construction happens
+// once for all of them.
+//
+// # What it guarantees
+//
+//   - An org that does not resolve gets no store (see the package doc).
+//   - At most MaxResident stores are open at once, independently of how many
+//     tenants exist. That decoupling is the property that makes tenant count an
+//     operations question instead of an architecture one.
+//   - Evicting one tenant closes that tenant's store and nothing else. This is
+//     inherited rather than implemented: Services.Close tears down only the
+//     store and search closer it was assembled with, never anything owned by
+//     the shared base.
+//
+// # What it does not do
+//
+// It never creates a schema. An unknown org is denied, not provisioned
+// (TKT-TNPRV8), and no tenant is ever erased here (TKT-TNERAS).
+type Registry struct {
+	resolver    Resolver
+	open        Opener
+	maxResident int
+
+	mu        sync.Mutex
+	residents map[string]*resident
+	recency   *list.List // front = most recently used
+}
+
+// NewRegistry builds a registry over a resolver and an opener.
+//
+// maxResident <= 0 takes [DefaultMaxResident]. Both collaborators are required
+// and nil is rejected at construction rather than at first request, per
+// CLAUDE.md — and here for a sharper reason than usual: a registry that failed
+// only on use would fail inside a request, where the natural recovery is to
+// serve the request some other way.
+func NewRegistry(resolver Resolver, open Opener, maxResident int) (*Registry, error) {
+	if resolver == nil {
+		return nil, errors.New("tenant.NewRegistry: resolver is required")
+	}
+	if open == nil {
+		return nil, errors.New("tenant.NewRegistry: opener is required")
+	}
+	if maxResident <= 0 {
+		maxResident = DefaultMaxResident
+	}
+	return &Registry{
+		resolver:    resolver,
+		open:        open,
+		maxResident: maxResident,
+		residents:   make(map[string]*resident),
+		recency:     list.New(),
+	}, nil
+}
+
+// Acquire resolves orgID and leases its services, opening the store if the
+// tenant is not resident.
+//
+// Returns an error and a nil lease for any org it cannot resolve — including
+// the empty org — so a caller cannot accidentally proceed with a usable handle.
+// Check the error; do not check the lease for nil and carry on.
+//
+// The caller must Release the returned lease.
+func (r *Registry) Acquire(ctx context.Context, orgID string) (*Lease, error) {
+	t, err := r.resolver.Resolve(orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	r.mu.Lock()
+	if res, ok := r.residents[t.OrgID]; ok && !res.evicting {
+		res.refs++
+		r.recency.MoveToFront(res.element)
+		r.mu.Unlock()
+		return &Lease{Tenant: res.tenant, svc: res.svc, registry: r}, nil
+	}
+	r.mu.Unlock()
+
+	// Open outside the lock: opening a store connects to a database and runs
+	// migrations, and holding the registry lock across that would stall every
+	// other tenant's requests behind one tenant's cold start.
+	//
+	// The cost is that concurrent first requests for the same tenant can open
+	// more than one store. That is wasteful, not incorrect — the loser is
+	// closed below, and pgstore.Migrate is already safe to start concurrently,
+	// serializing under an advisory lock keyed on the schema. Single-flighting
+	// it belongs with the provisioning work (TKT-TNPRV8), which has to
+	// single-flight schema creation anyway and should own one mechanism rather
+	// than two.
+	svc, err := r.open(ctx, t)
+	if err != nil {
+		return nil, fmt.Errorf("tenant %q: open store: %w", t.OrgID, err)
+	}
+	if svc == nil {
+		// An opener returning (nil, nil) would put a nil store into the
+		// resident set and hand it to a request. Refuse it here: this is the
+		// zero-value-means-allowed shape the package doc warns about, and the
+		// only place it could enter.
+		return nil, fmt.Errorf("tenant %q: opener returned no services", t.OrgID)
+	}
+
+	r.mu.Lock()
+	if res, ok := r.residents[t.OrgID]; ok && !res.evicting {
+		// Another goroutine won the race. Use its store and close ours.
+		res.refs++
+		r.recency.MoveToFront(res.element)
+		r.mu.Unlock()
+		//nolint:contextcheck // teardown is not request-scoped; Services.Close takes no ctx
+		closeServices(t, svc)
+		return &Lease{Tenant: res.tenant, svc: res.svc, registry: r}, nil
+	}
+	res := &resident{tenant: t, svc: svc, refs: 1}
+	res.element = r.recency.PushFront(t.OrgID)
+	r.residents[t.OrgID] = res
+	evicted := r.evictLocked()
+	r.mu.Unlock()
+
+	// Eviction must NOT inherit this request's context. The tenant being closed
+	// is a different tenant from the one being served, so canceling the
+	// request must not abandon another tenant's pool half-torn-down.
+	//nolint:contextcheck // teardown is not request-scoped; Services.Close takes no ctx
+	closeAll(evicted)
+	return &Lease{Tenant: t, svc: svc, registry: r}, nil
+}
+
+// release drops one reference, closing the store if the tenant was already
+// evicted and this was the last holder.
+func (r *Registry) release(orgID string) {
+	r.mu.Lock()
+	res, ok := r.residents[orgID]
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
+	res.refs--
+	var closing *resident
+	if res.refs <= 0 && res.evicting {
+		delete(r.residents, orgID)
+		closing = res
+	}
+	r.mu.Unlock()
+
+	if closing != nil {
+		closeServices(closing.tenant, closing.svc)
+	}
+}
+
+// evictLocked trims the resident set to the bound, returning the residents
+// whose stores the caller must close. Requires r.mu.
+//
+// Only unreferenced residents are closed here. One still in use is marked
+// evicting instead: it leaves the recency list and the bound immediately, and
+// its last [Lease.Release] closes it. So the bound is a bound on *idle* stores,
+// and a burst of concurrent tenants can exceed it briefly rather than closing a
+// store a request is reading through. Overshooting the connection budget for
+// the length of one request is recoverable; a use-after-close on a pgx pool is
+// a panic.
+func (r *Registry) evictLocked() []*resident {
+	var closing []*resident
+	for r.recency.Len() > r.maxResident {
+		oldest := r.recency.Back()
+		if oldest == nil {
+			break
+		}
+		orgID, _ := oldest.Value.(string)
+		res, ok := r.residents[orgID]
+		if !ok {
+			r.recency.Remove(oldest)
+			continue
+		}
+		r.recency.Remove(oldest)
+		res.element = nil
+		if res.refs > 0 {
+			res.evicting = true
+			continue
+		}
+		delete(r.residents, orgID)
+		closing = append(closing, res)
+	}
+	return closing
+}
+
+// Close releases every resident store.
+//
+// Referenced residents are closed too: Close is process shutdown, where waiting
+// for in-flight requests is the server's job and not the registry's. It does
+// not close the shared base, which the registry does not own.
+func (r *Registry) Close() error {
+	r.mu.Lock()
+	residents := make([]*resident, 0, len(r.residents))
+	for _, res := range r.residents {
+		residents = append(residents, res)
+	}
+	r.residents = make(map[string]*resident)
+	r.recency.Init()
+	r.mu.Unlock()
+
+	closeAll(residents)
+	return nil
+}
+
+// Resident reports how many tenant stores are currently open. Exposed for
+// tests and for an operator metric: it is the number that must stay under the
+// connection budget, so it is the number worth watching.
+func (r *Registry) Resident() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.residents)
+}
+
+// closeAll closes a batch of evicted residents.
+func closeAll(residents []*resident) {
+	for _, res := range residents {
+		closeServices(res.tenant, res.svc)
+	}
+}
+
+// closeServices closes one tenant's services, logging rather than propagating a
+// failure.
+//
+// Eviction happens on the path of a *different* tenant's request, so returning
+// the error would fail a request that did nothing wrong and has no way to act
+// on it. The leak is bounded — one tenant's pool — and observable, which is the
+// better trade than a confusing failure.
+func closeServices(t Tenant, svc *appbuild.Services) {
+	if svc == nil {
+		return
+	}
+	if err := svc.Close(); err != nil {
+		slog.Warn("tenant: closing evicted tenant store failed",
+			"org_id", t.OrgID, "schema", t.Schema, "error", err)
+	}
+}

--- a/internal/tenant/registry_test.go
+++ b/internal/tenant/registry_test.go
@@ -1,0 +1,437 @@
+package tenant_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/tenant"
+)
+
+// countingOpener hands out a distinct zero-valued Services per call and records
+// how many were opened.
+//
+// A zero-valued *appbuild.Services is a legitimate stand-in here because
+// Services.Close nil-checks every field it tears down, so it exercises the
+// registry's lifecycle without needing a database. The real store's behavior
+// is covered by the postgres isolation test, which is where it belongs — these
+// tests are about the registry's bookkeeping, and a real store would make them
+// database-gated for no extra coverage of the logic under test.
+type countingOpener struct {
+	mu     sync.Mutex
+	opened []string
+	fail   map[string]error
+}
+
+func (c *countingOpener) open(_ context.Context, t tenant.Tenant) (*appbuild.Services, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err, ok := c.fail[t.OrgID]; ok {
+		return nil, err
+	}
+	c.opened = append(c.opened, t.OrgID)
+	return &appbuild.Services{}, nil
+}
+
+func (c *countingOpener) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.opened)
+}
+
+func testResolver(t *testing.T, orgs ...string) tenant.Resolver {
+	t.Helper()
+	tenants := make([]tenant.Tenant, 0, len(orgs))
+	for i, o := range orgs {
+		tenants = append(tenants, tenant.Tenant{
+			OrgID:  o,
+			Schema: fmt.Sprintf("tenant_%d", i),
+			DSN:    fmt.Sprintf("host=localhost search_path=tenant_%d", i),
+		})
+	}
+	r, err := tenant.NewMapResolver(tenants)
+	if err != nil {
+		t.Fatalf("NewMapResolver: %v", err)
+	}
+	return r
+}
+
+func TestRegistry_RequiresCollaborators(t *testing.T) {
+	t.Parallel()
+
+	opener := (&countingOpener{}).open
+	if _, err := tenant.NewRegistry(nil, opener, 2); err == nil {
+		t.Error("NewRegistry accepted a nil resolver")
+	}
+	if _, err := tenant.NewRegistry(testResolver(t, "a"), nil, 2); err == nil {
+		t.Error("NewRegistry accepted a nil opener")
+	}
+}
+
+// TestRegistry_UnknownTenantGetsNoStore is the registry's half of the
+// fail-closed property: an org that does not resolve must never reach an
+// opener, so it cannot connect to anything at all.
+func TestRegistry_UnknownTenantGetsNoStore(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "org-a"), opener.open, 2)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	for _, orgID := range []string{"", "org-unknown"} {
+		lease, err := reg.Acquire(t.Context(), orgID)
+		if !errors.Is(err, tenant.ErrUnknownTenant) {
+			t.Fatalf("Acquire(%q) error = %v, want ErrUnknownTenant", orgID, err)
+		}
+		if lease != nil {
+			t.Fatalf("Acquire(%q) returned a lease alongside an error", orgID)
+		}
+	}
+	if opener.count() != 0 {
+		t.Errorf("opener ran %d times for unresolvable orgs; it must never be reached", opener.count())
+	}
+	if reg.Resident() != 0 {
+		t.Errorf("Resident() = %d after only failed acquisitions, want 0", reg.Resident())
+	}
+}
+
+// TestRegistry_OpenFailureYieldsNoLease pins that a store that fails to open is
+// an error and not a half-usable lease — the same fail-closed rule one level
+// down from resolution.
+func TestRegistry_OpenFailureYieldsNoLease(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("connection refused")
+	opener := &countingOpener{fail: map[string]error{"org-a": boom}}
+	reg, err := tenant.NewRegistry(testResolver(t, "org-a"), opener.open, 2)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	lease, err := reg.Acquire(t.Context(), "org-a")
+	if !errors.Is(err, boom) {
+		t.Fatalf("Acquire error = %v, want it to wrap %v", err, boom)
+	}
+	if lease != nil {
+		t.Fatal("Acquire returned a lease for a store that failed to open")
+	}
+	if reg.Resident() != 0 {
+		t.Errorf("Resident() = %d after a failed open, want 0", reg.Resident())
+	}
+}
+
+// TestRegistry_NilServicesRefused covers the one route by which a nil store
+// could enter the resident set and be handed to a request.
+// nilOpener is the mistake the registry must catch: an opener that reports
+// success while handing back nothing. Named rather than inlined so the
+// nilnil exemption sits on the declaration and explains itself — returning
+// (nil, nil) is the bug under test, not an accident.
+func nilOpener(context.Context, tenant.Tenant) (*appbuild.Services, error) {
+	return nil, nil //nolint:nilnil // the invalid return this test exists to reject
+}
+
+func TestRegistry_NilServicesRefused(t *testing.T) {
+	t.Parallel()
+
+	reg, err := tenant.NewRegistry(testResolver(t, "org-a"), nilOpener, 2)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	lease, err := reg.Acquire(t.Context(), "org-a")
+	if err == nil {
+		t.Fatal("an opener returning (nil, nil) was accepted")
+	}
+	if lease != nil {
+		t.Fatal("a lease was returned over nil services")
+	}
+}
+
+func TestRegistry_ReusesResidentStore(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "org-a"), opener.open, 2)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	first, err := reg.Acquire(t.Context(), "org-a")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	second, err := reg.Acquire(t.Context(), "org-a")
+	if err != nil {
+		t.Fatalf("Acquire (second): %v", err)
+	}
+	if first.Services() != second.Services() {
+		t.Error("two acquisitions of one tenant returned different stores")
+	}
+	if opener.count() != 1 {
+		t.Errorf("opened %d stores for one tenant, want 1", opener.count())
+	}
+	first.Release()
+	second.Release()
+}
+
+// TestRegistry_BoundsResidentSet is the resident-set property RES-D54281's
+// horizon requires: open stores are capped by an operator-set number, not by
+// how many tenants exist. Each open store costs on the order of 17 database
+// connections, so without this the tenant count would be bounded by
+// max_connections.
+func TestRegistry_BoundsResidentSet(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "a", "b", "c", "d", "e"), opener.open, 2)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	for _, org := range []string{"a", "b", "c", "d", "e"} {
+		lease, err := reg.Acquire(t.Context(), org)
+		if err != nil {
+			t.Fatalf("Acquire(%s): %v", org, err)
+		}
+		// Released immediately, so nothing is pinned and the bound is exact.
+		lease.Release()
+		if got := reg.Resident(); got > 2 {
+			t.Fatalf("Resident() = %d after acquiring %s, want <= 2", got, org)
+		}
+	}
+	if got := reg.Resident(); got != 2 {
+		t.Errorf("Resident() = %d after five tenants, want 2", got)
+	}
+	if opener.count() != 5 {
+		t.Errorf("opened %d stores, want 5 (each evicted tenant reopens)", opener.count())
+	}
+}
+
+// TestRegistry_EvictionLeavesSiblingsUsable pins the property that makes
+// per-tenant eviction safe at all: closing one tenant's Services tears down
+// only what that Services was assembled with. If eviction ever reached
+// something shared, evicting one tenant would break every other.
+func TestRegistry_EvictionLeavesSiblingsUsable(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "a", "b"), opener.open, 1)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	leaseA, err := reg.Acquire(t.Context(), "a")
+	if err != nil {
+		t.Fatalf("Acquire(a): %v", err)
+	}
+	svcA := leaseA.Services()
+	leaseA.Release()
+
+	// Acquiring b evicts a, since the bound is one.
+	leaseB, err := reg.Acquire(t.Context(), "b")
+	if err != nil {
+		t.Fatalf("Acquire(b): %v", err)
+	}
+	defer leaseB.Release()
+
+	if leaseB.Services() == svcA {
+		t.Fatal("tenant b was handed tenant a's store")
+	}
+	if leaseB.Tenant.OrgID != "b" {
+		t.Errorf("lease tenant = %q, want b", leaseB.Tenant.OrgID)
+	}
+	// b's store must still be usable after a was evicted and closed.
+	if err := leaseB.Services().Close(); err != nil {
+		t.Errorf("closing b after a was evicted: %v", err)
+	}
+}
+
+// TestRegistry_EvictionWaitsForInFlightUse is the use-after-close guard. A
+// referenced store must not be closed under a request: in a pgx pool that is a
+// panic, not an error, so it would take the process down rather than fail one
+// request.
+func TestRegistry_EvictionWaitsForInFlightUse(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "a", "b"), opener.open, 1)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	// Hold a's lease: a request is in flight.
+	leaseA, err := reg.Acquire(t.Context(), "a")
+	if err != nil {
+		t.Fatalf("Acquire(a): %v", err)
+	}
+
+	// Acquiring b pushes a out of the bound while a is still referenced.
+	leaseB, err := reg.Acquire(t.Context(), "b")
+	if err != nil {
+		t.Fatalf("Acquire(b): %v", err)
+	}
+	defer leaseB.Release()
+
+	// a is still resident because it is still in use. The bound is a bound on
+	// idle stores; overshooting it for the length of one request is the
+	// deliberate trade against a use-after-close.
+	if reg.Resident() != 2 {
+		t.Errorf("Resident() = %d while a is in flight, want 2 (a pending eviction)", reg.Resident())
+	}
+	if err := leaseA.Services().Close(); err != nil {
+		t.Errorf("a's store was closed out from under an in-flight lease: %v", err)
+	}
+
+	// Releasing a completes its deferred eviction.
+	leaseA.Release()
+	if reg.Resident() != 1 {
+		t.Errorf("Resident() = %d after releasing the evicted tenant, want 1", reg.Resident())
+	}
+}
+
+// TestRegistry_DoubleReleaseIsSafe covers a handler that defers Release and also
+// releases explicitly. A second release must not drop another caller's
+// reference, which would re-open the use-after-close Lease exists to prevent.
+func TestRegistry_DoubleReleaseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "a"), opener.open, 1)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	first, err := reg.Acquire(t.Context(), "a")
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	second, err := reg.Acquire(t.Context(), "a")
+	if err != nil {
+		t.Fatalf("Acquire (second): %v", err)
+	}
+
+	first.Release()
+	first.Release() // the accidental double release
+	first.Release()
+
+	// The second holder's reference must have survived, so the store is
+	// still resident and still usable.
+	if reg.Resident() != 1 {
+		t.Fatalf("Resident() = %d after a double release, want 1", reg.Resident())
+	}
+	if err := second.Services().Close(); err != nil {
+		t.Errorf("store closed by a double release: %v", err)
+	}
+	second.Release()
+}
+
+// TestRegistry_ConcurrentAcquireIsSafe runs under -race. Concurrent first
+// requests for one tenant may open more than one store — wasteful, not
+// incorrect — but exactly one must end up resident and every caller must get a
+// usable lease.
+func TestRegistry_ConcurrentAcquireIsSafe(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "a", "b", "c"), opener.open, 2)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	const goroutines = 24
+	var wg sync.WaitGroup
+	orgs := []string{"a", "b", "c"}
+	errs := make(chan error, goroutines)
+	for i := range goroutines {
+		wg.Add(1)
+		go func(org string) {
+			defer wg.Done()
+			lease, err := reg.Acquire(context.Background(), org)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if lease.Services() == nil {
+				errs <- errors.New("lease carried nil services")
+			}
+			lease.Release()
+		}(orgs[i%len(orgs)])
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent Acquire: %v", err)
+	}
+	if got := reg.Resident(); got > 2 {
+		t.Errorf("Resident() = %d after concurrent traffic, want <= 2", got)
+	}
+}
+
+func TestRegistry_CloseReleasesEverything(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	reg, err := tenant.NewRegistry(testResolver(t, "a", "b"), opener.open, 4)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	for _, org := range []string{"a", "b"} {
+		lease, err := reg.Acquire(t.Context(), org)
+		if err != nil {
+			t.Fatalf("Acquire(%s): %v", org, err)
+		}
+		lease.Release()
+	}
+	if reg.Resident() != 2 {
+		t.Fatalf("Resident() = %d, want 2", reg.Resident())
+	}
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if reg.Resident() != 0 {
+		t.Errorf("Resident() = %d after Close, want 0", reg.Resident())
+	}
+}
+
+// TestRegistry_DefaultBoundApplied pins that a non-positive bound takes the
+// documented default rather than meaning "unbounded" — an unbounded resident
+// set would exhaust the cluster's connections under enough tenants.
+func TestRegistry_DefaultBoundApplied(t *testing.T) {
+	t.Parallel()
+
+	opener := &countingOpener{}
+	orgs := make([]string, tenant.DefaultMaxResident+3)
+	for i := range orgs {
+		orgs[i] = fmt.Sprintf("org-%d", i)
+	}
+	reg, err := tenant.NewRegistry(testResolver(t, orgs...), opener.open, 0)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = reg.Close() })
+
+	for _, org := range orgs {
+		lease, err := reg.Acquire(t.Context(), org)
+		if err != nil {
+			t.Fatalf("Acquire(%s): %v", org, err)
+		}
+		lease.Release()
+	}
+	if got := reg.Resident(); got != tenant.DefaultMaxResident {
+		t.Errorf("Resident() = %d, want DefaultMaxResident (%d)", got, tenant.DefaultMaxResident)
+	}
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -1,0 +1,198 @@
+// Package tenant resolves a verified organization to the storage it — and only
+// it — may reach.
+//
+// # Why this package exists
+//
+// rela's ACL is union semantics with no deny primitive, so "deny unless the
+// principal's org matches the row's org" cannot be written as a role rule. That
+// is not an oversight to be patched: it means tenant isolation must come from
+// somewhere other than the ACL.
+//
+// It comes from the store handle. Under the schema-per-tenant design
+// (RES-D54281) each tenant's data lives in its own PostgreSQL schema, and a
+// tenant's store is a connection pool pinned to that schema by `search_path`.
+// A request resolved to tenant T therefore *cannot* address tenant U's rows:
+// the attempt is `relation "entities" does not exist`, enforced by PostgreSQL,
+// not a missing `WHERE` clause a reviewer has to spot. The ACL keeps doing what
+// it already does, within a tenant.
+//
+// This package is the lookup that decides which handle a request gets.
+//
+// # Fail closed
+//
+// The requirement is one sentence — no cross-tenant data leaks — and every
+// ambiguous case resolves the same way: no tenant, no store, no request. An
+// unknown org, an absent org, and a malformed tenant record are all errors, and
+// never a zero value or a default store.
+//
+// That last clause is deliberate. rela already carries fail-open traps where a
+// zero value means "allow" — a zero `ReadQueryResult` aliases `AllowAll`, and
+// `nopReadGate.HoldsPermission` returns true unconditionally. A resolver
+// returning a zero-valued store on an unknown org would be the worst member of
+// that family: it would not widen permissions inside a tenant, it would hand
+// one tenant another tenant's database. So [Resolver] returns an error, and
+// callers must not treat a failed resolution as a reason to fall back.
+//
+// # What lives here and what does not
+//
+// Resolution and per-tenant store acquisition live here. Provisioning
+// (creating and migrating a new tenant's schema, TKT-TNPRV8) and erasure
+// (dropping it, TKT-TNERAS) deliberately do not: this package resolves tenants
+// that already exist and denies ones that do not. Nothing in it issues DDL.
+package tenant
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// ErrUnknownTenant reports that an org is not a tenant of this deployment.
+//
+// Distinguished from a lookup failure on purpose. Both deny the request — see
+// the package doc — but they are different operational events: an unknown org
+// is routine (a stale session, or an org awaiting provisioning), whereas a
+// lookup that broke is an outage. Callers that log them identically will not be
+// able to tell a quiet afternoon from a failing tenant map.
+var ErrUnknownTenant = errors.New("tenant: unknown organization")
+
+// schemaNamePattern constrains a tenant's PostgreSQL schema name.
+//
+// Schema names are a trust boundary. Today they come from an operator-authored
+// file, which is inside the boundary, but they are interpolated into DDL and
+// into a connection's `search_path`, and the moment provisioning derives one
+// from an `org_id` claim (TKT-TNPRV8) the input becomes external. Validating
+// now — where the rule is cheap and the file is small — means that change is a
+// new caller rather than a new attack surface.
+//
+// The character class is deliberately narrower than PostgreSQL's: lowercase
+// only, so a name cannot differ from another only by case-folding; no leading
+// digit, so it is a bare identifier needing no quoting; and capped at 31
+// characters, comfortably inside PostgreSQL's 63-byte NAMEDATALEN so a name can
+// never be silently truncated into a collision with another tenant's.
+var schemaNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,30}$`)
+
+// Tenant is one organization's storage location.
+//
+// The DSN is the whole point of the type: every deployment tier RES-D54281
+// contemplates — one schema per tenant on a shared cluster today, a dedicated
+// database for a tenant that outgrows it, a different cluster once tenants
+// shard — is a different DSN and nothing else. Keeping storage topology behind
+// this one string is what makes those tiers a config change rather than a
+// redesign.
+type Tenant struct {
+	// OrgID is the verified `org_id` claim this tenant is keyed by. It is the
+	// entire interface between rela and the identity provider: Pratique is the
+	// authority on org identity, rela is the authority on where an org's data
+	// lives, and exactly one stable string joins them.
+	OrgID string
+
+	// Schema is the PostgreSQL schema holding this tenant's data. Recorded
+	// separately from the DSN because provisioning and erasure need to name it
+	// as an identifier, not just connect through it.
+	Schema string
+
+	// DSN connects to Schema. For the shared-cluster tier this is the
+	// deployment's base DSN with `search_path` pinned; for a promoted tenant it
+	// may point at another database or another host entirely.
+	//
+	// It carries a password, so it must never reach a command line — the
+	// invariant TKT-1J5KEV established for every DSN in rela.
+	DSN string
+}
+
+// validate rejects a tenant record that could not safely be used.
+//
+// Called at load rather than at first request. A tenant map is small,
+// operator-authored, and read once, so there is no reason for a typo to surface
+// as a failed request hours later when it can surface as a failed boot.
+func (t Tenant) validate() error {
+	if t.OrgID == "" {
+		return errors.New("org_id is required")
+	}
+	if !schemaNamePattern.MatchString(t.Schema) {
+		return fmt.Errorf("schema %q must match %s", t.Schema, schemaNamePattern)
+	}
+	if t.DSN == "" {
+		return errors.New("dsn is required")
+	}
+	return nil
+}
+
+// Resolver maps a verified organization to its storage.
+//
+// One method, because RES-D54281 requires the lookup to be a single seam: keep
+// it true and "where the tenant map lives" stays an implementation choice. The
+// file-backed [MapResolver] is the current implementation; a control-schema
+// table becomes the natural one once provisioning needs to add a tenant without
+// a deploy.
+//
+// Implementations must return [ErrUnknownTenant] for an org they do not know,
+// and must never return a usable [Tenant] alongside an error.
+type Resolver interface {
+	Resolve(orgID string) (Tenant, error)
+}
+
+// MapResolver resolves from an in-memory table built at load.
+//
+// Immutable after construction, hence safe for concurrent use without a lock
+// and without a cache: the map *is* the cache. That is a property of the
+// current file-backed source, not of the [Resolver] interface — a DB-backed
+// implementation will need both, which is why invalidation is the interface's
+// problem to solve later and not a shape imposed on it now.
+type MapResolver struct {
+	byOrg map[string]Tenant
+}
+
+// NewMapResolver builds a resolver over the given tenants, rejecting a table
+// that cannot be safely served.
+//
+// Two orgs mapping to one schema is refused, and it is the check worth
+// understanding: it is a cross-tenant data leak spelled as a typo. Nothing
+// downstream would report it — both orgs would resolve, both would connect,
+// both would read and write the same rows, and the symptom would be one
+// tenant seeing another's data with every layer behaving exactly as designed.
+// Duplicate org IDs are refused for the adjacent reason: whichever entry lost
+// would be silently ignored, so a well-meant edit could point an org at the
+// wrong schema.
+func NewMapResolver(tenants []Tenant) (*MapResolver, error) {
+	byOrg := make(map[string]Tenant, len(tenants))
+	bySchema := make(map[string]string, len(tenants))
+	for i, t := range tenants {
+		if err := t.validate(); err != nil {
+			return nil, fmt.Errorf("tenant %d: %w", i, err)
+		}
+		if _, dup := byOrg[t.OrgID]; dup {
+			return nil, fmt.Errorf("tenant %d: duplicate org_id %q", i, t.OrgID)
+		}
+		if other, dup := bySchema[t.Schema]; dup {
+			return nil, fmt.Errorf(
+				"tenant %d: org_id %q and %q both map to schema %q, which would "+
+					"share one tenant's data with the other",
+				i, t.OrgID, other, t.Schema)
+		}
+		byOrg[t.OrgID] = t
+		bySchema[t.Schema] = t.OrgID
+	}
+	return &MapResolver{byOrg: byOrg}, nil
+}
+
+// Resolve returns the tenant for orgID, or [ErrUnknownTenant].
+//
+// An empty orgID is unknown rather than a distinct error. A principal without
+// an org is either unverified or came from an issuer that asserts no org;
+// either way it addresses no tenant, and giving that case its own error would
+// invite a caller to handle it separately — which is the shape a fallback grows
+// out of.
+func (r *MapResolver) Resolve(orgID string) (Tenant, error) {
+	t, ok := r.byOrg[orgID]
+	if !ok {
+		return Tenant{}, fmt.Errorf("%w: %q", ErrUnknownTenant, orgID)
+	}
+	return t, nil
+}
+
+// Len reports how many tenants this resolver knows. Exposed so a host can log
+// its tenant count at boot and so an operator can confirm the file it deployed
+// is the file that loaded.
+func (r *MapResolver) Len() int { return len(r.byOrg) }

--- a/internal/tenant/tenant_test.go
+++ b/internal/tenant/tenant_test.go
@@ -1,0 +1,224 @@
+package tenant_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/tenant"
+)
+
+func TestMapResolver_ResolvesKnownOrg(t *testing.T) {
+	t.Parallel()
+
+	r, err := tenant.NewMapResolver([]tenant.Tenant{
+		{OrgID: "org-a", Schema: "tenant_a", DSN: "host=localhost search_path=tenant_a"},
+		{OrgID: "org-b", Schema: "tenant_b", DSN: "host=localhost search_path=tenant_b"},
+	})
+	if err != nil {
+		t.Fatalf("NewMapResolver: %v", err)
+	}
+
+	got, err := r.Resolve("org-b")
+	if err != nil {
+		t.Fatalf("Resolve(org-b): %v", err)
+	}
+	if got.Schema != "tenant_b" {
+		t.Errorf("schema = %q, want tenant_b", got.Schema)
+	}
+	if r.Len() != 2 {
+		t.Errorf("Len() = %d, want 2", r.Len())
+	}
+}
+
+// TestMapResolver_FailsClosed is the core security property of the resolver:
+// anything that is not a known tenant yields an error AND a zero Tenant, so a
+// caller that ignores the error still cannot reach a database.
+func TestMapResolver_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	r, err := tenant.NewMapResolver([]tenant.Tenant{
+		{OrgID: "org-a", Schema: "tenant_a", DSN: "host=localhost"},
+	})
+	if err != nil {
+		t.Fatalf("NewMapResolver: %v", err)
+	}
+
+	for _, orgID := range []string{"", "org-unknown", "ORG-A", " org-a", "org-a "} {
+		t.Run("org="+orgID, func(t *testing.T) {
+			t.Parallel()
+			got, err := r.Resolve(orgID)
+			if !errors.Is(err, tenant.ErrUnknownTenant) {
+				t.Fatalf("Resolve(%q) error = %v, want ErrUnknownTenant", orgID, err)
+			}
+			if got.DSN != "" || got.Schema != "" {
+				t.Errorf("Resolve(%q) returned a usable tenant %+v alongside an error", orgID, got)
+			}
+		})
+	}
+}
+
+// TestMapResolver_RejectsDuplicateSchema pins the check that exists because the
+// failure it prevents is invisible: two orgs on one schema would resolve,
+// connect, and read each other's rows with every layer behaving as designed.
+func TestMapResolver_RejectsDuplicateSchema(t *testing.T) {
+	t.Parallel()
+
+	_, err := tenant.NewMapResolver([]tenant.Tenant{
+		{OrgID: "org-a", Schema: "shared", DSN: "host=localhost"},
+		{OrgID: "org-b", Schema: "shared", DSN: "host=localhost"},
+	})
+	if err == nil {
+		t.Fatal("two orgs mapped to one schema was accepted; that is a cross-tenant leak")
+	}
+	if !strings.Contains(err.Error(), "shared") {
+		t.Errorf("error %q should name the offending schema", err)
+	}
+}
+
+func TestMapResolver_RejectsInvalidTenants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tenants []tenant.Tenant
+	}{
+		{"empty org", []tenant.Tenant{{OrgID: "", Schema: "a", DSN: "d"}}},
+		{"empty dsn", []tenant.Tenant{{OrgID: "o", Schema: "a", DSN: ""}}},
+		{"empty schema", []tenant.Tenant{{OrgID: "o", Schema: "", DSN: "d"}}},
+		{"uppercase schema", []tenant.Tenant{{OrgID: "o", Schema: "Tenant", DSN: "d"}}},
+		{"leading digit schema", []tenant.Tenant{{OrgID: "o", Schema: "1tenant", DSN: "d"}}},
+		{"hyphen schema", []tenant.Tenant{{OrgID: "o", Schema: "ten-ant", DSN: "d"}}},
+		{"quote in schema", []tenant.Tenant{{OrgID: "o", Schema: `a";DROP`, DSN: "d"}}},
+		{"too long schema", []tenant.Tenant{{OrgID: "o", Schema: strings.Repeat("a", 32), DSN: "d"}}},
+		{"duplicate org", []tenant.Tenant{
+			{OrgID: "o", Schema: "a", DSN: "d"},
+			{OrgID: "o", Schema: "b", DSN: "d"},
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := tenant.NewMapResolver(tc.tenants); err == nil {
+				t.Fatalf("NewMapResolver accepted %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestMapResolver_AcceptsMaximumLengthSchema pins the boundary of the length
+// cap, which exists so a name can never be truncated by PostgreSQL into a
+// collision with another tenant's.
+func TestMapResolver_AcceptsMaximumLengthSchema(t *testing.T) {
+	t.Parallel()
+
+	name := "a" + strings.Repeat("b", 30) // 31 chars: the documented maximum
+	if _, err := tenant.NewMapResolver([]tenant.Tenant{
+		{OrgID: "o", Schema: name, DSN: "d"},
+	}); err != nil {
+		t.Fatalf("31-character schema rejected: %v", err)
+	}
+}
+
+func TestLoadConfig_ExplicitDSNs(t *testing.T) {
+	t.Parallel()
+
+	path := writeConfig(t, `
+tenants:
+  - org_id: org-a
+    schema: tenant_a
+    dsn: "host=alpha dbname=rela search_path=tenant_a,public"
+  - org_id: org-b
+    schema: tenant_b
+    dsn: "host=beta dbname=rela search_path=tenant_b,public"
+`)
+	cfg, err := tenant.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	r, err := cfg.Resolver()
+	if err != nil {
+		t.Fatalf("Resolver: %v", err)
+	}
+	got, err := r.Resolve("org-b")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// An explicit per-tenant DSN is the sharding tier: it must survive
+	// untouched, including the host, or promoting a tenant to its own cluster
+	// would silently return it to the shared one.
+	if !strings.Contains(got.DSN, "host=beta") {
+		t.Errorf("DSN = %q, want the explicit host=beta preserved", got.DSN)
+	}
+}
+
+func TestLoadConfig_RejectsEmptyAndMalformed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no tenants", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := tenant.LoadConfig(writeConfig(t, "tenants: []\n"))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if _, err := cfg.Resolver(); err == nil {
+			t.Fatal("a tenant map with no tenants was accepted")
+		}
+	})
+
+	t.Run("no dsn and no base_dsn", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := tenant.LoadConfig(writeConfig(t, "tenants:\n  - org_id: a\n    schema: tenant_a\n"))
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if _, err := cfg.Resolver(); err == nil {
+			t.Fatal("a tenant with no derivable DSN was accepted")
+		}
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		t.Parallel()
+		if _, err := tenant.LoadConfig(writeConfig(t, "tenants: [unclosed\n")); err == nil {
+			t.Fatal("malformed YAML was accepted; it must not degrade to an empty map")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		if _, err := tenant.LoadConfig(filepath.Join(t.TempDir(), "absent.yaml")); err == nil {
+			t.Fatal("a missing tenant map was accepted")
+		}
+	})
+}
+
+// TestLoadConfig_RejectsInvalidSchemaBeforeDerivation pins that a bad schema
+// name is refused before it is interpolated into a connection string, rather
+// than after.
+func TestLoadConfig_RejectsInvalidSchemaBeforeDerivation(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := tenant.LoadConfig(writeConfig(t, `
+base_dsn: "host=localhost dbname=rela user=rela"
+tenants:
+  - org_id: org-a
+    schema: "public,tenant_b"
+`))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if _, err := cfg.Resolver(); err == nil {
+		t.Fatal("a schema name containing a search_path separator was accepted")
+	}
+}
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), tenant.ConfigFileName)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/tickets/entities/docs-checklists/DOCS-TNT9RS.md
+++ b/tickets/entities/docs-checklists/DOCS-TNT9RS.md
@@ -1,0 +1,58 @@
+---
+id: DOCS-TNT9RS
+type: docs-checklist
+title: 'Docs: tenant resolution spine'
+status: done
+---
+
+## Code Documentation
+
+- [x] Package doc on `internal/tenant` states why the package exists: isolation
+  cannot be an ACL rule (union semantics, no deny primitive), so it comes from
+  the store handle instead. It also states the fail-closed rule and names the
+  existing fail-open traps a reader should not accidentally join.
+- [x] `Tenant`, `Resolver`, `MapResolver`, `Registry`, `Lease` and `Opener` all
+  carry doc comments explaining the decision behind them, not a restatement of
+  the signature.
+- [x] The tenant-map storage decision is recorded where the type lives
+  (`Config`'s doc in `config.go`), with the recursion argument that drove it —
+  the map cannot live inside the thing it shards, so a config file is the
+  bootstrap layer that a database-backed map would sit on top of rather than
+  replace.
+- [x] The connection-ceiling reasoning is recorded on `DefaultMaxResident`,
+  including the ~17-connections-per-store measurement from RES-S8CH9C and why
+  the default is deliberately small.
+- [x] `AppBuildOpener` documents the `appbuild.New` / `WithDatabaseURL`
+  asymmetry — the option is consumed by `Discover` while `New` reads the field,
+  so passing the option here would compile, do nothing, and put every tenant on
+  one DSN. That trap is worth a paragraph because it is silent.
+- [x] `dsnForSchema` documents why the DSN is rebuilt by re-serializing the
+  parsed config rather than by appending `?search_path=`: pgx accepts two DSN
+  dialects and query-string surgery corrupts the key/value one into a DSN that
+  still connects, on the wrong schema.
+- [x] The `!postgres` stub documents why it errors rather than returning the
+  base DSN — an unpinned DSN would put every tenant on one `search_path`.
+- [x] Test doc comments state what property each test pins and what a failure
+  would mean, rather than describing the mechanics.
+
+## Project Documentation
+
+- [x] TKT-TNT9RS records both open questions RES-D54281 left, with reasoning:
+  where the tenant map lives, and how the connection ceiling and resident-set
+  bound are honoured.
+- [x] PLAN-TNT9RS records the re-verification done against develop rather than
+  against ticket statuses, including the `appbuild.New` / `WithDatabaseURL`
+  asymmetry that changed the implementation approach.
+- [x] Deferred work is filed as TKT-TNPRV8 (provisioning) and TKT-TNERAS
+  (erasure), each carrying the design questions RES-D54281 raised for it — the
+  trust assumption behind lazy provisioning, and the audit-log residue and
+  backup-retention SLA for erasure.
+- [x] ~~`docs/postgres-backend.md` updated~~ (N/A: the registry is not mounted
+  in any binary, so there is no operator-facing behaviour to document yet.
+  `tenants.yaml` becomes operator documentation when a host reads it —
+  documenting a config file no binary loads would be documenting a plan.)
+- [x] ~~`docs/acl-security.md` updated~~ (N/A: nothing about ACL evaluation
+  changed. That document's statement that `org_id` is "recorded, not enforced"
+  remains accurate on every shipping path, and would become wrong only when the
+  registry is actually mounted.)
+- [x] ~~CHANGELOG~~ (N/A: no user-visible behaviour change.)

--- a/tickets/entities/planning-checklists/PLAN-TNT9RS.md
+++ b/tickets/entities/planning-checklists/PLAN-TNT9RS.md
@@ -1,0 +1,139 @@
+---
+id: PLAN-TNT9RS
+type: planning-checklist
+title: 'Planning: tenant resolution spine — org_id -> DSN -> Services, fail closed'
+status: done
+---
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined
+- [x] Acceptance criteria documented
+
+**Problem.** RES-D54281 chose schema-per-tenant and named the resolution seam
+"the spine of the work". Every prerequisite it listed has shipped, and nothing
+consumes them: `NewSharedBase` and `SharedBase.Assemble` are exported and
+documented for a multi-store host, and have **zero production callers**.
+`principal.OrgID()` is carried, forge-proof, all the way to the ACL and is used
+only for audit attribution — `internal/acl` contains zero references to it.
+
+**Scope (in):**
+- New `internal/tenant` package: `Tenant`, `Resolver`, `Registry`.
+- Config-file-backed resolver (`tenants.yaml`), validated at load.
+- `Registry` assembling per-tenant `*appbuild.Services` over one `*SharedBase`,
+  with a bounded resident set and eviction that closes only the evicted store.
+- Fail-closed resolution: unknown/empty/invalid org returns an error and no store.
+- Postgres-build isolation test against a real database.
+
+**Scope (out):**
+- Provisioning (TKT-TNPRV8) and erasure (TKT-TNERAS) — filed, not built.
+- Mounting the registry in `rela-server`'s HTTP path. `dataentry.App` is
+  per-store and at `//plimsoll:max-methods=104`; RES-D54281 says explicitly not
+  to put per-request tenant logic on `App`.
+- Apartment-style shared pooling; cluster sharding.
+- Non-HTTP entry points (scheduler, CLI, MCP).
+
+**Acceptance Criteria:** see TKT-TNT9RS. The load-bearing one is #7 — an entity
+written through tenant A's store is not visible through tenant B's store, proven
+by an executed test against a live PostgreSQL.
+
+## Research
+
+- [x] **Re-verified against develop `11c02c1b`, not against ticket statuses.**
+  The four prerequisite tickets all read `status: backlog` while their code is
+  merged, so every claim below was checked in code.
+- [x] `WithDatabaseURL` / `resolveDatabaseURL` exist (`appbuild.go:856,868`).
+  **Important asymmetry:** `appbuild.New` reads `Config.DatabaseURL` and
+  *ignores* `WithDatabaseURL`; only `Discover` consumes the option. A registry
+  must therefore set `Config.DatabaseURL` per tenant, not pass the option.
+- [x] `SharedBase` exists (`appbuild.go:1141`); all three backends take
+  `*SharedBase` (fs:48, postgres:47, memory:39).
+- [x] `feedChannel = "rela_changed"` is a single shared constant
+  (`pgstore/feed.go:55`), schema carried in the payload and derived from
+  `current_schema()`.
+- [x] `pgstore/statekv.go` exists, wired through `stateKVFor`
+  (`versionsweep_postgres.go:158`) into `assemble`.
+- [x] Nothing maps an org to a DSN or a schema. No runtime `CREATE SCHEMA`, no
+  runtime `SET search_path`, no `DROP SCHEMA` outside test cleanup.
+- [x] **RES-D54281's load-bearing claim re-verified: `pgstore` needs zero
+  changes.** Schema is purely the connection's `search_path`; production code
+  never issues `SET search_path` and reads the schema back via
+  `current_schema()`.
+- [x] Connection ceiling (RES-S8CH9C, reused by RES-D54281): `pgstore.Open`
+  builds a pool with **no `MaxConns`** (defaults `max(4, numCPU)`) plus a
+  dedicated non-pooled `LISTEN` connection plus the sweep — ~17 connections per
+  open store. TKT-9TOEBH removed the per-tenant *channel*, not the per-tenant
+  *pool*.
+- [x] `internal/cache.LRU` exists but has **no eviction callback**, so it cannot
+  close an evicted store. The registry needs its own recency handling.
+- [x] `backendtest_postgres.go:88-116` already creates N isolated schemas on one
+  database and hands back a DSN pinned via `dsnWithSearchPath` — which
+  re-serializes the parsed config rather than appending `?search_path=`, because
+  pgx accepts both URL and key/value DSNs and query-string surgery corrupts the
+  latter. Reuse this construction.
+
+## Approach
+
+### Step 1 — `internal/tenant`: the value and the lookup
+
+`Tenant{OrgID, Schema, DSN}`, and `Resolver` with one method
+`Resolve(orgID) (Tenant, error)`. A sentinel `ErrUnknownTenant` so callers can
+distinguish "not a tenant" from "lookup broke" — both deny, but they are
+different operational events.
+
+### Step 2 — the file-backed resolver
+
+`tenants.yaml`: a base DSN plus a list of `{org_id, schema}`. Validation at
+load, not at first use: non-empty org, schema matching
+`^[a-z][a-z0-9_]{0,30}$`, no duplicate org, **and no duplicate schema** — two
+orgs sharing a schema is a cross-tenant leak spelled as a config typo.
+
+Per-tenant DSNs are derived by re-serializing the parsed base DSN with
+`search_path=<schema>,public`, the same mechanism as the test harness (`public`
+stays on the path for `pg_trgm` operators). An explicit per-tenant DSN override
+is allowed, which is what keeps cluster-sharding a config change.
+
+### Step 3 — `Registry`: org -> `*Services`
+
+Holds one `*appbuild.SharedBase` and a `Resolver`. `Acquire(ctx, orgID)`
+resolves, then returns a cached `*Services` or assembles one by opening the
+backend against the tenant's DSN. Bounded by an operator-set `MaxResident`;
+exceeding it evicts the least-recently-used tenant and closes its store.
+
+The awkward part is that eviction must not close a `*Services` a request is
+still using. Handle it with explicit reference counting and a release call,
+rather than hoping request lifetimes are shorter than eviction pressure — a
+use-after-close here is a crash at best.
+
+### Step 4 — the isolation test
+
+On the postgres build, against a live database: create two schemas, build one
+shared base, acquire two tenants, write an entity as A, assert it is invisible
+as B, and assert the reverse. Then assert the fail-closed cases return an error
+and a nil `*Services`.
+
+### Step 5 — arch-lint
+
+Add a `tenant` component. It depends on `appbuild` (it assembles Services),
+which means nothing may depend on `tenant` except a future host binary.
+
+## Risk Assessment
+
+- **Use-after-close on eviction** — the sharpest risk. An evicted store closed
+  while a request holds it is a panic. Mitigated by reference counting and by
+  never evicting an in-use entry.
+- **The postgres path may be unverifiable locally.** The isolation test is the
+  centrepiece and needs a live PostgreSQL. If none is available, say so plainly
+  rather than claiming the path is verified.
+- **Cross-tenant mutation through the shared base.** `meta` and `aclPolicy` are
+  pointers handed to every tenant. Already pinned by
+  `TestSharedBase_AssemblyDoesNotMutateSharedValues`; this work makes a
+  violation a cross-tenant defect rather than a curiosity.
+- **Scope creep into provisioning.** Deliberately resisted: the registry never
+  runs `CREATE SCHEMA`. An unknown org is a denial, and provisioning is
+  TKT-TNPRV8.
+- **A partially-mounted routing spine could look like isolation without being
+  it.** This ticket does not mount the registry in the HTTP path, so nothing in
+  the shipping server changes behaviour. That is the honest state and the PR
+  must say so rather than implying tenant isolation is live.

--- a/tickets/entities/review-checklists/REV-TNT9RS.md
+++ b/tickets/entities/review-checklists/REV-TNT9RS.md
@@ -1,0 +1,86 @@
+---
+id: REV-TNT9RS
+type: review-checklist
+title: 'Review: tenant resolution spine — org_id -> DSN -> Services, fail closed'
+status: done
+---
+
+## Automated Checks
+
+- [x] `just test` — full suite passes. `internal/tenant` at 85.8% statement coverage.
+- [x] `just test -race` on `internal/tenant` — passes, including the concurrent
+  acquisition test that exists specifically to be run under `-race`.
+- [x] **`just test-postgres` equivalent against a LIVE PostgreSQL** — run as
+  `RELA_TEST_DATABASE_URL=... RELA_TEST_DATABASE_REQUIRED=1 go test -race -tags
+  postgres ./internal/tenant/`. All three isolation tests pass. `REQUIRED=1` is
+  set deliberately so a missing database would fail rather than skip, since a
+  skip and a pass are indistinguishable in an exit code.
+- [x] `just lint` — clean for `internal/tenant`. Two `//nolint:contextcheck`
+  directives, both matching the existing precedent at
+  `internal/docscapture/server.go:90` ("teardown is not request-scoped; Close
+  takes no ctx") and each carrying its own reason.
+- [x] `just arch-lint` — OK, no warnings. New `tenant` component declared,
+  depending on `appbuild` only.
+- [x] `just plimsoll` — clean; no new type approaches a load line.
+- [x] `just comment-lint` — clean across 11116 comments.
+- [x] Build-tag isolation re-verified: `go list -deps ./cmd/rela-server` and
+  `./cmd/rela` contain no `jackc/pgx`. This is why the DSN derivation is split
+  across `dsn_postgres.go` / `dsn_nopostgres.go` rather than importing pgx from
+  `config.go`.
+
+## Manual Review
+
+- [x] **The isolation test was verified to be capable of failing.** A passing
+  security test proves nothing unless it can fail, so the test was deliberately
+  sabotaged (both tenants pointed at one DSN, simulating a `search_path`
+  derivation that silently did nothing) and it failed with:
+
+  ```text
+  --- FAIL: TestTenantIsolation_OneTenantCannotReadAnother (0.51s)
+      isolation_postgres_test.go:125: CROSS-TENANT LEAK: tenant A read foreign
+      entity TKT-B1 (map[title:tenant B confidential]); search_path is not
+      isolating these tenants
+  ```
+
+  The sabotage was then reverted and the suite re-run green. This is the single
+  most important line in this checklist: the centrepiece assertion is live.
+
+- [x] Fail-closed reviewed on every path. Unknown org, empty org, open failure,
+  and an opener returning `(nil, nil)` each yield an error and a nil lease.
+  Pinned by `TestMapResolver_FailsClosed`,
+  `TestRegistry_UnknownTenantGetsNoStore`,
+  `TestRegistry_OpenFailureYieldsNoLease`, `TestRegistry_NilServicesRefused`,
+  and `TestTenantIsolation_UnknownOrgReachesNoDatabase`.
+- [x] No zero value can mean "allowed". The registry refuses a nil `*Services`
+  before it can enter the resident set, which is the only route by which one
+  could reach a request.
+- [x] Use-after-close reviewed. Eviction of a referenced store is deferred to
+  its last release; `TestRegistry_EvictionWaitsForInFlightUse` pins it, and
+  `TestRegistry_DoubleReleaseIsSafe` pins that a defer-plus-explicit release
+  cannot drop another holder's reference.
+- [x] Duplicate-schema detection reviewed — this is the check for the failure
+  that no test downstream would catch, because two orgs sharing a schema
+  produces a system where every layer behaves exactly as designed.
+- [x] Schema-name validation reviewed against the regex RES-D54281 specifies.
+  Rejects uppercase, leading digits, hyphens, embedded quotes, over-length, and
+  a name containing a `search_path` separator (`public,tenant_b`) — the last
+  being the one that would matter once provisioning derives a name from a claim.
+- [x] Shared-base non-mutation is inherited, not re-implemented; already pinned
+  upstream by `TestSharedBase_AssemblyDoesNotMutateSharedValues`.
+- [x] ~~SPA / frontend review~~ (N/A: no frontend surface; the registry is not
+  yet mounted in any HTTP path).
+- [x] ~~Migration review~~ (N/A: no schema changes; this ticket adds no SQL and
+  `pgstore` is untouched, which was re-verified as still true.)
+
+## Verification
+
+- [x] **Scope honesty.** The registry is NOT mounted in `rela-server`. Nothing
+  in the shipping binaries changes behaviour, and tenant isolation is therefore
+  not live in any deployment. This is stated in the ticket, in the package doc,
+  and in the PR body rather than left for a reader to infer.
+- [x] Deferred work is filed, not half-built: provisioning is TKT-TNPRV8 and
+  erasure is TKT-TNERAS. No `CREATE SCHEMA` or `DROP SCHEMA` is reachable from
+  this code.
+- [x] The known pre-existing flake
+  (`TestMemoryQueue_Conformance/IdempotencyKeyFreedAfterCompletion`, arrived
+  with #1444) was not observed in this run. It is unrelated to this change.

--- a/tickets/entities/tickets/TKT-TNERAS.md
+++ b/tickets/entities/tickets/TKT-TNERAS.md
@@ -1,0 +1,84 @@
+---
+id: TKT-TNERAS
+type: ticket
+title: 'tenant: erase an org — DROP SCHEMA CASCADE, a documented retention SLA, and the audit-log residue'
+kind: enhancement
+priority: medium
+effort: m
+tags: [security, needs-design]
+status: backlog
+---
+
+## Description
+
+A schema-per-tenant deployment gets a clean GDPR erasure story almost for free,
+and RES-D54281 chose it partly for that. `DROP SCHEMA CASCADE` erases entities,
+relations, **attachments** (bytes are in the database, `pgstore/attachment.go`),
+search, and version history in one statement — because a schema holds *all* of a
+tenant's data.
+
+"Almost" free is doing work in that sentence. There are two residues outside the
+schema boundary, and both must be decided rather than discovered.
+
+## Residue 1: PITR backups
+
+pgBackRest point-in-time-recovery backups retain a dropped schema for the whole
+retention window. No amount of `DROP SCHEMA` changes that, and pretending
+otherwise is the failure mode.
+
+The standard, honest answer: **retention expiry *is* the erasure SLA.** Document
+"erased within N days", not "immediately", and make N a number the operator can
+state to a customer.
+
+## Residue 2: the audit log
+
+The audit sink is filesystem JSONL (`appbuild.go`), **shared across tenants** in
+this design, and it records entity IDs, entity types, and principals. `DROP
+SCHEMA` does not touch it.
+
+This is **not a cross-tenant leak** — tenants have no disk access, and the log is
+operator-oriented. But it **is retained personal data outside the erasure
+boundary**, which is a different and still-real problem. The existing
+`history-purge` tooling is per-entity and CLI-only, so it does not cover this.
+
+Three options, and this ticket must pick one:
+
+1. **A per-tenant sink** — the log follows the tenant and is deleted with it.
+2. **A tenant field plus a retention policy** — one log, filterable, aged out.
+3. **A documented exclusion** — the audit log is operator telemetry with its own
+   retention, stated explicitly rather than left implicit.
+
+`audit.Audit` is a one-method interface and the only hardcoding is a single
+`filepath.Join`, so a per-tenant or DB-backed sink is a drop-in. The cost here is
+the decision, not the code.
+
+## Scope
+
+**In scope**
+
+- An erasure path that drops a tenant's schema and removes it from the tenant
+  map, with the resident-set entry evicted and its store closed first (dropping
+  a schema out from under an open pool is not a graceful shutdown).
+- The retention SLA, written down where an operator will find it.
+- The audit-log decision, implemented.
+
+**Out of scope**
+
+- Resolution (TKT-TNT9RS) and provisioning (TKT-TNPRV8).
+- Per-entity GDPR purge, which already exists (`pgstore/purge.go`,
+  `internal/cli/history_purge.go`) and is a different, row-level facility with
+  no tenant dimension.
+
+## Acceptance criteria
+
+1. Erasing a tenant closes its store, evicts it from the resident set, drops its
+   schema, and removes it from the map — in that order.
+2. After erasure the org fails closed exactly as an unknown org does.
+3. The backup-retention SLA is documented as a stated number of days.
+4. The audit-log residue is resolved by an implemented decision, not a TODO.
+
+## Notes
+
+- Erasure is irreversible and reachable from an authenticated path, so it needs
+  a sharper authorization story than "a verified principal from that org". Who
+  may erase a tenant is part of the design work here.

--- a/tickets/entities/tickets/TKT-TNPRV8.md
+++ b/tickets/entities/tickets/TKT-TNPRV8.md
@@ -1,0 +1,101 @@
+---
+id: TKT-TNPRV8
+type: ticket
+title: 'tenant: provision a new org — eager IdP webhook plus a single-flighted lazy backstop'
+kind: enhancement
+priority: medium
+effort: l
+tags: [security, needs-design]
+status: backlog
+---
+
+## Description
+
+TKT-TNT9RS resolves a verified `org_id` to a store and **fails closed** on an
+org it does not know. This ticket is the other half: making an org *become*
+known — creating its schema, migrating it, and adding it to the tenant map.
+
+RES-D54281 specifies the shape and the reasoning; this ticket carries it out.
+
+## Approach (from RES-D54281)
+
+- **Eager**: Pratique posts `org.created` to the existing self-authenticating IdP
+  webhook (`internal/dataentry/webhook.go`, which already carries `org_id` and
+  authenticates with a separate `aud`). The handler creates the schema and runs
+  `pgstore.Migrate`. This is the fast path: the tenant's first request finds a
+  ready schema, and a failure is loud and early where retry is easy.
+- **Lazy**: a verified-but-unknown org arriving on a request provisions on the
+  spot, which makes a missed webhook self-healing.
+- **Both.** Eager is the fast path, lazy is the backstop.
+- **Single-flight the lazy path.** `pgstore.Migrate` is already concurrent-start
+  safe — one transaction under `pg_advisory_xact_lock(key,
+  hashtext(current_schema()))` — so a herd serializes rather than corrupts. A
+  single-flight in front makes nine concurrent requests wait on one migration
+  instead of queueing nine.
+- **Return `202` plus a status the SPA polls.** Do not hold an HTTP request open
+  across schema creation and migration: that turns a slow migration into a
+  client timeout with a half-created tenant and no owner.
+
+## The trust assumption must be written down, not assumed
+
+This is the part of the ticket that is a security decision rather than
+plumbing. **Provisioning on an unknown-but-verified org means anyone who can
+mint an assertion can create schemas.**
+
+That is acceptable *today* only because of a specific, currently-true property:
+there is exactly one issuer, `aud` is pinned, Pratique guarantees `org_id` is
+present on every verified assertion, and an orgless session never receives an
+assertion at all. So "verified org never seen" means *new*, not *malicious*.
+
+**It stops holding the day a second issuer exists.** Record the assumption
+next to the code that depends on it, and make the lazy path something an
+operator can turn off — a deployment that provisions only via the webhook
+should be able to say so and have unknown orgs stay a hard denial.
+
+Note also the rate-limit dimension: schema creation is expensive and
+unbounded-in-principle. A cap on provisioning rate is not gold-plating here.
+
+## Interaction with the resident-set bound
+
+TKT-TNT9RS bounds the resident set because each open store costs ~17
+connections (untuned pool + dedicated LISTEN connection + sweep). Provisioning
+adds a second, different pressure: the number of *schemas* on a cluster, which
+is bounded by disk and by how long `pgstore.Migrate` takes to run N times with
+mixed-version states. These are separate ceilings and should be reasoned about
+separately.
+
+## Scope
+
+**In scope**
+
+- `org.created` webhook handling: create schema, migrate, register the tenant.
+- The lazy backstop, single-flighted, operator-disableable.
+- `202` + a pollable provisioning status.
+- Whatever the tenant map needs to accept a write at runtime. TKT-TNT9RS chose
+  an operator-authored config file **precisely because there was no runtime
+  writer yet**; this ticket is that writer, and is therefore the right place to
+  decide whether the `Resolver` implementation moves to a control-schema table.
+  The interface should not need to change — that was the point of the seam.
+- Strict schema-name derivation from `org_id` (`^[a-z][a-z0-9_]{0,30}$`), since
+  a schema name reached from a claim is a trust boundary.
+
+**Out of scope**
+
+- Resolution and routing (TKT-TNT9RS).
+- Erasure (TKT-TNERAS).
+- Reconciliation against the IdP. RES-D54281 identifies the one legitimate
+  feature request to Pratique — org enumeration or `org.created` event replay,
+  as the backstop for missed webhooks. Track separately; note that the lazy
+  path already covers the common case.
+
+## Acceptance criteria
+
+1. An `org.created` webhook creates and migrates a schema, and the org resolves
+   afterwards without a restart.
+2. The lazy path provisions an unknown verified org, is single-flighted (pinned
+   by a concurrency test), and can be disabled by the operator — with unknown
+   orgs then remaining a hard denial.
+3. Provisioning returns `202` and a pollable status; no request is held open
+   across migration.
+4. The trust assumption is documented at the code that depends on it.
+5. Schema names derived from a claim are validated before use.

--- a/tickets/entities/tickets/TKT-TNT9RS.md
+++ b/tickets/entities/tickets/TKT-TNT9RS.md
@@ -1,0 +1,224 @@
+---
+id: TKT-TNT9RS
+type: ticket
+title: 'tenant: resolve a verified org to a store, fail closed on an unknown tenant'
+kind: enhancement
+priority: high
+effort: l
+tags: [security]
+status: done
+---
+
+## Description
+
+Multi-tenant SaaS (RES-D54281) turns on one lookup: a verified `org_id` must
+select **which store a request may touch**. Nothing does that today. `OrgID` is
+carried, forge-proof, all the way to the ACL (`principal.go:185`,
+`router.go:408`) and is then **used for nothing but recording**
+(`docs/acl-security.md`, `principal.go` — "recorded, not enforced").
+
+Build the resolution spine: `org_id -> DSN -> *appbuild.Services`, with a
+bounded resident set, and **fail closed** when the org does not resolve.
+
+This is the piece RES-D54281 calls "the spine of the work". The four
+prerequisites it named have all shipped — explicit DSN (TKT-1J5KEV, #1318),
+shared-base/per-store split (TKT-P938T7), one shared NOTIFY channel
+(TKT-9TOEBH), Postgres-backed `state.KV` (TKT-VC27L3) — so `SharedBase.Assemble`
+is already documented as "a multi-store host calls it directly, once per store".
+This ticket is the caller that documentation was written for.
+
+**This ticket does not provision tenants and does not erase them.** See
+TKT-TNPRV8 and TKT-TNERAS.
+
+### Why isolation is not an ACL rule
+
+`internal/acl` is union semantics with no deny primitive, so "deny unless org
+matches" is inexpressible as a role rule — RES-D54281 establishes this and
+`TestAssertedRoles_OrgIsNotEvaluated` pins the absence.
+
+Isolation therefore comes from **the store handle a request can reach**. A
+request resolved to tenant T holds a `*Services` whose store is a pool pinned to
+schema T by `search_path`. A cross-tenant read is not a missing `WHERE` clause
+that a reviewer must spot; it is `relation "entities" does not exist`, enforced
+by PostgreSQL. That is the whole reason RES-D54281 chose schema-per-tenant over
+a `tenant_id` column: the column form makes every one of ~20 indexes and every
+query a place where one missed predicate is a silent leak **with no compile
+error**.
+
+## Decision: where the tenant map lives
+
+RES-D54281 decided the map is **rela-owned, not a JWT claim and not Pratique**,
+and left storage open. **Decided here: an operator-authored config file,
+`tenants.yaml`, loaded at boot, behind a one-method `Resolver` interface.**
+
+Reasoning, in the order that decided it:
+
+1. **It cannot live in the thing it shards.** RES-D54281 names the recursion
+   directly: the map "cannot live inside the thing it shards". A table in a
+   tenant schema is circular by construction, and a table in a *control* schema
+   means the process needs a DSN to find DSNs — so there is always a
+   bootstrap-config layer underneath. A config file **is** that layer. Putting
+   the map in a database does not remove the file; it adds a database *and*
+   keeps the file.
+2. **The operator already authors exactly one config.** That is the premise of
+   the whole design — one metamodel, one `acl.yaml`, one `data-entry.yaml`. A
+   `tenants.yaml` beside them is the shape the operator is already in, and it is
+   reviewable, diffable, and deployable by the same path as the rest.
+3. **The interface is the real decision; the backing store is not.** RES-D54281
+   says the requirement is that "the lookup must be a single seam: one
+   interface, one cache with explicit invalidation. Keep that true and 'where
+   the map lives' stays a config change." A file satisfies the seam at the
+   lowest cost, and a DB-backed `Resolver` is a drop-in the day self-serve
+   signup needs writes at runtime.
+4. **A file is honest about the current scale.** There is no self-serve signup
+   yet (TKT-TNPRV8 is not built), so today every tenant arrives through an
+   operator action anyway. A control-schema table would be infrastructure built
+   for a provisioning flow that does not exist, and it would have to be designed
+   *before* the thing that writes to it — the wrong order.
+
+**What this deliberately does not decide:** the day provisioning lands
+(TKT-TNPRV8), the resolver behind the interface likely becomes DB-backed so a
+webhook can write a tenant without a deploy. That is a swap of one
+implementation, which is precisely the property being bought here.
+
+**Rejected: DSN in a JWT claim.** Already rejected by RES-D54281, restated here
+because it is the tempting shortcut. Storage topology in an identity token means
+Pratique knows about database clusters and every rebalance becomes a Pratique
+deploy; it also breaks `jwtauth`'s deliberate provider-agnosticism.
+
+## Decision: the connection ceiling and the resident set
+
+RES-S8CH9C measured it and RES-D54281 reuses the number: `pgstore.Open` builds a
+pool with **no `MaxConns` set** (defaults to `max(4, numCPU)`), plus **one
+dedicated non-pooled connection for `LISTEN`** (`open.go:57`), plus the sweep.
+On a 16-core box that is **~17 connections per open store**. Against a typical
+`max_connections=100` that is ~5 tenants resident, not 500.
+
+TKT-9TOEBH already removed the per-tenant LISTEN connection at the *channel*
+level (one `rela_changed` channel for every schema), but a resolver that calls
+`pgstore.Open` per tenant still gets a pool and a listener per tenant, because
+`Open` owns that construction.
+
+So the ceiling is **not** something this ticket can delete; it is something this
+ticket must **refuse to exceed**. Two rules follow, and they are the design:
+
+1. **The resident set is bounded, and the bound is a number the operator sets** —
+   not the tenant count. RES-D54281's horizon requires "live-project count
+   bounded independently of total tenant count", and that is the only property
+   that makes 500 tenants on one process a question about latency rather than
+   about `max_connections`.
+2. **Eviction closes the store.** `Services.Close()` is already per-store by
+   construction (TKT-P938T7 pinned it: it "tears down the store and search
+   closer it was assembled with, never anything belonging to the base"), which
+   is exactly what makes eviction safe. Evicting tenant A must leave the shared
+   base and every other resident tenant untouched.
+
+Apartment-style pooling — one shared pool with `SET search_path` per checkout —
+is the eventual answer and RES-D54281 describes it. It is **out of scope here**
+because it collides with the version sweep, which deliberately runs a whole tick
+on one acquired connection under a session-scoped advisory lock and whose doc
+warns that issuing inserts via the pool would "silently void the single-writer
+guarantee". Rotating `search_path` on a shared pool breaks that. Bounding the
+resident set gets the same headroom without touching the sweep's invariant.
+
+## Decision: fail closed
+
+The security requirement is one sentence — **no cross-tenant data leaks** — and
+every ambiguous case resolves the same way: **no tenant, no store, no request.**
+
+Specifically, all of these are denials, not fallbacks:
+
+- No `org_id` on the principal (unverified, or a verified principal from an
+  issuer that does not assert one).
+- An `org_id` that is not in the map.
+- A tenant entry that fails validation.
+
+The trap being avoided is the one RES-D54281 catalogues under "known fail-open
+traps": a zero-value `ReadQueryResult` **aliases `AllowAll`**, and
+`nopReadGate.HoldsPermission` returns `true` unconditionally. A resolver that
+returned a zero-valued or default store on an unknown org would join that list
+as the worst member — it would not widen permissions within a tenant, it would
+hand one tenant another tenant's database. **A missing tenant must be an error
+value, never a zero value.**
+
+## Scope
+
+**In scope**
+
+- A `tenant` package: `Tenant` (org ID + DSN + schema), `Resolver` (one method:
+  org ID -> `Tenant`), and a config-file-backed implementation.
+- Strict schema-name validation. RES-D54281 flags schema names as "a trust
+  boundary needing strict validation (`^[a-z][a-z0-9_]{0,30}$`)" — an
+  operator-authored file is inside the trust boundary but a typo must still fail
+  loudly at load, not at first `CREATE`.
+- A registry that resolves an org to an assembled `*appbuild.Services` over one
+  shared `*appbuild.SharedBase`, with a bounded resident set and eviction that
+  closes the evicted store only.
+- Duplicate detection at load: two orgs mapping to one schema is a
+  cross-tenant leak spelled as a config typo, and must fail at boot.
+- Tests, on the postgres build, proving the isolation property against a real
+  database: two tenants, two schemas, one process; data written as tenant A is
+  **not readable** as tenant B.
+
+**Out of scope**
+
+- **Provisioning** — webhook, lazy backstop, single-flight, 202+poll (TKT-TNPRV8).
+  This ticket resolves tenants that already exist and fails closed on ones that
+  do not; it never runs `CREATE SCHEMA`.
+- **Erasure** — `DROP SCHEMA CASCADE`, retention SLA, the audit-log decision
+  (TKT-TNERAS).
+- **Mounting the registry in `rela-server`'s HTTP path.** `dataentry.App` is one
+  App per store and sits at `//plimsoll:max-methods=104`; an App-per-tenant host
+  is its own ticket and its own review. RES-D54281 is explicit: "Do **not** put
+  per-request tenant logic on `App`."
+- Apartment-style shared pooling, and cluster sharding.
+- The non-HTTP entry points (scheduler, CLI, MCP), which build principals from
+  plain literals and have no org. RES-D54281 flags deciding what a CLI write
+  means in a SaaS deployment; that decision is not this ticket's.
+
+## Load-bearing constraints
+
+- **The shared base is shared and must not be mutated.** `meta` and `aclPolicy`
+  are pointers handed to every tenant. TKT-P938T7 pinned this with
+  `TestSharedBase_AssemblyDoesNotMutateSharedValues`; a registry assembling N
+  Services makes a violation a cross-tenant defect rather than a curiosity.
+- **Closing one tenant must not disturb another.** Already true of
+  `Services.Close()`; the registry must not add anything that breaks it.
+- **Constructors reject nil required fields** (CLAUDE.md). A registry without a
+  base or without a resolver must fail at construction.
+- **The DSN must never reach a command line** (TKT-1J5KEV's constraint). A
+  tenants file read in Go code is fine; a `--tenant-dsn` flag is not.
+
+## Acceptance criteria
+
+1. A `Resolver` maps a verified org ID to a tenant record, and returns a
+   distinguishable "unknown tenant" error — not a zero value — for anything it
+   cannot resolve.
+2. An unknown, empty, or invalid org yields **no store**. Pinned by a test that
+   asserts the error, and asserts no `*Services` is returned.
+3. A registry assembles per-tenant `Services` over one shared base, and the
+   metamodel and ACL policy are parsed once regardless of tenant count.
+4. The resident set is bounded by an operator-set limit; exceeding it evicts,
+   and eviction closes the evicted store and nothing else. Pinned by a test that
+   evicts one tenant and keeps using another.
+5. Two orgs mapping to the same schema fails at load, not at first request.
+6. Schema names are validated against `^[a-z][a-z0-9_]{0,30}$` at load.
+7. **On the postgres build, against a live database: an entity written through
+   tenant A's store is not visible through tenant B's store.** This is the
+   ticket's centrepiece, and it must be an executed assertion, not prose.
+8. `just test`, `just lint`, `just arch-lint`, `just plimsoll`, and
+   `just comment-lint` pass.
+
+## Notes
+
+- The test harness for criterion 7 already exists and is routine:
+  `internal/appbuild/backendtest/backendtest_postgres.go:88-116` creates a
+  private schema per test and hands back a DSN pinned to it via
+  `dsnWithSearchPath`, which re-serializes the parsed config rather than doing
+  query-string surgery (pgx accepts both URL and key/value DSNs, and appending
+  `?search_path=` silently corrupts the latter). Reuse that construction rather
+  than inventing a second one.
+- RES-D54281's load-bearing claim — **`pgstore` needs zero changes** — is
+  re-verified and still holds: schema is purely the connection's `search_path`,
+  and `current_schema()` derives the NOTIFY payload's schema field and every
+  advisory-lock key. This ticket adds no pgstore code.

--- a/tickets/relations/RES-D54281--informs--TKT-TNERAS.md
+++ b/tickets/relations/RES-D54281--informs--TKT-TNERAS.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: informs
+to: TKT-TNERAS
+---

--- a/tickets/relations/RES-D54281--informs--TKT-TNPRV8.md
+++ b/tickets/relations/RES-D54281--informs--TKT-TNPRV8.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: informs
+to: TKT-TNPRV8
+---

--- a/tickets/relations/RES-D54281--informs--TKT-TNT9RS.md
+++ b/tickets/relations/RES-D54281--informs--TKT-TNT9RS.md
@@ -1,0 +1,5 @@
+---
+from: RES-D54281
+relation: informs
+to: TKT-TNT9RS
+---

--- a/tickets/relations/TKT-TNERAS--affects--store-backends.md
+++ b/tickets/relations/TKT-TNERAS--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNERAS
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-TNERAS--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-TNERAS--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNERAS
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-TNPRV8--affects--store-backends.md
+++ b/tickets/relations/TKT-TNPRV8--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNPRV8
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-TNPRV8--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-TNPRV8--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNPRV8
+relation: implements
+to: FEAT-CO4YP
+---

--- a/tickets/relations/TKT-TNT9RS--affects--authorization.md
+++ b/tickets/relations/TKT-TNT9RS--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNT9RS
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-TNT9RS--affects--store-backends.md
+++ b/tickets/relations/TKT-TNT9RS--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNT9RS
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-TNT9RS--has-docs--DOCS-TNT9RS.md
+++ b/tickets/relations/TKT-TNT9RS--has-docs--DOCS-TNT9RS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNT9RS
+relation: has-docs
+to: DOCS-TNT9RS
+---

--- a/tickets/relations/TKT-TNT9RS--has-planning--PLAN-TNT9RS.md
+++ b/tickets/relations/TKT-TNT9RS--has-planning--PLAN-TNT9RS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNT9RS
+relation: has-planning
+to: PLAN-TNT9RS
+---

--- a/tickets/relations/TKT-TNT9RS--has-review--REV-TNT9RS.md
+++ b/tickets/relations/TKT-TNT9RS--has-review--REV-TNT9RS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNT9RS
+relation: has-review
+to: REV-TNT9RS
+---

--- a/tickets/relations/TKT-TNT9RS--implements--FEAT-CO4YP.md
+++ b/tickets/relations/TKT-TNT9RS--implements--FEAT-CO4YP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-TNT9RS
+relation: implements
+to: FEAT-CO4YP
+---


### PR DESCRIPTION
Implements **TKT-TNT9RS** — the tenant resolution spine from RES-D54281. All four prerequisites it named have shipped, so this is the first genuinely new multi-tenancy work: `org_id -> DSN -> *appbuild.Services`, with a bounded resident set and fail-closed behaviour on an unresolvable tenant.

## What this is not

**The registry is not mounted in `rela-server`.** No shipping binary changes behaviour, and **tenant isolation is not live in any deployment**. This lands the resolver and per-tenant store acquisition as a reviewable unit; wiring it into the HTTP path is separate work (`dataentry.App` is one App per store and sits at `//plimsoll:max-methods=104`, and RES-D54281 says explicitly not to put per-request tenant logic on `App`).

Stated up front because a partially-mounted routing spine could easily read as isolation that is already enforced.

## Why isolation is not an ACL rule

`internal/acl` is union semantics with no deny primitive, so "deny unless org matches" is inexpressible as a role rule. Isolation comes from **the store handle a request can reach**: a tenant's store is a pool pinned to its schema by `search_path`, and rela's SQL is unqualified (`FROM entities`). A cross-tenant read is therefore `relation does not exist`, enforced by PostgreSQL — not a missing `WHERE` a reviewer has to spot.

Re-verified against develop: **`pgstore` needs zero changes**, and none were made.

## Decisions made explicitly

**Where the tenant map lives — an operator-authored `tenants.yaml`, behind a one-method `Resolver`.** RES-D54281 decided the map is rela-owned but left storage open. The deciding argument is recursion: the map cannot live inside the thing it shards, and a control-schema table means the process needs a DSN to find DSNs — so a bootstrap-config layer always exists underneath. A file *is* that layer; a database would sit on top of it rather than replace it. It also matches a deployment where the operator already authors exactly one config and every tenant arrives through an operator action, because provisioning does not exist yet. The interface is the real decision: a DB-backed resolver is a drop-in when TKT-TNPRV8 needs runtime writes.

**Connection ceiling.** `pgstore.Open` builds a pool with no `MaxConns` plus a dedicated `LISTEN` connection plus the sweep — ~17 connections per open store (RES-S8CH9C). TKT-9TOEBH removed the per-tenant *channel*, not the per-tenant *pool*, so the ceiling is something this must refuse to exceed rather than something it can delete.

**Resident-set bounding.** Open stores are capped by an operator-set number, independent of tenant count — the property RES-D54281's horizon requires. Eviction closes only the evicted store, which is safe because `Services.Close` already tears down only what it was assembled with (pinned upstream by TKT-P938T7). Apartment-style shared pooling is deferred: it collides with the version sweep's single-writer guarantee, and bounding the resident set buys the same headroom without touching that invariant.

**Fail closed.** Unknown org, empty org, open failure, and an opener returning `(nil, nil)` all yield an error and no store — never a zero value. rela already has fail-open traps where a zero value means "allow"; a resolver joining that family would hand one tenant another tenant's database.

## The isolation test, and proof it can fail

Two tenants, two schemas, one database, one process, run against a **live PostgreSQL** (not compile-only):

```
--- PASS: TestTenantIsolation_OneTenantCannotReadAnother (0.76s)
--- PASS: TestTenantIsolation_UnknownOrgReachesNoDatabase (0.00s)
--- PASS: TestTenantIsolation_EvictionDoesNotDisturbSiblings (0.74s)
```

A passing security test proves nothing unless it can fail, so it was deliberately sabotaged (both tenants pointed at one DSN, simulating a `search_path` derivation that silently did nothing):

```
--- FAIL: TestTenantIsolation_OneTenantCannotReadAnother (0.51s)
    CROSS-TENANT LEAK: tenant A read foreign entity TKT-B1
    (map[title:tenant B confidential]); search_path is not isolating these tenants
```

Sabotage reverted, suite re-run green.

## Deliberately deferred, filed not half-built

- **TKT-TNPRV8** — provisioning: `org.created` webhook, single-flighted lazy backstop, 202+poll. Carries the trust assumption that needs writing down: provisioning an unknown-but-verified org means anyone who can mint an assertion can create schemas, which holds only while there is one issuer with `aud` pinned.
- **TKT-TNERAS** — erasure: `DROP SCHEMA CASCADE`, the backup-retention SLA, and the audit-log residue (shared JSONL is retained personal data outside the erasure boundary — not a leak, but a decision owed).

No `CREATE SCHEMA` or `DROP SCHEMA` is reachable from this code.

## Checks

`just test` (85.8% coverage on the new package), `-race`, `just lint`, `just arch-lint`, `just plimsoll`, `just comment-lint` — all clean. Postgres path verified against a real database with `RELA_TEST_DATABASE_REQUIRED=1` so a missing DB would fail rather than skip.

pgx is confined to a `postgres`-tagged file, so `go list -deps` confirms the default `rela` / `rela-server` binaries still do not link it.

The known pre-existing flake (`TestMemoryQueue_Conformance/IdempotencyKeyFreedAfterCompletion`, arrived with #1444) was not observed in this run and is unrelated.

https://claude.ai/code/session_01LeqEBvAixB2pbPp19RjfkR