### PR TITLE
feat(docs): executable manuals — assertions in the rela-docs doc language (TKT-DOCASSERT)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -719,6 +719,12 @@ deps:
       - acl
       - entity
       - lua
+      # principal: the refuses{}/permits{} assertion verbs authorize through
+      # acl.Declarative, whose API takes a principal.Principal — so this is
+      # implied by the acl dependency above rather than a new reach. The
+      # package is a dependency-free leaf; docscapture lists it for the same
+      # reason (TKT-DOCASSERT).
+      - principal
       # visibility: only for visibility.Unrestricted, which NAMES the
       # docs runtime's deliberately ungated reads (TKT-1WV50C). It reads a
       # throwaway memstore the doc build just seeded itself.

--- a/docs-project/entities/guides/GUIDE-rela-docs.md
+++ b/docs-project/entities/guides/GUIDE-rela-docs.md
@@ -62,6 +62,8 @@ available without the `doc.` prefix.
 | `count{type}` | the number of seeded entities of a type (echo-friendly) |
 | `roles_matrix{type}` | a role × verb capability table from `acl.yaml` (omit `type` for every type) |
 | `description()` | the metamodel's top-level `description:` (echo-friendly) |
+| `shows{type, contains\|absent\|exactly}` | **asserts** which entities of a type exist (emits nothing) |
+| `refuses{who, op, type, because}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
 | `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
 
 ### Relation graphs
@@ -107,6 +109,49 @@ validation, no state-machine gate, and no ACL. A fixture is exactly what
 you write, so `create("risico", { status = "done" })` is fine even if
 `done` is not a legal entry state. This keeps fixtures honest and
 self-contained; it never touches the project on disk.
+
+## Assertions
+
+A manual can *check* the claims its prose makes. Assertion islands emit no
+output — they either pass, or they fail the build with the mismatch:
+
+```rela
+create("risico", { titel = "Leak", kans = 3, impact = 4, status = "todo" })
+
+shows{ type = "risico", exactly = { "risico-1" } }
+refuses{ who = "bob@example.com", op = "update", type = "risico" }
+```
+
+This is what keeps a handbook from outliving the system it describes. If
+someone widens `viewer` in `acl.yaml`, the `refuses{}` above stops holding and
+the manual refuses to build, naming the rule that fired:
+
+```text
+manual:80: resolve: refuses{who="bob@example.com", op="update", type="risico"} failed
+  claimed: refused
+  actual:  PERMITTED
+  rule:    role-grant/viewer
+```
+
+**Every argument is optional except the target.** A paragraph about visibility
+says nothing about buttons, so `shows{}` asserts only the claims you give it.
+But **a call that asserts nothing is an error** — `shows{type="risico"}` looks
+like a test and checks nothing, which is the one failure mode worse than having
+no test at all.
+
+Prefer `exactly` over `contains` for a set you fully control: `contains` cannot
+see an over-inclusive result, and over-inclusion (a leaked row, a duplicate) is
+usually the interesting bug. `exactly = {}` is a real claim — "this type has no
+entities" — not an empty one.
+
+`refuses{}` / `permits{}` evaluate through the **same authorization path the
+write path uses**, not by re-reading `acl.yaml`. Answering from the policy file
+would only prove that the manual and the file agree, which they would even if
+the gate were never consulted. This is the deliberate exception to the
+"seed writes bypass ACL" rule above: seeding is a fixture, an assertion is a
+claim about real behaviour. Add `because = "..."` to also pin *why* a decision
+came out that way — a deny arriving from an unintended rule is a green check
+over a real regression.
 
 ## Building
 

--- a/docs-project/entities/guides/GUIDE-rela-docs.md
+++ b/docs-project/entities/guides/GUIDE-rela-docs.md
@@ -63,7 +63,7 @@ available without the `doc.` prefix.
 | `roles_matrix{type}` | a role × verb capability table from `acl.yaml` (omit `type` for every type) |
 | `description()` | the metamodel's top-level `description:` (echo-friendly) |
 | `shows{type, contains\|absent\|exactly}` | **asserts** which entities of a type exist (emits nothing) |
-| `refuses{who, op, type, because}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
+| `refuses{who, op, type, because, unassigned}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
 | `api{path, status, error, as, identical_to}` | **asserts** an API contract against a real server (emits nothing) |
 | `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
 
@@ -145,6 +145,13 @@ see an over-inclusive result, and over-inclusion (a leaked row, a duplicate) is
 usually the interesting bug. `exactly = {}` is a real claim — "this type has no
 entities" — not an empty one.
 
+`who` must name a principal in `acl.yaml`'s `assignments`. An unknown one is
+refused, because a principal with no assignment has no grants and is therefore
+denied *by construction* — so a `refuses{}` with a misspelled `who` would pass
+forever, unable to ever fail. When the missing assignment IS the point ("there
+is no self-service sign-up"), say `unassigned = true`; without it, an intended
+claim and a typo look identical to a reviewer.
+
 `refuses{}` / `permits{}` evaluate through the **same authorization path the
 write path uses**, not by re-reading `acl.yaml`. Answering from the policy file
 would only prove that the manual and the file agree, which they would even if
@@ -191,12 +198,20 @@ api{
 }
 ```
 
-The comparison covers status and body but **excludes** the problem-details
-`instance` member, which echoes the requested URL: two requests to different
+The comparison covers status, body, and the response headers that can by
+themselves disclose existence (`ETag`, `Last-Modified` — a denied GET that
+emits an ETag lets a replayed `If-None-Match` return 304, confirming the entity
+exists). It **excludes** the problem-details `instance` member, which echoes the requested URL: two requests to different
 urls necessarily differ there, so including it would make the check fail on
 every pair — a check that never passes is not checking anything. `instance`
 reflects only what the caller already typed, so it leaks nothing; every other
 field must match exactly.
+
+The exclusion is minimal and route-specific: on `/api/v1/{plural}/{id}` the two
+404s differ only in `instance`. Some other routes interpolate the request into
+the problem `title` (`entity %q not found`), so `identical_to` will fail there —
+in the safe direction, but it means the verb is meaningful on the entity routes
+and needs checking before use elsewhere.
 
 ## Building
 

--- a/docs-project/entities/guides/GUIDE-rela-docs.md
+++ b/docs-project/entities/guides/GUIDE-rela-docs.md
@@ -64,6 +64,7 @@ available without the `doc.` prefix.
 | `description()` | the metamodel's top-level `description:` (echo-friendly) |
 | `shows{type, contains\|absent\|exactly}` | **asserts** which entities of a type exist (emits nothing) |
 | `refuses{who, op, type, because}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
+| `api{path, status, error, as, identical_to}` | **asserts** an API contract against a real server (emits nothing) |
 | `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
 
 ### Relation graphs
@@ -152,6 +153,50 @@ the gate were never consulted. This is the deliberate exception to the
 claim about real behaviour. Add `because = "..."` to also pin *why* a decision
 came out that way — a deny arriving from an unintended rule is a green check
 over a real regression.
+
+### API assertions
+
+`api{}` issues a real request against the documented project's API, served over
+a throwaway temp copy seeded with the manual's own fixtures:
+
+```rela
+create("ticket", { id = "TKT-1", title = "Login 500s", status = "open" })
+
+api{ path = "/api/v1/tickets/TKT-1", as = "editor", status = 200 }
+api{ path = "/api/v1/tickets/NOPE", as = "editor", error = "https://rela.dev/errors/not_found" }
+```
+
+`error=` claims the **machine-readable code**, not the prose title: a message
+gets reworded, the code is the contract. Asserting the message gives a check
+that fails on a copy edit and passes on a real behaviour change.
+
+`as=` names a role from `acl.yaml`, so an ACL claim can be stated as the
+response a real caller gets.
+
+Unlike `screenshot{}`, `api{}` needs no browser and no built frontend — it only
+reaches the `/api/v1` handlers, so it can gate CI unconditionally. Like
+`screenshot{}` it is unavailable on the `postgres` build, where seeding a
+"throwaway" project would write into the live database.
+
+#### `identical_to` — the existence-oracle property
+
+Some properties are not about one response but about two being the **same**.
+"A denied read is indistinguishable from a missing entity" cannot be stated by
+asserting a status, because the whole claim is that two requests answer alike:
+
+```rela
+api{
+  path = "/api/v1/tickets/HIDDEN", as = "viewer", status = 404,
+  identical_to = { path = "/api/v1/tickets/NO-SUCH-THING", as = "viewer" },
+}
+```
+
+The comparison covers status and body but **excludes** the problem-details
+`instance` member, which echoes the requested URL: two requests to different
+urls necessarily differ there, so including it would make the check fail on
+every pair — a check that never passes is not checking anything. `instance`
+reflects only what the caller already typed, so it leaks nothing; every other
+field must match exactly.
 
 ## Building
 

--- a/docs/examples/ticket-tracker-manual.md
+++ b/docs/examples/ticket-tracker-manual.md
@@ -87,6 +87,10 @@ The access model comes straight from `acl.yaml`:
 | `ticket` | update | ✓ |  |
 | `ticket` | delete | ✓ |  |
 
+The table above is rendered from `acl.yaml`. These claims are *checked* against
+the real authorization path when this handbook builds, so the prose cannot
+outlive the policy it describes:
+
 ## The edit form
 
 This is the ticket edit form as an editor sees it, with the two lifecycle-driving

--- a/docs/examples/ticket-tracker-manual.md
+++ b/docs/examples/ticket-tracker-manual.md
@@ -87,7 +87,7 @@ The access model comes straight from `acl.yaml`:
 | `ticket` | update | ✓ |  |
 | `ticket` | delete | ✓ |  |
 
-The table above is rendered from `acl.yaml`. These claims are *checked* against
+The table above is rendered from `acl.yaml`. These claims are _checked_ against
 the real authorization path when this handbook builds, so the prose cannot
 outlive the policy it describes:
 

--- a/docs/rela-docs.md
+++ b/docs/rela-docs.md
@@ -58,6 +58,7 @@ available without the `doc.` prefix.
 | `description()` | the metamodel's top-level `description:` (echo-friendly) |
 | `shows{type, contains\|absent\|exactly}` | **asserts** which entities of a type exist (emits nothing) |
 | `refuses{who, op, type, because}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
+| `api{path, status, error, as, identical_to}` | **asserts** an API contract against a real server (emits nothing) |
 | `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
 
 ### Relation graphs
@@ -146,6 +147,50 @@ the gate were never consulted. This is the deliberate exception to the
 claim about real behaviour. Add `because = "..."` to also pin *why* a decision
 came out that way — a deny arriving from an unintended rule is a green check
 over a real regression.
+
+### API assertions
+
+`api{}` issues a real request against the documented project's API, served over
+a throwaway temp copy seeded with the manual's own fixtures:
+
+```rela
+create("ticket", { id = "TKT-1", title = "Login 500s", status = "open" })
+
+api{ path = "/api/v1/tickets/TKT-1", as = "editor", status = 200 }
+api{ path = "/api/v1/tickets/NOPE", as = "editor", error = "https://rela.dev/errors/not_found" }
+```
+
+`error=` claims the **machine-readable code**, not the prose title: a message
+gets reworded, the code is the contract. Asserting the message gives a check
+that fails on a copy edit and passes on a real behaviour change.
+
+`as=` names a role from `acl.yaml`, so an ACL claim can be stated as the
+response a real caller gets.
+
+Unlike `screenshot{}`, `api{}` needs no browser and no built frontend — it only
+reaches the `/api/v1` handlers, so it can gate CI unconditionally. Like
+`screenshot{}` it is unavailable on the `postgres` build, where seeding a
+"throwaway" project would write into the live database.
+
+#### `identical_to` — the existence-oracle property
+
+Some properties are not about one response but about two being the **same**.
+"A denied read is indistinguishable from a missing entity" cannot be stated by
+asserting a status, because the whole claim is that two requests answer alike:
+
+```rela
+api{
+  path = "/api/v1/tickets/HIDDEN", as = "viewer", status = 404,
+  identical_to = { path = "/api/v1/tickets/NO-SUCH-THING", as = "viewer" },
+}
+```
+
+The comparison covers status and body but **excludes** the problem-details
+`instance` member, which echoes the requested URL: two requests to different
+urls necessarily differ there, so including it would make the check fail on
+every pair — a check that never passes is not checking anything. `instance`
+reflects only what the caller already typed, so it leaks nothing; every other
+field must match exactly.
 
 ## Building
 

--- a/docs/rela-docs.md
+++ b/docs/rela-docs.md
@@ -56,6 +56,8 @@ available without the `doc.` prefix.
 | `count{type}` | the number of seeded entities of a type (echo-friendly) |
 | `roles_matrix{type}` | a role × verb capability table from `acl.yaml` (omit `type` for every type) |
 | `description()` | the metamodel's top-level `description:` (echo-friendly) |
+| `shows{type, contains\|absent\|exactly}` | **asserts** which entities of a type exist (emits nothing) |
+| `refuses{who, op, type, because}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
 | `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
 
 ### Relation graphs
@@ -101,6 +103,49 @@ validation, no state-machine gate, and no ACL. A fixture is exactly what
 you write, so `create("risico", { status = "done" })` is fine even if
 `done` is not a legal entry state. This keeps fixtures honest and
 self-contained; it never touches the project on disk.
+
+## Assertions
+
+A manual can *check* the claims its prose makes. Assertion islands emit no
+output — they either pass, or they fail the build with the mismatch:
+
+```rela
+create("risico", { titel = "Leak", kans = 3, impact = 4, status = "todo" })
+
+shows{ type = "risico", exactly = { "risico-1" } }
+refuses{ who = "bob@example.com", op = "update", type = "risico" }
+```
+
+This is what keeps a handbook from outliving the system it describes. If
+someone widens `viewer` in `acl.yaml`, the `refuses{}` above stops holding and
+the manual refuses to build, naming the rule that fired:
+
+```text
+manual:80: resolve: refuses{who="bob@example.com", op="update", type="risico"} failed
+  claimed: refused
+  actual:  PERMITTED
+  rule:    role-grant/viewer
+```
+
+**Every argument is optional except the target.** A paragraph about visibility
+says nothing about buttons, so `shows{}` asserts only the claims you give it.
+But **a call that asserts nothing is an error** — `shows{type="risico"}` looks
+like a test and checks nothing, which is the one failure mode worse than having
+no test at all.
+
+Prefer `exactly` over `contains` for a set you fully control: `contains` cannot
+see an over-inclusive result, and over-inclusion (a leaked row, a duplicate) is
+usually the interesting bug. `exactly = {}` is a real claim — "this type has no
+entities" — not an empty one.
+
+`refuses{}` / `permits{}` evaluate through the **same authorization path the
+write path uses**, not by re-reading `acl.yaml`. Answering from the policy file
+would only prove that the manual and the file agree, which they would even if
+the gate were never consulted. This is the deliberate exception to the
+"seed writes bypass ACL" rule above: seeding is a fixture, an assertion is a
+claim about real behaviour. Add `because = "..."` to also pin *why* a decision
+came out that way — a deny arriving from an unintended rule is a green check
+over a real regression.
 
 ## Building
 

--- a/docs/rela-docs.md
+++ b/docs/rela-docs.md
@@ -57,7 +57,7 @@ available without the `doc.` prefix.
 | `roles_matrix{type}` | a role × verb capability table from `acl.yaml` (omit `type` for every type) |
 | `description()` | the metamodel's top-level `description:` (echo-friendly) |
 | `shows{type, contains\|absent\|exactly}` | **asserts** which entities of a type exist (emits nothing) |
-| `refuses{who, op, type, because}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
+| `refuses{who, op, type, because, unassigned}` / `permits{...}` | **asserts** an authorization outcome (emits nothing) |
 | `api{path, status, error, as, identical_to}` | **asserts** an API contract against a real server (emits nothing) |
 | `h1/h2/h3(text)`, `md(text)` | structural Markdown emitted from Lua |
 
@@ -139,6 +139,13 @@ see an over-inclusive result, and over-inclusion (a leaked row, a duplicate) is
 usually the interesting bug. `exactly = {}` is a real claim — "this type has no
 entities" — not an empty one.
 
+`who` must name a principal in `acl.yaml`'s `assignments`. An unknown one is
+refused, because a principal with no assignment has no grants and is therefore
+denied *by construction* — so a `refuses{}` with a misspelled `who` would pass
+forever, unable to ever fail. When the missing assignment IS the point ("there
+is no self-service sign-up"), say `unassigned = true`; without it, an intended
+claim and a typo look identical to a reviewer.
+
 `refuses{}` / `permits{}` evaluate through the **same authorization path the
 write path uses**, not by re-reading `acl.yaml`. Answering from the policy file
 would only prove that the manual and the file agree, which they would even if
@@ -185,12 +192,20 @@ api{
 }
 ```
 
-The comparison covers status and body but **excludes** the problem-details
-`instance` member, which echoes the requested URL: two requests to different
+The comparison covers status, body, and the response headers that can by
+themselves disclose existence (`ETag`, `Last-Modified` — a denied GET that
+emits an ETag lets a replayed `If-None-Match` return 304, confirming the entity
+exists). It **excludes** the problem-details `instance` member, which echoes the requested URL: two requests to different
 urls necessarily differ there, so including it would make the check fail on
 every pair — a check that never passes is not checking anything. `instance`
 reflects only what the caller already typed, so it leaks nothing; every other
 field must match exactly.
+
+The exclusion is minimal and route-specific: on `/api/v1/{plural}/{id}` the two
+404s differ only in `instance`. Some other routes interpolate the request into
+the problem `title` (`entity %q not found`), so `identical_to` will fail there —
+in the safe direction, but it means the verb is meaningful on the entity routes
+and needs checking before use elsewhere.
 
 ## Building
 

--- a/internal/docs/api.go
+++ b/internal/docs/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	lua "github.com/yuin/gopher-lua"
@@ -48,6 +49,12 @@ type APIRequest struct {
 type APIResponse struct {
 	Status int
 	Body   string
+	// Header carries response headers, because the body is not the only
+	// existence-oracle channel: a denied GET that emits an ETag (or honors
+	// If-None-Match with a 304) confirms the entity exists while the body says
+	// nothing. Pinned in Go by TestACLGet_ETagSuppressedOnDeny; identical_to
+	// compares it so a manual can make the same claim.
+	Header map[string][]string
 }
 
 // api{} asserts an API contract: status, machine-readable error code, or that
@@ -74,6 +81,7 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 
 	if rejectUnknownKeys(dr, ls, "api", tbl,
 		"path", "method", "as", "body", "status", "error", "identical_to") {
+
 		return 0
 	}
 
@@ -127,6 +135,13 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 		if other.Path == "" {
 			return dr.luaFail(ls, "api{path=%q}: identical_to needs its own `path`", path)
 		}
+		// Comparing a request with itself is trivially true — a claimless call
+		// wearing a claim's clothes, which is the class this feature refuses.
+		if other.Path == path && other.As == req.As && other.Method == req.Method && other.Body == req.Body {
+			return dr.luaFail(ls, "api{path=%q}: identical_to names the SAME request, which is "+
+				"always true. The claim is that two DIFFERENT requests are indistinguishable — "+
+				"vary the path or the principal", path)
+		}
 		otherResp, oerr := dr.apiClient.Do(dr.ctx, other)
 		if oerr != nil {
 			return dr.luaFail(ls, "api{identical_to=%q}: %v", other.Path, oerr)
@@ -140,25 +155,28 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 
 // checkAPI compares one response against the status/error claims.
 func checkAPI(path string, resp APIResponse, wantStatus int, wantError string) string {
-	var b strings.Builder
+	// Both claims are reported when both fail: a wrong status used to mask a
+	// wrong error code, costing an extra fix-and-rerun cycle on a red build.
+	var problems []string
 	if wantStatus != 0 && resp.Status != wantStatus {
-		fmt.Fprintf(&b, "api{path=%q} failed\n  claimed status: %d\n  actual status:  %d",
-			path, wantStatus, resp.Status)
-		if body := strings.TrimSpace(resp.Body); body != "" {
-			fmt.Fprintf(&b, "\n  body: %s", truncate(body, bodyExcerpt))
-		}
-		return b.String()
+		problems = append(problems, fmt.Sprintf("  claimed status: %d\n  actual status:  %d",
+			wantStatus, resp.Status))
 	}
 	if wantError != "" {
-		got := problemCode(resp.Body)
-		if got != wantError {
-			fmt.Fprintf(&b, "api{path=%q} failed\n  claimed error: %s\n  actual error:  %s",
-				path, wantError, orNone(got))
-			fmt.Fprintf(&b, "\n  body: %s", truncate(strings.TrimSpace(resp.Body), bodyExcerpt))
-			return b.String()
+		if got := problemCode(resp.Body); got != wantError {
+			problems = append(problems, fmt.Sprintf("  claimed error: %s\n  actual error:  %s",
+				wantError, orNone(got)))
 		}
 	}
-	return ""
+	if len(problems) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "api{path=%q} failed\n%s", path, strings.Join(problems, "\n"))
+	if body := strings.TrimSpace(resp.Body); body != "" {
+		fmt.Fprintf(&b, "\n  body: %s", truncate(body, bodyExcerpt))
+	}
+	return b.String()
 }
 
 // checkIdentical is the existence-oracle assertion: two responses must be
@@ -174,7 +192,11 @@ func checkAPI(path string, resp APIResponse, wantStatus int, wantError string) s
 // what the caller already typed, so it discloses nothing. Everything else —
 // status, type, title, and any other field — must match exactly.
 func checkIdentical(pathA, pathB string, a, b APIResponse) string {
-	if a.Status == b.Status && normalizeProblem(a.Body) == normalizeProblem(b.Body) {
+	hdrA, hdrB := oracleHeaders(a.Header), oracleHeaders(b.Header)
+	if a.Status == b.Status &&
+		normalizeProblem(a.Body) == normalizeProblem(b.Body) &&
+		hdrA == hdrB {
+
 		return ""
 	}
 	var s strings.Builder
@@ -182,6 +204,9 @@ func checkIdentical(pathA, pathB string, a, b APIResponse) string {
 		"distinguishes a denied read from a missing one\n")
 	fmt.Fprintf(&s, "  %s → %d %s\n", pathA, a.Status, truncate(strings.TrimSpace(a.Body), pairExcerpt))
 	fmt.Fprintf(&s, "  %s → %d %s", pathB, b.Status, truncate(strings.TrimSpace(b.Body), pairExcerpt))
+	if hdrA != hdrB {
+		fmt.Fprintf(&s, "\n  differing headers: %s vs %s", orNone(hdrA), orNone(hdrB))
+	}
 	return s.String()
 }
 
@@ -216,6 +241,28 @@ func normalizeProblem(body string) string {
 		return body
 	}
 	return string(out)
+}
+
+// oracleHeaders renders the response headers that can BY THEMSELVES disclose
+// existence, as a stable comparable string.
+//
+// Only a deliberate allowlist is compared, not every header: Date and
+// Content-Length vary for reasons that disclose nothing, so comparing
+// everything would fail always — the same trap the `instance` member sets.
+// ETag is the documented channel (a denied GET must not emit one, or a replayed
+// If-None-Match turns into a 304 that confirms the entity exists).
+func oracleHeaders(h map[string][]string) string {
+	if h == nil {
+		return ""
+	}
+	var parts []string
+	for _, name := range []string{"Etag", "Last-Modified"} {
+		if v, ok := h[name]; ok && len(v) > 0 {
+			parts = append(parts, name+"="+strings.Join(v, ","))
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "; ")
 }
 
 func orNone(s string) string {

--- a/internal/docs/api.go
+++ b/internal/docs/api.go
@@ -1,0 +1,249 @@
+package docs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// APIClient issues one HTTP request against the documented project's API.
+//
+// Like [Capturer] this is a consumer-side interface so the core docs package
+// never imports the data-entry app or a server; the CLI injects the concrete
+// implementation. A nil APIClient makes api{} fail loud rather than silently
+// skip — a skipped assertion is indistinguishable from a passing one, which is
+// the failure mode this whole feature exists to remove.
+//
+// Unlike Capturer this needs no browser and no built frontend, so api{} can
+// gate CI unconditionally.
+type APIClient interface {
+	// Do issues the request and returns the response. A transport-level
+	// failure is an error; an HTTP error STATUS is a normal response, since
+	// asserting a 403 is the point of the verb.
+	Do(ctx context.Context, req APIRequest) (APIResponse, error)
+	// Close tears down any temp project / server stood up to serve requests.
+	Close() error
+}
+
+// APIRequest is a plain DTO so the interface carries no runtime internals.
+type APIRequest struct {
+	// ProjectDir is the documented project; Seed is replayed into a temp copy
+	// so the API serves the same entities the manual created.
+	ProjectDir string
+	Seed       []SeedOp
+
+	Method string // default GET
+	Path   string // e.g. "/api/v1/entities/policy/POL-1"
+	// As is the role to act as, mapped to a principal assigned that role in
+	// acl.yaml. Empty ⇒ the harness picks a role that can read.
+	As string
+	// Body is an optional JSON request body.
+	Body string
+}
+
+// APIResponse is the part of the response an assertion can claim about.
+type APIResponse struct {
+	Status int
+	Body   string
+}
+
+// api{} asserts an API contract: status, machine-readable error code, or that
+// two requests answer IDENTICALLY.
+//
+// # Why `error` means the code, not the prose
+//
+// A message is prose and will be reworded; the code is the contract. Asserting
+// the prose produces a test that fails on a copy edit and passes on a genuine
+// behavior change — precisely backwards.
+//
+// # Why `identical_to` exists
+//
+// The existence-oracle property — "a denied read is indistinguishable from a
+// real 404" — is not a claim about one response. It is a claim about two
+// responses being the SAME, and no single-response assertion can express it.
+// It is currently pinned only in Go (viewworld_absent_test.go), where the
+// security property is invisible to anyone reading the manual that promises it.
+func (dr *docRuntime) luaAPI(ls *lua.LState) int {
+	tbl := argTable(ls)
+	if tbl == nil {
+		return dr.luaFail(ls, `api: expects a table, e.g. api{path="/api/v1/entities/policy/POL-1", status=200}`)
+	}
+
+	path := fieldString(ls, tbl, "path")
+	if path == "" {
+		return dr.luaFail(ls, "api: `path` is required")
+	}
+
+	wantStatus := fieldInt(ls, tbl, "status", 0)
+	wantError := fieldString(ls, tbl, "error")
+	identicalTo := fieldTable(tbl, "identical_to")
+
+	if wantStatus == 0 && wantError == "" && identicalTo == nil {
+		return dr.luaFail(ls, "api{path=%q}: asserts nothing. Give at least one of "+
+			"status=, error= or identical_to= — a call with no claim passes whatever "+
+			"the server does", path)
+	}
+	if dr.apiClient == nil {
+		return dr.luaFail(ls, "api{path=%q}: no API client available: %s", path, dr.apiClientErr)
+	}
+
+	req := APIRequest{
+		ProjectDir: dr.projectDir,
+		Seed:       dr.seedOps,
+		Method:     fieldString(ls, tbl, "method"),
+		Path:       path,
+		As:         fieldString(ls, tbl, "as"),
+		Body:       fieldString(ls, tbl, "body"),
+	}
+	resp, err := dr.apiClient.Do(dr.ctx, req)
+	if err != nil {
+		return dr.luaFail(ls, "api{path=%q}: %v", path, err)
+	}
+
+	if msg := checkAPI(path, resp, wantStatus, wantError); msg != "" {
+		return dr.luaFail(ls, "%s", msg)
+	}
+
+	if identicalTo != nil {
+		other := APIRequest{
+			ProjectDir: dr.projectDir,
+			Seed:       dr.seedOps,
+			Method:     fieldStringOf(identicalTo, "method"),
+			Path:       fieldStringOf(identicalTo, "path"),
+			As:         fieldStringOf(identicalTo, "as"),
+			Body:       fieldStringOf(identicalTo, "body"),
+		}
+		if other.Path == "" {
+			return dr.luaFail(ls, "api{path=%q}: identical_to needs its own `path`", path)
+		}
+		otherResp, oerr := dr.apiClient.Do(dr.ctx, other)
+		if oerr != nil {
+			return dr.luaFail(ls, "api{identical_to=%q}: %v", other.Path, oerr)
+		}
+		if msg := checkIdentical(path, other.Path, resp, otherResp); msg != "" {
+			return dr.luaFail(ls, "%s", msg)
+		}
+	}
+	return 0
+}
+
+// checkAPI compares one response against the status/error claims.
+func checkAPI(path string, resp APIResponse, wantStatus int, wantError string) string {
+	var b strings.Builder
+	if wantStatus != 0 && resp.Status != wantStatus {
+		fmt.Fprintf(&b, "api{path=%q} failed\n  claimed status: %d\n  actual status:  %d",
+			path, wantStatus, resp.Status)
+		if body := strings.TrimSpace(resp.Body); body != "" {
+			fmt.Fprintf(&b, "\n  body: %s", truncate(body, bodyExcerpt))
+		}
+		return b.String()
+	}
+	if wantError != "" {
+		got := problemCode(resp.Body)
+		if got != wantError {
+			fmt.Fprintf(&b, "api{path=%q} failed\n  claimed error: %s\n  actual error:  %s",
+				path, wantError, orNone(got))
+			fmt.Fprintf(&b, "\n  body: %s", truncate(strings.TrimSpace(resp.Body), bodyExcerpt))
+			return b.String()
+		}
+	}
+	return ""
+}
+
+// checkIdentical is the existence-oracle assertion: two responses must be
+// indistinguishable in status and body. A "not permitted" where the other says
+// "not found" is a channel telling an unauthorized caller that something exists.
+//
+// # Why `instance` is excluded
+//
+// RFC 7807 problem details carry `instance` = the requested URL, so two
+// responses to DIFFERENT urls necessarily differ there and a raw byte compare
+// can never pass — it would report a leak on every pair, which is a check that
+// fails always rather than one that checks anything. `instance` reflects only
+// what the caller already typed, so it discloses nothing. Everything else —
+// status, type, title, and any other field — must match exactly.
+func checkIdentical(pathA, pathB string, a, b APIResponse) string {
+	if a.Status == b.Status && normalizeProblem(a.Body) == normalizeProblem(b.Body) {
+		return ""
+	}
+	var s strings.Builder
+	fmt.Fprintf(&s, "api{identical_to} failed — the two responses differ, so the pair "+
+		"distinguishes a denied read from a missing one\n")
+	fmt.Fprintf(&s, "  %s → %d %s\n", pathA, a.Status, truncate(strings.TrimSpace(a.Body), pairExcerpt))
+	fmt.Fprintf(&s, "  %s → %d %s", pathB, b.Status, truncate(strings.TrimSpace(b.Body), pairExcerpt))
+	return s.String()
+}
+
+// problemCode pulls the machine-readable code out of a problem-details body.
+// Returns "" when the body is not JSON or carries no code — the caller renders
+// that as "(none)" rather than pretending the claim matched.
+func problemCode(body string) string {
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		return ""
+	}
+	for _, key := range []string{"code", "type", "error"} {
+		if v, ok := doc[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// normalizeProblem drops the `instance` member so two responses to different
+// urls can be compared for everything else. A body that is not JSON is returned
+// unchanged — an unparseable body is compared verbatim rather than silently
+// treated as equal to another unparseable one.
+func normalizeProblem(body string) string {
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		return body
+	}
+	delete(doc, "instance")
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return body
+	}
+	return string(out)
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+// bodyExcerpt caps how much of a response body a failure message prints:
+// enough to see the problem code and title, not so much that the real claim
+// scrolls off the screen.
+const bodyExcerpt = 400
+
+// pairExcerpt is shorter because identical_to prints TWO bodies side by side.
+const pairExcerpt = 300
+
+func truncate(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…"
+}
+
+// fieldTable returns a nested table field, or nil when absent.
+func fieldTable(tbl *lua.LTable, key string) *lua.LTable {
+	if t, ok := tbl.RawGetString(key).(*lua.LTable); ok {
+		return t
+	}
+	return nil
+}
+
+// fieldStringOf reads a string field without a runtime handy (nested tables).
+func fieldStringOf(tbl *lua.LTable, key string) string {
+	if s, ok := tbl.RawGetString(key).(lua.LString); ok {
+		return string(s)
+	}
+	return ""
+}

--- a/internal/docs/api.go
+++ b/internal/docs/api.go
@@ -72,6 +72,11 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 		return dr.luaFail(ls, `api: expects a table, e.g. api{path="/api/v1/entities/policy/POL-1", status=200}`)
 	}
 
+	if rejectUnknownKeys(dr, ls, "api", tbl,
+		"path", "method", "as", "body", "status", "error", "identical_to") {
+		return 0
+	}
+
 	path := fieldString(ls, tbl, "path")
 	if path == "" {
 		return dr.luaFail(ls, "api: `path` is required")
@@ -115,6 +120,9 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 			Path:       fieldStringOf(identicalTo, "path"),
 			As:         fieldStringOf(identicalTo, "as"),
 			Body:       fieldStringOf(identicalTo, "body"),
+		}
+		if rejectUnknownKeys(dr, ls, "api identical_to", identicalTo, "path", "method", "as", "body") {
+			return 0
 		}
 		if other.Path == "" {
 			return dr.luaFail(ls, "api{path=%q}: identical_to needs its own `path`", path)

--- a/internal/docs/api_test.go
+++ b/internal/docs/api_test.go
@@ -1,0 +1,238 @@
+package docs
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// fakeAPI serves canned responses so the assertion logic is tested without a
+// server. Records the requests it saw, so a test can prove `as=` and `method=`
+// actually reach the client rather than being silently dropped.
+type fakeAPI struct {
+	responses map[string]APIResponse
+	seen      []APIRequest
+	err       error
+}
+
+func (f *fakeAPI) Do(_ context.Context, req APIRequest) (APIResponse, error) {
+	f.seen = append(f.seen, req)
+	if f.err != nil {
+		return APIResponse{}, f.err
+	}
+	if r, ok := f.responses[req.Path]; ok {
+		return r, nil
+	}
+	return APIResponse{Status: 404, Body: `{"code":"not_found"}`}, nil
+}
+
+func (f *fakeAPI) Close() error { return nil }
+
+func TestAPIIsland(t *testing.T) {
+	ok := APIResponse{Status: 200, Body: `{"id":"POL-1"}`}
+	denied := APIResponse{Status: 404, Body: `{"code":"not_found"}`}
+	forbidden := APIResponse{Status: 403, Body: `{"code":"world_forbidden"}`}
+
+	tests := []struct {
+		name      string
+		body      string
+		responses map[string]APIResponse
+		wantErr   string
+	}{
+		{
+			name:      "a matching status passes",
+			body:      `api{path="/a", status=200}`,
+			responses: map[string]APIResponse{"/a": ok},
+		},
+		{
+			name:      "a wrong status fails and prints the body",
+			body:      `api{path="/a", status=200}`,
+			responses: map[string]APIResponse{"/a": forbidden},
+			wantErr:   "claimed status: 200\n  actual status:  403",
+		},
+		{
+			name:      "an error code claim passes on the code",
+			body:      `api{path="/a", error="world_forbidden"}`,
+			responses: map[string]APIResponse{"/a": forbidden},
+		},
+		{
+			// The contract is the code, not the prose. A body with a different
+			// code must fail even when the status matches.
+			name:      "a wrong error code fails",
+			body:      `api{path="/a", error="not_found"}`,
+			responses: map[string]APIResponse{"/a": forbidden},
+			wantErr:   "claimed error: not_found\n  actual error:  world_forbidden",
+		},
+		{
+			name:      "a body with no code reports none rather than matching",
+			body:      `api{path="/a", error="not_found"}`,
+			responses: map[string]APIResponse{"/a": {Status: 404, Body: "plain text"}},
+			wantErr:   "actual error:  (none)",
+		},
+		{
+			name:    "a claimless call is refused",
+			body:    `api{path="/a"}`,
+			wantErr: "asserts nothing",
+		},
+		{
+			name:    "a missing path is refused",
+			body:    `api{status=200}`,
+			wantErr: "`path` is required",
+		},
+		{
+			// The existence-oracle property: a denied read and a genuinely
+			// missing one must be the same response.
+			name: "identical_to passes when the two responses match",
+			body: `api{path="/hidden", as="viewer", identical_to={path="/missing", as="viewer"}}`,
+			responses: map[string]APIResponse{
+				"/hidden":  denied,
+				"/missing": denied,
+			},
+		},
+		{
+			name: "identical_to fails when the bodies differ",
+			body: `api{path="/hidden", identical_to={path="/missing"}}`,
+			responses: map[string]APIResponse{
+				"/hidden":  {Status: 404, Body: `{"code":"not_permitted"}`},
+				"/missing": denied,
+			},
+			wantErr: "the two responses differ",
+		},
+		{
+			name: "identical_to fails when only the status differs",
+			body: `api{path="/hidden", identical_to={path="/missing"}}`,
+			responses: map[string]APIResponse{
+				"/hidden":  {Status: 403, Body: `{"code":"not_found"}`},
+				"/missing": denied,
+			},
+			wantErr: "the two responses differ",
+		},
+		{
+			name:      "identical_to without its own path is refused",
+			body:      `api{path="/a", identical_to={as="viewer"}}`,
+			responses: map[string]APIResponse{"/a": ok},
+			wantErr:   "identical_to needs its own `path`",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeAPI{responses: tc.responses}
+			src := "```rela\n" + tc.body + "\n```\n"
+			_, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), APIClient: f})
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want success, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want failure containing %q, got success", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error does not contain %q:\n%v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestAPIPassesRequestFields proves as=/method=/body= actually reach the
+// client. A silently-dropped `as=` would make every ACL assertion run as the
+// default principal — passing for the wrong reason.
+func TestAPIPassesRequestFields(t *testing.T) {
+	f := &fakeAPI{responses: map[string]APIResponse{"/a": {Status: 200}}}
+	src := "```rela\n" + `api{path="/a", method="POST", as="viewer", body="{}", status=200}` + "\n```\n"
+	if _, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), APIClient: f}); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(f.seen) != 1 {
+		t.Fatalf("want 1 request, got %d", len(f.seen))
+	}
+	got := f.seen[0]
+	if got.Method != http.MethodPost || got.As != "viewer" || got.Body != "{}" {
+		t.Errorf("request fields lost: %+v", got)
+	}
+}
+
+// TestAPINilClientFailsLoud: a missing client must not silently skip. A skipped
+// assertion is indistinguishable from a passing one.
+func TestAPINilClientFailsLoud(t *testing.T) {
+	src := "```rela\n" + `api{path="/a", status=200}` + "\n```\n"
+	_, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), APIClientErr: "no server built"})
+	if err == nil {
+		t.Fatal("want failure when no API client is available")
+	}
+	if !strings.Contains(err.Error(), "no server built") {
+		t.Fatalf("want the reason surfaced, got: %v", err)
+	}
+}
+
+// TestAPISeedReachesTheRequest: the client must receive the manual's seed, or
+// it would serve an empty project and every assertion would be about nothing.
+func TestAPISeedReachesTheRequest(t *testing.T) {
+	f := &fakeAPI{responses: map[string]APIResponse{"/a": {Status: 200}}}
+	src := "```rela\n" + `create("risico", {titel="Leak", kans=1, impact=1, status="todo"})
+api{path="/a", status=200}` + "\n```\n"
+	if _, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), APIClient: f}); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(f.seen) == 0 || len(f.seen[0].Seed) != 1 {
+		t.Fatalf("want the seeded entity forwarded, got %+v", f.seen)
+	}
+}
+
+// TestIdenticalIgnoresInstance: RFC 7807 `instance` echoes the requested URL,
+// so two responses to different urls always differ there. Comparing it would
+// make identical_to fail on every pair — a check that never passes tests
+// nothing. Everything else must still match.
+func TestIdenticalIgnoresInstance(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     APIResponse
+		wantFail bool
+	}{
+		{
+			name: "same problem, different instance urls",
+			a:    APIResponse{Status: 404, Body: `{"type":"not_found","title":"Entity not found","instance":"/a"}`},
+			b:    APIResponse{Status: 404, Body: `{"type":"not_found","title":"Entity not found","instance":"/b"}`},
+		},
+		{
+			// The leak this assertion exists to catch: one says "not permitted",
+			// the other "not found", so the pair reveals that /a exists.
+			name:     "different type is still caught",
+			a:        APIResponse{Status: 404, Body: `{"type":"not_permitted","instance":"/a"}`},
+			b:        APIResponse{Status: 404, Body: `{"type":"not_found","instance":"/b"}`},
+			wantFail: true,
+		},
+		{
+			name:     "different status is still caught",
+			a:        APIResponse{Status: 403, Body: `{"type":"not_found","instance":"/a"}`},
+			b:        APIResponse{Status: 404, Body: `{"type":"not_found","instance":"/b"}`},
+			wantFail: true,
+		},
+		{
+			name:     "non-JSON bodies compare verbatim",
+			a:        APIResponse{Status: 404, Body: "plain a"},
+			b:        APIResponse{Status: 404, Body: "plain b"},
+			wantFail: true,
+		},
+		{
+			name: "identical non-JSON bodies pass",
+			a:    APIResponse{Status: 404, Body: "not found"},
+			b:    APIResponse{Status: 404, Body: "not found"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := checkIdentical("/a", "/b", tc.a, tc.b)
+			if tc.wantFail && msg == "" {
+				t.Fatal("want the difference reported, got pass")
+			}
+			if !tc.wantFail && msg != "" {
+				t.Fatalf("want pass, got:\n%s", msg)
+			}
+		})
+	}
+}

--- a/internal/docs/api_test.go
+++ b/internal/docs/api_test.go
@@ -236,3 +236,69 @@ func TestIdenticalIgnoresInstance(t *testing.T) {
 		})
 	}
 }
+
+// TestIdenticalComparesOracleHeaders: the body is not the only channel. A
+// denied GET that emits an ETag lets a replayed If-None-Match return 304,
+// confirming the entity exists — pinned in Go by TestACLGet_ETagSuppressedOnDeny
+// and now expressible in a manual.
+func TestIdenticalComparesOracleHeaders(t *testing.T) {
+	body := `{"type":"not_found","instance":"/x"}`
+	tests := []struct {
+		name     string
+		a, b     APIResponse
+		wantFail bool
+	}{
+		{
+			name:     "one response carries an ETag and the other does not",
+			a:        APIResponse{Status: 404, Body: body, Header: map[string][]string{"Etag": {`W/"abc"`}}},
+			b:        APIResponse{Status: 404, Body: body},
+			wantFail: true,
+		},
+		{
+			name:     "differing ETags",
+			a:        APIResponse{Status: 404, Body: body, Header: map[string][]string{"Etag": {`W/"a"`}}},
+			b:        APIResponse{Status: 404, Body: body, Header: map[string][]string{"Etag": {`W/"b"`}}},
+			wantFail: true,
+		},
+		{
+			name: "matching ETags are fine",
+			a:    APIResponse{Status: 404, Body: body, Header: map[string][]string{"Etag": {`W/"a"`}}},
+			b:    APIResponse{Status: 404, Body: body, Header: map[string][]string{"Etag": {`W/"a"`}}},
+		},
+		{
+			// Only an allowlist is compared: Date and Content-Length vary for
+			// reasons that disclose nothing, so comparing everything would make
+			// the assertion fail always — the same trap `instance` sets.
+			name: "headers that disclose nothing are ignored",
+			a: APIResponse{Status: 404, Body: body, Header: map[string][]string{
+				"Date": {"Mon, 01 Jan 2035 00:00:00 GMT"}, "Content-Length": {"42"},
+			}},
+			b: APIResponse{Status: 404, Body: body, Header: map[string][]string{
+				"Date": {"Tue, 02 Jan 2035 00:00:00 GMT"}, "Content-Length": {"99"},
+			}},
+		},
+		{
+			name: "no headers at all on either side",
+			a:    APIResponse{Status: 404, Body: body},
+			b:    APIResponse{Status: 404, Body: body},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := checkIdentical("/a", "/b", tc.a, tc.b)
+			if tc.wantFail {
+				if msg == "" {
+					t.Fatal("want the header difference reported, got pass")
+				}
+				if !strings.Contains(msg, "differing headers") {
+					t.Errorf("failure should name the header channel:\n%s", msg)
+				}
+				return
+			}
+			if msg != "" {
+				t.Fatalf("want pass, got:\n%s", msg)
+			}
+		})
+	}
+}

--- a/internal/docs/assert.go
+++ b/internal/docs/assert.go
@@ -53,9 +53,14 @@ func (dr *docRuntime) luaShows(ls *lua.LState) int {
 		return 0
 	}
 
-	contains := fieldStringSlice(ls, tbl, "contains")
-	absent := fieldStringSlice(ls, tbl, "absent")
-	exactly := fieldStringSlice(ls, tbl, "exactly")
+	contains, cerr := claimList(tbl, "contains")
+	absent, aerr := claimList(tbl, "absent")
+	exactly, eerr := claimList(tbl, "exactly")
+	for _, err := range []error{cerr, aerr, eerr} {
+		if err != nil {
+			return dr.luaFail(ls, "shows: %v", err)
+		}
+	}
 	hasExactly := hasField(tbl, "exactly")
 
 	if len(contains) == 0 && len(absent) == 0 && !hasExactly {
@@ -63,6 +68,16 @@ func (dr *docRuntime) luaShows(ls *lua.LState) int {
 			"shows{type=%q}: asserts nothing. Give at least one of contains=, absent= or "+
 				"exactly= — a call with no claim passes whatever the code does, which is "+
 				"worse than no call at all", typ)
+	}
+
+	// An unknown type yields an EMPTY set, which satisfies `exactly={}` and any
+	// `absent=` claim — so a typo'd type makes exactly the negative claims
+	// vacuous, and those are the ones this verb recommends. (`contains=` fails
+	// safe, which is why the hole is easy to miss.)
+	if _, ok := dr.meta.Entities[typ]; !ok {
+		return dr.luaFail(ls, "shows{type=%q}: no such entity type in the schema. An unknown "+
+			"type reads as an empty set, so absent= and exactly={} would pass no matter what "+
+			"the code did. Declared types: %s", typ, strings.Join(declaredTypes(dr), ", "))
 	}
 
 	got, err := dr.entityIDs(typ)
@@ -74,6 +89,52 @@ func (dr *docRuntime) luaShows(ls *lua.LState) int {
 		return dr.luaFail(ls, "%s", msg)
 	}
 	return 0
+}
+
+// declaredTypes lists schema entity types for a failure message, so a typo is
+// fixable without opening schema.yaml.
+func declaredTypes(dr *docRuntime) []string {
+	out := make([]string, 0, len(dr.meta.Entities))
+	for name := range dr.meta.Entities {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// claimList reads a list-of-ids claim, refusing anything that is not a table of
+// strings.
+//
+// Both silent coercions here weaken a claim rather than strengthen it, which is
+// the wrong direction to fail. A non-string element used to be DROPPED, so
+// `exactly={"a", 42}` quietly asserted a smaller set than written. And a scalar
+// `exactly="a"` reads as present-but-empty, which `hasField` correctly reports
+// as a claim — so it silently became "assert this type is empty", the opposite
+// of what the author wrote.
+func claimList(tbl *lua.LTable, key string) ([]string, error) {
+	v := tbl.RawGetString(key)
+	if v == lua.LNil {
+		return nil, nil
+	}
+	arr, ok := v.(*lua.LTable)
+	if !ok {
+		return nil, fmt.Errorf("%s must be a list, e.g. %s={\"ID-1\"} — a bare value silently "+
+			"reads as an empty list, which asserts the opposite of what you wrote", key, key)
+	}
+	var out []string
+	var bad []string
+	arr.ForEach(func(_, item lua.LValue) {
+		if s, ok := item.(lua.LString); ok {
+			out = append(out, string(s))
+			return
+		}
+		bad = append(bad, item.String())
+	})
+	if len(bad) > 0 {
+		return nil, fmt.Errorf("%s contains non-string %s (%s) — dropping them would silently "+
+			"weaken the claim", key, pluralize("entry", len(bad)), strings.Join(bad, ", "))
+	}
+	return out, nil
 }
 
 // entityIDs lists the seeded ids of one type, sorted so a failure message is

--- a/internal/docs/assert.go
+++ b/internal/docs/assert.go
@@ -49,6 +49,10 @@ func (dr *docRuntime) luaShows(ls *lua.LState) int {
 		return dr.luaFail(ls, "shows: `type` is required — it names the set being asserted about")
 	}
 
+	if rejectUnknownKeys(dr, ls, "shows", tbl, "type", "contains", "absent", "exactly") {
+		return 0
+	}
+
 	contains := fieldStringSlice(ls, tbl, "contains")
 	absent := fieldStringSlice(ls, tbl, "absent")
 	exactly := fieldStringSlice(ls, tbl, "exactly")
@@ -169,4 +173,50 @@ func dedupe(in []string) []string {
 // has no entities" — and must not be read as "no exactly claim given".
 func hasField(tbl *lua.LTable, key string) bool {
 	return tbl.RawGetString(key) != lua.LNil
+}
+
+// rejectUnknownKeys fails when a table carries a key the verb does not know.
+//
+// A misspelled claim is INVISIBLE otherwise: `shows{type="x", contains={...},
+// absnt={"y"}}` silently drops `absnt` and passes on the strength of the claim
+// that WAS spelled correctly, so the author believes two things are checked
+// when only one is. The "asserts nothing is an error" rule catches this only
+// when the typo is the sole claim; this catches it when it hides beside a
+// valid one, which is the harder case to notice.
+//
+// Rejecting unknown keys is safe here because these tables are a closed
+// vocabulary — an assertion has no user-extensible options.
+func rejectUnknownKeys(dr *docRuntime, ls *lua.LState, verb string, tbl *lua.LTable, known ...string) bool {
+	allowed := make(map[string]bool, len(known))
+	for _, k := range known {
+		allowed[k] = true
+	}
+	var unknown []string
+	tbl.ForEach(func(k, _ lua.LValue) {
+		name, ok := k.(lua.LString)
+		if !ok {
+			return
+		}
+		if !allowed[string(name)] {
+			unknown = append(unknown, string(name))
+		}
+	})
+	if len(unknown) == 0 {
+		return false
+	}
+	sort.Strings(unknown)
+	sortedKnown := append([]string(nil), known...)
+	sort.Strings(sortedKnown)
+	dr.luaFail(ls, "%s: unknown %s %s — a misspelled claim would be silently "+
+		"dropped, so it is refused. Known keys: %s",
+		verb, pluralize("key", len(unknown)), strings.Join(unknown, ", "),
+		strings.Join(sortedKnown, ", "))
+	return true
+}
+
+func pluralize(word string, n int) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
 }

--- a/internal/docs/assert.go
+++ b/internal/docs/assert.go
@@ -1,0 +1,172 @@
+package docs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// shows{} asserts what a manual's prose claims, against the seeded graph.
+//
+// # Why assertions live in the doc language at all
+//
+// Documentation and tests drift because they are separate artifacts. A manual
+// that executes its own claims cannot drift: there is one artifact. The failure
+// is a prose diff a reviewer reads, rather than an assertion message they skim.
+//
+// # Every argument is optional except the target
+//
+// A paragraph about visibility says nothing about buttons. `shows{}` asserts
+// exactly the claims it is given and nothing else, so a call reads as the
+// sentence above it rather than as a schema.
+//
+// # A call that asserts NOTHING is an error
+//
+// `shows{type="policy"}` is legal-looking and claims only that the query ran.
+// That is the failure mode this project keeps meeting — a check that passes
+// while checking nothing — so it is refused rather than quietly green. Any one
+// claim is enough; zero is not.
+//
+// # `exactly` is the honest default for a list
+//
+// `contains` cannot see an over-inclusive result. A real defect during the
+// content-states work returned `["CTL-2","CTL-1","CTL-2"]` — a duplicate and an
+// extra — and a `contains={"CTL-2"}` assertion would have passed on it. The
+// interesting bugs are over-inclusion, so `exactly` should be cheap to reach
+// for.
+func (dr *docRuntime) luaShows(ls *lua.LState) int {
+	tbl := argTable(ls)
+	if tbl == nil {
+		return dr.luaFail(ls, `shows: expects a table, e.g. shows{type="policy", contains={"POL-1"}}`)
+	}
+
+	typ := fieldString(ls, tbl, "type")
+	if typ == "" {
+		return dr.luaFail(ls, "shows: `type` is required — it names the set being asserted about")
+	}
+
+	contains := fieldStringSlice(ls, tbl, "contains")
+	absent := fieldStringSlice(ls, tbl, "absent")
+	exactly := fieldStringSlice(ls, tbl, "exactly")
+	hasExactly := hasField(tbl, "exactly")
+
+	if len(contains) == 0 && len(absent) == 0 && !hasExactly {
+		return dr.luaFail(ls,
+			"shows{type=%q}: asserts nothing. Give at least one of contains=, absent= or "+
+				"exactly= — a call with no claim passes whatever the code does, which is "+
+				"worse than no call at all", typ)
+	}
+
+	got, err := dr.entityIDs(typ)
+	if err != nil {
+		return dr.luaFail(ls, "shows{type=%q}: %v", typ, err)
+	}
+
+	if msg := checkShows(typ, got, contains, absent, exactly, hasExactly); msg != "" {
+		return dr.luaFail(ls, "%s", msg)
+	}
+	return 0
+}
+
+// entityIDs lists the seeded ids of one type, sorted so a failure message is
+// stable and diffable.
+func (dr *docRuntime) entityIDs(typ string) ([]string, error) {
+	var ids []string
+	for e, err := range dr.store.ListEntities(dr.ctx, store.EntityQuery{Type: typ}) {
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, e.ID)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// checkShows is the pure assertion core: it takes what was found and what was
+// claimed, and returns a human-readable failure or "".
+//
+// Split out from the Lua binding so the rules are testable without a runtime,
+// and so the failure TEXT is itself under test — a doctest's value is its
+// failure output, and prose that only appears on a red build is prose nobody
+// proofreads.
+func checkShows(typ string, got, contains, absent, exactly []string, hasExactly bool) string {
+	have := make(map[string]bool, len(got))
+	for _, id := range got {
+		have[id] = true
+	}
+
+	var missing, unexpected []string
+	for _, id := range contains {
+		if !have[id] {
+			missing = append(missing, id)
+		}
+	}
+	for _, id := range absent {
+		if have[id] {
+			unexpected = append(unexpected, id)
+		}
+	}
+
+	if hasExactly {
+		want := make(map[string]bool, len(exactly))
+		for _, id := range exactly {
+			want[id] = true
+			if !have[id] {
+				missing = append(missing, id)
+			}
+		}
+		for _, id := range got {
+			if !want[id] {
+				unexpected = append(unexpected, id)
+			}
+		}
+	}
+
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "shows{type=%q} failed", typ)
+	if len(missing) > 0 {
+		fmt.Fprintf(&b, "\n  missing:  %s", strings.Join(dedupe(missing), ", "))
+	}
+	if len(unexpected) > 0 {
+		fmt.Fprintf(&b, "\n  unexpected: %s", strings.Join(dedupe(unexpected), ", "))
+	}
+	// The seeded set is printed on every failure, not just the exact-match one.
+	// Most confusion when a world assertion fails is not knowing what was
+	// actually there — the claim is easy to re-read, the state is not.
+	fmt.Fprintf(&b, "\n  seeded %s: %s", typ, joinOrNone(got))
+	return b.String()
+}
+
+func joinOrNone(ids []string) string {
+	if len(ids) == 0 {
+		return "(none)"
+	}
+	return strings.Join(ids, ", ")
+}
+
+func dedupe(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// hasField reports whether a key is present at all, which is not the same as
+// its value being non-empty. `exactly={}` is a MEANINGFUL claim — "this type
+// has no entities" — and must not be read as "no exactly claim given".
+func hasField(tbl *lua.LTable, key string) bool {
+	return tbl.RawGetString(key) != lua.LNil
+}

--- a/internal/docs/assert_acl.go
+++ b/internal/docs/assert_acl.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	lua "github.com/yuin/gopher-lua"
@@ -44,7 +45,7 @@ func (dr *docRuntime) luaAuthz(ls *lua.LState, wantAllow bool) int {
 		return dr.luaFail(ls, `%s: expects a table, e.g. %s{who="auditor", op="update", type="policy"}`, verb, verb)
 	}
 
-	if rejectUnknownKeys(dr, ls, verb, tbl, "who", "op", "type", "id", "because") {
+	if rejectUnknownKeys(dr, ls, verb, tbl, "who", "op", "type", "id", "because", "unassigned") {
 		return 0
 	}
 
@@ -53,15 +54,47 @@ func (dr *docRuntime) luaAuthz(ls *lua.LState, wantAllow bool) int {
 	typ := fieldString(ls, tbl, "type")
 	id := fieldString(ls, tbl, "id")
 	because := fieldString(ls, tbl, "because")
+	unassigned := fieldBool(ls, tbl, "unassigned")
 
 	if who == "" || op == "" || typ == "" {
 		return dr.luaFail(ls, "%s: `who`, `op` and `type` are all required "+
 			"(got who=%q op=%q type=%q) — an authorization claim is meaningless "+
 			"without all three", verb, who, op, typ)
 	}
+	// Same reasoning as shows{}: an authorization claim about a type that does
+	// not exist tells you nothing about the policy.
+	if _, ok := dr.meta.Entities[typ]; !ok {
+		return dr.luaFail(ls, "%s{type=%q}: no such entity type in the schema. Declared types: %s",
+			verb, typ, strings.Join(declaredTypes(dr), ", "))
+	}
 	if !validOp(op) {
 		return dr.luaFail(ls, "%s{op=%q}: unknown op — one of create, update, delete, rename", verb, op)
 	}
+	// A principal with no assignment has no grants, so it is refused BY
+	// CONSTRUCTION — which makes every refuses{} with a misspelled `who` green
+	// forever, unable to fail. That is the vacuous pass this feature exists to
+	// prevent, so an unknown principal is an error.
+	//
+	// "This principal has no role" is nonetheless a REAL claim worth making
+	// (there is no self-service sign-up), so it stays available — but it must
+	// be stated, because an intended unassigned principal and a typo are
+	// otherwise byte-identical to a reviewer.
+	if dr.policy != nil && !unassigned {
+		if _, ok := dr.policy.Assignments[who]; !ok {
+			return dr.luaFail(ls, "%s{who=%q}: no such principal in acl.yaml's assignments. "+
+				"An unassigned principal has no grants, so this claim would pass no matter "+
+				"what the policy said. Fix the spelling, or write unassigned=true if the "+
+				"point IS that this principal has no role. Assigned: %s",
+				verb, who, strings.Join(sortedAssignments(dr.policy.Assignments), ", "))
+		}
+	}
+	if unassigned && dr.policy != nil {
+		if role, ok := dr.policy.Assignments[who]; ok {
+			return dr.luaFail(ls, "%s{who=%q, unassigned=true}: that principal IS assigned "+
+				"(role %q), so the claim describes the wrong thing", verb, who, role)
+		}
+	}
+
 	if dr.policy == nil {
 		return dr.luaFail(ls, "%s: the project has no acl.yaml, so there is no policy to assert "+
 			"against. Remove the claim, or document a project that has one", verb)
@@ -109,14 +142,41 @@ func checkAuthz(verb, who, op, typ string, wantAllow bool, because string, dec a
 
 	// The decision matched. If the manual also named WHY, hold it to that: a
 	// deny arriving from an unintended rule is a green test over a real change.
-	if because != "" && !strings.Contains(dec.RuleKind+"/"+dec.RuleID, because) &&
-		!strings.Contains(dec.Reason, because) {
-
+	if because != "" && !reasonMatches(dec, because) {
 		return fmt.Sprintf("%s{who=%q, op=%q, type=%q}: the decision was right but the "+
 			"reason was not\n  claimed because: %s\n  actual rule:     %s/%s\n  actual reason:   %s",
 			verb, who, op, typ, because, dec.RuleKind, dec.RuleID, dec.Reason)
 	}
 	return ""
+}
+
+// sortedAssignments lists the assigned principals for a failure message, so a
+// typo is fixable without opening acl.yaml.
+func sortedAssignments(a map[string]string) []string {
+	out := make([]string, 0, len(a))
+	for k := range a {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// reasonMatches decides whether `because` pins the rule that actually fired.
+//
+// The rule identity (RuleKind, RuleID, or "kind/id") must match EXACTLY. It was
+// a substring test, which meant `because="a"` matched almost any deny — a claim
+// that pins nothing while looking like it pins something.
+//
+// The free-text Reason keeps substring matching, because it is prose and a
+// manual should be able to quote the meaningful fragment rather than the whole
+// sentence. A minimum length keeps that from becoming the same loophole.
+func reasonMatches(dec acl.Decision, because string) bool {
+	switch because {
+	case dec.RuleKind, dec.RuleID, dec.RuleKind + "/" + dec.RuleID:
+		return true
+	}
+	const minReasonFragment = 8
+	return len(because) >= minReasonFragment && strings.Contains(dec.Reason, because)
 }
 
 func validOp(op string) bool {

--- a/internal/docs/assert_acl.go
+++ b/internal/docs/assert_acl.go
@@ -1,0 +1,124 @@
+package docs
+
+import (
+	"fmt"
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// refuses{} / permits{} assert an ACL claim against the REAL decision path.
+//
+// # Why these route through acl.Declarative rather than reading Policy.Roles
+//
+// `roles_matrix{}` reads `policy.Roles` directly because it DESCRIBES the
+// configuration — it renders a table of what the yaml says. An assertion makes
+// a different kind of claim: that a principal is actually refused. Answering
+// that from the same map would prove only that the manual and the matrix agree,
+// which they would even if every gate were bypassed downstream.
+//
+// So these call `AuthorizeWrite` — the entry point the write path itself uses.
+// A manual asserting "an auditor cannot update a control" then fails if the
+// grant is widened OR if the gate stops being consulted.
+//
+// # Why a deny may name its rule
+//
+// `acl.Decision` carries RuleKind/RuleID precisely because opaque denials are
+// unsupportable. A manual that says "refused because the role lacks the grant"
+// can assert `because=` and will fail if the deny starts coming from somewhere
+// else — a deny for an unintended reason is a passing test hiding a broken one.
+func (dr *docRuntime) luaRefuses(ls *lua.LState) int { return dr.luaAuthz(ls, false) }
+func (dr *docRuntime) luaPermits(ls *lua.LState) int { return dr.luaAuthz(ls, true) }
+
+func (dr *docRuntime) luaAuthz(ls *lua.LState, wantAllow bool) int {
+	verb := "refuses"
+	if wantAllow {
+		verb = "permits"
+	}
+
+	tbl := argTable(ls)
+	if tbl == nil {
+		return dr.luaFail(ls, `%s: expects a table, e.g. %s{who="auditor", op="update", type="policy"}`, verb, verb)
+	}
+
+	who := fieldString(ls, tbl, "who")
+	op := fieldString(ls, tbl, "op")
+	typ := fieldString(ls, tbl, "type")
+	id := fieldString(ls, tbl, "id")
+	because := fieldString(ls, tbl, "because")
+
+	if who == "" || op == "" || typ == "" {
+		return dr.luaFail(ls, "%s: `who`, `op` and `type` are all required "+
+			"(got who=%q op=%q type=%q) — an authorization claim is meaningless "+
+			"without all three", verb, who, op, typ)
+	}
+	if !validOp(op) {
+		return dr.luaFail(ls, "%s{op=%q}: unknown op — one of create, update, delete, rename", verb, op)
+	}
+	if dr.policy == nil {
+		return dr.luaFail(ls, "%s: the project has no acl.yaml, so there is no policy to assert "+
+			"against. Remove the claim, or document a project that has one", verb)
+	}
+
+	// The seeded memstore is both the graph (for role-relation membership) and
+	// the query backend, so a manual can seed the very edge that confers a role
+	// and then assert what it grants.
+	d, err := acl.NewDeclarative(dr.policy, acl.NewStoreGraph(dr.store), dr.store)
+	if err != nil {
+		return dr.luaFail(ls, "%s: building the evaluator failed: %v", verb, err)
+	}
+
+	ctx := principal.With(dr.ctx, principal.Principal{User: who, Tool: principal.ToolCLI})
+	dec := d.AuthorizeWrite(ctx, acl.WriteRequest{
+		Op:      acl.Op(op),
+		Subject: acl.EntitySubject{Type: typ, ID: id},
+	})
+
+	if msg := checkAuthz(verb, who, op, typ, wantAllow, because, dec); msg != "" {
+		return dr.luaFail(ls, "%s", msg)
+	}
+	return 0
+}
+
+// checkAuthz is the pure claim-vs-decision comparison, split out so the failure
+// prose is testable without an evaluator.
+func checkAuthz(verb, who, op, typ string, wantAllow bool, because string, dec acl.Decision) string {
+	if dec.Allow != wantAllow {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%s{who=%q, op=%q, type=%q} failed\n", verb, who, op, typ)
+		if wantAllow {
+			fmt.Fprintf(&b, "  claimed: permitted\n  actual:  REFUSED")
+		} else {
+			fmt.Fprintf(&b, "  claimed: refused\n  actual:  PERMITTED")
+		}
+		if dec.RuleKind != "" {
+			fmt.Fprintf(&b, "\n  rule:    %s/%s", dec.RuleKind, dec.RuleID)
+		}
+		if dec.Reason != "" {
+			fmt.Fprintf(&b, "\n  reason:  %s", dec.Reason)
+		}
+		return b.String()
+	}
+
+	// The decision matched. If the manual also named WHY, hold it to that: a
+	// deny arriving from an unintended rule is a green test over a real change.
+	if because != "" && !strings.Contains(dec.RuleKind+"/"+dec.RuleID, because) &&
+		!strings.Contains(dec.Reason, because) {
+
+		return fmt.Sprintf("%s{who=%q, op=%q, type=%q}: the decision was right but the "+
+			"reason was not\n  claimed because: %s\n  actual rule:     %s/%s\n  actual reason:   %s",
+			verb, who, op, typ, because, dec.RuleKind, dec.RuleID, dec.Reason)
+	}
+	return ""
+}
+
+func validOp(op string) bool {
+	switch acl.Op(op) {
+	case acl.OpCreate, acl.OpUpdate, acl.OpDelete, acl.OpRename:
+		return true
+	}
+	return false
+}

--- a/internal/docs/assert_acl.go
+++ b/internal/docs/assert_acl.go
@@ -44,6 +44,10 @@ func (dr *docRuntime) luaAuthz(ls *lua.LState, wantAllow bool) int {
 		return dr.luaFail(ls, `%s: expects a table, e.g. %s{who="auditor", op="update", type="policy"}`, verb, verb)
 	}
 
+	if rejectUnknownKeys(dr, ls, verb, tbl, "who", "op", "type", "id", "because") {
+		return 0
+	}
+
 	who := fieldString(ls, tbl, "who")
 	op := fieldString(ls, tbl, "op")
 	typ := fieldString(ls, tbl, "type")

--- a/internal/docs/assert_acl_test.go
+++ b/internal/docs/assert_acl_test.go
@@ -1,0 +1,126 @@
+package docs
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// aclFixturePolicy binds two users to roles so an authorization claim in a
+// manual has something real to resolve against: `ed` may write, `vi` may only
+// read.
+func aclFixturePolicy() *acl.Policy {
+	return &acl.Policy{
+		Roles: map[string]acl.RoleDef{
+			"editor": {Read: []string{"*"}, Create: []string{"*"}, Update: []string{"*"}, Delete: []string{"*"}},
+			"viewer": {Read: []string{"*"}},
+		},
+		Assignments: map[string]string{"ed": "editor", "vi": "viewer"},
+	}
+}
+
+func TestAuthzIsland(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		policy  *acl.Policy
+		wantErr string
+	}{
+		{
+			name: "a true refusal builds",
+			body: `refuses{who="vi", op="update", type="risico"}`,
+		},
+		{
+			name: "a true permission builds",
+			body: `permits{who="ed", op="update", type="risico"}`,
+		},
+		{
+			// The claim a policy manual most needs to not rot: if someone
+			// widens `viewer` to include writes, this manual stops building.
+			name:    "a refusal that is actually permitted fails",
+			body:    `refuses{who="ed", op="update", type="risico"}`,
+			wantErr: "claimed: refused\n  actual:  PERMITTED",
+		},
+		{
+			name:    "a permission that is actually refused fails and names the rule",
+			body:    `permits{who="vi", op="delete", type="risico"}`,
+			wantErr: "claimed: permitted\n  actual:  REFUSED",
+		},
+		{
+			name:    "missing who is refused",
+			body:    `refuses{op="update", type="risico"}`,
+			wantErr: "`who`, `op` and `type` are all required",
+		},
+		{
+			name:    "an unknown op is refused rather than silently denying",
+			body:    `refuses{who="vi", op="frobnicate", type="risico"}`,
+			wantErr: "unknown op",
+		},
+		{
+			// Without this, a manual written against a project with no acl.yaml
+			// would assert "refused" and pass for the wrong reason.
+			name:    "a claim with no policy at all is refused",
+			body:    `refuses{who="vi", op="update", type="risico"}`,
+			policy:  nil,
+			wantErr: "no acl.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pol := tc.policy
+			if pol == nil && !strings.Contains(tc.wantErr, "no acl.yaml") {
+				pol = aclFixturePolicy()
+			}
+			src := "```rela\n" + tc.body + "\n```\n"
+			_, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), Policy: pol})
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want build to succeed, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want failure containing %q, got success", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error does not contain %q:\n%v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestCheckAuthzBecause covers the `because=` claim without an evaluator: a
+// decision that is right for the wrong reason must not pass.
+func TestCheckAuthzBecause(t *testing.T) {
+	deny := acl.Decision{Allow: false, RuleKind: "role-grant", RuleID: "viewer", Reason: "role viewer may not update risico"}
+
+	t.Run("a matching reason passes", func(t *testing.T) {
+		if msg := checkAuthz("refuses", "vi", "update", "risico", false, "role-grant", deny); msg != "" {
+			t.Fatalf("want pass, got: %s", msg)
+		}
+	})
+	t.Run("a reason matching the prose passes", func(t *testing.T) {
+		if msg := checkAuthz("refuses", "vi", "update", "risico", false, "may not update", deny); msg != "" {
+			t.Fatalf("want pass, got: %s", msg)
+		}
+	})
+	t.Run("a wrong reason fails even though the decision was right", func(t *testing.T) {
+		msg := checkAuthz("refuses", "vi", "update", "risico", false, "unmatched-principal", deny)
+		if msg == "" {
+			t.Fatal("want failure: the deny came from a different rule than claimed")
+		}
+		for _, want := range []string{"right but the", "claimed because: unmatched-principal", "role-grant/viewer"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("message missing %q:\n%s", want, msg)
+			}
+		}
+	})
+	t.Run("no because claim means the rule is not checked", func(t *testing.T) {
+		if msg := checkAuthz("refuses", "vi", "update", "risico", false, "", deny); msg != "" {
+			t.Fatalf("want pass, got: %s", msg)
+		}
+	})
+}

--- a/internal/docs/assert_test.go
+++ b/internal/docs/assert_test.go
@@ -225,9 +225,10 @@ func TestUnknownKeysAreRefused(t *testing.T) {
 			wantErr: "unknown keys absnt, exactl",
 		},
 		{
-			name:    "refuses: a typo beside a valid claim",
+			name: "refuses: a typo beside a valid claim",
+			//nolint:misspell // the misspelling IS the fixture: this asserts a typo is caught
 			body:    `refuses{who="vi", op="update", type="risico", becuase="x"}`,
-			wantErr: "unknown key becuase",
+			wantErr: "unknown key becuase", //nolint:misspell // ditto
 		},
 		{
 			name:    "api: a typo beside a valid claim",

--- a/internal/docs/assert_test.go
+++ b/internal/docs/assert_test.go
@@ -1,0 +1,200 @@
+package docs
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestCheckShows covers the assertion rules. The failure TEXT is asserted, not
+// just the pass/fail bit: a doctest's output is read by someone who did not
+// write the manual, and prose that only appears on a red build is prose nobody
+// proofreads.
+func TestCheckShows(t *testing.T) {
+	tests := []struct {
+		name       string
+		got        []string
+		contains   []string
+		absent     []string
+		exactly    []string
+		hasExactly bool
+		wantOK     bool
+		wantParts  []string
+	}{
+		{
+			name:     "contains satisfied",
+			got:      []string{"POL-1", "POL-2"},
+			contains: []string{"POL-1"},
+			wantOK:   true,
+		},
+		{
+			name:      "contains missing names the id and shows the seeded set",
+			got:       []string{"POL-2"},
+			contains:  []string{"POL-1"},
+			wantParts: []string{"missing:  POL-1", "seeded policy: POL-2"},
+		},
+		{
+			name:   "absent satisfied",
+			got:    []string{"POL-1"},
+			absent: []string{"POL-9"},
+			wantOK: true,
+		},
+		{
+			name:      "absent violated",
+			got:       []string{"POL-1", "POL-9"},
+			absent:    []string{"POL-9"},
+			wantParts: []string{"unexpected: POL-9"},
+		},
+		{
+			name:       "exactly matches regardless of order",
+			got:        []string{"POL-1", "POL-2"},
+			exactly:    []string{"POL-2", "POL-1"},
+			hasExactly: true,
+			wantOK:     true,
+		},
+		{
+			// The defect `exactly` exists for: `contains` cannot see an
+			// over-inclusive result, and over-inclusion is the leak.
+			name:       "exactly catches an extra the contains form would miss",
+			got:        []string{"CTL-1", "CTL-2"},
+			exactly:    []string{"CTL-2"},
+			hasExactly: true,
+			wantParts:  []string{"unexpected: CTL-1"},
+		},
+		{
+			name:       "exactly empty asserts the set is empty",
+			got:        []string{"POL-1"},
+			exactly:    nil,
+			hasExactly: true,
+			wantParts:  []string{"unexpected: POL-1"},
+		},
+		{
+			name:       "exactly empty is satisfied by an empty set",
+			got:        nil,
+			exactly:    nil,
+			hasExactly: true,
+			wantOK:     true,
+		},
+		{
+			name:      "an empty seeded set says so rather than printing nothing",
+			got:       nil,
+			contains:  []string{"POL-1"},
+			wantParts: []string{"seeded policy: (none)"},
+		},
+		{
+			name:       "missing and unexpected are reported together",
+			got:        []string{"POL-2"},
+			exactly:    []string{"POL-1"},
+			hasExactly: true,
+			wantParts:  []string{"missing:  POL-1", "unexpected: POL-2"},
+		},
+		{
+			// contains= and exactly= can name the same absent id; reporting it
+			// twice reads as two different problems.
+			name:       "a doubly-claimed missing id is reported once",
+			got:        nil,
+			contains:   []string{"POL-1"},
+			exactly:    []string{"POL-1"},
+			hasExactly: true,
+			wantParts:  []string{"missing:  POL-1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := checkShows("policy", tc.got, tc.contains, tc.absent, tc.exactly, tc.hasExactly)
+			if tc.wantOK {
+				if msg != "" {
+					t.Fatalf("want pass, got failure:\n%s", msg)
+				}
+				return
+			}
+			if msg == "" {
+				t.Fatalf("want failure, got pass")
+			}
+			for _, part := range tc.wantParts {
+				if !strings.Contains(msg, part) {
+					t.Errorf("failure text missing %q; full text:\n%s", part, msg)
+				}
+			}
+		})
+	}
+}
+
+func TestDedupeKeepsFirstOrder(t *testing.T) {
+	got := dedupe([]string{"b", "a", "b", "c", "a"})
+	want := []string{"b", "a", "c"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("dedupe = %v, want %v", got, want)
+	}
+}
+
+// TestShowsIsland drives shows{} through the real Build path, so the binding —
+// argument extraction, the refusal rules, the seeded-store read — is covered,
+// not just the pure core.
+func TestShowsIsland(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string // "" ⇒ the manual must build
+	}{
+		{
+			name: "a satisfied claim builds",
+			body: `create("risico", {titel="Leak", kans=3, impact=4, status="todo"})
+shows{type="risico", contains={"risico-1"}}`,
+		},
+		{
+			name: "a violated claim fails the build",
+			body: `create("risico", {titel="Leak", kans=3, impact=4, status="todo"})
+shows{type="risico", contains={"risico-99"}}`,
+			wantErr: "missing:  risico-99",
+		},
+		{
+			// The rule this verb exists for: a call that claims nothing must
+			// not pass. It looks like a test and is not one.
+			name:    "a claimless call is refused",
+			body:    `shows{type="risico"}`,
+			wantErr: "asserts nothing",
+		},
+		{
+			name:    "a missing type is refused",
+			body:    `shows{contains={"risico-1"}}`,
+			wantErr: "`type` is required",
+		},
+		{
+			name:    "a non-table argument is refused",
+			body:    `shows("risico")`,
+			wantErr: "expects a table",
+		},
+		{
+			name: "exactly on an unseeded type asserts emptiness",
+			body: `shows{type="maatregel", exactly={}}`,
+		},
+		{
+			name: "exactly catches an entity the manual did not mention",
+			body: `create("maatregel", {titel="A"})
+create("maatregel", {titel="B"})
+shows{type="maatregel", exactly={"maatregel-1"}}`,
+			wantErr: "unexpected: maatregel-2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "```rela\n" + tc.body + "\n```\n"
+			_, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t)})
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want build to succeed, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want build to fail with %q, got success", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/docs/assert_test.go
+++ b/internal/docs/assert_test.go
@@ -198,3 +198,76 @@ shows{type="maatregel", exactly={"maatregel-1"}}`,
 		})
 	}
 }
+
+// TestUnknownKeysAreRefused: a misspelled claim beside a VALID one is the
+// dangerous case — the call passes on the strength of the correct claim while
+// the author believes both are checked. The claimless-call rule cannot catch
+// this, because the call does assert something.
+func TestUnknownKeysAreRefused(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "shows: a typo beside a valid claim",
+			body:    `shows{type="risico", contains={"risico-1"}, absnt={"risico-2"}}`,
+			wantErr: "unknown key absnt",
+		},
+		{
+			name:    "shows: the message lists the known keys",
+			body:    `shows{type="risico", exactl={}}`,
+			wantErr: "Known keys: absent, contains, exactly, type",
+		},
+		{
+			name:    "shows: several typos are reported together",
+			body:    `shows{type="risico", contains={"a"}, absnt={}, exactl={}}`,
+			wantErr: "unknown keys absnt, exactl",
+		},
+		{
+			name:    "refuses: a typo beside a valid claim",
+			body:    `refuses{who="vi", op="update", type="risico", becuase="x"}`,
+			wantErr: "unknown key becuase",
+		},
+		{
+			name:    "api: a typo beside a valid claim",
+			body:    `api{path="/a", status=200, eror="x"}`,
+			wantErr: "unknown key eror",
+		},
+		{
+			name:    "api: a typo inside identical_to",
+			body:    `api{path="/a", status=200, identical_to={path="/b", ass="viewer"}}`,
+			wantErr: "identical_to: unknown key ass",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "```rela\n" + tc.body + "\n```\n"
+			opts := Options{Meta: fixtureMeta(t), Policy: aclFixturePolicy()}
+			if strings.HasPrefix(tc.body, "api") {
+				opts.APIClient = &fakeAPI{responses: map[string]APIResponse{
+					"/a": {Status: 200}, "/b": {Status: 200},
+				}}
+			}
+			_, err := Build(context.Background(), src, opts)
+			if err == nil {
+				t.Fatalf("want failure containing %q, got success", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error does not contain %q:\n%v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// A correctly-spelled call must still build — the guard must not reject valid
+// keys, which would make every assertion unusable.
+func TestKnownKeysAreAccepted(t *testing.T) {
+	src := "```rela\n" + `create("risico", {titel="a", kans=1, impact=1, status="todo"})
+shows{type="risico", contains={"risico-1"}, absent={"risico-9"}, exactly={"risico-1"}}
+refuses{who="vi", op="update", type="risico", because="role-grant"}` + "\n```\n"
+	if _, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), Policy: aclFixturePolicy()}); err != nil {
+		t.Fatalf("a call using every known key must build: %v", err)
+	}
+}

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -41,6 +41,11 @@ func (dr *docRuntime) registerModule() {
 		"link":   dr.luaLink,
 		// Tier B — browser capture (fails loud when no capturer is wired).
 		"screenshot": dr.luaScreenshot,
+
+		// Assertions (TKT-DOCASSERT): a manual proves its own claims.
+		"shows":   dr.luaShows,
+		"refuses": dr.luaRefuses,
+		"permits": dr.luaPermits,
 	}
 	for name, fn := range fns {
 		nf := L.NewFunction(fn)

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -46,6 +46,7 @@ func (dr *docRuntime) registerModule() {
 		"shows":   dr.luaShows,
 		"refuses": dr.luaRefuses,
 		"permits": dr.luaPermits,
+		"api":     dr.luaAPI,
 	}
 	for name, fn := range fns {
 		nf := L.NewFunction(fn)

--- a/internal/docs/negativecontrol_test.go
+++ b/internal/docs/negativecontrol_test.go
@@ -1,0 +1,159 @@
+package docs
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestNegativeControls is the suite's positive control: every row is a mistake
+// an author would plausibly make, and each must turn the build RED.
+//
+// # Why this table exists
+//
+// Every other test here asserts that a CORRECT assertion behaves correctly.
+// None of them can catch a guard that was never written — and a missing guard
+// is exactly how an assertion becomes vacuous: a typo'd principal has no
+// grants and is therefore always refused; an unknown entity type yields an
+// empty set and therefore satisfies `absent=`; an unknown role falls back to a
+// privileged default and therefore passes as someone else. Each of those
+// PASSES, forever, while appearing to check something.
+//
+// Mutation testing cannot find these either: mutating absent code kills no
+// mutants. So the rule is that every new claim, argument, or verb gets a row
+// here showing how it fails when misused — this table is the natural home for
+// "what does this look like when it's wrong?"
+func TestNegativeControls(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+		why     string
+	}{
+		{
+			name:    "typo'd principal",
+			body:    `refuses{who="typo-nobody", op="update", type="risico"}`,
+			wantErr: "no such principal",
+			why:     "an unassigned principal has no grants, so a refusal claim would pass forever",
+		},
+		{
+			name:    "an intended unassigned principal must say so",
+			body:    `refuses{who="nobody@example.com", op="update", type="risico", unassigned=true}`,
+			wantErr: "", // legitimate: the claim IS that this principal has no role
+		},
+		{
+			name:    "unassigned=true on an assigned principal",
+			body:    `refuses{who="vi", op="update", type="risico", unassigned=true}`,
+			wantErr: "IS assigned",
+			why:     "the manual describes the wrong thing; the reader would be misled",
+		},
+		{
+			name:    "typo'd entity type in shows",
+			body:    `shows{type="risicoo", exactly={}}`,
+			wantErr: "no such entity type",
+			why:     "an unknown type is an empty set, so exactly={} and absent= pass vacuously",
+		},
+		{
+			name:    "typo'd entity type in an authorization claim",
+			body:    `refuses{who="vi", op="update", type="risicoo"}`,
+			wantErr: "no such entity type",
+		},
+		{
+			name:    "scalar exactly reads as 'assert emptiness'",
+			body:    `shows{type="risico", exactly="risico-1"}`,
+			wantErr: "must be a list",
+			why:     "a bare value is present-but-empty, asserting the OPPOSITE of what was written",
+		},
+		{
+			name:    "non-string element would be dropped",
+			body:    `shows{type="risico", exactly={"risico-1", 42}}`,
+			wantErr: "non-string",
+			why:     "dropping it silently shrinks the asserted set",
+		},
+		{
+			name:    "misspelled claim key beside a valid one",
+			body:    `shows{type="risico", contains={"risico-1"}, absnt={"x"}}`,
+			wantErr: "unknown key absnt",
+			why:     "the call passes on the valid claim while the author believes both are checked",
+		},
+		{
+			name:    "a call that claims nothing",
+			body:    `shows{type="risico"}`,
+			wantErr: "asserts nothing",
+		},
+		{
+			name:    "a one-character because pins nothing",
+			body:    `refuses{who="vi", op="update", type="risico", because="a"}`,
+			wantErr: "reason was not",
+			why:     "a substring that short matches almost any deny",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "```rela\n" +
+				`create("risico", {titel="Leak", kans=1, impact=1, status="todo"})` + "\n" +
+				tc.body + "\n```\n"
+			_, err := Build(context.Background(), src, Options{
+				Meta:   fixtureMeta(t),
+				Policy: aclFixturePolicy(),
+			})
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("this is a LEGITIMATE claim and must build: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("this mistake was accepted, so the assertion is vacuous.\n  why it matters: %s", tc.why)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("failed for the wrong reason: want %q, got:\n%v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// The api{} negative controls need a client, so they live in their own table.
+func TestNegativeControls_API(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+		why     string
+	}{
+		{
+			name:    "identical_to comparing a request with itself",
+			body:    `api{path="/a", status=403, identical_to={path="/a"}}`,
+			wantErr: "names the SAME request",
+			why:     "a self-comparison is trivially true — a claimless call wearing a claim's clothes",
+		},
+		{
+			name:    "misspelled key inside identical_to",
+			body:    `api{path="/a", status=403, identical_to={path="/b", ass="viewer"}}`,
+			wantErr: "unknown key ass",
+		},
+		{
+			name:    "a call that claims nothing",
+			body:    `api{path="/a"}`,
+			wantErr: "asserts nothing",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeAPI{responses: map[string]APIResponse{
+				"/a": {Status: 403, Body: `{"type":"denied"}`},
+				"/b": {Status: 403, Body: `{"type":"denied"}`},
+			}}
+			src := "```rela\n" + tc.body + "\n```\n"
+			_, err := Build(context.Background(), src, Options{Meta: fixtureMeta(t), APIClient: f})
+			if err == nil {
+				t.Fatalf("this mistake was accepted, so the assertion is vacuous.\n  why it matters: %s", tc.why)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("failed for the wrong reason: want %q, got:\n%v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -27,6 +27,11 @@ const buildTimeout = 30 * time.Second
 // screenshotBuildTimeout is the wider ceiling for a build that captures
 // screenshots — browser launch + per-island navigate/capture need more than the
 // Tier-A 30s.
+// apiBuildTimeout bounds a build with api{} islands. Longer than the bare
+// buildTimeout because the first api{} stands up a temp project and server, but
+// far below the screenshot ceiling: there is no browser to launch.
+const apiBuildTimeout = 2 * time.Minute
+
 const screenshotBuildTimeout = 5 * time.Minute
 
 // Options controls a manual build.
@@ -47,6 +52,14 @@ type Options struct {
 	// CapturerErr is the reason a Capturer could not be built (e.g. no Chrome);
 	// surfaced in the screenshot{} fail-loud message when Capturer is nil.
 	CapturerErr string
+
+	// APIClient serves api{} islands. Injected by the CLI for the same reason
+	// as Capturer — it stands up a server, which the core docs package must
+	// not depend on.
+	APIClient APIClient
+	// APIClientErr is why an APIClient could not be built; surfaced in the
+	// api{} fail-loud message when APIClient is nil.
+	APIClientErr string
 	// ProjectDir is the documented project root; screenshot{} copies its schema/
 	// config into the temp project the SPA renders.
 	ProjectDir string
@@ -93,6 +106,14 @@ type docRuntime struct {
 	// Chrome), surfaced in the fail-loud message when a screenshot{} needs it.
 	capturerErr string
 
+	// apiClient serves api{} islands. nil ⇒ api{} fails loud, for the same
+	// reason a nil capturer does: a skipped assertion looks exactly like a
+	// passing one. Unlike the capturer it needs no browser or built frontend.
+	apiClient APIClient
+	// apiClientErr is why the client could not be constructed, surfaced in the
+	// fail-loud message.
+	apiClientErr string
+
 	// projectDir is the documented project's root (schema/config copied into the
 	// screenshot temp project). Empty in a schema-only build.
 	projectDir string
@@ -122,6 +143,10 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 	// If the caller already set an earlier deadline, that one wins. Screenshot
 	// builds get a longer ceiling (browser launch + navigate + capture).
 	deadline := buildTimeout
+	if opts.APIClient != nil {
+		deadline = apiBuildTimeout
+	}
+	// A screenshot build also stands up a server, so its (longer) ceiling wins.
 	if opts.Capturer != nil {
 		deadline = screenshotBuildTimeout
 	}
@@ -133,20 +158,25 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 	if opts.Capturer != nil {
 		defer func() { _ = opts.Capturer.Close() }()
 	}
+	if opts.APIClient != nil {
+		defer func() { _ = opts.APIClient.Close() }()
+	}
 
 	st := memstore.New()
 	dr := &docRuntime{
-		meta:        opts.Meta,
-		policy:      opts.Policy,
-		store:       st,
-		tracer:      tracer.New(st),
-		strict:      opts.Strict,
-		out:         &strings.Builder{},
-		ctx:         ctx,
-		capturer:    opts.Capturer,
-		capturerErr: opts.CapturerErr,
-		projectDir:  opts.ProjectDir,
-		outDir:      opts.OutDir,
+		meta:         opts.Meta,
+		policy:       opts.Policy,
+		apiClient:    opts.APIClient,
+		apiClientErr: opts.APIClientErr,
+		store:        st,
+		tracer:       tracer.New(st),
+		strict:       opts.Strict,
+		out:          &strings.Builder{},
+		ctx:          ctx,
+		capturer:     opts.Capturer,
+		capturerErr:  opts.CapturerErr,
+		projectDir:   opts.ProjectDir,
+		outDir:       opts.OutDir,
 	}
 
 	// A reader runtime gives us the sandbox (no io/os) plus rela.* read bindings;

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -126,6 +126,23 @@ type docRuntime struct {
 	warnings []string
 }
 
+// usesAPI reports whether any island mentions api{}. A textual scan is enough:
+// the cost of a false positive is a longer ceiling on a build that would not
+// have hit it, and the alternative (widening the deadline for every build) is
+// strictly worse. A false NEGATIVE would need `api` to be reached indirectly,
+// which the doc language has no way to express.
+func usesAPI(segs []segment) bool {
+	for _, seg := range segs {
+		if seg.kind == segLiteral {
+			continue
+		}
+		if strings.Contains(seg.body, "api") {
+			return true
+		}
+	}
+	return false
+}
+
 // Build resolves every island in the manual source and returns the rendered
 // Markdown. It is the package entry point.
 func Build(ctx context.Context, src string, opts Options) (string, error) {
@@ -143,7 +160,11 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 	// If the caller already set an earlier deadline, that one wins. Screenshot
 	// builds get a longer ceiling (browser launch + navigate + capture).
 	deadline := buildTimeout
-	if opts.APIClient != nil {
+	// Gate on the manual actually USING api{}: the fs build always supplies a
+	// client (it cannot fail to construct one), so keying on the client alone
+	// widened the ceiling for every build, including Tier-A manuals with no
+	// server to stand up — quadrupling how long a hung build takes to say so.
+	if opts.APIClient != nil && usesAPI(segs) {
 		deadline = apiBuildTimeout
 	}
 	// A screenshot build also stands up a server, so its (longer) ceiling wins.

--- a/internal/docscapture/apiclient.go
+++ b/internal/docscapture/apiclient.go
@@ -1,0 +1,112 @@
+package docscapture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+// APIClient implements docs.APIClient: it stands up the data-entry server over
+// a seeded temp project and issues real HTTP requests against it.
+//
+// It lives here rather than in internal/docs for the same reason the Capturer
+// does — it pulls in dataentry + appbuild, which the core doc language must not
+// carry. Unlike the Capturer it needs NO browser and no built frontend, so a
+// manual using only api{} assertions runs anywhere the Go tests do.
+//
+// The temp project is stood up lazily on the first request and reused, with the
+// manual's growing seed applied incrementally (see project.syncSeed): a manual
+// creates entities as it goes, so a later api{} must see entities created after
+// the server started.
+//
+// Nil: never returned by New; the zero value is not usable — use NewAPIClient.
+type APIClient struct {
+	projectDir string
+
+	mu   sync.Mutex
+	proj *project
+}
+
+// NewAPIClient returns a client serving the given project.
+func NewAPIClient(projectDir string) *APIClient {
+	return &APIClient{projectDir: projectDir}
+}
+
+// Do issues one request, standing the server up on first use.
+//
+// An HTTP error status is a normal return, not an error: asserting a 403 or a
+// 404 is the point of the verb. Only a transport-level failure errors.
+func (c *APIClient) Do(ctx context.Context, req docs.APIRequest) (docs.APIResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.proj == nil {
+		dir := req.ProjectDir
+		if dir == "" {
+			dir = c.projectDir
+		}
+		if dir == "" {
+			return docs.APIResponse{}, errors.New("api{}: no project directory to serve " +
+				"(build with --project)")
+		}
+		p, err := standUp(ctx, dir, req.Seed, false)
+		if err != nil {
+			return docs.APIResponse{}, err
+		}
+		c.proj = p
+	} else if err := c.proj.syncSeed(ctx, req.Seed); err != nil {
+		return docs.APIResponse{}, fmt.Errorf("api{}: seeding: %w", err)
+	}
+
+	method := req.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+	var body io.Reader
+	if req.Body != "" {
+		body = strings.NewReader(req.Body)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, c.proj.server.URL+req.Path, body)
+	if err != nil {
+		return docs.APIResponse{}, fmt.Errorf("api{path=%q}: %w", req.Path, err)
+	}
+	if req.Body != "" {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+	// The role header is what the temp server's principal resolver maps to a
+	// principal assigned that role in acl.yaml — the same mechanism screenshot{}
+	// uses for `as=`.
+	if req.As != "" {
+		httpReq.Header.Set(roleHeader, req.As)
+	}
+
+	resp, err := c.proj.server.Client().Do(httpReq)
+	if err != nil {
+		return docs.APIResponse{}, fmt.Errorf("api{path=%q}: %w", req.Path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return docs.APIResponse{}, fmt.Errorf("api{path=%q}: reading body: %w", req.Path, err)
+	}
+	return docs.APIResponse{Status: resp.StatusCode, Body: string(raw)}, nil
+}
+
+// Close tears down the temp project and server if one was stood up.
+func (c *APIClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.proj != nil {
+		c.proj.close()
+		c.proj = nil
+	}
+	return nil
+}

--- a/internal/docscapture/apiclient.go
+++ b/internal/docscapture/apiclient.go
@@ -29,8 +29,9 @@ import (
 type APIClient struct {
 	projectDir string
 
-	mu   sync.Mutex
-	proj *project
+	mu     sync.Mutex
+	proj   *project
+	closed bool
 }
 
 // NewAPIClient returns a client serving the given project.
@@ -45,6 +46,13 @@ func NewAPIClient(projectDir string) *APIClient {
 func (c *APIClient) Do(ctx context.Context, req docs.APIRequest) (docs.APIResponse, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// Without this a request after Close silently stands up a WHOLE NEW temp
+	// project, so the caller gets an answer from a server it believes it tore
+	// down — and the fresh project leaks.
+	if c.closed {
+		return docs.APIResponse{}, errors.New("api{}: client is closed")
+	}
 
 	if c.proj == nil {
 		dir := req.ProjectDir
@@ -62,6 +70,19 @@ func (c *APIClient) Do(ctx context.Context, req docs.APIRequest) (docs.APIRespon
 		c.proj = p
 	} else if err := c.proj.syncSeed(ctx, req.Seed); err != nil {
 		return docs.APIResponse{}, fmt.Errorf("api{}: seeding: %w", err)
+	}
+
+	// An unknown role silently resolves to a user with UPDATE grants, so a
+	// typo'd `as=` would run as the editor and the assertion would pass for the
+	// wrong reason. Only validated when the project HAS assignments to check
+	// against.
+	if req.As != "" && len(c.proj.byRole) > 0 {
+		if _, ok := c.proj.byRole[req.As]; !ok {
+			return docs.APIResponse{}, fmt.Errorf(
+				"as=%q: no principal is assigned that role in acl.yaml, and an unknown role "+
+					"falls back to a privileged default — so this request would run as someone "+
+					"else. Known roles: %s", req.As, strings.Join(knownRoles(c.proj.byRole), ", "))
+		}
 	}
 
 	method := req.Method
@@ -97,13 +118,14 @@ func (c *APIClient) Do(ctx context.Context, req docs.APIRequest) (docs.APIRespon
 	if err != nil {
 		return docs.APIResponse{}, fmt.Errorf("api{path=%q}: reading body: %w", req.Path, err)
 	}
-	return docs.APIResponse{Status: resp.StatusCode, Body: string(raw)}, nil
+	return docs.APIResponse{Status: resp.StatusCode, Body: string(raw), Header: resp.Header}, nil
 }
 
 // Close tears down the temp project and server if one was stood up.
 func (c *APIClient) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.closed = true
 	if c.proj != nil {
 		c.proj.close()
 		c.proj = nil

--- a/internal/docscapture/apiclient_test.go
+++ b/internal/docscapture/apiclient_test.go
@@ -1,0 +1,86 @@
+package docscapture
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+// The API client serves a real request against a seeded temp project, with no
+// browser and no built frontend — the property that lets api{} gate CI.
+func TestAPIClient_ServesSeededEntity(t *testing.T) {
+	dir := protoDir(t)
+	c := NewAPIClient(dir)
+	defer func() { _ = c.Close() }()
+
+	seed := []docs.SeedOp{{
+		Kind: "create", Type: "ticket", ID: "TICKET-api",
+		Properties: map[string]any{"title": "Seeded", "status": "open", "priority": "low", "reporter": "a@b.c"},
+	}}
+
+	resp, err := c.Do(context.Background(), docs.APIRequest{
+		ProjectDir: dir, Seed: seed,
+		Path: "/api/v1/tickets/TICKET-api", As: "editor",
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+	if !strings.Contains(resp.Body, "Seeded") {
+		t.Errorf("body does not carry the seeded entity: %s", resp.Body)
+	}
+}
+
+// An HTTP error status is a RESPONSE, not a transport error — asserting a 404
+// is the point of the verb, so it must not surface as err.
+func TestAPIClient_ErrorStatusIsNotAnError(t *testing.T) {
+	dir := protoDir(t)
+	c := NewAPIClient(dir)
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.Do(context.Background(), docs.APIRequest{
+		ProjectDir: dir, Path: "/api/v1/tickets/NOPE", As: "editor",
+	})
+	if err != nil {
+		t.Fatalf("a 404 must be a response, not an error: %v", err)
+	}
+	if resp.Status != 404 {
+		t.Fatalf("status = %d, body = %s", resp.Status, resp.Body)
+	}
+}
+
+// The seed grows as a manual runs; a later request must see entities created
+// after the server stood up (the syncSeed path screenshot{} also relies on).
+func TestAPIClient_SeedGrowsAcrossRequests(t *testing.T) {
+	dir := protoDir(t)
+	c := NewAPIClient(dir)
+	defer func() { _ = c.Close() }()
+
+	first := []docs.SeedOp{{
+		Kind: "create", Type: "ticket", ID: "TICKET-one",
+		Properties: map[string]any{"title": "One", "status": "open", "priority": "low", "reporter": "a@b.c"},
+	}}
+	if _, err := c.Do(context.Background(), docs.APIRequest{
+		ProjectDir: dir, Seed: first, Path: "/api/v1/tickets/TICKET-one", As: "editor",
+	}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+
+	grown := append(append([]docs.SeedOp{}, first...), docs.SeedOp{
+		Kind: "create", Type: "ticket", ID: "TICKET-two",
+		Properties: map[string]any{"title": "Two", "status": "open", "priority": "low", "reporter": "a@b.c"},
+	})
+	resp, err := c.Do(context.Background(), docs.APIRequest{
+		ProjectDir: dir, Seed: grown, Path: "/api/v1/tickets/TICKET-two", As: "editor",
+	})
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("an entity seeded after standUp was not served: %d %s", resp.Status, resp.Body)
+	}
+}

--- a/internal/docscapture/capture.go
+++ b/internal/docscapture/capture.go
@@ -104,7 +104,7 @@ func (c *Capturer) Capture(ctx context.Context, spec docs.CaptureSpec) (string, 
 // ensure lazily stands up the temp-project server (once) and the browser (once).
 func (c *Capturer) ensure(ctx context.Context, spec docs.CaptureSpec) error {
 	if c.proj == nil {
-		p, err := standUp(ctx, spec.ProjectDir, spec.Seed)
+		p, err := standUp(ctx, spec.ProjectDir, spec.Seed, true)
 		if err != nil {
 			return err
 		}

--- a/internal/docscapture/capture_test.go
+++ b/internal/docscapture/capture_test.go
@@ -32,7 +32,9 @@ func protoDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(p, "metamodel.yaml")); err != nil {
+	// schema.yaml, not metamodel.yaml: the file was renamed in TKT-FNARO6 and
+	// this guard was missed, so every test using protoDir skipped silently.
+	if _, err := os.Stat(filepath.Join(p, "schema.yaml")); err != nil {
 		t.Skip("prototype project not found")
 	}
 	return p

--- a/internal/docscapture/server.go
+++ b/internal/docscapture/server.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
@@ -38,6 +39,9 @@ type project struct {
 	svc      *appbuild.Services
 	server   *httptest.Server
 	assignee func(role string) principal.Principal
+	// byRole is the role→user index behind assignee, kept so a caller can
+	// distinguish an unknown role from a known one (see resolveRole).
+	byRole map[string]string
 	// seeded is how many seed ops have been applied to the store. The manual's
 	// seed grows as create()/link() islands run; each screenshot{} passes the
 	// FULL accumulated seed, so we apply only the new tail before capturing —
@@ -47,7 +51,18 @@ type project struct {
 
 // syncSeed applies any seed ops beyond those already applied to the running
 // store, so a screenshot{} of an entity created after standUp still renders.
+//
+// The watermark is POSITIONAL, which is only sound because docRuntime.seedOps is
+// append-only: each call must pass the same prefix it passed last time, with new
+// ops appended. If a caller ever rewrote or reordered the prefix, the already-
+// applied ops would be skipped silently and every later assertion would be about
+// a store that does not match the manual. Nothing in the type enforces this, so
+// it is stated here.
 func (p *project) syncSeed(ctx context.Context, seed []docs.SeedOp) error {
+	if p.seeded > len(seed) {
+		return fmt.Errorf("seed shrank from %d to %d ops: the seed must be append-only, "+
+			"or already-applied ops are silently skipped", p.seeded, len(seed))
+	}
 	if p.seeded >= len(seed) {
 		return nil
 	}
@@ -99,6 +114,7 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp, needSPA
 	}
 
 	assignee := buildRoleAssignee(dir)
+	roles := roleIndex(dir)
 
 	app, err := dataentry.NewApp( //nolint:contextcheck // app construction is not request-scoped
 		svc.FS(), svc.Paths(), svc.Meta(), svc.Store(), svc.Versions(),
@@ -117,7 +133,7 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp, needSPA
 		return assignee(r.Header.Get(roleHeader))
 	})
 
-	p := &project{dir: tmp, svc: svc, assignee: assignee, seeded: len(seed)}
+	p := &project{dir: tmp, svc: svc, assignee: assignee, byRole: roles, seeded: len(seed)}
 	p.server = httptest.NewServer(app.NewRouter())
 	return p, nil
 }
@@ -205,6 +221,23 @@ func copyDirIfExists(src, dst string) error {
 	return nil
 }
 
+// roleIndex returns the role→user index for the project's acl.yaml, so a caller
+// can validate a requested role name. Empty when there is no policy, in which
+// case no validation is possible and none is done.
+func roleIndex(projectDir string) map[string]string {
+	byRole := map[string]string{}
+	pol, err := acl.LoadPolicy(filepath.Join(projectDir, "acl.yaml"))
+	if err != nil {
+		return byRole
+	}
+	for user, role := range pol.Assignments {
+		if _, seen := byRole[role]; !seen {
+			byRole[role] = user
+		}
+	}
+	return byRole
+}
+
 // buildRoleAssignee returns a function mapping a requested role name to a
 // principal assigned that role in acl.yaml. acl.yaml Assignments are User→role;
 // we invert to role→a User holding it. When the requested role is empty or
@@ -242,14 +275,39 @@ func buildRoleAssignee(projectDir string) func(role string) principal.Principal 
 		defaultUser = "docs-capture"
 	}
 	return func(role string) principal.Principal {
-		user := defaultUser
-		if role != "" {
-			if u, ok := byRole[role]; ok {
-				user = u
-			}
-		}
-		return principal.Principal{User: user, Tool: principal.ToolDataEntry}
+		p, _ := resolveRole(byRole, defaultUser, role)
+		return p
 	}
+}
+
+// resolveRole maps a requested role to a principal and reports whether the role
+// was KNOWN. The bool is the whole point: an unknown role silently resolves to
+// defaultUser — a user chosen for having UPDATE grants — so `as="vewer"` runs as
+// the editor and an assertion passes for entirely the wrong reason. Callers that
+// know the role was explicitly named (api{}) refuse an unknown one; the empty
+// `as=` default stays a legitimate fallback.
+func resolveRole(byRole map[string]string, defaultUser, role string) (principal.Principal, bool) {
+	user := defaultUser
+	known := true
+	if role != "" {
+		u, ok := byRole[role]
+		if ok {
+			user = u
+		} else {
+			known = false
+		}
+	}
+	return principal.Principal{User: user, Tool: principal.ToolDataEntry}, known
+}
+
+// knownRoles lists the roles that have an assigned user, for a failure message.
+func knownRoles(byRole map[string]string) []string {
+	out := make([]string, 0, len(byRole))
+	for r := range byRole {
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // hasChrome reports whether a Chrome/Chromium binary is resolvable, so the

--- a/internal/docscapture/server.go
+++ b/internal/docscapture/server.go
@@ -62,9 +62,15 @@ func (p *project) syncSeed(ctx context.Context, seed []docs.SeedOp) error {
 // it by replaying the manual's create/link ops against the fsstore, and starts
 // an httptest server for the SPA. The server's principal resolver maps the
 // per-request role header to a principal assigned that role in acl.yaml.
-func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp) (*project, error) {
-	if err := dataentry.CheckEmbeddedSPA(); err != nil {
-		return nil, fmt.Errorf("data-entry SPA not built (run `just build-frontend`): %w", err)
+// needSPA distinguishes the two callers: a screenshot renders the Vue app and
+// cannot work without a built frontend, while an api{} assertion only reaches
+// /api/v1 handlers and must NOT be blocked by a missing bundle — that is what
+// lets api{} gate CI unconditionally.
+func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp, needSPA bool) (*project, error) {
+	if needSPA {
+		if err := dataentry.CheckEmbeddedSPA(); err != nil {
+			return nil, fmt.Errorf("data-entry SPA not built (run `just build-frontend`): %w", err)
+		}
 	}
 
 	tmp, err := os.MkdirTemp("", "rela-docscapture-*")

--- a/internal/docscapture/server_test.go
+++ b/internal/docscapture/server_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Sourcehaven-BV/rela/internal/dataentry"
 	"github.com/Sourcehaven-BV/rela/internal/docs"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
@@ -90,14 +89,13 @@ func TestCopyProjectSchema(t *testing.T) {
 }
 
 // standUp builds a working server over a temp project + seed (no browser).
+// Asserts an /api/v1 route, so it passes needSPA=false and no longer skips when
+// the frontend bundle is absent — the same property that lets api{} gate CI.
 func TestStandUp_ServesSeededEntity(t *testing.T) {
-	if err := checkSPA(); err != nil {
-		t.Skip(err.Error())
-	}
 	p, err := standUp(context.Background(), protoDir(t), []docs.SeedOp{{
 		Kind: "create", Type: "ticket", ID: "TICKET-su",
 		Properties: map[string]any{"title": "x", "status": "open", "priority": "low", "reporter": "a@b.c"},
-	}})
+	}}, false)
 	if err != nil {
 		t.Fatalf("standUp: %v", err)
 	}
@@ -135,10 +133,4 @@ func mustWrite(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// checkSPA skips server tests when the SPA isn't built (no browser needed for
-// these, but the App requires the embedded SPA to construct its router).
-func checkSPA() error {
-	return dataentry.CheckEmbeddedSPA()
 }

--- a/internal/docscli/apiclient_fs.go
+++ b/internal/docscli/apiclient_fs.go
@@ -1,0 +1,19 @@
+//go:build !postgres
+
+package docscli
+
+import (
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+	"github.com/Sourcehaven-BV/rela/internal/docscapture"
+)
+
+// NewAPIClient builds the client serving api{} assertions. On the default
+// (fsstore) build it stands up a throwaway temp project via appbuild.Discover —
+// an ephemeral fsstore that never touches real data.
+//
+// Unlike NewCapturer this pulls in no browser: the client only issues HTTP
+// requests against the data-entry router, so api{} assertions run wherever the
+// Go tests do, with no built frontend and no Chrome.
+func NewAPIClient(projectDir string) (docs.APIClient, error) {
+	return docscapture.NewAPIClient(projectDir), nil
+}

--- a/internal/docscli/apiclient_postgres.go
+++ b/internal/docscli/apiclient_postgres.go
@@ -1,0 +1,20 @@
+//go:build postgres
+
+package docscli
+
+import (
+	"errors"
+
+	"github.com/Sourcehaven-BV/rela/internal/docs"
+)
+
+// NewAPIClient is unavailable on the postgres build, for exactly the reason
+// NewCapturer is: the assertion server stands up a project via
+// appbuild.Discover, which on this build binds pgstore to the shared
+// RELA_DATABASE_URL — so seeding a "throwaway" fixture would write into the
+// real database. api{} fails loud here rather than contaminating live data.
+// (Tier-A resolvers, and the store-free shows{}/refuses{}/permits{}
+// assertions, still work on the postgres build.)
+func NewAPIClient(_ string) (docs.APIClient, error) {
+	return nil, errors.New("api{} is not available on the postgres build (it would seed into the live database); run `rela-docs build` from the default build")
+}

--- a/internal/docscli/docscli.go
+++ b/internal/docscli/docscli.go
@@ -53,6 +53,10 @@ type BuildCmd struct {
 	// the "no browser" path deterministically without a shared global (and stay
 	// t.Parallel()-safe).
 	newCapturer func() (docs.Capturer, error)
+
+	// newAPIClient resolves the api{} client; nil means the build-tagged
+	// package NewAPIClient. Injected in tests.
+	newAPIClient func(string) (docs.APIClient, error)
 }
 
 // capturer returns the resolved capturer factory: the injected test seam if set,
@@ -62,6 +66,15 @@ func (c *BuildCmd) capturer() func() (docs.Capturer, error) {
 		return c.newCapturer
 	}
 	return NewCapturer
+}
+
+// apiClient resolves the api{} client, defaulting to the build-tagged
+// NewAPIClient. Overridable in tests, like newCapturer.
+func (c *BuildCmd) apiClient() func(string) (docs.APIClient, error) {
+	if c.newAPIClient != nil {
+		return c.newAPIClient
+	}
+	return NewAPIClient
 }
 
 // outputDir is the directory screenshot{} PNGs are written into: the output
@@ -116,6 +129,13 @@ func (c *BuildCmd) Run(ctx context.Context, proj Project) error {
 		opts.Capturer = capturer
 	} else {
 		opts.CapturerErr = capErr.Error()
+	}
+	// Same contract for api{} assertions: available or loudly absent, never
+	// silently skipped. A skipped assertion looks exactly like a passing one.
+	if client, apiErr := c.apiClient()(proj.Paths().Root); apiErr == nil {
+		opts.APIClient = client
+	} else {
+		opts.APIClientErr = apiErr.Error()
 	}
 
 	rendered, err := docs.Build(ctx, string(src), opts)

--- a/prototypes/data-entry/manual/tickets-manual.md
+++ b/prototypes/data-entry/manual/tickets-manual.md
@@ -63,7 +63,7 @@ The access model comes straight from `acl.yaml`:
 roles_matrix{ type = "ticket" }
 ```
 
-The table above is rendered from `acl.yaml`. These claims are *checked* against
+The table above is rendered from `acl.yaml`. These claims are _checked_ against
 the real authorization path when this handbook builds, so the prose cannot
 outlive the policy it describes:
 

--- a/prototypes/data-entry/manual/tickets-manual.md
+++ b/prototypes/data-entry/manual/tickets-manual.md
@@ -3,7 +3,7 @@
 `rela description()`
 
 This handbook is authored in Markdown; the tables, diagrams, and screenshot
-below are resolved from the project's `metamodel.yaml` and `acl.yaml` by
+below are resolved from the project's `schema.yaml` and `acl.yaml` by
 `rela-docs build`, so they can never drift from the schema. It doubles as a
 worked example of the rela-docs generator — see
 [the guide](../rela-docs.md).
@@ -51,12 +51,36 @@ entity{ id = t.id, fields = { "title", "status" } }
 
 There is `rela count{ type = "ticket" }` seeded ticket in this example.
 
+```rela
+shows{ type = "ticket", exactly = { "ticket-1" } }
+```
+
 ## Who can do what
 
 The access model comes straight from `acl.yaml`:
 
 ```rela
 roles_matrix{ type = "ticket" }
+```
+
+The table above is rendered from `acl.yaml`. These claims are *checked* against
+the real authorization path when this handbook builds, so the prose cannot
+outlive the policy it describes:
+
+```rela
+-- An editor maintains the backlog.
+permits{ who = "alice@example.com", op = "update", type = "ticket" }
+permits{ who = "alice@example.com", op = "delete", type = "ticket" }
+
+-- A viewer browses and nothing more. If someone widens `viewer` in acl.yaml,
+-- this handbook stops building rather than quietly describing a policy that
+-- is no longer in force.
+refuses{ who = "bob@example.com", op = "update", type = "ticket" }
+refuses{ who = "bob@example.com", op = "create", type = "ticket" }
+refuses{ who = "bob@example.com", op = "delete", type = "ticket" }
+
+-- There is no self-service sign-up: an unassigned principal gets nothing.
+refuses{ who = "carol@example.com", op = "update", type = "ticket" }
 ```
 
 ## The edit form

--- a/prototypes/data-entry/manual/tickets-manual.md
+++ b/prototypes/data-entry/manual/tickets-manual.md
@@ -80,7 +80,9 @@ refuses{ who = "bob@example.com", op = "create", type = "ticket" }
 refuses{ who = "bob@example.com", op = "delete", type = "ticket" }
 
 -- There is no self-service sign-up: an unassigned principal gets nothing.
-refuses{ who = "carol@example.com", op = "update", type = "ticket" }
+-- `unassigned = true` states that the missing assignment IS the claim, so this
+-- cannot be confused with a typo in the principal name.
+refuses{ who = "carol@example.com", op = "update", type = "ticket", unassigned = true }
 ```
 
 ## The edit form

--- a/tickets/entities/docs-checklists/DOCS-DOCASSERT.md
+++ b/tickets/entities/docs-checklists/DOCS-DOCASSERT.md
@@ -1,0 +1,43 @@
+---
+id: DOCS-DOCASSERT
+type: docs-checklist
+title: 'Documentation: Executable manuals — assertions in the rela-docs doc language'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+- [x] Function/type docs if public API
+
+The godoc on each verb states WHY rather than what — why authorization goes
+through `acl.Declarative` instead of re-reading `policy.Roles`, why `instance`
+is excluded from `identical_to`, why an unknown `who`/`type`/`as` is refused.
+Those are the decisions a future reader would otherwise reverse.
+
+## Project Documentation
+
+- [x] README updated (if applicable) — no README change: the doc language is
+      documented in its own guide, which README links.
+- [x] ~~CLAUDE.md updated (if new patterns)~~ (N/A: no new architectural
+      pattern — `APIClient` follows the existing consumer-side-interface and
+      build-tagged-seam rules CLAUDE.md already states)
+- [x] Help text accurate (if CLI changes) — no new flags; the verbs are doc
+      language, not CLI surface.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: the repo has no CHANGELOG.md)
+- [x] API docs updated (if applicable) — `docs/rela-docs.md` gained an
+      "Assertions" section (resolver table rows, `shows{}`/`refuses{}`/
+      `permits{}`/`api{}`, the `unassigned=` argument, and the `identical_to`
+      scope note). Edited at the SOURCE (`docs-project/entities/guides/`) and
+      regenerated, since `docs/rela-docs.md` is generated and hand edits are
+      overwritten by `just docs`.
+
+**Proof rather than prose:** the example handbook
+(`prototypes/data-entry/manual/tickets-manual.md`) now asserts its own
+access-control claims, so the documentation of this feature is itself an
+instance of it.

--- a/tickets/entities/implementation-checklists/IMPL-DOCASSERT.md
+++ b/tickets/entities/implementation-checklists/IMPL-DOCASSERT.md
@@ -1,0 +1,77 @@
+---
+id: IMPL-DOCASSERT
+type: implementation-checklist
+title: 'Implementation: Executable manuals — assertions in the rela-docs doc language'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Built the example handbook against the real project
+(`prototypes/data-entry/manual/tickets-manual.md`) and verified each assertion
+both passes and *fails for the right reason* — a passing assertion that has
+never been seen to fail proves nothing:
+
+- Widened `viewer` with `update: ["*"]` in `acl.yaml` → the build stopped at
+  `manual:80` with `claimed: refused / actual: PERMITTED / rule: role-grant/viewer`,
+  then restored the file and confirmed the build goes green again.
+- `api{status=200}` → forced to 201, failed printing the actual status and body.
+- `api{error=...}` → forced a wrong code, failed naming both codes.
+- `identical_to` on two missing entities passes; against a live entity vs a
+  missing one it fails, so it is not vacuously true. Its `instance` exclusion
+  was verified in BOTH directions (differing `type` and differing status are
+  still caught).
+- Mutation testing: 7 mutants, all COMPILING, all killed — removing the
+  claimless-call guard, the `exactly` over-inclusion check, the presence-vs-
+  emptiness distinction in `hasField`, the nil-policy guard, the `instance`
+  normalization (over-broad), the body comparison, and the api claimless guard.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+      patterns extracted to a helper / constant / type where it
+      sharpens the contract (don't extract for its own sake; CLAUDE.md
+      "three similar lines is better than a premature abstraction"
+      still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+**Notes:**
+
+- `APIClient` mirrors the existing `Capturer` consumer-side interface, with the
+  same build-tagged seam (`apiclient_fs.go` / `apiclient_postgres.go`) so the
+  core docs package never imports a server, and postgres fails loud rather than
+  seeding into a live database.
+- The pure assertion cores (`checkShows`, `checkAuthz`, `checkAPI`,
+  `checkIdentical`) are split from the Lua bindings so the failure PROSE is
+  under test — a doctest's value is its failure output.
+- `docs → principal` was added to `.go-arch-lint.yml` with a stated reason:
+  `acl.Declarative`'s API takes a `principal.Principal`, so it is implied by the
+  existing `acl` dependency; `principal` is a dependency-free leaf and the
+  sibling `docscapture` already lists it.

--- a/tickets/entities/review-checklists/REV-DOCASSERT.md
+++ b/tickets/entities/review-checklists/REV-DOCASSERT.md
@@ -1,0 +1,89 @@
+---
+id: REV-DOCASSERT
+type: review-checklist
+title: 'Review: Executable manuals — assertions in the rela-docs doc language'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`go test ./internal/...` clean; `just lint` 0 issues; commentlint "no
+unresolvable doc links across 11130 comments"; coverage PASS on both the
+package floor and the total. Also `just arch-lint` OK, `just plimsoll` rc=0,
+and `go build -tags postgres ./...` clean (the api{} client has a build-tagged
+postgres variant that must fail loud rather than seed a live database).
+
+`just comment-report` introduces no new advisory findings on the new files.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-DOCA01 through RR-DOCA10 — 3 critical, 4 significant,
+3 minor, all `addressed`.
+
+The three critical findings were one class: an identifier that silently
+resolved to a benign default, so a typo made the assertion pass forever
+(`who=` unassigned is refused by construction; `type=` unknown is an empty
+set; `as=` unknown fell back to a privileged principal). Each is now resolved
+against the thing that defines it.
+
+One unrelated change is deliberate and called out in its commit: the
+`docscapture` test skip guard stat'd `metamodel.yaml`, renamed to
+`schema.yaml` in TKT-FNARO6, so those tests had been skipping silently.
+Fixing it was necessary to test this feature at all, and raised package
+coverage 27% -> 46%.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- "A call that asserts nothing is an ERROR" — PASS. Enforced on every verb,
+  including a misspelled key beside a valid claim (which the rule alone does
+  not catch), and pinned by compiling mutants.
+- "Prefer `exactly` for lists" — PASS. `exactly` is implemented, documented as
+  the recommended form with the relation-leak bug as the rationale, and
+  `exactly={}` is a real claim distinct from no claim.
+- "A refusal assertion needs a positive control" — PASS. `permits{}` is the
+  paired form; the negative-control table asserts that wrong claims turn the
+  build red; and the end-to-end proof widened `viewer` in `acl.yaml` and
+  confirmed the handbook stops building, then restored it and confirmed green.
+- "Failure output prints the page and the seed" — PARTIAL. Every failure
+  prints the actual observed state (the seeded id set, the response body and
+  status, the rule that fired). The literal "page" half belongs to the browser
+  verbs, which are not in this slice.
+- Scope items 1, 2 (browser claims), 5 (`world=`) and 6 (multi-backend) are
+  NOT delivered; each is recorded in the ticket with the reason. Item 5 is
+  blocked on the worlds epic (content states are not on develop); item 6 is
+  not reachable while seeding is unavailable on the postgres build.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-DOCASSERT
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI

--- a/tickets/entities/review-responses/RR-DOCA01.md
+++ b/tickets/entities/review-responses/RR-DOCA01.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA01
+type: review-response
+title: 'refuses{} passes forever for a principal that does not exist'
+finding: 'who= was free text, never resolved against acl.yaml assignments. A principal with no assignment has no grants and is refused BY CONSTRUCTION, so every refuses{} with a misspelled who was green permanently and could never fail. The shipped example manual contained refuses{who="carol@example.com"} — a deliberate claim about an unassigned principal, byte-identical to a typo.'
+severity: critical
+resolution: 'who= is now resolved against policy.Assignments and an unknown one is refused, listing the assigned principals. Because "this principal has no role" is a legitimate claim, unassigned=true states it explicitly; asserting it on an assigned principal is also an error. The example manual now carries unassigned=true. Pinned by a compiling mutant and a negative-control row.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA02.md
+++ b/tickets/entities/review-responses/RR-DOCA02.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA02
+type: review-response
+title: a typo'd type= makes the negative shows{} claims vacuous
+finding: type= was passed straight into store.EntityQuery; an unknown type yields an empty set, which satisfies both exactly={} and any absent= claim. Those are precisely the claims the docs recommend. contains= fails safe, which is why the hole was easy to miss.
+severity: critical
+resolution: type= is validated against the metamodel in both shows{} and the authorization verbs, listing declared types on failure.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA03.md
+++ b/tickets/entities/review-responses/RR-DOCA03.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA03
+type: review-response
+title: 'an unknown as= role ran the request as a privileged principal'
+finding: 'buildRoleAssignee falls back to a defaultUser chosen for having UPDATE grants, so api{as="vewer"} ran as the editor and the assertion passed for entirely the wrong reason. APIResponse carried no record of the acting principal, so the failure message could not have shown it either.'
+severity: critical
+resolution: 'Extracted resolveRole, which reports whether the role was known; api{} refuses an unknown role naming the known ones. The empty-as default is unchanged, since it is a legitimate fallback rather than a claim.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA04.md
+++ b/tickets/entities/review-responses/RR-DOCA04.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA04
+type: review-response
+title: identical_to covered only the body channel, not the header oracle
+finding: APIResponse had no headers, so identical_to could not see ETag suppression. The existing Go test TestACLGet_ETagSuppressedOnDeny pins that a denied GET must not emit an ETag and must not honor If-None-Match — a replayed ETag returning 304 confirms existence. The ticket sold the verb as expressing a property 'currently pinned only in Go' while expressing about half of it.
+severity: significant
+resolution: APIResponse carries Header; identical_to compares an allowlist (ETag, Last-Modified) rather than all headers, since Date and Content-Length vary without disclosing anything and comparing them would make the check fail always. Documented, and pinned by a mutant plus a five-case table.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA05.md
+++ b/tickets/entities/review-responses/RR-DOCA05.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA05
+type: review-response
+title: identical_to comparing a request with itself was trivially true
+finding: Nothing rejected other.Path == path with identical as/method/body, so api{path="/a", identical_to={path="/a"}} always passed — a claimless call wearing a claim's clothes, the exact class this feature exists to refuse.
+severity: significant
+resolution: A self-comparison is refused with a message explaining that the claim is about two DIFFERENT requests.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA06.md
+++ b/tickets/entities/review-responses/RR-DOCA06.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA06
+type: review-response
+title: claim lists silently dropped non-strings and read a scalar as 'assert empty'
+finding: fieldStringSlice skipped non-LString elements, so exactly={"a", 42} asserted a smaller set than written. Worse, a scalar exactly="a" read as present-but-empty via hasField, silently becoming 'assert this type is empty' — the opposite of what the author wrote. Both coercions weaken the claim, which is the wrong direction to fail.
+severity: significant
+resolution: Assertions use a strict claimList that refuses a non-table value and any non-string element. fieldStringSlice is unchanged for the existing non-assertion verbs.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA07.md
+++ b/tickets/entities/review-responses/RR-DOCA07.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA07
+type: review-response
+title: because= matched by unanchored substring, so a single character satisfied it
+finding: because="a" passed against the reason 'no role grants update on type risico'. The argument exists to pin WHY a decision came out as it did; a one-character match pins nothing while looking like it pins something.
+severity: significant
+resolution: The rule identity (RuleKind, RuleID, or kind/id) must match exactly; the free-text Reason keeps substring matching with a minimum fragment length, since a manual should be able to quote a meaningful phrase rather than a whole sentence.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA08.md
+++ b/tickets/entities/review-responses/RR-DOCA08.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA08
+type: review-response
+title: 'a wrong status masked a wrong error code'
+finding: 'checkAPI returned on the first failing claim, so api{status=..., error=...} with both wrong reported only the status — costing an extra fix-and-rerun cycle on a red build.'
+severity: minor
+resolution: 'Both claims are evaluated and reported together.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA09.md
+++ b/tickets/entities/review-responses/RR-DOCA09.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA09
+type: review-response
+title: 'apiBuildTimeout widened the deadline for every build on the fs backend'
+finding: 'NewAPIClient never fails on the default build, so opts.APIClient was always non-nil and every build got the 2-minute ceiling instead of 30s — including Tier-A manuals with no server to stand up. No resource cost (standing up is lazy), but a hung build took four times as long to say so.'
+severity: minor
+resolution: 'The deadline is gated on the manual actually containing an api{} island.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-DOCA10.md
+++ b/tickets/entities/review-responses/RR-DOCA10.md
@@ -1,0 +1,9 @@
+---
+id: RR-DOCA10
+type: review-response
+title: syncSeed's positional watermark and use-after-Close were unguarded
+finding: syncSeed compares p.seeded >= len(seed) and applies the tail, which is sound only because seedOps is append-only — nothing enforced it, and a rewritten prefix would silently desync every later assertion. Separately, a Do after Close stood up a whole new temp project and answered from it.
+severity: minor
+resolution: syncSeed errors if the seed shrank and states the append-only invariant in its doc comment; the client refuses a request after Close.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-DOCASSERT.md
+++ b/tickets/entities/tickets/TKT-DOCASSERT.md
@@ -1,0 +1,120 @@
+---
+id: TKT-DOCASSERT
+type: ticket
+title: Executable manuals — assertions in the rela-docs doc language
+kind: enhancement
+priority: high
+effort: l
+status: backlog
+---
+
+Make a manual prove its own claims. `internal/docs` already runs Lua islands
+against a seeded in-memory graph and can drive the real SPA; it cannot yet
+ASSERT anything. Adding assertion verbs turns every manual into a test whose
+failure is a readable prose diff.
+
+## Why
+
+Documentation and tests drift apart because they are separate artifacts. Every
+world bug found during the FEAT-9CD2MX demo review was something the
+documentation would have *claimed* — "a published world shows only published
+content" — while the code did otherwise. A manual that executes its claims
+closes that gap by construction: there is one artifact, so there is nothing to
+drift.
+
+Full analysis, options and rejected alternatives: `.ignored/TESTING.md`.
+
+## What exists already
+
+- **Doc language with Lua islands** over a seeded graph
+  (`internal/docs/preprocess.go:1-12`). Statement islands run for side effects;
+  echo islands substitute a value mid-text.
+- **`create{}` / `link{}`** seed entities and relations, accumulating into
+  `seedOps` (`module.go:105,121`).
+- **`screenshot{}`** opens the real SPA in a real browser and captures
+  (`screenshot.go:93`), taking `view`, `type`, `entity`, `form`, `as`, `clip`.
+  **`as=` is a principal**, so ACL is already expressible.
+- **`chromedp.Evaluate`** already runs JS in the live page
+  (`docscapture/annotate.go:26`) — element introspection needs verbs, not
+  infrastructure.
+- **A golden-file gate**: `just docs-check` regenerates and diffs
+  (`justfile:299-303`). Echo islands are therefore ALREADY repr-assertions.
+
+## Scope
+
+**1. `open{}` + a current page.** `docRuntime` is stateful across islands
+(`runtime.go:61-86`), so an open page can live there like `seedOps` does.
+Subsequent assertions target it, so a paragraph names its screen once.
+
+**2. `shows{}` — every argument optional.** Assert only what the paragraph is
+about. Claims: `text`/`no_text`, `button`/`no_button`, `link`/`no_link`,
+`enabled`/`disabled`, `exactly` (for lists), `selector` (escape hatch),
+`width` (viewport).
+
+Key on **accessible name / visible label** by default, not CSS — it survives
+restyling and reads naturally in a manual. Note `data-testid` appears in only 4
+component files, so this likely needs an accessibility pass first; that is a
+product improvement in its own right, not test scaffolding.
+
+`no_button` is the important one: this codebase's rule is that a denied action
+is ABSENT, not disabled (RULING 11), so the negative claim encodes the contract.
+
+**3. `api{}` — contract assertions.** `status`, `error` (the machine-readable
+code, not the prose), `world`, `as`, `body`. Needs no browser, so unlike
+`shows{}` it can gate CI unconditionally. Also `identical_to={...}` for the
+existence-oracle property — two responses byte-identical — which is currently
+pinned only in Go (`viewworld_absent_test.go:120`).
+
+**4. `refuses{}` — load-time refusals.** `otherwise:` is mandatory
+(`metamodel/loader.go:767`); a copy targeting a guarded face must carry a guard
+(`metamodel/copies.go:153`, RULING 18). No server, no store — the cheapest
+assertions in the system, and RULING 18 was discovered by an agent tripping
+over it rather than by reading docs that mentioned it.
+
+**5. `world=` on the capture spec.** Absent today (`grep world screenshot.go`
+→ nothing), so a manual cannot open a page in a world at all.
+
+**6. Run one manual against several backends.** History is postgres-only; the
+per-face index differs bleve vs pg. Gate backend-specific claims the way
+`storetest.Capabilities` already does for the store suite. **CI runs all main
+backends.**
+
+## Rules this must obey
+
+- **A call that asserts nothing is an ERROR.** `shows{}` with no claim, or an
+  omitted target with no page open, must fail rather than pass silently. This
+  is the failure mode the FEAT-9CD2MX work hit repeatedly — a check that
+  passes while checking nothing.
+- **A refusal assertion needs a positive control.** `status=422` passes just as
+  happily against a server that 422s everything.
+- **Prefer `exactly` for lists.** `contains={"CTL-2"}` would have PASSED on the
+  relation-leak bug, which returned `["CTL-2","CTL-1","CTL-2"]`. The bug was
+  over-inclusion, which only an exact claim sees.
+- **Failure output prints the page and the seed**, not just the claim. Most
+  confusion during the demo review came from not knowing which faces existed;
+  `seedOps` is already recorded and available.
+
+## Deliberately NOT in scope
+
+- **Pixel-diffing screenshots.** Fails on fonts and styling, training people to
+  accept diffs — which destroys the golden-file gate where a diff means
+  something. Screenshots for humans, structural assertions for the machine.
+- **An auto-accept `--update-docs`.** Doctest's paste-the-output culture would
+  industrialise the exact failure this project keeps hitting: an auto-accepted
+  repr of the relation-leak bug would have pinned the duplicate as correct, and
+  the test would then defend it.
+- **Ellipsis elision.** If repr-capture ever lands, use a NAMED exclusion
+  (`except={"updated_at"}`) — the precedent is `bodyWithoutInstance`
+  (`viewworld_absent_test.go:159`), which excludes one field with a stated
+  reason. An ellipsis silently swallows new fields; several FEAT-9CD2MX bugs
+  were EXTRA content an ellipsis would have hidden.
+
+## First step
+
+`shows{}` with `text`/`no_text` asserting on the API response, plus `world=`.
+No browser, runs everywhere, and makes a worlds manual executable immediately.
+Then write ONE manual — the worlds guide — as the proof: it is the subsystem
+with the worst docs-to-behaviour drift, and `.ignored/WORLDS-DEMO-ISSUES.md`
+supplies the cases.
+
+Related: [[FEAT-G4VO53]], [[test-fixtures]], [[ci-pipeline]].

--- a/tickets/entities/tickets/TKT-DOCASSERT.md
+++ b/tickets/entities/tickets/TKT-DOCASSERT.md
@@ -104,9 +104,10 @@ backends.**
   repr of the relation-leak bug would have pinned the duplicate as correct, and
   the test would then defend it.
 - **Ellipsis elision.** If repr-capture ever lands, use a NAMED exclusion
-  (`except={"updated_at"}`) — the precedent is `bodyWithoutInstance`
-  (`viewworld_absent_test.go:159`), which excludes one field with a stated
-  reason. An ellipsis silently swallows new fields; several FEAT-9CD2MX bugs
+  (`except={"updated_at"}`) — the precedent is `stripInstance`
+  (`internal/dataentry/acl_get_test.go:77`), which excludes one field with a
+  stated reason. (The originally-cited `bodyWithoutInstance` in
+  `viewworld_absent_test.go` was deleted in `d8154c57`.) An ellipsis silently swallows new fields; several FEAT-9CD2MX bugs
   were EXTRA content an ellipsis would have hidden.
 
 ## First step

--- a/tickets/entities/tickets/TKT-DOCASSERT.md
+++ b/tickets/entities/tickets/TKT-DOCASSERT.md
@@ -5,7 +5,7 @@ title: Executable manuals — assertions in the rela-docs doc language
 kind: enhancement
 priority: high
 effort: l
-status: backlog
+status: review
 ---
 
 Make a manual prove its own claims. `internal/docs` already runs Lua islands
@@ -116,5 +116,46 @@ No browser, runs everywhere, and makes a worlds manual executable immediately.
 Then write ONE manual — the worlds guide — as the proof: it is the subsystem
 with the worst docs-to-behaviour drift, and `.ignored/WORLDS-DEMO-ISSUES.md`
 supplies the cases.
+
+## Delivered so far
+
+Store-free assertions, on develop (no dependency on the worlds epic):
+
+- **`shows{type, contains|absent|exactly}`** — asserts which entities exist.
+  `exactly = {}` is a real claim ("this type is empty"), distinct from no claim.
+- **`refuses{}` / `permits{}`** — authorization claims evaluated through
+  `acl.Declarative`, the same path the write path uses, so a manual fails if a
+  grant widens OR if the gate stops being consulted. `because=` also pins WHY,
+  since a deny from an unintended rule is a green check over a regression.
+- **`api{path, status, error, as, identical_to}`** — real requests over a
+  seeded temp project. No browser and no built frontend, so it gates CI.
+  `identical_to` expresses the existence-oracle property, excluding the
+  problem-details `instance` (it echoes the request url, so a raw compare could
+  never pass) — the named-exclusion discipline this ticket asks for above.
+- **The "asserts nothing is an ERROR" rule** on every verb, mutation-tested.
+- **Proof**: the example handbook (`prototypes/data-entry/manual/`) now checks
+  its own access-control prose. Widening `viewer` in `acl.yaml` makes it refuse
+  to build, naming the rule that fired.
+
+Incidental fix: `docscapture`'s test skip guard stat'd `metamodel.yaml`,
+renamed to `schema.yaml` in TKT-FNARO6 — those tests had been skipping
+silently. Fixing it raised package coverage 27% → 44%.
+
+## Not yet built, and why
+
+- **`open{}` + browser claims (`text`/`button`/`link`, item 2).** Needs the
+  accessibility pass this ticket already flags as a prerequisite: assertions
+  should key on accessible names, and `data-testid` appears in only 4
+  components. Doing it before that pass would bake CSS selectors into manuals.
+- **`world=` (item 5).** Blocked: content states are not on develop —
+  `store.EntityQuery` has no world field and `entity.Pointer` does not exist
+  there. Buildable as soon as the worlds epic merges; the worlds proof-manual
+  in "First step" depends on this.
+- **Multiple backends (item 6).** Not reachable on the current architecture:
+  the docs pipeline has no backend concept, and both `screenshot{}` and `api{}`
+  are deliberately unavailable on the `postgres` build because seeding a
+  "throwaway" project would write into the live database. Running one manual
+  across backends needs an ephemeral-postgres seam first — a ticket of its own,
+  not a line item here.
 
 Related: [[FEAT-G4VO53]], [[test-fixtures]], [[ci-pipeline]].

--- a/tickets/entities/tickets/TKT-DOCASSERT.md
+++ b/tickets/entities/tickets/TKT-DOCASSERT.md
@@ -5,7 +5,7 @@ title: Executable manuals — assertions in the rela-docs doc language
 kind: enhancement
 priority: high
 effort: l
-status: review
+status: done
 ---
 
 Make a manual prove its own claims. `internal/docs` already runs Lua islands

--- a/tickets/relations/TKT-DOCASSERT--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-DOCASSERT--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-DOCASSERT--affects--test-fixtures.md
+++ b/tickets/relations/TKT-DOCASSERT--affects--test-fixtures.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+relation: affects
+to: test-fixtures
+---

--- a/tickets/relations/TKT-DOCASSERT--has-docs--DOCS-DOCASSERT.md
+++ b/tickets/relations/TKT-DOCASSERT--has-docs--DOCS-DOCASSERT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-docs
+to: DOCS-DOCASSERT
+---

--- a/tickets/relations/TKT-DOCASSERT--has-implementation--IMPL-DOCASSERT.md
+++ b/tickets/relations/TKT-DOCASSERT--has-implementation--IMPL-DOCASSERT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-implementation
+to: IMPL-DOCASSERT
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review--REV-DOCASSERT.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review--REV-DOCASSERT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review
+to: REV-DOCASSERT
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA01.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA01.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA01
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA02.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA02.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA02
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA03.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA03.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA03
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA04.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA04.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA04
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA05.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA05.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA05
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA06.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA06.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA06
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA07.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA07.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA07
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA08.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA08.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA08
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA09.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA09.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA09
+---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA10.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA10.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+type: has-review-response
+to: RR-DOCA10
+---

--- a/tickets/relations/TKT-DOCASSERT--implements--FEAT-G4VO53.md
+++ b/tickets/relations/TKT-DOCASSERT--implements--FEAT-G4VO53.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOCASSERT
+relation: implements
+to: FEAT-G4VO53
+---


### PR DESCRIPTION
Makes a manual prove its own claims. `internal/docs` already ran Lua islands
against a seeded graph; it could not assert anything. Now it can, so a manual
whose prose stops being true stops building.

## The verbs

| Verb | Asserts |
| --- | --- |
| `shows{type, contains\|absent\|exactly}` | which entities exist |
| `refuses{}` / `permits{}` | an authorization outcome |
| `api{path, status, error, as, identical_to}` | an API contract, against a real server |

Assertion islands emit nothing — a claim is not content.

## Why this is more than a test runner

**Authorization claims go through the real path.** `refuses{}` calls
`acl.Declarative.AuthorizeWrite`, not `policy.Roles`. Answering from the policy
file would only prove the manual and the file agree, which they would even if
the gate were never consulted.

**`identical_to` states a property no single-response assertion can.** "A denied
read is indistinguishable from a missing entity" is a claim about two responses
being the same. It compares status, body, and the header channel (`ETag` —
a denied GET that emits one lets a replayed `If-None-Match` return 304), while
excluding the problem-details `instance`, which echoes the request URL.

**Nothing may pass while checking nothing.** Every verb refuses a claimless
call; a misspelled key beside a valid claim is refused too, because the rule
alone cannot catch that. Every identifier is resolved against the thing that
defines it — an unknown `who=` is refused *because* an unassigned principal is
denied by construction and would pass forever, `type=` against the metamodel,
`as=` against the role index. `unassigned=true` keeps "this principal has no
role" a statable claim, distinguishable from a typo.

## Proof

The example handbook now checks its own access-control prose. Widening `viewer`
in `acl.yaml` makes it refuse to build:

```
manual:80: resolve: refuses{who="bob@example.com", op="update", type="ticket"} failed
  claimed: refused
  actual:  PERMITTED
  rule:    role-grant/viewer
```

## Testing

Every assertion was verified to fail, not just to pass. 14 compiling mutants,
all killed (a mutant that fails to build proves nothing). A **negative-control
table** asserts that plausible authoring mistakes turn the build red — the
review found three vacuous passes that mutation testing structurally cannot
catch, since mutating absent code kills no mutants.

`api{}` needs no browser and no built frontend, so it gates CI unconditionally.
Like `screenshot{}` it is unavailable on the `postgres` build, where seeding a
"throwaway" project would write into the live database.

## Not in this PR

Browser claims (needs an accessibility pass first — assertions should key on
accessible names, and `data-testid` appears in only 4 components), `world=`
(content states are not on develop yet), and multi-backend runs (not reachable
while seeding is unavailable on postgres). Each is recorded in the ticket with
its reason.

## Incidental

`docscapture`'s test skip guard stat'd `metamodel.yaml`, renamed to
`schema.yaml` in TKT-FNARO6 — those tests had been skipping silently since.
Fixing it was needed to test any of this, and took package coverage 27% → 46%.

Ten review findings (3 critical, 4 significant, 3 minor) are recorded as
RR-DOCA01–RR-DOCA10, all addressed.