### PR TITLE
refactor(mcp): extract typeResolver + trace/export handlers off Server (TKT-YUETL7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
   three methods). When a callback would create a constructor cycle, the
   consumer defines the narrow interface and the wiring site supplies it —
   see `docs/architecture/consumer-side-interfaces.md` and the godoc on
-  `autocascade.Host`, `mcp.Services`, `scheduler.WorkspaceProvider`.
+  `autocascade.Host`, `mcp.GraphReader`, `scheduler.WorkspaceProvider`.
 - **Capability bundles, not service locators.** When a subsystem needs
   several collaborators, group them in a purpose-specific struct (see
   `internal/lua/deps.go` with `ReadDeps` / `WriteDeps`), split by read vs.

--- a/docs/architecture/consumer-side-interfaces.md
+++ b/docs/architecture/consumer-side-interfaces.md
@@ -2,7 +2,7 @@
 
 This is the in-depth version of the "Define interfaces at the call site"
 rule in the root `CLAUDE.md`. The worked code examples live as godoc on the
-real types (`autocascade.Host`, `mcp.Services`, `scheduler.WorkspaceProvider`,
+real types (`autocascade.Host`, `mcp.GraphReader`, `scheduler.WorkspaceProvider`,
 `store.EntityObserver`) — read those alongside this.
 
 ## The rule
@@ -50,7 +50,7 @@ cycle disappears because `Runner` borrows a Host for the duration of
   method (e.g. `autocascade.Host`, `store.EntityObserver`). Fully dissolves
   cycles.
 - **Constructor field** when the consumer holds the relationship across many
-  calls (e.g. `mcp.Services`, `scheduler.WorkspaceProvider`). Used when there
+  calls (e.g. `mcp.GraphReader`, `scheduler.WorkspaceProvider`). Used when there
   is no cycle, just a desire to keep the consumer's contract narrow.
 
 ## What this pattern rules out
@@ -149,8 +149,9 @@ at the same time.
 
 ## Existing examples to study
 
-- **`mcp.Services`** (`internal/mcp/server.go`) — scoped consumer-side
-  interface; Workspace satisfies it. Constructor-field form.
+- **`mcp.GraphReader`** (`internal/mcp/server.go`) — scoped consumer-side
+  read interface, held via the `mcp.Deps` capability bundle; `store.Store`
+  satisfies it structurally. Constructor-field form.
 - **`scheduler.WorkspaceProvider`** (`internal/scheduler/scheduler.go`) —
   four-method interface for what the scheduler needs. Constructor-field form.
 - **`store.EntityObserver`** (`internal/store/store.go`) — the *inverse*

--- a/internal/mcp/acl_test.go
+++ b/internal/mcp/acl_test.go
@@ -110,6 +110,7 @@ func gatedServer(t *testing.T) (*Server, context.Context) {
 	}
 
 	srv := &Server{deps: deps, logger: slog.New(slog.DiscardHandler)}
+	srv.types, srv.trace, srv.export = deps.handlers()
 	return srv, principal.With(ctx, principal.Principal{User: "alice", Tool: principal.ToolMCP})
 }
 
@@ -364,11 +365,11 @@ func TestACL_Trace_HiddenRootIsNotAnOracle(t *testing.T) {
 	t.Parallel()
 	s, ctx := gatedServer(t)
 
-	hidden, err := s.handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": hiddenID}))
+	hidden, err := s.trace.handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": hiddenID}))
 	if err != nil {
 		t.Fatalf("trace_from(hidden): %v", err)
 	}
-	absent, err := s.handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": "NO-SUCH-ID"}))
+	absent, err := s.trace.handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": "NO-SUCH-ID"}))
 	if err != nil {
 		t.Fatalf("trace_from(absent): %v", err)
 	}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -134,7 +134,7 @@ func (s *Server) handleReviewOrphansPrompt(
 	st := s.deps.Store
 	var resolved string
 	if entityType != "" {
-		resolved = s.resolveType(entityType)
+		resolved = s.types.resolveType(entityType)
 	}
 
 	type orphanSummary struct {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -160,8 +160,9 @@ type Watcher interface {
 
 // Server wraps the MCP server with rela-specific state.
 //
-// TODO(TKT-N0IKN9): Server is over the 40-method load line (49 methods).
-// Decompose; ratchet this number down as handlers move out.
+// TODO(TKT-N0IKN9): Server is over the 40-method load line (38 methods
+// after the first ratchet). Decompose; ratchet this number down as
+// handlers move out.
 //
 // 48 → 49: [Server.HTTPHandler] (TKT-BDG8U9). It belongs on Server — it
 // exposes THIS server over a second transport, the peer of [Server.Serve] —
@@ -169,12 +170,36 @@ type Watcher interface {
 // choice lives inside it, and the wiring site holds an http.Handler rather
 // than reaching for the SDK.
 //
-//plimsoll:max-methods=49
+// 49 → 38 (TKT-YUETL7): the type-name helpers moved to typeResolver (they
+// need only the metamodel) and the trace/export tool handlers moved to
+// traceHandler / exportHandler (store + tracer, and store + resolver,
+// respectively). Each is a field below, wired from Deps in [NewServer];
+// registerTools points the affected AddTool lines at the field's methods.
+// The remaining handlers genuinely span deps — the next TKT-N0IKN9 slice.
+//
+//plimsoll:max-methods=38
 type Server struct {
 	mcp       *mcpgo.Server
 	deps      Deps
 	logger    *slog.Logger
 	principal principal.Principal
+
+	// Extracted handler groups (TKT-YUETL7) — built from deps by
+	// Deps.handlers. Identity is NOT threaded into them: every handler
+	// reads the principal from its ctx, stamped by principalMiddleware.
+	types  typeResolver
+	trace  traceHandler
+	export exportHandler
+}
+
+// handlers builds the extracted handler groups a [Server] carries. One
+// derivation shared by [NewServer] and the test helpers that construct
+// Server literals, so the wiring cannot drift between them.
+func (d Deps) handlers() (typeResolver, traceHandler, exportHandler) {
+	types := typeResolver{meta: d.Meta}
+	return types,
+		traceHandler{store: d.Store, tracer: d.Tracer},
+		exportHandler{store: d.Store, types: types}
 }
 
 // Option configures a [Server] at construction.
@@ -242,6 +267,7 @@ func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 	if err := deps.validate(); err != nil {
 		return nil, err
 	}
+	s.types, s.trace, s.export = deps.handlers()
 
 	// Capabilities are inferred by the go-sdk from the features actually
 	// registered below (tools/resources/prompts each gain listChanged when

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -18,9 +18,9 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(toolDeleteRelation(), s.handleDeleteRelation)
 
 	// Trace tools
-	s.mcp.AddTool(toolTraceFrom(), s.handleTraceFrom)
-	s.mcp.AddTool(toolTraceTo(), s.handleTraceTo)
-	s.mcp.AddTool(toolFindPath(), s.handleFindPath)
+	s.mcp.AddTool(toolTraceFrom(), s.trace.handleTraceFrom)
+	s.mcp.AddTool(toolTraceTo(), s.trace.handleTraceTo)
+	s.mcp.AddTool(toolFindPath(), s.trace.handleFindPath)
 
 	// Analysis tools
 	s.mcp.AddTool(toolAnalyzeOrphans(), s.handleAnalyzeOrphans)
@@ -37,7 +37,7 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(toolListRelationTypes(), s.handleListRelationTypes)
 
 	// Utility tools
-	s.mcp.AddTool(toolExport(), s.handleExport)
+	s.mcp.AddTool(toolExport(), s.export.handleExport)
 
 	// Lua scripting tools
 	s.mcp.AddTool(toolLuaEval(), s.handleLuaEval)

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -25,7 +25,7 @@ func (s *Server) handleAnalyzeOrphans(
 	st := s.deps.Store
 	resolved := ""
 	if entityType != "" {
-		resolved = s.resolveType(entityType)
+		resolved = s.types.resolveType(entityType)
 	}
 
 	type orphanInfo struct {

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -29,7 +29,7 @@ func (s *Server) handleListEntities(
 	st := s.deps.Store
 	q := store.EntityQuery{}
 	if entityType != "" {
-		q.Type = s.resolveType(entityType)
+		q.Type = s.types.resolveType(entityType)
 	}
 
 	entities := make([]*entity.Entity, 0)
@@ -111,7 +111,7 @@ func (s *Server) handleSearchEntities(
 
 	q := search.Query{Text: query, Limit: limit}
 	if entityType != "" {
-		q.Types = []string{s.resolveType(entityType)}
+		q.Types = []string{s.types.resolveType(entityType)}
 	}
 
 	st := s.deps.Store
@@ -151,7 +151,7 @@ func (s *Server) handleCreateEntity(
 	customID := args.GetString("id", "")
 
 	// Resolve type
-	resolvedType, _, resolveErr := s.resolveEntityType(typeName)
+	resolvedType, _, resolveErr := s.types.resolveEntityType(typeName)
 	if resolveErr != nil {
 		return errorResult(resolveErr.Error()), nil
 	}
@@ -160,7 +160,7 @@ func (s *Server) handleCreateEntity(
 	properties := extractProperties(request)
 
 	// Validate property names early for better error messages
-	if errResult := s.validatePropertyNames(resolvedType, properties); errResult != nil {
+	if errResult := s.types.validatePropertyNames(resolvedType, properties); errResult != nil {
 		return errResult, nil
 	}
 
@@ -216,7 +216,7 @@ func (s *Server) handleUpdateEntity(
 	}
 
 	// Validate property names early for better error messages
-	if errResult := s.validatePropertyNames(e.Type, properties); errResult != nil {
+	if errResult := s.types.validatePropertyNames(e.Type, properties); errResult != nil {
 		return errResult, nil
 	}
 

--- a/internal/mcp/tools_export.go
+++ b/internal/mcp/tools_export.go
@@ -15,7 +15,17 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-func (s *Server) handleExport(
+// exportHandler serves the export tool. A type of its own rather than more
+// methods on [Server] (the urlHelpers pattern, TKT-YUETL7): exporting needs
+// only the gated [GraphReader] to enumerate rows, plus the shared
+// typeResolver for the optional type filter — no tracer, no writer, no
+// request state beyond the ctx each call receives.
+type exportHandler struct {
+	store GraphReader
+	types typeResolver
+}
+
+func (h exportHandler) handleExport(
 	ctx context.Context, request *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
 	args := newToolRequest(request)
@@ -25,10 +35,10 @@ func (s *Server) handleExport(
 	}
 	entityType := args.GetString("type", "")
 
-	st := s.deps.Store
+	st := h.store
 	q := store.EntityQuery{}
 	if entityType != "" {
-		q.Type = s.resolveType(entityType)
+		q.Type = h.types.resolveType(entityType)
 	}
 
 	entities := make([]*entity.Entity, 0)
@@ -51,17 +61,17 @@ func (s *Server) handleExport(
 
 	switch format {
 	case "json":
-		return s.exportJSON(entities, relations, entityType)
+		return h.exportJSON(entities, relations, entityType)
 	case "yaml":
-		return s.exportYAML(entities, relations, entityType)
+		return h.exportYAML(entities, relations, entityType)
 	case "csv":
-		return s.exportCSV(entities)
+		return h.exportCSV(entities)
 	default:
 		return errorResult("unsupported format: " + format), nil
 	}
 }
 
-func (s *Server) exportJSON(
+func (h exportHandler) exportJSON(
 	entities []*entity.Entity, relations []*entity.Relation, entityType string,
 ) (*mcpgo.CallToolResult, error) {
 	if entityType != "" {
@@ -107,7 +117,7 @@ func (s *Server) exportJSON(
 	return textResult(text), nil
 }
 
-func (s *Server) exportYAML(
+func (h exportHandler) exportYAML(
 	entities []*entity.Entity, relations []*entity.Relation, entityType string,
 ) (*mcpgo.CallToolResult, error) {
 	var data any
@@ -151,7 +161,7 @@ func (s *Server) exportYAML(
 	return textResult(string(out)), nil
 }
 
-func (s *Server) exportCSV(entities []*entity.Entity) (*mcpgo.CallToolResult, error) {
+func (h exportHandler) exportCSV(entities []*entity.Entity) (*mcpgo.CallToolResult, error) {
 	if len(entities) == 0 {
 		return textResult(""), nil
 	}

--- a/internal/mcp/tools_helpers.go
+++ b/internal/mcp/tools_helpers.go
@@ -11,9 +11,22 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
-func (s *Server) resolveType(typeName string) string {
+// typeResolver maps user-supplied type names onto metamodel entity types —
+// alias resolution, plural stripping, and property-name validation shared by
+// the entity, analysis, export, and prompt handlers.
+//
+// A type of its own rather than more methods on [Server] (the urlHelpers
+// pattern, TKT-YUETL7): these helpers need exactly one thing from the server —
+// the metamodel — no store, no tracer, no request state. Holding that one
+// field makes the dependency visible where methods on Server let every helper
+// reach all of deps.
+type typeResolver struct {
+	meta *metamodel.Metamodel
+}
+
+func (r typeResolver) resolveType(typeName string) string {
 	typeName = strings.TrimSpace(typeName)
-	meta := s.deps.Meta
+	meta := r.meta
 	resolved := meta.ResolveAlias(typeName)
 	if _, ok := meta.GetEntityDef(resolved); ok {
 		return resolved
@@ -37,9 +50,9 @@ func trimID(id string) string {
 	return strings.TrimSpace(id)
 }
 
-func (s *Server) resolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
-	resolved := s.resolveType(typeName)
-	def, ok := s.deps.Meta.GetEntityDef(resolved)
+func (r typeResolver) resolveEntityType(typeName string) (string, *metamodel.EntityDef, error) {
+	resolved := r.resolveType(typeName)
+	def, ok := r.meta.GetEntityDef(resolved)
 	if !ok {
 		return "", nil, fmt.Errorf("unknown entity type: %s", typeName)
 	}
@@ -124,13 +137,12 @@ func filterProperties(props map[string]any, keepNil bool) map[string]any {
 // (a nil value means "delete" in update_entity; deleting a required property would leave
 // the entity invalid, so we surface that as an actionable error rather than a misleading
 // success that analyze_validations later catches).
-func (s *Server) validatePropertyNames(entityType string, properties map[string]any) *mcpgo.CallToolResult {
+func (r typeResolver) validatePropertyNames(entityType string, properties map[string]any) *mcpgo.CallToolResult {
 	if properties == nil {
 		return nil
 	}
 
-	meta := s.deps.Meta
-	entityDef, ok := meta.GetEntityDef(entityType)
+	entityDef, ok := r.meta.GetEntityDef(entityType)
 	if !ok {
 		return nil // Type validation will catch this
 	}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -85,10 +85,13 @@ func makeTestServerWithStore(t *testing.T) (*Server, *memstore.MemStore) {
 	t.Helper()
 
 	meta, st := makeTestFixture(t)
-	return &Server{
-		deps:   newTestDeps(t, meta, st),
+	deps := newTestDeps(t, meta, st)
+	srv := &Server{
+		deps:   deps,
 		logger: slog.New(slog.DiscardHandler),
-	}, st
+	}
+	srv.types, srv.trace, srv.export = deps.handlers()
+	return srv, st
 }
 
 func getResultText(t *testing.T, result *mcpgo.CallToolResult) string {
@@ -763,7 +766,7 @@ func TestHandleTraceFrom(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"id": "REQ-001"})
-	result, err := s.handleTraceFrom(context.Background(), req)
+	result, err := s.trace.handleTraceFrom(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -777,7 +780,7 @@ func TestHandleTraceFrom_NotFound(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"id": "NONEXISTENT"})
-	result, err := s.handleTraceFrom(context.Background(), req)
+	result, err := s.trace.handleTraceFrom(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -790,7 +793,7 @@ func TestHandleTraceTo(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"id": "REQ-001"})
-	result, err := s.handleTraceTo(context.Background(), req)
+	result, err := s.trace.handleTraceTo(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -804,7 +807,7 @@ func TestHandleFindPath(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"from": "DEC-001", "to": "REQ-001"})
-	result, err := s.handleFindPath(context.Background(), req)
+	result, err := s.trace.handleFindPath(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -818,7 +821,7 @@ func TestHandleFindPath_NoPath(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"from": "REQ-002", "to": "REQ-003"})
-	result, err := s.handleFindPath(context.Background(), req)
+	result, err := s.trace.handleFindPath(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -832,7 +835,7 @@ func TestHandleFindPath_NotFound(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"from": "NONEXISTENT", "to": "REQ-001"})
-	result, err := s.handleFindPath(context.Background(), req)
+	result, err := s.trace.handleFindPath(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1090,7 +1093,7 @@ func TestResolveType(t *testing.T) {
 		{"unknown", "unknown"}, // falls through
 	}
 	for _, tt := range tests {
-		got := s.resolveType(tt.input)
+		got := s.types.resolveType(tt.input)
 		if got != tt.expected {
 			t.Errorf("resolveType(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
@@ -1100,7 +1103,7 @@ func TestResolveType(t *testing.T) {
 func TestResolveEntityType(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	resolved, def, err := s.resolveEntityType("requirement")
+	resolved, def, err := s.types.resolveEntityType("requirement")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1115,7 +1118,7 @@ func TestResolveEntityType(t *testing.T) {
 func TestResolveEntityType_Unknown(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	_, _, err := s.resolveEntityType("nonexistent")
+	_, _, err := s.types.resolveEntityType("nonexistent")
 	if err == nil {
 		t.Error("expected error for unknown type")
 	}

--- a/internal/mcp/tools_trace.go
+++ b/internal/mcp/tools_trace.go
@@ -10,23 +10,34 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/tracer"
 )
 
-func (s *Server) handleTraceFrom(
+// traceHandler serves the trace_from / trace_to / find_path tools. A type of
+// its own rather than more methods on [Server] (the urlHelpers pattern,
+// TKT-YUETL7): tracing needs exactly two collaborators — the gated
+// [GraphReader] for existence probes and the tracer for traversal. Identity
+// still arrives on the ctx via Server.principalMiddleware; the handler holds
+// no principal.
+type traceHandler struct {
+	store  GraphReader
+	tracer tracer.Tracer
+}
+
+func (h traceHandler) handleTraceFrom(
 	ctx context.Context, request *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
-	return s.handleTrace(ctx, request, func(t tracer.Tracer, id string, depth int) *tracer.TraceResult {
+	return h.handleTrace(ctx, request, func(t tracer.Tracer, id string, depth int) *tracer.TraceResult {
 		return t.TraceFrom(ctx, id, depth)
 	}, "No dependencies found")
 }
 
-func (s *Server) handleTraceTo(
+func (h traceHandler) handleTraceTo(
 	ctx context.Context, request *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
-	return s.handleTrace(ctx, request, func(t tracer.Tracer, id string, depth int) *tracer.TraceResult {
+	return h.handleTrace(ctx, request, func(t tracer.Tracer, id string, depth int) *tracer.TraceResult {
 		return t.TraceTo(ctx, id, depth)
 	}, "No upstream dependencies found")
 }
 
-func (s *Server) handleTrace(
+func (h traceHandler) handleTrace(
 	ctx context.Context,
 	request *mcpgo.CallToolRequest,
 	traceFn func(tracer.Tracer, string, int) *tracer.TraceResult,
@@ -40,18 +51,18 @@ func (s *Server) handleTrace(
 	id = trimID(id)
 	maxDepth := args.GetInt("max_depth", 0)
 
-	// Existence probe BEFORE traversal. This must go through deps.Store —
+	// Existence probe BEFORE traversal. This must go through h.store —
 	// the gated GraphReader — not a raw handle: under a networked wiring a
 	// hidden entity's GetEntity returns not-found, so "hidden" and "absent"
 	// produce the identical message and the probe is not an existence
 	// oracle (RR-FTJUUE). A raw probe here would defeat the gated tracer
 	// below, since it answers "is it in the store?" rather than "may this
 	// principal see it?".
-	if _, getErr := s.deps.Store.GetEntity(ctx, id); getErr != nil {
+	if _, getErr := h.store.GetEntity(ctx, id); getErr != nil {
 		return errorResult("entity not found: " + id), nil
 	}
 
-	result := traceFn(s.deps.Tracer, id, maxDepth)
+	result := traceFn(h.tracer, id, maxDepth)
 	if result == nil {
 		return textResult(emptyMsg), nil
 	}
@@ -63,7 +74,7 @@ func (s *Server) handleTrace(
 	return textResult(text), nil
 }
 
-func (s *Server) handleFindPath(
+func (h traceHandler) handleFindPath(
 	ctx context.Context, request *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
 	args := newToolRequest(request)
@@ -78,7 +89,7 @@ func (s *Server) handleFindPath(
 	}
 	to = trimID(to)
 
-	st := s.deps.Store
+	st := h.store
 	if _, fromErr := st.GetEntity(ctx, from); fromErr != nil {
 		return errorResult("source entity not found: " + from), nil
 	}
@@ -86,7 +97,7 @@ func (s *Server) handleFindPath(
 		return errorResult("target entity not found: " + to), nil
 	}
 
-	path := s.deps.Tracer.FindPath(ctx, from, to)
+	path := h.tracer.FindPath(ctx, from, to)
 	if path == nil {
 		return textResult(
 			fmt.Sprintf("No path found between %s and %s", from, to)), nil

--- a/tickets/entities/implementation-checklists/IMPL-527EQH.md
+++ b/tickets/entities/implementation-checklists/IMPL-527EQH.md
@@ -1,0 +1,51 @@
+---
+id: IMPL-527EQH
+type: implementation-checklist
+title: 'Implementation: Extract typeResolver + trace/export handlers off mcp.Server (plimsoll ratchet 49 → 38)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no new behavior — receiver-only moves; dispatch/golden suites pin the surfaces)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled (toolGetSchema/toolGetMetamodel aliasing untouched; principalMiddleware left at SDK level)
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A: test changes are mechanical re-points)
+- [x] ~~No hardcoded values in assertions~~ (N/A)
+- [x] ~~Only values that matter~~ (N/A)
+- [x] ~~Interpolated values from objects~~ (N/A)
+- [x] ~~Property comparisons from original object~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (full suite + `-race ./internal/mcp/...`)
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence (PR #1463, commit b013fb44):**
+- Server 49 → **38**; reviewer independently counted 38 and confirmed the
+directive has no slack.
+- `typeResolver` (meta only), `traceHandler` (GraphReader + tracer),
+`exportHandler` (GraphReader only — one dep, the cleanest cut).
+- Reviewer's normalized-receiver diff showed the moved bodies are
+byte-identical modulo field renames: no statement, branch, error string or
+argument order changed.
+- Doc-drift fix verified accurate: `mcp.Services` is genuinely gone from
+code; remaining mentions are archived tickets, correctly untouched.
+- Gates: build, go vet, golangci-lint (0 issues), arch-lint, comment-lint
+(11071 comments, no unresolvable doclinks), `-race` — all green.
+
+## Quality
+
+- [x] Code follows project patterns (urlHelpers precedent — reviewer verified it's a real in-repo precedent, not an invented justification)
+- [x] Checked for DRY opportunities (one shared `Deps.handlers` derivation so production and test wiring can't drift)
+- [x] No security issues introduced (handlers hold the narrow GraphReader, never store.Store, so a networked wiring substitutes a visibility-gated reader without touching them; no principal field on any handler — threading identity in would now require adding a visible field)
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-SJA174.md
+++ b/tickets/entities/planning-checklists/PLAN-SJA174.md
@@ -1,0 +1,119 @@
+---
+id: PLAN-SJA174
+type: planning-checklist
+title: 'Planning: Extract typeResolver + trace/export handlers off mcp.Server'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** IN: `internal/mcp` — `typeResolver` (3 shared helpers off
+tools_helpers.go), `traceHandler` (4 methods, tools_trace.go), `exportHandler`
+(4 methods, tools_export.go); registerTools line re-points; directive 49 → 38;
+the `mcp.Services` → `Deps` doc-drift fix in consumer-side-interfaces.md. OUT:
+entity/relation/analysis/schema/prompt/resource clusters (later arc steps), any
+behavior/wire/identity change.
+
+**Acceptance Criteria:**
+1. `just plimsoll` with directive at 38.
+2. Full suite green — dispatch_test.go + golden_test.go pin tool behavior end
+to end.
+3. arch-lint/comment-lint/golangci-lint clean.
+
+## Research
+
+- [x] ~~Run `/research`~~ (N/A: mechanical extraction; full package survey done instead)
+- [x] ~~Searched for existing libraries~~ (N/A: no new functionality)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — Explore survey of all 49 Server methods: clusters,
+per-cluster deps footprint, ranked candidates with risk notes (recorded in the
+arc roadmap).
+
+**Existing Solutions:** `urlHelpers`/`mdHelpers` (internal/lua) for the
+focused-type shape; `GraphReader`/`GraphCounter`/`Watcher` in server.go are the
+existing consumer-side interfaces to reuse; the 25 `tool*()` builders are
+already receiver-free.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** typeResolver first (the cross-cluster substrate:
+resolveType/resolveEntityType/validatePropertyNames over deps.Meta only), then
+the two cleanest read-only clusters: traceHandler {store GraphReader, tracer}
+and exportHandler {store} — export touches exactly one dep. Server keeps
+principalMiddleware/HTTPHandler/Serve/register*; handlers read identity from ctx
+(middleware wraps at SDK level). Alternative rejected: starting with the
+analysis cluster (−9) — bigger win but 5 deps wide; trace+export deliver −8 at
+near-zero risk and install the injection seam first.
+
+**Files to modify:** internal/mcp/{tools_helpers.go, tools_trace.go,
+tools_export.go, server.go, tools.go},
+docs/architecture/consumer-side-interfaces.md
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** Unchanged — MCP tool args validated by the same
+moved-verbatim code.
+
+**Security-Sensitive Operations:** Identity attribution: principalMiddleware
+stays on Server above all handlers; NO principal is threaded into handler
+structs (pinned by principal_test.go/acl_test.go). Read gating unchanged —
+handlers keep the same GraphReader they reached via deps.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] ~~Integration test approach defined~~ (N/A: no new behavior — dispatch/golden suites are the integration tests)
+
+**Test Scenarios:** dispatch_test.go exercises registration→handler routing;
+golden_test.go pins tool output. Both must pass unchanged.
+
+**Edge Cases:** The toolGetSchema/toolGetMetamodel aliasing (both register
+handleGetSchema) is out of scope but must not be disturbed by tools.go edits.
+
+**Negative Tests:** Existing invalid-type/unknown-entity error tests pass
+unchanged through typeResolver.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:** Low — all moved methods unexported, read-only clusters, no watcher
+involvement (that's the entity cluster, a later step). Effort: m.
+
+## Documentation Planning
+
+- [x] User-facing docs identified: the consumer-side-interfaces.md drift fix is in scope
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: refactor kind; the one doc edit is named in scope)
+
+**Documentation Impact:** docs/architecture/consumer-side-interfaces.md — stale
+`mcp.Services` reference updated to the `Deps` bundle.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: repeats the established extraction design; plan derived from a dedicated structural survey with risk ranking)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: no review run)
+
+**Design Review Findings:** N/A

--- a/tickets/entities/review-checklists/REV-S5R0EH.md
+++ b/tickets/entities/review-checklists/REV-S5R0EH.md
@@ -1,0 +1,33 @@
+---
+id: REV-S5R0EH
+type: review-checklist
+title: 'Review: Extract typeResolver + trace/export handlers off mcp.Server (plimsoll ratchet 49 → 38)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (full suite + `-race ./internal/mcp/...`; CI green except the Rela Tickets gate, resolved by this ticket's files landing on the branch)
+- [x] Linters pass (golangci-lint 0 issues, plimsoll at 38, arch-lint OK, comment-lint clean across 11071 comments)
+- [x] Coverage floors hold
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer, independent verification of the 11c02c1b..b013fb44 diff)
+- [x] All critical/significant findings addressed (none — reviewer's normalized-receiver diff showed the moved bodies are byte-identical modulo field renames)
+- [x] Minor finding addressed: [[RR-OSJQWC]] — handler-field assignment hazard, closed structurally in the very next arc slice via the embedded `handlerSet`
+
+## Verification
+
+- [x] Identity/ACL invariant verified: principalMiddleware still a Server method registered at SDK level before registerTools; zero principal references outside server.go; no handler struct carries a principal field
+- [x] Narrow-reader invariant verified end-to-end: handlers hold `GraphReader`, not `store.Store`; the wiring site passes `reads.Reader` from `GatedReads()`, so a networked wiring substitutes a visibility-gated reader without touching a handler
+- [x] toolGetSchema/toolGetMetamodel aliasing confirmed intact
+- [x] Method count independently verified at 38, matching the directive with no slack
+- [x] Tests: call-site re-points only; TestACL_Trace_HiddenRootIsNotAnOracle (the hidden-vs-absent oracle guard) survives and passes
+- [x] Doc-drift fix verified accurate against the current code
+
+**Note:** the RR-FTJUUE existence-oracle comment in tools_trace.go was correctly
+updated to track the new field — the reviewer specifically checked for stale
+prose here and found none.

--- a/tickets/entities/review-responses/RR-OSJQWC.md
+++ b/tickets/entities/review-responses/RR-OSJQWC.md
@@ -1,0 +1,17 @@
+---
+id: RR-OSJQWC
+type: review-response
+title: Handler-field assignment is a separate opt-in step test constructors must remember (nil-panic at request time if forgotten)
+finding: Deps.handlers() centralizes the derivation, but ASSIGNING the result stays a separate step each deps-carrying test constructor must remember. A Server built without it does not fail loudly at construction — it nil-panics at request time on the first resolveType call. Both current call sites are correct, but this is the first slice of a multi-PR arc and every later extraction adds another field to the same forget-to-assign hazard. Reviewer suggested a test-only constructor so a half-wired Server cannot be built.
+severity: minor
+resolution: 'Closed structurally in the very next arc slice (TKT-MGNE5L / PR #1468) rather than deferred: the six handler groups were collapsed into a single named `handlerSet` struct EMBEDDED on Server, so wiring is one assignment (`s.handlerSet = deps.handlers()`) that cannot be partially forgotten — adding a future handler group adds a field to handlerSet and every call site picks it up automatically, with no per-field assignment to miss. Field promotion keeps every existing `s.trace.…` reference working. (That refactor was independently motivated: the 6-value return tripped gocritic''s tooManyResultsChecker.)'
+status: addressed
+---
+
+Nit from the TKT-YUETL7 code review (cranky-code-reviewer, PR #1463). Reviewer's
+verdict on the PR itself was a clean pass: normalized-receiver diff proved a
+pure move; principalMiddleware still SDK-level with no principal in any handler
+struct; handlers hold the narrow GraphReader (so a networked wiring substitutes
+a gated reader without touching them); toolGetSchema/toolGetMetamodel aliasing
+intact; directive matches the real count of 38; tests re-pointed only, with
+TestACL_Trace_HiddenRootIsNotAnOracle surviving intact.

--- a/tickets/entities/tickets/TKT-YUETL7.md
+++ b/tickets/entities/tickets/TKT-YUETL7.md
@@ -1,0 +1,42 @@
+---
+id: TKT-YUETL7
+type: ticket
+title: Extract typeResolver + trace/export handlers off mcp.Server (plimsoll ratchet 49 → 38)
+kind: refactor
+priority: medium
+effort: m
+status: done
+---
+
+Sub-ticket of [[TKT-N0IKN9]], opening the `mcp.Server` arc. Server sits at
+`//plimsoll:max-methods=49` with only 4 struct fields; every tool handler is a
+`*Server` method reaching through `s.deps.X` — there is no per-cluster
+injection, which is precisely the seam this extraction installs.
+
+## What
+
+**Pure structural extraction, no behavior change, no wire-visible change.**
+
+- `typeResolver` — tiny value type over `deps.Meta` taking the three shared
+helpers from `tools_helpers.go` (`resolveType`, `resolveEntityType`,
+`validatePropertyNames`). The cross-cluster substrate every later extraction
+needs (the mdHelpers shape: one field, state-free helpers). −3.
+- `traceHandler` — `tools_trace.go` (4 methods: `handleTraceFrom`,
+`handleTraceTo`, `handleTrace`, `handleFindPath`) over `{store GraphReader;
+tracer}`. −4.
+- `exportHandler` — `tools_export.go` (4 methods: `handleExport`, `exportJSON`,
+`exportYAML`, `exportCSV`) over `{store GraphReader}` — the cleanest cut in the
+package (one dep). −4.
+
+`registerTools` stays on Server; the affected `AddTool` lines re-point to
+`s.trace.handleX` / `s.export.handleX`. Ratchet directive 49 → 38 (under the 40
+load line — but the directive stays until the arc's later steps decide whether
+Server can drop it entirely).
+
+Also fix the doc drift: `docs/architecture/consumer-side-interfaces.md` still
+names `mcp.Services`; the type is now the `Deps` capability bundle.
+
+## Done when
+
+plimsoll with lowered directive, full test suite green (dispatch_test.go and
+golden_test.go are the behavior guards), arch-lint/comment-lint/lint clean.

--- a/tickets/relations/TKT-YUETL7--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-YUETL7--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YUETL7
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-YUETL7--has-implementation--IMPL-527EQH.md
+++ b/tickets/relations/TKT-YUETL7--has-implementation--IMPL-527EQH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YUETL7
+relation: has-implementation
+to: IMPL-527EQH
+---

--- a/tickets/relations/TKT-YUETL7--has-planning--PLAN-SJA174.md
+++ b/tickets/relations/TKT-YUETL7--has-planning--PLAN-SJA174.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YUETL7
+relation: has-planning
+to: PLAN-SJA174
+---

--- a/tickets/relations/TKT-YUETL7--has-review--REV-S5R0EH.md
+++ b/tickets/relations/TKT-YUETL7--has-review--REV-S5R0EH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YUETL7
+relation: has-review
+to: REV-S5R0EH
+---

--- a/tickets/relations/TKT-YUETL7--has-review-response--RR-OSJQWC.md
+++ b/tickets/relations/TKT-YUETL7--has-review-response--RR-OSJQWC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YUETL7
+relation: has-review-response
+to: RR-OSJQWC
+---

--- a/tickets/relations/TKT-YUETL7--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-YUETL7--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YUETL7
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Pure structural ratchet of `mcp.Server` — first slice of the mcp arc of TKT-N0IKN9. The three shared type-name helpers (`resolveType` / `resolveEntityType` / `validatePropertyNames`) move onto a `typeResolver` holding only the metamodel; the four trace tool handlers move onto `traceHandler` (`GraphReader` + `tracer.Tracer`); the four export methods move onto `exportHandler` (`GraphReader` + the shared `typeResolver`, which `handleExport` needs for its type filter). `Deps.handlers()` derives all three in one place, shared by `NewServer` and the test helpers that build `Server` literals; `registerTools` re-points only the affected `AddTool` lines, and `principalMiddleware` stays on Server — identity still arrives on the ctx, never threaded into a handler struct. The `//plimsoll:max-methods` directive ratchets 49 → 38 with a history line in the runtime.go style. Also fixes doc drift: `docs/architecture/consumer-side-interfaces.md` and the root CLAUDE.md still cited the long-gone `mcp.Services`; both now point at `mcp.GraphReader` / the `Deps` bundle. No behavior or wire-visible change; dispatch/golden/principal/acl tests pass unchanged apart from mechanical receiver re-points.

https://claude.ai/code/session_016Br8QmRwRReoeZx55EfwyQ