### PR TITLE
refactor(lua): extract HTTP/cache/AI binding clusters off Runtime (TKT-DOPCTI)

### DIFF
--- a/internal/lua/ai.go
+++ b/internal/lua/ai.go
@@ -39,22 +39,35 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/ai"
 )
 
-// registerAIModule installs the top-level `ai` global with `chat` and
-// `complete` functions. The global is registered unconditionally; if no
-// provider is wired into the Runtime, the functions return a typed
-// not_configured error so scripts can feature-detect uniformly.
+// aiBindings implements the ai.* module bindings: chat, complete, and
+// embed. A type of its own rather than more methods on [Runtime] (the
+// urlHelpers rationale in urls.go): the bindings need exactly one thing
+// from the runtime — the wired provider — plus the *lua.LState each is
+// called with, so they hold the provider and nothing else. The
+// capability gate stays where it was: registerBindings on Runtime
+// registers this module only when caps.AI was granted.
+type aiBindings struct {
+	// provider is the wired AI provider. Nil: accepted — each binding
+	// returns a typed not_configured error so scripts can feature-detect
+	// uniformly.
+	provider ai.Provider
+}
+
+// registerAIModule installs the top-level `ai` global with `chat`,
+// `complete`, and `embed` functions.
 func (r *Runtime) registerAIModule() {
+	b := aiBindings{provider: r.aiProvider}
 	tbl := r.L.NewTable()
-	r.L.SetField(tbl, "chat", r.L.NewFunction(r.luaAIChat))
-	r.L.SetField(tbl, "complete", r.L.NewFunction(r.luaAIComplete))
-	r.L.SetField(tbl, "embed", r.L.NewFunction(r.luaAIEmbed))
+	r.L.SetField(tbl, "chat", r.L.NewFunction(b.luaAIChat))
+	r.L.SetField(tbl, "complete", r.L.NewFunction(b.luaAIComplete))
+	r.L.SetField(tbl, "embed", r.L.NewFunction(b.luaAIEmbed))
 	r.L.SetGlobal("ai", tbl)
 }
 
 // luaAIChat implements ai.chat({messages, model?, temperature?, max_tokens?})
 // -> (result_table, nil) on success, (nil, err_table) on failure.
-func (r *Runtime) luaAIChat(ls *lua.LState) int {
-	if r.aiProvider == nil {
+func (b aiBindings) luaAIChat(ls *lua.LState) int {
+	if b.provider == nil {
 		return pushAIError(ls, &ai.Error{
 			Kind:    ai.ErrNotConfigured,
 			Message: "AI is not configured: create .rela/ai.yaml with base_url and model",
@@ -69,7 +82,7 @@ func (r *Runtime) luaAIChat(ls *lua.LState) int {
 		return 0
 	}
 
-	resp, err := r.aiProvider.Chat(chatContext(r), req)
+	resp, err := b.provider.Chat(chatContext(ls), req)
 	if err != nil {
 		var aiErr *ai.Error
 		if !errors.As(err, &aiErr) {
@@ -89,8 +102,8 @@ func (r *Runtime) luaAIChat(ls *lua.LState) int {
 // luaAIComplete implements ai.complete(prompt) -> (string, nil) or
 // (nil, err_table). Convenience wrapper around ai.chat for the common
 // single-user-message case.
-func (r *Runtime) luaAIComplete(ls *lua.LState) int {
-	if r.aiProvider == nil {
+func (b aiBindings) luaAIComplete(ls *lua.LState) int {
+	if b.provider == nil {
 		return pushAIError(ls, &ai.Error{
 			Kind:    ai.ErrNotConfigured,
 			Message: "AI is not configured: create .rela/ai.yaml with base_url and model",
@@ -99,7 +112,7 @@ func (r *Runtime) luaAIComplete(ls *lua.LState) int {
 
 	prompt := ls.CheckString(1)
 
-	resp, err := r.aiProvider.Chat(chatContext(r), ai.ChatRequest{
+	resp, err := b.provider.Chat(chatContext(ls), ai.ChatRequest{
 		Messages: []ai.Message{{Role: "user", Content: prompt}},
 	})
 	if err != nil {
@@ -116,11 +129,11 @@ func (r *Runtime) luaAIComplete(ls *lua.LState) int {
 	return 2
 }
 
-// chatContext returns the context to use for AI calls. If the runtime
-// has a Lua-state context (set by applyTimeout), use that so timeouts
+// chatContext returns the context to use for AI calls. If the Lua
+// state has a context (set by applyTimeout), use that so timeouts
 // propagate; otherwise fall back to context.Background().
-func chatContext(r *Runtime) context.Context {
-	if ctx := r.L.Context(); ctx != nil {
+func chatContext(ls *lua.LState) context.Context {
+	if ctx := ls.Context(); ctx != nil {
 		return ctx
 	}
 	return context.Background()
@@ -220,8 +233,8 @@ func pushAIError(ls *lua.LState, e *ai.Error) int {
 // (nil, err_table). Input can be a string (single text) or a table of
 // strings (batch). Result is always an array of arrays (one vector per
 // input). Optional second arg is an options table with model override.
-func (r *Runtime) luaAIEmbed(ls *lua.LState) int {
-	if r.aiProvider == nil {
+func (b aiBindings) luaAIEmbed(ls *lua.LState) int {
+	if b.provider == nil {
 		return pushAIError(ls, &ai.Error{
 			Kind:    ai.ErrNotConfigured,
 			Message: "AI is not configured: create .rela/ai.yaml with base_url and model",
@@ -234,7 +247,7 @@ func (r *Runtime) luaAIEmbed(ls *lua.LState) int {
 		return 0
 	}
 
-	resp, err := r.aiProvider.Embed(chatContext(r), req)
+	resp, err := b.provider.Embed(chatContext(ls), req)
 	if err != nil {
 		var aiErr *ai.Error
 		if !errors.As(err, &aiErr) {

--- a/internal/lua/cache.go
+++ b/internal/lua/cache.go
@@ -244,6 +244,24 @@ func logFields(event, namespacedKey string) []any {
 	}
 }
 
+// cacheBindings implements the rela.cache.* bindings: get, set, and
+// memoize. A type of its own rather than more methods on [Runtime]
+// (the urlHelpers rationale in urls.go): the bindings need exactly two
+// things from the runtime — the cache backend and the current script
+// path — so they hold those and nothing else.
+//
+// scriptPath is a func, not a captured string, because the runtime's
+// scriptPath is MUTABLE after registration: RunFile/RunFileContent set
+// it per run and external callers change it via [Runtime.SetScriptPath]
+// between RunString calls. A value captured at construction would
+// freeze the cache namespace at whatever the path was when bindings
+// were registered — usually "" — permanently disabling (or worse,
+// cross-contaminating) the cache. The closure reads the live field.
+type cacheBindings struct {
+	cache      cacheStore
+	scriptPath func() string
+}
+
 // registerCacheBindings installs rela.cache.{get,set,memoize} on the
 // supplied rela table. It is a no-op if the runtime has no cache wired.
 // Each binding guards against the inline/eval case (no scriptPath) by
@@ -254,10 +272,14 @@ func (r *Runtime) registerCacheBindings(rela *glua.LTable) {
 	if r.cache == nil {
 		return
 	}
+	c := &cacheBindings{
+		cache:      r.cache,
+		scriptPath: func() string { return r.scriptPath },
+	}
 	tbl := r.L.NewTable()
-	r.L.SetField(tbl, "get", r.L.NewFunction(r.luaCacheGet))
-	r.L.SetField(tbl, "set", r.L.NewFunction(r.luaCacheSet))
-	r.L.SetField(tbl, "memoize", r.L.NewFunction(r.luaCacheMemoize))
+	r.L.SetField(tbl, "get", r.L.NewFunction(c.luaCacheGet))
+	r.L.SetField(tbl, "set", r.L.NewFunction(c.luaCacheSet))
+	r.L.SetField(tbl, "memoize", r.L.NewFunction(c.luaCacheMemoize))
 	r.L.SetField(rela, "cache", tbl)
 }
 
@@ -273,8 +295,9 @@ func (r *Runtime) registerCacheBindings(rela *glua.LTable) {
 // any reliance on the user key not containing the separator. Raw
 // script paths are never stored in cache keys (they'd leak structure
 // on any memory dump).
-func (r *Runtime) requireCacheContext(ls *glua.LState, userKey string) string {
-	if r.scriptPath == "" {
+func (c *cacheBindings) requireCacheContext(ls *glua.LState, userKey string) string {
+	path := c.scriptPath()
+	if path == "" {
 		ls.RaiseError("cache: not available in inline/eval contexts")
 		return ""
 	}
@@ -283,7 +306,7 @@ func (r *Runtime) requireCacheContext(ls *glua.LState, userKey string) string {
 			len(userKey), maxCacheKeyBytes)
 		return ""
 	}
-	return hashKey(r.scriptPath) + userKey
+	return hashKey(path) + userKey
 }
 
 // cacheOptions captures the parsed options table for set/memoize.
@@ -397,15 +420,15 @@ var (
 // luaCacheGet implements rela.cache.get(key) -> value|nil. It accepts no
 // options; a second argument raises a Lua error to prevent the
 // "user passed opts expecting them to do something" footgun.
-func (r *Runtime) luaCacheGet(ls *glua.LState) int {
+func (c *cacheBindings) luaCacheGet(ls *glua.LState) int {
 	userKey := ls.CheckString(1)
 	// Hard-reject any second argument: get has no options.
 	if ls.GetTop() > 1 && ls.Get(2) != glua.LNil {
 		ls.RaiseError("cache.get: takes 1 argument (key); no options accepted")
 		return 0
 	}
-	namespacedKey := r.requireCacheContext(ls, userKey)
-	values, ok := r.cache.get(namespacedKey)
+	namespacedKey := c.requireCacheContext(ls, userKey)
+	values, ok := c.cache.get(namespacedKey)
 	if !ok {
 		slog.Debug("cache miss", logFields("miss", namespacedKey)...)
 		ls.Push(glua.LNil)
@@ -433,17 +456,17 @@ func (r *Runtime) luaCacheGet(ls *glua.LState) int {
 // Lua values (functions, userdata, coroutines) at API time, so scripts
 // cannot accidentally poison the cache with a handle that will
 // eventually be stale.
-func (r *Runtime) luaCacheSet(ls *glua.LState) int {
+func (c *cacheBindings) luaCacheSet(ls *glua.LState) int {
 	userKey := ls.CheckString(1)
 	valArg := ls.Get(2)
 	opts := parseCacheOptions(ls, 3, setAllowedOpts)
 
-	namespacedKey := r.requireCacheContext(ls, userKey)
+	namespacedKey := c.requireCacheContext(ls, userKey)
 
 	// Nil value -> delete. This matches Lua table semantics ("nil means
 	// absent") and avoids a separate rela.cache.delete surface.
 	if valArg == glua.LNil {
-		r.cache.delete(namespacedKey)
+		c.cache.delete(namespacedKey)
 		slog.Debug("cache delete", logFields("delete", namespacedKey)...)
 		return 0
 	}
@@ -455,7 +478,7 @@ func (r *Runtime) luaCacheSet(ls *glua.LState) int {
 		return 0
 	}
 
-	r.cache.set(namespacedKey, []any{luaValueToGo(valArg)}, opts.ttlOrDefault())
+	c.cache.set(namespacedKey, []any{luaValueToGo(valArg)}, opts.ttlOrDefault())
 	slog.Debug("cache store", logFields("store", namespacedKey)...)
 	return 0
 }
@@ -478,16 +501,16 @@ func (r *Runtime) luaCacheSet(ls *glua.LState) int {
 // alongside memoization must use a different key (e.g. `key .. ":aux"`).
 // Detecting and skipping the overwrite would require versioning every
 // entry, and is not worth the complexity for an uncommon pattern.
-func (r *Runtime) luaCacheMemoize(ls *glua.LState) int {
+func (c *cacheBindings) luaCacheMemoize(ls *glua.LState) int {
 	userKey := ls.CheckString(1)
 	fn := ls.CheckFunction(2)
 	opts := parseCacheOptions(ls, 3, memoizeAllowedOpts)
 
-	namespacedKey := r.requireCacheContext(ls, userKey)
+	namespacedKey := c.requireCacheContext(ls, userKey)
 
 	// Check cache unless explicitly bypassed.
 	if !opts.bypass {
-		if values, ok := r.cache.get(namespacedKey); ok {
+		if values, ok := c.cache.get(namespacedKey); ok {
 			slog.Debug("cache hit", logFields("hit", namespacedKey)...)
 			for _, v := range values {
 				ls.Push(GoToLuaValue(ls, v))
@@ -528,7 +551,7 @@ func (r *Runtime) luaCacheMemoize(ls *glua.LState) int {
 		goValues[i] = luaValueToGo(ls.Get(topBefore + 1 + i))
 	}
 
-	r.cache.set(namespacedKey, goValues, opts.ttlOrDefault())
+	c.cache.set(namespacedKey, goValues, opts.ttlOrDefault())
 	slog.Debug("cache store", logFields("store", namespacedKey)...)
 
 	// The returns are already on the stack; just report the count.

--- a/internal/lua/http.go
+++ b/internal/lua/http.go
@@ -99,17 +99,31 @@ func newHTTPClient() *http.Client {
 // scheduler ticks, MCP tool calls).
 var httpClient = newHTTPClient()
 
+// httpBindings implements the http.* module bindings: request plus the
+// per-method convenience functions. A type of its own rather than more
+// methods on [Runtime] (the urlHelpers rationale in urls.go): these
+// functions need nothing from the runtime — no store, no deps, no
+// capabilities, not even the Lua state, since each receives the
+// *lua.LState it is called with and the request context comes from that
+// state (see httpContext). The capability gate stays where it was:
+// registerBindings on Runtime registers this module only when caps.HTTP
+// was granted.
+//
+// Nil: the zero value is ready to use; it holds no state to initialize.
+type httpBindings struct{}
+
 // registerHTTPModule installs the top-level `http` global with `request`
 // plus the per-method convenience functions (get, post, put, patch, delete).
 // JSON helpers live separately under rela.json (see json.go).
 func (r *Runtime) registerHTTPModule() {
+	h := httpBindings{}
 	tbl := r.L.NewTable()
-	r.L.SetField(tbl, "request", r.L.NewFunction(r.luaHTTPRequest))
-	r.L.SetField(tbl, "get", r.L.NewFunction(r.luaHTTPGet))
-	r.L.SetField(tbl, "post", r.L.NewFunction(r.luaHTTPPost))
-	r.L.SetField(tbl, "put", r.L.NewFunction(r.luaHTTPPut))
-	r.L.SetField(tbl, "patch", r.L.NewFunction(r.luaHTTPPatch))
-	r.L.SetField(tbl, "delete", r.L.NewFunction(r.luaHTTPDelete))
+	r.L.SetField(tbl, "request", r.L.NewFunction(h.luaHTTPRequest))
+	r.L.SetField(tbl, "get", r.L.NewFunction(h.luaHTTPGet))
+	r.L.SetField(tbl, "post", r.L.NewFunction(h.luaHTTPPost))
+	r.L.SetField(tbl, "put", r.L.NewFunction(h.luaHTTPPut))
+	r.L.SetField(tbl, "patch", r.L.NewFunction(h.luaHTTPPatch))
+	r.L.SetField(tbl, "delete", r.L.NewFunction(h.luaHTTPDelete))
 	r.L.SetGlobal("http", tbl)
 }
 
@@ -124,39 +138,39 @@ func (r *Runtime) registerHTTPModule() {
 //	timeout    (number, optional, seconds)
 //
 // Returns (response_table, nil) on success, (nil, err_table) on failure.
-func (r *Runtime) luaHTTPRequest(ls *lua.LState) int {
+func (h httpBindings) luaHTTPRequest(ls *lua.LState) int {
 	opts := ls.CheckTable(1)
 	parsed, err := parseHTTPRequestOpts(opts)
 	if err != nil {
 		ls.RaiseError("http.request: %s", err.Error())
 		return 0
 	}
-	return r.doHTTPRequest(ls, "http.request", parsed)
+	return h.doHTTPRequest(ls, "http.request", parsed)
 }
 
 // luaHTTPGet implements http.get(url, opts?) -> (response, nil) | (nil, err).
-func (r *Runtime) luaHTTPGet(ls *lua.LState) int {
-	return r.luaHTTPSimple(ls, "http.get", http.MethodGet, false)
+func (h httpBindings) luaHTTPGet(ls *lua.LState) int {
+	return h.luaHTTPSimple(ls, "http.get", http.MethodGet, false)
 }
 
 // luaHTTPPost implements http.post(url, body, opts?) -> (response, nil) | (nil, err).
-func (r *Runtime) luaHTTPPost(ls *lua.LState) int {
-	return r.luaHTTPSimple(ls, "http.post", http.MethodPost, true)
+func (h httpBindings) luaHTTPPost(ls *lua.LState) int {
+	return h.luaHTTPSimple(ls, "http.post", http.MethodPost, true)
 }
 
 // luaHTTPPut implements http.put(url, body, opts?) -> (response, nil) | (nil, err).
-func (r *Runtime) luaHTTPPut(ls *lua.LState) int {
-	return r.luaHTTPSimple(ls, "http.put", http.MethodPut, true)
+func (h httpBindings) luaHTTPPut(ls *lua.LState) int {
+	return h.luaHTTPSimple(ls, "http.put", http.MethodPut, true)
 }
 
 // luaHTTPPatch implements http.patch(url, body, opts?) -> (response, nil) | (nil, err).
-func (r *Runtime) luaHTTPPatch(ls *lua.LState) int {
-	return r.luaHTTPSimple(ls, "http.patch", http.MethodPatch, true)
+func (h httpBindings) luaHTTPPatch(ls *lua.LState) int {
+	return h.luaHTTPSimple(ls, "http.patch", http.MethodPatch, true)
 }
 
 // luaHTTPDelete implements http.delete(url, opts?) -> (response, nil) | (nil, err).
-func (r *Runtime) luaHTTPDelete(ls *lua.LState) int {
-	return r.luaHTTPSimple(ls, "http.delete", http.MethodDelete, false)
+func (h httpBindings) luaHTTPDelete(ls *lua.LState) int {
+	return h.luaHTTPSimple(ls, "http.delete", http.MethodDelete, false)
 }
 
 // luaHTTPSimple implements the convenience-method shape:
@@ -166,7 +180,7 @@ func (r *Runtime) luaHTTPDelete(ls *lua.LState) int {
 //
 // fnName ("http.get", etc.) is used as the prefix on raised errors so
 // scripts see the entry-point name in error messages, not "http.request".
-func (r *Runtime) luaHTTPSimple(ls *lua.LState, fnName, method string, withBody bool) int {
+func (h httpBindings) luaHTTPSimple(ls *lua.LState, fnName, method string, withBody bool) int {
 	rawURL := ls.CheckString(1)
 	body := ""
 	optsPos := 2
@@ -187,7 +201,7 @@ func (r *Runtime) luaHTTPSimple(ls *lua.LState, fnName, method string, withBody 
 	opts.method = method
 	opts.url = reqURL
 	opts.body = body
-	return r.doHTTPRequest(ls, fnName, opts)
+	return h.doHTTPRequest(ls, fnName, opts)
 }
 
 // doHTTPRequest performs the actual HTTP request and pushes the result
@@ -199,8 +213,8 @@ func (r *Runtime) luaHTTPSimple(ls *lua.LState, fnName, method string, withBody 
 // convenience methods and http.request now agree on a growing set of request
 // features (body, form, basic auth), and a parameter list that grows with each
 // one is how a caller ends up passing headers where the body goes.
-func (r *Runtime) doHTTPRequest(ls *lua.LState, fnName string, o httpRequestOpts) int {
-	ctx := httpContext(r)
+func (h httpBindings) doHTTPRequest(ls *lua.LState, fnName string, o httpRequestOpts) int {
+	ctx := httpContext(ls)
 	if o.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, o.timeout)
@@ -249,9 +263,9 @@ func (r *Runtime) doHTTPRequest(ls *lua.LState, fnName string, o httpRequestOpts
 }
 
 // httpContext returns the context for HTTP calls, propagating the
-// runtime's Lua-state context (for timeout) or falling back to Background.
-func httpContext(r *Runtime) context.Context {
-	if ctx := r.L.Context(); ctx != nil {
+// Lua state's context (for timeout) or falling back to Background.
+func httpContext(ls *lua.LState) context.Context {
+	if ctx := ls.Context(); ctx != nil {
 		return ctx
 	}
 	return context.Background()

--- a/internal/lua/runtime.go
+++ b/internal/lua/runtime.go
@@ -68,7 +68,7 @@ func stripShebang(code string) string {
 // of entities and relations) registered at all; calling those from Lua raises
 // a "attempt to call a nil value" error from the VM itself.
 //
-// TODO(TKT-N0IKN9): Runtime is a god-object (60 methods). Decompose toward the
+// TODO(TKT-N0IKN9): Runtime is a god-object (45 methods). Decompose toward the
 // 40-method load line; ratchet this number down as bindings move out.
 //
 // 119 → 120 (TKT-ZF2DTV): reader(), the single choke point every read binding
@@ -93,7 +93,13 @@ func stripShebang(code string) string {
 // exists. ai.* and http.* register method values for the same reason. See
 // registerMailModule.
 //
-//plimsoll:max-methods=61
+// 61 → 46 (TKT-DOPCTI): the HTTP, cache, and AI clusters moved to
+// httpBindings (stateless), cacheBindings (cacheStore + a scriptPath
+// closure over the runtime's mutable field), and aiBindings (just the
+// provider). The register* wiring seams stay here, as do the caps.AI /
+// caps.HTTP gates in registerBindings.
+//
+//plimsoll:max-methods=46
 type Runtime struct {
 	L             *lua.LState
 	deps          WriteDeps // EntityManager is nil on a reader runtime.

--- a/tickets/entities/implementation-checklists/IMPL-9ADMME.md
+++ b/tickets/entities/implementation-checklists/IMPL-9ADMME.md
@@ -1,0 +1,52 @@
+---
+id: IMPL-9ADMME
+type: implementation-checklist
+title: 'Implementation: Extract HTTP/cache/AI binding clusters off lua.Runtime (ratchet 60 → ~45)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no new behavior — receiver-only moves; http_test.go/cache/ai suites drive every moved binding through Lua)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled (scriptPath held as `func() string` closure — godoc explains SetScriptPath/RunFile mutate after registration, a captured string would freeze the cache namespace at "")
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A: no test changes)
+- [x] ~~No hardcoded values in assertions~~ (N/A: no test changes)
+- [x] ~~Only values that matter~~ (N/A: no test changes)
+- [x] ~~Interpolated values from objects~~ (N/A: no test changes)
+- [x] ~~Property comparisons from original object~~ (N/A: no test changes)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (full `go test ./...` green — the acceptance proof for a behavior-preserving refactor)
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence (from the implementing agent, PR #1462, commit
+9084dfbc):**
+- Runtime 60 → 45 verified by grep; directive ratcheted with history line;
+TODO count updated.
+- Local gates all green: build, ./internal/lua tests, full suite, `-race` on
+internal/lua, plimsoll, arch-lint, comment-lint, golangci-lint.
+- CI green on all jobs except Rela Tickets (expected — resolved when this
+ticket's files land on the branch).
+- Deviation from plan (improvement): `httpBindings` is an empty stateless
+struct and `aiBindings`/`cacheBindings` hold no Lua-state field — every binding
+receives its `*lua.LState` as an argument, and an unread field would trip
+`unused`. Full urlHelpers parity, strictly better than the planned state-holding
+shape.
+
+## Quality
+
+- [x] Code follows project patterns (urlHelpers/mdHelpers precedent; cacheStore consumer-side interface reused)
+- [x] Checked for DRY opportunities (httpContext/chatContext narrowed to *lua.LState — removes the Runtime coupling instead of duplicating it)
+- [x] No security issues introduced (caps.HTTP and caps.AI gates unmoved in registerBindings)
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-KK1HVB.md
+++ b/tickets/entities/planning-checklists/PLAN-KK1HVB.md
@@ -1,0 +1,116 @@
+---
+id: PLAN-KK1HVB
+type: planning-checklist
+title: 'Planning: Extract HTTP/cache/AI binding clusters off lua.Runtime'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** IN: `internal/lua/{http.go, cache.go, ai.go, runtime.go}` — move the
+HTTP (8), cache (4) and AI (3) binding methods onto focused types; `register*`
+methods stay on Runtime as wiring seams; ratchet `//plimsoll:max-methods` 60 →
+45. Stacked on TKT-4WBLG6. OUT: elevation/output/lifecycle clusters, any
+behavior or capability-gating change.
+
+**Acceptance Criteria:**
+1. `just plimsoll` passes with the Runtime directive at 45.
+2. Full `go test ./...` + `-race` on internal/lua green — http_test.go (856
+lines) and the cache/ai suites drive every binding through Lua unchanged.
+3. arch-lint/comment-lint/golangci-lint clean.
+
+## Research
+
+- [x] ~~Run `/research`~~ (N/A: continuation of the TKT-4WBLG6 extraction pattern)
+- [x] ~~Searched for existing libraries~~ (N/A: no new functionality)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — structural survey of Runtime's 105 methods performed;
+per-cluster field usage verified by grep (HTTP touches only L/L.Context; cache
+touches cache+scriptPath+L; AI touches aiProvider+L).
+
+**Existing Solutions:** `urlHelpers` (urls.go) and the fresh
+mdHelpers/mdASTConverter/mdEntityRefs (TKT-4WBLG6) are the in-package templates;
+`cacheStore` in runtime.go is already the narrow consumer-side interface the
+cache type needs.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** Three types — `httpBindings` (Lua state only;
+`httpContext` signature narrowed to `*lua.LState`), `cacheBindings`
+(`cacheStore` + `scriptPath func() string` closure, because
+`Runtime.SetScriptPath` mutates the field after registration), `aiBindings`
+(provider + state). The `caps.HTTP` gate stays in `registerBindings` — gating
+location is a security property and does not move. Alternative rejected: one
+combined "ioBindings" type — the three clusters have disjoint deps and lumping
+them recreates the grab-bag this arc removes.
+
+**Files to modify:** internal/lua/{http.go, cache.go, ai.go, runtime.go}
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** Unchanged — Lua-supplied request params
+validated by the same moved-verbatim code.
+
+**Security-Sensitive Operations:** The HTTP capability gate (`caps.HTTP` in
+`registerBindings`) is the one security-relevant seam near this change and is
+explicitly out of scope: registration stays on Runtime, gate unmoved.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] ~~Integration test approach defined~~ (N/A: no new behavior — existing Lua-level suites are the integration tests)
+
+**Test Scenarios:** http_test.go, cache tests, ai tests drive all 15 moved
+bindings through actual Lua scripts; pass unchanged.
+
+**Edge Cases:** scriptPath mutation after registration (SetScriptPath) must keep
+propagating — hence closure, pinned by existing cache-memoize tests that set a
+script path.
+
+**Negative Tests:** Existing capability-denied (caps.HTTP off) and error-path
+tests pass unchanged.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:** Low — unexported-only moves; the one stateful wrinkle (scriptPath) is
+called out with its mitigation. Stacked-branch conflict risk handled by basing
+on TKT-4WBLG6's branch. Effort: m.
+
+## Documentation Planning
+
+- [x] ~~User-facing docs identified~~ (N/A: internal refactor)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: refactor kind)
+
+**Documentation Impact:** N/A — internal change, no user-facing docs needed.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: repeats the TKT-4WBLG6 extraction design one cluster over; no new interfaces or behavior)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: no review run)
+
+**Design Review Findings:** N/A

--- a/tickets/entities/review-checklists/REV-40F0AJ.md
+++ b/tickets/entities/review-checklists/REV-40F0AJ.md
@@ -1,0 +1,28 @@
+---
+id: REV-40F0AJ
+type: review-checklist
+title: 'Review: Extract HTTP/cache/AI binding clusters off lua.Runtime (ratchet 60 → ~45)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (full suite + `-race ./internal/lua/` locally; CI green on all jobs except the Rela Tickets gate, which this ticket's files landing on the branch resolves)
+- [x] Linters pass (golangci-lint, plimsoll with directive ratcheted 60 → 45, arch-lint, comment-lint)
+- [x] Coverage floors hold
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer, independent verification of the 79dd186c..9084dfbc diff)
+- [x] All critical/significant findings addressed (none — verdict: sound, genuine pure move)
+- [x] Nit recorded: [[RR-ZECAQE]] (godoc dropped a sentence that was stale anyway — wont-fix with reason)
+
+## Verification
+
+- [x] Capability gates verified byte-identical (caps.AI / caps.HTTP blocks in registerBindings unchanged; only line numbers shifted)
+- [x] scriptPath closure verified to read the live field — SetScriptPath and RunFileContent mutations both observed post-registration
+- [x] aiProvider/cache by-value snapshots verified safe: only writers are Options, applied before registerBindings
+- [x] Zero test-file changes; cache namespacing pinned by untouched cache_test.go
+- [x] Method count independently verified: Runtime 45, matching the directive

--- a/tickets/entities/review-responses/RR-ZECAQE.md
+++ b/tickets/entities/review-responses/RR-ZECAQE.md
@@ -1,0 +1,15 @@
+---
+id: RR-ZECAQE
+type: review-response
+title: registerAIModule godoc dropped 'registered unconditionally' sentence — which was stale anyway
+finding: 'The rewritten registerAIModule godoc no longer says the ai global is ''registered unconditionally'' with a not_configured fallback. The not_configured half moved to the provider field''s Nil: tag (better home); the ''unconditionally'' half was factually wrong even before the refactor — registration is gated on caps.AI, so the global is absent without the capability. The new aiBindings doc states the truth.'
+severity: nit
+reason: Reviewer confirmed the refactor corrected a stale claim rather than losing a true one; no code or comment change needed. Noted here so the deleted sentence in the diff has an explanation.
+status: wont-fix
+---
+
+Nit from the TKT-DOPCTI code review (cranky-code-reviewer, PR #1462). Reviewer
+also verified: caps.HTTP/caps.AI gates byte-identical; scriptPath closure reads
+the live field (SetScriptPath and RunFileContent both observed); the
+aiProvider/cache by-value snapshots are safe because their only writers are
+Options applied before registerBindings; zero test changes.

--- a/tickets/entities/tickets/TKT-DOPCTI.md
+++ b/tickets/entities/tickets/TKT-DOPCTI.md
@@ -1,0 +1,47 @@
+---
+id: TKT-DOPCTI
+type: ticket
+title: Extract HTTP/cache/AI binding clusters off lua.Runtime (ratchet 60 → ~45)
+kind: refactor
+priority: medium
+effort: m
+status: done
+---
+
+Sub-ticket of [[TKT-N0IKN9]], continuing the `lua.Runtime` arc after
+[[TKT-4WBLG6]] (markdown cluster, 105 → 60).
+
+## What
+
+**Pure structural extraction, no behavior change, no exported-API change.**
+Three shallow binding clusters move off Runtime into focused types, keeping each
+`register*` method on Runtime as the one-line wiring seam:
+
+- **HTTP** (`http.go`, −8): `luaHTTPRequest/Get/Post/Put/Patch/Delete`,
+`luaHTTPSimple`, `doHTTPRequest` → `httpBindings`. `httpContext` narrowed to
+take `*lua.LState` instead of `*Runtime`. The `caps.HTTP` capability gate stays
+in `registerBindings` — no security semantics move.
+- **Cache** (`cache.go`, −4): `requireCacheContext`, `luaCacheGet/Set/Memoize`
+→ `cacheBindings` holding the narrow `cacheStore` interface + a `scriptPath
+func() string` closure (scriptPath is mutable via `SetScriptPath` after
+construction, so it must NOT be captured by value).
+- **AI** (`ai.go`, −3): `luaAIChat/Complete/Embed` → `aiBindings` holding
+`ai.Provider`.
+
+## Rebase note (2026-08-29)
+
+Originally stacked on TKT-4WBLG6's branch; after that merged (#1461) this was
+rebased onto `develop`, which had meanwhile landed TKT-XWZIOB (mail.send, 60 →
+61). Both histories are preserved in the directive comment and the arithmetic
+re-derived: **61 → 46**, not the originally-planned 60 → 45. Two develop-side
+changes were merged in rather than overwritten: `doHTTPRequest` now takes an
+`httpRequestOpts` struct instead of 7 positional args (develop's refactor, kept,
+with the receiver retargeted to `httpBindings`), and the `mail.send`
+method-value rationale.
+
+Ratchet `//plimsoll:max-methods` on Runtime **61 → 46** (verified by count).
+
+## Done when
+
+plimsoll passes with the lowered directive, full test suite + race on
+internal/lua green, arch-lint/comment-lint/golangci-lint clean.

--- a/tickets/relations/TKT-DOPCTI--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-DOPCTI--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOPCTI
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-DOPCTI--depends-on--TKT-4WBLG6.md
+++ b/tickets/relations/TKT-DOPCTI--depends-on--TKT-4WBLG6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOPCTI
+relation: depends-on
+to: TKT-4WBLG6
+---

--- a/tickets/relations/TKT-DOPCTI--has-implementation--IMPL-9ADMME.md
+++ b/tickets/relations/TKT-DOPCTI--has-implementation--IMPL-9ADMME.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOPCTI
+relation: has-implementation
+to: IMPL-9ADMME
+---

--- a/tickets/relations/TKT-DOPCTI--has-planning--PLAN-KK1HVB.md
+++ b/tickets/relations/TKT-DOPCTI--has-planning--PLAN-KK1HVB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOPCTI
+relation: has-planning
+to: PLAN-KK1HVB
+---

--- a/tickets/relations/TKT-DOPCTI--has-review--REV-40F0AJ.md
+++ b/tickets/relations/TKT-DOPCTI--has-review--REV-40F0AJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOPCTI
+relation: has-review
+to: REV-40F0AJ
+---

--- a/tickets/relations/TKT-DOPCTI--has-review-response--RR-ZECAQE.md
+++ b/tickets/relations/TKT-DOPCTI--has-review-response--RR-ZECAQE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOPCTI
+relation: has-review-response
+to: RR-ZECAQE
+---

--- a/tickets/relations/TKT-DOPCTI--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-DOPCTI--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-DOPCTI
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Pure structural refactor continuing the TKT-N0IKN9 decomposition arc, stacked on the markdown-cluster PR (tkt-4wblg6-lua-md-helpers). Moves three shallow binding clusters off `lua.Runtime`: the eight HTTP bindings onto a stateless `httpBindings` (with `httpContext`/`chatContext` narrowed to take `*lua.LState`), the four cache bindings onto `cacheBindings`, and the three AI bindings onto `aiBindings` holding only the provider. The `caps.HTTP`/`caps.AI` capability gates are untouched — they stay in `registerBindings` on Runtime, which still owns the `register*Module` wiring seams. `cacheBindings` holds `scriptPath` as a closure over the runtime's mutable field (not a captured string), because `Runtime.SetScriptPath` and `RunFile` change it after registration and a frozen value would break cache namespacing. No behavior, exported-API, or Lua-visible change; the plimsoll directive ratchets 60 → 45.

https://claude.ai/code/session_016Br8QmRwRReoeZx55EfwyQ