### PR TITLE
refactor(fsstore): extract fileLayout + mdCodec off FSStore (TKT-Y683LJ)

### DIFF
--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -497,5 +497,5 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 
 // writeEntity writes an entity to disk using temp-file + rename.
 func (s *FSStore) writeEntity(e *entity.Entity) error {
-	return s.writeEntityFile(e)
+	return s.codec.writeEntityFile(e)
 }

--- a/internal/store/fsstore/entity.go
+++ b/internal/store/fsstore/entity.go
@@ -266,11 +266,11 @@ func (s *FSStore) updateEntity(_ context.Context, e *entity.Entity) error {
 	// or it would resurrect the stale record on the next reload. Part of the
 	// type-change-on-update store contract (storetest UpdateChangesType).
 	if meta.Type != e.Type {
-		oldKey := s.entityFileKey(meta.Type, e.ID)
+		oldKey := s.layout.entityFileKey(meta.Type, e.ID)
 		if err := s.rooted.Remove(oldKey); err != nil && !os.IsNotExist(err) {
 			return err
 		}
-		s.echoes.Forget(s.absPath(oldKey))
+		s.echoes.Forget(s.layout.absPath(oldKey))
 	}
 
 	// Update index
@@ -332,17 +332,17 @@ func (s *FSStore) deleteEntity(_ context.Context, id string, cascade bool) (*sto
 	// relation file removed before a later failure stays removed, but the
 	// whole op runs under s.mu and the index is updated only on success.
 	for _, rm := range related {
-		key := s.relationFileKey(rm.From, rm.Type, rm.To)
+		key := s.layout.relationFileKey(rm.From, rm.Type, rm.To)
 		if err := s.rooted.Remove(key); err != nil && !os.IsNotExist(err) {
 			return nil, fmt.Errorf("delete relation file %s--%s--%s: %w", rm.From, rm.Type, rm.To, err)
 		}
-		s.echoes.Forget(s.absPath(key))
+		s.echoes.Forget(s.layout.absPath(key))
 	}
-	key := s.entityFileKey(meta.Type, id)
+	key := s.layout.entityFileKey(meta.Type, id)
 	if err := s.rooted.Remove(key); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-	s.echoes.Forget(s.absPath(key))
+	s.echoes.Forget(s.layout.absPath(key))
 
 	// Cascade attachments — under the per-entity layout the
 	// attachment directory is owned 1:1 by the entity.
@@ -446,15 +446,15 @@ func (s *FSStore) renameEntity(_ context.Context, oldID, newID string) (*store.R
 		}
 
 		// Delete old relation file.
-		oldKey := s.relationFileKey(rm.From, rm.Type, rm.To)
+		oldKey := s.layout.relationFileKey(rm.From, rm.Type, rm.To)
 		_ = s.rooted.Remove(oldKey)
-		s.echoes.Forget(s.absPath(oldKey))
+		s.echoes.Forget(s.layout.absPath(oldKey))
 	}
 
 	// Delete old entity file.
-	oldKey := s.entityFileKey(meta.Type, oldID)
+	oldKey := s.layout.entityFileKey(meta.Type, oldID)
 	_ = s.rooted.Remove(oldKey)
-	s.echoes.Forget(s.absPath(oldKey))
+	s.echoes.Forget(s.layout.absPath(oldKey))
 
 	// Move the attachment directory (if any) onto the new ID.
 	if err := s.renameAttachmentDir(oldID, newID); err != nil {

--- a/internal/store/fsstore/formatter.go
+++ b/internal/store/fsstore/formatter.go
@@ -19,8 +19,8 @@ func (s *FSStore) FormatEntity(ctx context.Context, id string, dryRun bool) (boo
 	}
 
 	s.mu.RLock()
-	order := s.propertyOrder(e.Type)
-	key := s.entityFileKey(e.Type, e.ID)
+	order := s.layout.propertyOrder(e.Type)
+	key := s.layout.entityFileKey(e.Type, e.ID)
 	s.mu.RUnlock()
 
 	formatted, err := formatEntity(e, order)
@@ -56,7 +56,7 @@ func (s *FSStore) FormatRelation(ctx context.Context, from, relType, to string, 
 	}
 
 	s.mu.RLock()
-	key := s.relationFileKey(from, relType, to)
+	key := s.layout.relationFileKey(from, relType, to)
 	s.mu.RUnlock()
 
 	formatted, err := formatRelation(r)

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -95,11 +95,11 @@ type attachMeta struct {
 
 // FSStore is a filesystem-backed store implementation.
 //
-// TODO(TKT-N0IKN9): FSStore is over the 40-method load line (89 methods).
+// TODO(TKT-N0IKN9): FSStore is over the 40-method load line (81 methods).
 // Decompose; ratchet this number down as responsibilities move out.
 // (84 → 95 with the Tx contract, TKT-GXHI8: each write method split into
 // an exported txMu wrapper + unexported core so Tx callbacks can re-enter;
-// 95 → 89 with the fileLayout extraction, TKT-Y683LJ.)
+// 95 → 81 with the fileLayout + mdCodec extractions, TKT-Y683LJ.)
 //
 // The exported surface (33) is mostly the mandated store.Store interface (~28
 // methods incl. Tx) plus the Formatter and watcher side-interfaces; consumers
@@ -107,7 +107,7 @@ type attachMeta struct {
 // the interface size as the non-interface public methods
 // (FormatEntity/Relation, Start/StopWatching) move to composed helpers.
 //
-//plimsoll:max-methods=89
+//plimsoll:max-methods=81
 //plimsoll:max-exported-methods=33
 type FSStore struct {
 	// rooted is the validated-key I/O surface. Every read, write,
@@ -128,6 +128,10 @@ type FSStore struct {
 	// layout resolves file keys, plural directory names, and property
 	// order from the immutable path/key/schema configuration.
 	layout fileLayout
+
+	// codec reads and writes entity/relation markdown files (including
+	// git-crypt inaccessible-shell handling).
+	codec mdCodec
 
 	// Keys (root-relative forward-slash) for the non-layout subtrees.
 	attachKey string
@@ -202,25 +206,28 @@ func New(cfg Config) (*FSStore, error) {
 		return nil, errors.New("fsstore: Config.Schemas must be populated from the metamodel; an empty map indicates a bootstrap-ordering bug")
 	}
 
+	layout := fileLayout{
+		entitiesKey:  cfg.EntitiesKey,
+		relationsKey: cfg.RelationsKey,
+		schemas:      cfg.Schemas,
+		rooted:       cfg.Rooted,
+	}
+
 	s := &FSStore{
 		rooted:             cfg.Rooted,
 		rawReader:          cfg.FS,
 		streamingSupported: cfg.Rooted.SupportsStreaming(),
-		layout: fileLayout{
-			entitiesKey:  cfg.EntitiesKey,
-			relationsKey: cfg.RelationsKey,
-			schemas:      cfg.Schemas,
-			rooted:       cfg.Rooted,
-		},
-		attachKey:   cfg.AttachmentsKey,
-		cacheKey:    cfg.CacheKey,
-		observers:   cfg.Observers,
-		entities:    make(map[string]entityMeta),
-		relations:   make(map[string]relationMeta),
-		attachments: make(map[string]attachMeta),
-		propCache:   make(map[string]map[string]int),
-		subscribers: make(map[int]chan store.Event),
-		echoes:      newEchoTracker(recentHashCapacity),
+		layout:             layout,
+		codec:              mdCodec{rooted: cfg.Rooted, layout: layout},
+		attachKey:          cfg.AttachmentsKey,
+		cacheKey:           cfg.CacheKey,
+		observers:          cfg.Observers,
+		entities:           make(map[string]entityMeta),
+		relations:          make(map[string]relationMeta),
+		attachments:        make(map[string]attachMeta),
+		propCache:          make(map[string]map[string]int),
+		subscribers:        make(map[int]chan store.Event),
+		echoes:             newEchoTracker(recentHashCapacity),
 	}
 
 	s.cleanupTempFiles()

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -95,10 +95,11 @@ type attachMeta struct {
 
 // FSStore is a filesystem-backed store implementation.
 //
-// TODO(TKT-N0IKN9): FSStore is over the 40-method load line (95 methods).
+// TODO(TKT-N0IKN9): FSStore is over the 40-method load line (89 methods).
 // Decompose; ratchet this number down as responsibilities move out.
 // (84 → 95 with the Tx contract, TKT-GXHI8: each write method split into
-// an exported txMu wrapper + unexported core so Tx callbacks can re-enter.)
+// an exported txMu wrapper + unexported core so Tx callbacks can re-enter;
+// 95 → 89 with the fileLayout extraction, TKT-Y683LJ.)
 //
 // The exported surface (33) is mostly the mandated store.Store interface (~28
 // methods incl. Tx) plus the Formatter and watcher side-interfaces; consumers
@@ -106,7 +107,7 @@ type attachMeta struct {
 // the interface size as the non-interface public methods
 // (FormatEntity/Relation, Start/StopWatching) move to composed helpers.
 //
-//plimsoll:max-methods=95
+//plimsoll:max-methods=89
 //plimsoll:max-exported-methods=33
 type FSStore struct {
 	// rooted is the validated-key I/O surface. Every read, write,
@@ -124,12 +125,13 @@ type FSStore struct {
 	// walking the decorator chain per attachment write.
 	streamingSupported bool
 
-	// Keys (root-relative forward-slash) for the standard subtrees.
-	entitiesKey  string
-	relationsKey string
-	attachKey    string
-	cacheKey     string
-	schemas      map[string]store.EntityTypeSchema
+	// layout resolves file keys, plural directory names, and property
+	// order from the immutable path/key/schema configuration.
+	layout fileLayout
+
+	// Keys (root-relative forward-slash) for the non-layout subtrees.
+	attachKey string
+	cacheKey  string
 
 	// txMu serializes an open Tx against ordinary writers: Tx holds it
 	// for the whole callback, every exported write method takes it
@@ -204,18 +206,21 @@ func New(cfg Config) (*FSStore, error) {
 		rooted:             cfg.Rooted,
 		rawReader:          cfg.FS,
 		streamingSupported: cfg.Rooted.SupportsStreaming(),
-		entitiesKey:        cfg.EntitiesKey,
-		relationsKey:       cfg.RelationsKey,
-		attachKey:          cfg.AttachmentsKey,
-		cacheKey:           cfg.CacheKey,
-		schemas:            cfg.Schemas,
-		observers:          cfg.Observers,
-		entities:           make(map[string]entityMeta),
-		relations:          make(map[string]relationMeta),
-		attachments:        make(map[string]attachMeta),
-		propCache:          make(map[string]map[string]int),
-		subscribers:        make(map[int]chan store.Event),
-		echoes:             newEchoTracker(recentHashCapacity),
+		layout: fileLayout{
+			entitiesKey:  cfg.EntitiesKey,
+			relationsKey: cfg.RelationsKey,
+			schemas:      cfg.Schemas,
+			rooted:       cfg.Rooted,
+		},
+		attachKey:   cfg.AttachmentsKey,
+		cacheKey:    cfg.CacheKey,
+		observers:   cfg.Observers,
+		entities:    make(map[string]entityMeta),
+		relations:   make(map[string]relationMeta),
+		attachments: make(map[string]attachMeta),
+		propCache:   make(map[string]map[string]int),
+		subscribers: make(map[int]chan store.Event),
+		echoes:      newEchoTracker(recentHashCapacity),
 	}
 
 	s.cleanupTempFiles()
@@ -226,25 +231,6 @@ func New(cfg Config) (*FSStore, error) {
 	s.loadAttachmentsIndex()
 
 	return s, nil
-}
-
-// absPath resolves a key to an absolute path. Used by the watcher
-// (which needs absolute paths for fsnotify) and the self-echo LRU
-// interaction points, where paths must match what SafeFS.OnPostWrite
-// observes.
-//
-// Returns ("", nil) on resolve failure — keys constructed from
-// configured fields should always resolve, but upstream validators
-// (storeutil.ValidateID) don't cover all cases RootedFS rejects
-// (e.g. Windows reserved names). A resolve failure here means no
-// file was ever written under that key, so the LRU can safely no-op
-// a Forget and the watcher can safely skip-setup.
-func (s *FSStore) absPath(key string) string {
-	abs, err := s.rooted.AbsPath(key)
-	if err != nil {
-		return ""
-	}
-	return abs
 }
 
 // loadAttachmentsIndex walks the attachments directory and populates
@@ -362,35 +348,13 @@ func (s *FSStore) notifyRenamed(oldID string, renamed *entity.Entity) {
 	}
 }
 
-// entityFileKey returns the key for an entity file:
-// "<entitiesKey>/<plural>/<id>.md" — forward slashes, no leading slash.
-func (s *FSStore) entityFileKey(entityType, id string) string {
-	plural := entityType + "s"
-	if schema, ok := s.schemas[entityType]; ok && schema.Plural != "" {
-		plural = schema.Plural
-	}
-	return path.Join(s.entitiesKey, plural, id+".md")
-}
-
-func (s *FSStore) relationFileKey(from, relType, to string) string {
-	return path.Join(s.relationsKey, from+"--"+relType+"--"+to+".md")
-}
-
-// propertyOrder returns the property order for an entity type, if configured.
-func (s *FSStore) propertyOrder(entityType string) []string {
-	if schema, ok := s.schemas[entityType]; ok {
-		return schema.PropertyOrder
-	}
-	return nil
-}
-
 // cleanupTempFiles removes orphaned temp files left by interrupted
 // writes. Two suffixes are swept: ".new" (legacy direct fsstore
 // atomic-write) and ".tmp" (SafeFS atomic-write). Both are produced by
 // writeFile → rename paths and are never expected to survive a normal
 // process shutdown.
 func (s *FSStore) cleanupTempFiles() {
-	for _, dirKey := range []string{s.entitiesKey, s.relationsKey} {
+	for _, dirKey := range []string{s.layout.entitiesKey, s.layout.relationsKey} {
 		if dirKey == "" {
 			continue
 		}

--- a/internal/store/fsstore/gitcrypt_integration_test.go
+++ b/internal/store/fsstore/gitcrypt_integration_test.go
@@ -179,7 +179,7 @@ func TestScan_SkipsUnknownEntityTypeDirectories(t *testing.T) {
 	// A directory whose plural does not map to any metamodel-declared
 	// type must be skipped at scan time. This is the invariant that
 	// makes buildInaccessibleEntity safe to assume entityType is always
-	// in s.schemas.
+	// in the layout's schemas.
 	fs := storage.NewMemFS()
 	require.NoError(t, fs.MkdirAll("/entities/unknowns", 0o755))
 	require.NoError(t, fs.WriteFile("/entities/unknowns/UNK-1.md", []byte(`---

--- a/internal/store/fsstore/index.go
+++ b/internal/store/fsstore/index.go
@@ -161,7 +161,7 @@ func (s *FSStore) rebuildPropCache() error {
 // scanEntityDirs walks the entity type directories concurrently and
 // populates the index from directory structure alone (no file reads).
 func (s *FSStore) scanEntityDirs() error {
-	typeDirs, err := s.rooted.ReadDir(s.entitiesKey)
+	typeDirs, err := s.rooted.ReadDir(s.layout.entitiesKey)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -169,7 +169,7 @@ func (s *FSStore) scanEntityDirs() error {
 		return err
 	}
 
-	pluralToType := s.buildPluralToTypeMap()
+	pluralToType := s.layout.buildPluralToTypeMap()
 
 	type result struct {
 		entries []entityMeta
@@ -185,7 +185,7 @@ func (s *FSStore) scanEntityDirs() error {
 		wg.Add(1)
 		go func(idx int, dirName string) {
 			defer wg.Done()
-			entityType := s.resolveEntityType(dirName, pluralToType)
+			entityType := s.layout.resolveEntityType(dirName, pluralToType)
 			if entityType == "" {
 				// Directory does not map to a metamodel-declared type.
 				// Skipping prevents indexing files for types we cannot
@@ -194,7 +194,7 @@ func (s *FSStore) scanEntityDirs() error {
 				// orphan directory as invisible until cleaned up.
 				return
 			}
-			files, readErr := s.rooted.ReadDir(path.Join(s.entitiesKey, dirName))
+			files, readErr := s.rooted.ReadDir(path.Join(s.layout.entitiesKey, dirName))
 			if readErr != nil {
 				return
 			}
@@ -226,7 +226,7 @@ func (s *FSStore) scanEntityDirs() error {
 // scanRelationDir lists the relations directory and parses relation keys
 // from filenames (FROM--TYPE--TO.md). No file reads needed.
 func (s *FSStore) scanRelationDir() error {
-	files, err := s.rooted.ReadDir(s.relationsKey)
+	files, err := s.rooted.ReadDir(s.layout.relationsKey)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -274,37 +274,12 @@ func parseRelationFilename(name string) (from, relType, to string) {
 	return from, relType, to
 }
 
-// buildPluralToTypeMap builds a reverse map from plural directory names to entity types.
-func (s *FSStore) buildPluralToTypeMap() map[string]string {
-	m := make(map[string]string, len(s.schemas))
-	for typ, schema := range s.schemas {
-		if schema.Plural != "" {
-			m[schema.Plural] = typ
-		}
-	}
-	return m
-}
-
-// resolveEntityType maps a plural directory name back to the entity type.
-// Returns "" when the directory does not map to any metamodel-declared
-// type — callers skip such directories.
-//
-// The schema's Plural field is canonical: app.buildSchemas resolves it
-// via metamodel.EntityDef.GetPlural so fsstore does not have to
-// re-guess via "+s" at call time.
-func (s *FSStore) resolveEntityType(dirName string, pluralToType map[string]string) string {
-	if typ, ok := pluralToType[dirName]; ok {
-		return typ
-	}
-	return ""
-}
-
 // newestEntityFileMtime returns the newest mtime across all entity files.
 // Uses stat only — no file reads.
 func (s *FSStore) newestEntityFileMtime() time.Time {
 	var newest time.Time
 	for _, meta := range s.entities {
-		key := s.entityFileKey(meta.Type, meta.ID)
+		key := s.layout.entityFileKey(meta.Type, meta.ID)
 		if info, err := s.rooted.Stat(key); err == nil {
 			if info.ModTime().After(newest) {
 				newest = info.ModTime()
@@ -319,7 +294,7 @@ func (s *FSStore) newestEntityFileMtime() time.Time {
 func (s *FSStore) newestRelationFileMtime() time.Time {
 	var newest time.Time
 	for _, meta := range s.relations {
-		key := s.relationFileKey(meta.From, meta.Type, meta.To)
+		key := s.layout.relationFileKey(meta.From, meta.Type, meta.To)
 		if info, err := s.rooted.Stat(key); err == nil {
 			if info.ModTime().After(newest) {
 				newest = info.ModTime()
@@ -333,13 +308,13 @@ func (s *FSStore) newestRelationFileMtime() time.Time {
 func (s *FSStore) entitiesDirMtime() time.Time {
 	var latest time.Time
 
-	info, err := s.rooted.Stat(s.entitiesKey)
+	info, err := s.rooted.Stat(s.layout.entitiesKey)
 	if err != nil {
 		return latest
 	}
 	latest = info.ModTime()
 
-	entries, err := s.rooted.ReadDir(s.entitiesKey)
+	entries, err := s.rooted.ReadDir(s.layout.entitiesKey)
 	if err != nil {
 		return latest
 	}
@@ -358,7 +333,7 @@ func (s *FSStore) entitiesDirMtime() time.Time {
 
 // relationsDirMtime returns the mtime of the relations directory.
 func (s *FSStore) relationsDirMtime() time.Time {
-	info, err := s.rooted.Stat(s.relationsKey)
+	info, err := s.rooted.Stat(s.layout.relationsKey)
 	if err != nil {
 		return time.Time{}
 	}

--- a/internal/store/fsstore/index.go
+++ b/internal/store/fsstore/index.go
@@ -42,7 +42,7 @@ func (s *FSStore) loadPersistedIndex() *persistedIndex {
 	if s.cacheKey == "" {
 		return nil
 	}
-	data, err := s.readDataFile(path.Join(s.cacheKey, indexFile))
+	data, err := s.codec.readDataFile(path.Join(s.cacheKey, indexFile))
 	if err != nil {
 		return nil
 	}

--- a/internal/store/fsstore/layout.go
+++ b/internal/store/fsstore/layout.go
@@ -1,0 +1,103 @@
+package fsstore
+
+import (
+	"path"
+
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// fileLayout resolves file keys, plural directory names, and
+// schema-declared property order — the path/key/schema half of the
+// store's configuration. It is immutable after [New]: every field is
+// fixed from [Config] and never written again, so its methods are pure
+// functions of configuration and are safe to call with or without the
+// store's locks held.
+//
+// A type of its own rather than more methods on [FSStore], because
+// layout resolution needs NOTHING from the store's mutable state — no
+// mu, no index maps, no observers. Hanging these helpers off FSStore
+// buried a pure function group inside a god-object; the linter counts
+// methods per type, and so does anyone reading FSStore's API.
+type fileLayout struct {
+	// entitiesKey and relationsKey are root-relative forward-slash
+	// keys for the standard subtrees (e.g. "entities", "relations").
+	entitiesKey  string
+	relationsKey string
+
+	// schemas maps entity types to their storage-relevant
+	// configuration (plural directory name + property order). Complete
+	// by construction: [New] rejects an empty map.
+	schemas map[string]store.EntityTypeSchema
+
+	// rooted resolves keys to absolute paths for the watcher and the
+	// self-echo LRU. It is used read-only here; all file I/O stays on
+	// FSStore.
+	rooted *storage.RootedFS
+}
+
+// entityFileKey returns the key for an entity file:
+// "<entitiesKey>/<plural>/<id>.md" — forward slashes, no leading slash.
+func (l fileLayout) entityFileKey(entityType, id string) string {
+	plural := entityType + "s"
+	if schema, ok := l.schemas[entityType]; ok && schema.Plural != "" {
+		plural = schema.Plural
+	}
+	return path.Join(l.entitiesKey, plural, id+".md")
+}
+
+func (l fileLayout) relationFileKey(from, relType, to string) string {
+	return path.Join(l.relationsKey, from+"--"+relType+"--"+to+".md")
+}
+
+// propertyOrder returns the property order for an entity type, if configured.
+func (l fileLayout) propertyOrder(entityType string) []string {
+	if schema, ok := l.schemas[entityType]; ok {
+		return schema.PropertyOrder
+	}
+	return nil
+}
+
+// absPath resolves a key to an absolute path. Used by the watcher
+// (which needs absolute paths for fsnotify) and the self-echo LRU
+// interaction points, where paths must match what SafeFS.OnPostWrite
+// observes.
+//
+// Returns "" on resolve failure — keys constructed from configured
+// fields should always resolve, but upstream validators
+// (storeutil.ValidateID) don't cover all cases RootedFS rejects
+// (e.g. Windows reserved names). A resolve failure here means no
+// file was ever written under that key, so the LRU can safely no-op
+// a Forget and the watcher can safely skip-setup.
+func (l fileLayout) absPath(key string) string {
+	abs, err := l.rooted.AbsPath(key)
+	if err != nil {
+		return ""
+	}
+	return abs
+}
+
+// buildPluralToTypeMap builds a reverse map from plural directory names to entity types.
+func (l fileLayout) buildPluralToTypeMap() map[string]string {
+	m := make(map[string]string, len(l.schemas))
+	for typ, schema := range l.schemas {
+		if schema.Plural != "" {
+			m[schema.Plural] = typ
+		}
+	}
+	return m
+}
+
+// resolveEntityType maps a plural directory name back to the entity type.
+// Returns "" when the directory does not map to any metamodel-declared
+// type — callers skip such directories.
+//
+// The schema's Plural field is canonical: app.buildSchemas resolves it
+// via metamodel.EntityDef.GetPlural so fsstore does not have to
+// re-guess via "+s" at call time.
+func (l fileLayout) resolveEntityType(dirName string, pluralToType map[string]string) string {
+	if typ, ok := pluralToType[dirName]; ok {
+		return typ
+	}
+	return ""
+}

--- a/internal/store/fsstore/markdown.go
+++ b/internal/store/fsstore/markdown.go
@@ -236,7 +236,7 @@ func (s *FSStore) readEntityFile(key, id, entityType string) (*entity.Entity, er
 // that names the markdown body, so consumers know exactly which fields
 // exist but are unreadable.
 //
-// Invariant: entityType is always present in s.schemas. [New] rejects
+// Invariant: entityType is always present in the layout's schemas. [New] rejects
 // stores constructed without a populated Schemas map, and unknown-type
 // directories are skipped at scan time and in the watcher path. The
 // resulting Inaccessible slice always has at least one entry (the
@@ -246,7 +246,7 @@ func (s *FSStore) buildInaccessibleEntity(key, id, entityType string, reason ent
 	if info, err := s.rooted.Stat(key); err == nil {
 		e.UpdatedAt = info.ModTime()
 	}
-	props := s.propertyOrder(entityType)
+	props := s.layout.propertyOrder(entityType)
 	e.Inaccessible = make([]entity.InaccessibleField, 0, len(props)+1)
 	for _, name := range props {
 		e.Inaccessible = append(e.Inaccessible, entity.InaccessibleField{Name: name, Reason: reason})
@@ -280,8 +280,8 @@ func formatEntity(e *entity.Entity, propertyOrder []string) (string, error) {
 
 // writeEntityFile writes an entity to a markdown file using temp-file + rename.
 func (s *FSStore) writeEntityFile(e *entity.Entity) error {
-	key := s.entityFileKey(e.Type, e.ID)
-	order := s.propertyOrder(e.Type)
+	key := s.layout.entityFileKey(e.Type, e.ID)
+	order := s.layout.propertyOrder(e.Type)
 	content, err := formatEntity(e, order)
 	if err != nil {
 		return err
@@ -373,7 +373,7 @@ func formatRelation(r *entity.Relation) (string, error) {
 
 // writeRelationFile writes a relation to a markdown file using temp-file + rename.
 func (s *FSStore) writeRelationFile(r *entity.Relation) error {
-	key := s.relationFileKey(r.From, r.Type, r.To)
+	key := s.layout.relationFileKey(r.From, r.Type, r.To)
 	content, err := formatRelation(r)
 	if err != nil {
 		return err

--- a/internal/store/fsstore/markdown.go
+++ b/internal/store/fsstore/markdown.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/frontmatter"
 	"github.com/Sourcehaven-BV/rela/internal/markdown"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
 // errConflictedFile is returned when a file has unresolved git conflict markers.
@@ -190,19 +191,37 @@ func formatMarkdown(content string) string {
 
 // --- entity I/O ---
 
+// mdCodec reads and writes entity/relation markdown files — the
+// serialization seam between domain types and on-disk bytes, fixed at
+// [New]. Like [fileLayout] it is immutable after construction and
+// touches none of the store's mutable state (no mu, no index maps, no
+// observers), so its methods are safe with or without the store's
+// locks held; all I/O flows through the same RootedFS barrier the
+// store uses. Git-crypt-encrypted files are recognized here and
+// returned as inaccessible shells rather than parse errors.
+type mdCodec struct {
+	// rooted is the validated-key I/O surface for reads, writes, and
+	// the Stat calls that populate UpdatedAt.
+	rooted *storage.RootedFS
+
+	// layout resolves file keys and schema property order for the
+	// write paths and inaccessible-shell construction.
+	layout fileLayout
+}
+
 // readEntityFile reads and parses an entity from a markdown file key.
 //
 // id and entityType are caller-supplied (the caller already knows them
 // from the index); they are used to populate the resulting entity if the
 // file is git-crypt encrypted and its frontmatter cannot be read.
-func (s *FSStore) readEntityFile(key, id, entityType string) (*entity.Entity, error) {
-	data, err := s.readDataFile(key)
+func (c mdCodec) readEntityFile(key, id, entityType string) (*entity.Entity, error) {
+	data, err := c.readDataFile(key)
 	if err != nil {
 		return nil, err
 	}
 
 	if isGitCryptEncrypted(data) {
-		return s.buildInaccessibleEntity(key, id, entityType, entity.InaccessibleReasonGitCrypt), nil
+		return c.buildInaccessibleEntity(key, id, entityType, entity.InaccessibleReasonGitCrypt), nil
 	}
 
 	doc, err := parseDocument(string(data))
@@ -216,7 +235,7 @@ func (s *FSStore) readEntityFile(key, id, entityType string) (*entity.Entity, er
 	e := entity.New(docID, docType)
 	e.Content = doc.content
 
-	if info, err := s.rooted.Stat(key); err == nil {
+	if info, err := c.rooted.Stat(key); err == nil {
 		e.UpdatedAt = info.ModTime()
 	}
 
@@ -241,12 +260,12 @@ func (s *FSStore) readEntityFile(key, id, entityType string) (*entity.Entity, er
 // directories are skipped at scan time and in the watcher path. The
 // resulting Inaccessible slice always has at least one entry (the
 // content marker), so every IsLocked() guard fires reliably.
-func (s *FSStore) buildInaccessibleEntity(key, id, entityType string, reason entity.InaccessibleReason) *entity.Entity {
+func (c mdCodec) buildInaccessibleEntity(key, id, entityType string, reason entity.InaccessibleReason) *entity.Entity {
 	e := entity.New(id, entityType)
-	if info, err := s.rooted.Stat(key); err == nil {
+	if info, err := c.rooted.Stat(key); err == nil {
 		e.UpdatedAt = info.ModTime()
 	}
-	props := s.layout.propertyOrder(entityType)
+	props := c.layout.propertyOrder(entityType)
 	e.Inaccessible = make([]entity.InaccessibleField, 0, len(props)+1)
 	for _, name := range props {
 		e.Inaccessible = append(e.Inaccessible, entity.InaccessibleField{Name: name, Reason: reason})
@@ -279,14 +298,14 @@ func formatEntity(e *entity.Entity, propertyOrder []string) (string, error) {
 }
 
 // writeEntityFile writes an entity to a markdown file using temp-file + rename.
-func (s *FSStore) writeEntityFile(e *entity.Entity) error {
-	key := s.layout.entityFileKey(e.Type, e.ID)
-	order := s.layout.propertyOrder(e.Type)
+func (c mdCodec) writeEntityFile(e *entity.Entity) error {
+	key := c.layout.entityFileKey(e.Type, e.ID)
+	order := c.layout.propertyOrder(e.Type)
 	content, err := formatEntity(e, order)
 	if err != nil {
 		return err
 	}
-	return s.writeDataFile(key, []byte(content), 0o644)
+	return c.writeDataFile(key, []byte(content), 0o644)
 }
 
 // --- relation I/O ---
@@ -296,14 +315,14 @@ func (s *FSStore) writeEntityFile(e *entity.Entity) error {
 // from, relType, to are caller-supplied (derived from the filename); they
 // are used to populate the resulting relation if the file is git-crypt
 // encrypted and its frontmatter cannot be read.
-func (s *FSStore) readRelationFile(key, from, relType, to string) (*entity.Relation, error) {
-	data, err := s.readDataFile(key)
+func (c mdCodec) readRelationFile(key, from, relType, to string) (*entity.Relation, error) {
+	data, err := c.readDataFile(key)
 	if err != nil {
 		return nil, err
 	}
 
 	if isGitCryptEncrypted(data) {
-		return s.buildInaccessibleRelation(key, from, relType, to, entity.InaccessibleReasonGitCrypt), nil
+		return c.buildInaccessibleRelation(key, from, relType, to, entity.InaccessibleReasonGitCrypt), nil
 	}
 
 	doc, err := parseDocument(string(data))
@@ -318,7 +337,7 @@ func (s *FSStore) readRelationFile(key, from, relType, to string) (*entity.Relat
 	)
 	r.Content = doc.content
 
-	if info, err := s.rooted.Stat(key); err == nil {
+	if info, err := c.rooted.Stat(key); err == nil {
 		r.UpdatedAt = info.ModTime()
 	}
 
@@ -338,12 +357,12 @@ func (s *FSStore) readRelationFile(key, from, relType, to string) (*entity.Relat
 // whose content cannot be read. The endpoints are caller-supplied. The
 // relation has no metamodel-declared properties (unlike entities), so
 // the sole inaccessible entry names the markdown body.
-func (s *FSStore) buildInaccessibleRelation(
+func (c mdCodec) buildInaccessibleRelation(
 	key, from, relType, to string,
 	reason entity.InaccessibleReason,
 ) *entity.Relation {
 	r := entity.NewRelation(from, relType, to)
-	if info, err := s.rooted.Stat(key); err == nil {
+	if info, err := c.rooted.Stat(key); err == nil {
 		r.UpdatedAt = info.ModTime()
 	}
 	r.Inaccessible = []entity.InaccessibleField{
@@ -372,13 +391,13 @@ func formatRelation(r *entity.Relation) (string, error) {
 }
 
 // writeRelationFile writes a relation to a markdown file using temp-file + rename.
-func (s *FSStore) writeRelationFile(r *entity.Relation) error {
-	key := s.layout.relationFileKey(r.From, r.Type, r.To)
+func (c mdCodec) writeRelationFile(r *entity.Relation) error {
+	key := c.layout.relationFileKey(r.From, r.Type, r.To)
 	content, err := formatRelation(r)
 	if err != nil {
 		return err
 	}
-	return s.writeDataFile(key, []byte(content), 0o644)
+	return c.writeDataFile(key, []byte(content), 0o644)
 }
 
 // writeDataFile writes content to the given key through RootedFS.
@@ -391,13 +410,13 @@ func (s *FSStore) writeRelationFile(r *entity.Relation) error {
 // MemFS.OnPostWrite for tests). That's where the actual on-disk
 // bytes are visible — fsstore sees only plaintext here and must not
 // record a plaintext hash the watcher can't match.
-func (s *FSStore) writeDataFile(key string, content []byte, perm os.FileMode) error {
-	return s.rooted.WriteFile(key, content, perm)
+func (c mdCodec) writeDataFile(key string, content []byte, perm os.FileMode) error {
+	return c.rooted.WriteFile(key, content, perm)
 }
 
 // readDataFile reads the given key through RootedFS. RootedFS
 // validates the key and delegates to the underlying FS (which applies
 // any decoding decorators — none currently in production).
-func (s *FSStore) readDataFile(key string) ([]byte, error) {
-	return s.rooted.ReadFile(key)
+func (c mdCodec) readDataFile(key string) ([]byte, error) {
+	return c.rooted.ReadFile(key)
 }

--- a/internal/store/fsstore/propcache.go
+++ b/internal/store/fsstore/propcache.go
@@ -41,10 +41,10 @@ func removeEntityFromCache(cache map[string]map[string]int, e *entity.Entity) {
 
 // loadEntity reads a single entity from disk.
 func (s *FSStore) loadEntity(id, entityType string) (*entity.Entity, error) {
-	return s.readEntityFile(s.entityFileKey(entityType, id), id, entityType)
+	return s.readEntityFile(s.layout.entityFileKey(entityType, id), id, entityType)
 }
 
 // loadRelation reads a single relation from disk.
 func (s *FSStore) loadRelation(from, relType, to string) (*entity.Relation, error) {
-	return s.readRelationFile(s.relationFileKey(from, relType, to), from, relType, to)
+	return s.readRelationFile(s.layout.relationFileKey(from, relType, to), from, relType, to)
 }

--- a/internal/store/fsstore/propcache.go
+++ b/internal/store/fsstore/propcache.go
@@ -41,10 +41,10 @@ func removeEntityFromCache(cache map[string]map[string]int, e *entity.Entity) {
 
 // loadEntity reads a single entity from disk.
 func (s *FSStore) loadEntity(id, entityType string) (*entity.Entity, error) {
-	return s.readEntityFile(s.layout.entityFileKey(entityType, id), id, entityType)
+	return s.codec.readEntityFile(s.layout.entityFileKey(entityType, id), id, entityType)
 }
 
 // loadRelation reads a single relation from disk.
 func (s *FSStore) loadRelation(from, relType, to string) (*entity.Relation, error) {
-	return s.readRelationFile(s.layout.relationFileKey(from, relType, to), from, relType, to)
+	return s.codec.readRelationFile(s.layout.relationFileKey(from, relType, to), from, relType, to)
 }

--- a/internal/store/fsstore/relation.go
+++ b/internal/store/fsstore/relation.go
@@ -218,11 +218,11 @@ func (s *FSStore) deleteRelation(_ context.Context, from, relType, to string) er
 	}
 
 	// Delete file.
-	fileKey := s.relationFileKey(from, relType, to)
+	fileKey := s.layout.relationFileKey(from, relType, to)
 	if err := s.rooted.Remove(fileKey); err != nil {
 		return err
 	}
-	s.echoes.Forget(s.absPath(fileKey))
+	s.echoes.Forget(s.layout.absPath(fileKey))
 
 	// Update index.
 	delete(s.relations, key)

--- a/internal/store/fsstore/relation.go
+++ b/internal/store/fsstore/relation.go
@@ -239,5 +239,5 @@ func (s *FSStore) deleteRelation(_ context.Context, from, relType, to string) er
 
 // writeRelation writes a relation to disk using temp-file + rename.
 func (s *FSStore) writeRelation(r *entity.Relation) error {
-	return s.writeRelationFile(r)
+	return s.codec.writeRelationFile(r)
 }

--- a/internal/store/fsstore/watcher.go
+++ b/internal/store/fsstore/watcher.go
@@ -82,10 +82,10 @@ func (s *FSStore) StartWatching() error {
 	s.mu.Unlock()
 
 	var dirs []string
-	if abs := s.absPath(s.entitiesKey); abs != "" {
+	if abs := s.layout.absPath(s.layout.entitiesKey); abs != "" {
 		dirs = append(dirs, abs)
 	}
-	if abs := s.absPath(s.relationsKey); abs != "" {
+	if abs := s.layout.absPath(s.layout.relationsKey); abs != "" {
 		dirs = append(dirs, abs)
 	}
 	if len(dirs) == 0 {
@@ -153,13 +153,13 @@ func (s *FSStore) handleExternalEvent(ev storage.ChangeEvent) {
 // isEntityPath reports whether path lives under the entities directory.
 // path is absolute (from fsnotify); converted via absPath(entitiesKey).
 func (s *FSStore) isEntityPath(path string) bool {
-	abs := s.absPath(s.entitiesKey)
+	abs := s.layout.absPath(s.layout.entitiesKey)
 	return abs != "" && hasPathPrefix(path, abs)
 }
 
 // isRelationPath reports whether path lives under the relations directory.
 func (s *FSStore) isRelationPath(path string) bool {
-	abs := s.absPath(s.relationsKey)
+	abs := s.layout.absPath(s.layout.relationsKey)
 	return abs != "" && hasPathPrefix(path, abs)
 }
 
@@ -265,8 +265,8 @@ func (s *FSStore) entityIdentityFromPath(path string) (id, entityType string, ok
 	if parent == "" {
 		return "", "", false
 	}
-	pluralToType := s.buildPluralToTypeMap()
-	entityType = s.resolveEntityType(parent, pluralToType)
+	pluralToType := s.layout.buildPluralToTypeMap()
+	entityType = s.layout.resolveEntityType(parent, pluralToType)
 	if entityType == "" {
 		return "", "", false
 	}
@@ -337,7 +337,7 @@ func (s *FSStore) parseEntityFromPath(data []byte, path string) (*entity.Entity,
 		if !ok {
 			return nil, errors.New("encrypted entity file: cannot derive id/type from path")
 		}
-		key := s.entityFileKey(entityType, id)
+		key := s.layout.entityFileKey(entityType, id)
 		return s.buildInaccessibleEntity(key, id, entityType, entity.InaccessibleReasonGitCrypt), nil
 	}
 	doc, err := parseDocument(string(data))

--- a/internal/store/fsstore/watcher.go
+++ b/internal/store/fsstore/watcher.go
@@ -338,7 +338,7 @@ func (s *FSStore) parseEntityFromPath(data []byte, path string) (*entity.Entity,
 			return nil, errors.New("encrypted entity file: cannot derive id/type from path")
 		}
 		key := s.layout.entityFileKey(entityType, id)
-		return s.buildInaccessibleEntity(key, id, entityType, entity.InaccessibleReasonGitCrypt), nil
+		return s.codec.buildInaccessibleEntity(key, id, entityType, entity.InaccessibleReasonGitCrypt), nil
 	}
 	doc, err := parseDocument(string(data))
 	if err != nil {

--- a/tickets/entities/implementation-checklists/IMPL-UCOK9W.md
+++ b/tickets/entities/implementation-checklists/IMPL-UCOK9W.md
@@ -1,0 +1,57 @@
+---
+id: IMPL-UCOK9W
+type: implementation-checklist
+title: 'Implementation: Extract fileLayout (and mdCodec) off fsstore.FSStore (plimsoll ratchet 95 → ~81)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no new behavior — the storetest conformance harness is the control, and changing it would destroy the evidence)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled (both steps landed; purity claim verified per-method before moving)
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A: zero test files changed — the right answer for this risk profile)
+- [x] ~~No hardcoded values in assertions~~ (N/A)
+- [x] ~~Only values that matter~~ (N/A)
+- [x] ~~Interpolated values from objects~~ (N/A)
+- [x] ~~Property comparisons from original object~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (storetest conformance + fsstore suites, `-race`, all three build tags)
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence (PR #1465, commits 672df120 + f64ebe4a):**
+- FSStore 95 → **81**; the 14 removed are exactly the 14 moved methods.
+Exported set diffed identical (33 vs 33) — the `store.Store` surface is
+untouched.
+- Both steps landed: `fileLayout` (6) and `mdCodec` (8).
+- Purity is STRUCTURALLY enforced, not merely claimed: both new types use
+value receivers (no pointer-receiver methods exist), and neither file references
+entities/relations/propCache/observers/mu/txMu/echoes/watcher.
+- Do-not-touch list verified: tx.go byte-identical; emit/notify* bodies
+identical; lock-op count 66 in base and 66 on branch; notifyRenamed still emits
+a single rename event; the mu-held-across-batch watcher property intact;
+echo.go/gitcrypt.go/attachment.go/graphquery.go byte-identical.
+- git-crypt inaccessible-shell path moved verbatim (still builds
+len(props)+1 so IsLocked always fires); all 5 git-crypt tests pass.
+- Gates verified at the real commit with `-count=1` in the correct
+worktree: ./internal/store/... all pass, `-race` on fsstore, plimsoll,
+arch-lint, comment-lint, go vet, and builds under default/memorybackend/
+postgres tags.
+
+## Quality
+
+- [x] Code follows project patterns (urlHelpers-style focused immutable collaborator)
+- [x] Checked for DRY opportunities (writeEntity/writeRelation pass-throughs noted and deliberately deferred — [[RR-Y9C2DP]])
+- [x] No security issues introduced (path containment still in storage.RootedFS, moved by reference not reimplemented; git-crypt handling verbatim)
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-WFLYKO.md
+++ b/tickets/entities/planning-checklists/PLAN-WFLYKO.md
@@ -1,0 +1,120 @@
+---
+id: PLAN-WFLYKO
+type: planning-checklist
+title: 'Planning: Extract fileLayout (and mdCodec) off fsstore.FSStore'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** IN: `internal/store/fsstore` — step 1 `fileLayout` (6 immutable
+path/key/ schema-resolution methods), step 2 `mdCodec` (8 markdown read/write
+methods, same PR, only if step 1 fully green); directive 95 → 89 → 81. OUT:
+tx.go, emit/observer notification, watcher/reconciler, index maps, attachment
+cluster, any lock or event-ordering change, any `store.Store` surface change.
+
+**Acceptance Criteria:**
+1. `just plimsoll` with the lowered directive.
+2. `go test ./internal/store/...` green — the storetest conformance harness
+plus fsstore's gitcrypt/recovery/persistence/fuzz suites ARE the behavior spec;
+full `go test ./...` and `-race` on fsstore too.
+3. arch-lint/comment-lint/golangci-lint clean.
+
+## Research
+
+- [x] ~~Run `/research`~~ (N/A: mechanical extraction; full struct survey done instead)
+- [x] ~~Searched for existing libraries~~ (N/A: no new functionality)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — Explore survey of all 95 FSStore methods: per-file
+clusters, exclusive field ownership, ranked candidates with an explicit
+do-not-touch list (recorded in the arc roadmap).
+
+**Existing Solutions:** `urlHelpers`/`mdHelpers` shape for the immutable
+collaborator; `storeutil` already hosts the shared cross-backend helpers
+(fsstore uses it broadly — no new duplication introduced).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** fileLayout = pure function of config fixed at `New`
+(entityFileKey/relationFileKey/propertyOrder/absPath +
+buildPluralToTypeMap/resolveEntityType); no lock, no mutable state, no events —
+verified in the survey against each method body. mdCodec = {rooted, layout}
+owning the markdown file IO including the git-crypt inaccessible-shell path
+(better cohesion: the codec owns unreadable-file handling). Alternatives
+rejected for this PR: attachmentStore (−8 but called under s.mu from entity.go —
+needs the lock-contract decision), indexStore (−14 but the maps are shared with
+watcher.go — two-phase later), eventBus (explicitly rejected in the survey: 1
+method for a second lock on every write path and changed emission ordering).
+
+**Files to modify:** internal/store/fsstore/{filelayout.go (new), fsstore.go,
+index.go, markdown.go (+ mdcodec.go or in place)}
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** Unchanged — path containment stays in
+`storage.RootedFS`, which moves by reference, not by reimplementation.
+
+**Security-Sensitive Operations:** git-crypt handling (unreadable encrypted
+files become inaccessible shells, never plaintext leaks) moves verbatim with the
+codec; pinned by gitcrypt_test.go + gitcrypt_integration_test.go.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] ~~Integration test approach defined~~ (N/A: storetest conformance harness is the integration spec)
+
+**Test Scenarios:** storetest.RunAll + fuzz functions; fsstore's
+recovery/persistence tests pin index-cache freshness; gitcrypt tests pin the
+inaccessible-shell path.
+
+**Edge Cases:** None new — moved methods are pure config functions (step 1) and
+lock-free file IO (step 2); the risky clusters are explicitly out of scope.
+
+**Negative Tests:** Existing conflict-marker/git-crypt/unreadable-file tests
+pass unchanged.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:** Low for step 1 (immutable, no lock). Low-medium for step 2 —
+mitigated by the survey's verification that the codec methods touch no mutable
+index state, by the explicit skip instruction if that turns out wrong, and by
+the storetest harness. Effort: m.
+
+## Documentation Planning
+
+- [x] ~~User-facing docs identified~~ (N/A: internal refactor)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A: refactor kind)
+
+**Documentation Impact:** N/A — internal change.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: plan derived from a dedicated structural survey with per-candidate risk ranking and an explicit do-not-touch list; repeats the established extraction design)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A: no review run)
+
+**Design Review Findings:** N/A

--- a/tickets/entities/review-checklists/REV-B6YHXP.md
+++ b/tickets/entities/review-checklists/REV-B6YHXP.md
@@ -1,0 +1,34 @@
+---
+id: REV-B6YHXP
+type: review-checklist
+title: 'Review: Extract fileLayout (and mdCodec) off fsstore.FSStore (plimsoll ratchet 95 → ~81)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass — verified at the real commit with `-count=1` in the correct worktree: `./internal/store/...` (storetest conformance harness + fsstore + all sibling backends), `-race` on fsstore, builds under default/memorybackend/postgres tags
+- [x] Linters pass (plimsoll at 81, arch-lint OK, comment-lint clean, go vet clean, golangci-lint)
+- [x] Coverage floors hold
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer, independent verification of the 11c02c1b..672df120 diff)
+- [x] All critical/significant findings addressed (none — this was the highest-risk PR of the arc and it came back clean)
+- [x] Minor finding addressed: [[RR-0QSEHW]] (stale `s.schemas` comment — fixed in f64ebe4a); nit deferred with reason: [[RR-Y9C2DP]]
+
+## Verification
+
+- [x] Do-not-touch list verified item by item: tx.go byte-identical; emit/notifyPut/notifyDelete/notifyRenamed bodies identical; lock-op count 66 in base and 66 on branch (no second lock introduced); notifyRenamed still emits a single rename event, never delete+put; the mu-held-across-batch watcher property intact; echo.go/gitcrypt.go/attachment.go/graphquery.go byte-identical
+- [x] Purity claim verified as STRUCTURALLY enforced, not merely asserted: both new types use value receivers (no pointer-receiver methods exist, so they cannot mutate), and neither file references entities/relations/propCache/observers/mu/txMu/echoes/watcher. The `schemas` map aliasing is unchanged from base
+- [x] `store.Store` surface unchanged: exported method sets diffed identical (33 vs 33)
+- [x] Method count verified at 81; the 14 removed are exactly the 14 moved
+- [x] git-crypt inaccessible-shell path moved verbatim (still builds len(props)+1 so IsLocked always fires); all git-crypt tests pass
+- [x] Zero test files changed — correct for this risk profile, since the conformance suite is the control
+
+**Process note carried into later arc steps (recorded on [[RR-Y9C2DP]]):**
+verify in the worktree that actually has the commit checked out and use `go test
+-count=1`. A cached PASS from the base commit is indistinguishable from a real
+one — the reviewer hit exactly this and caught it.

--- a/tickets/entities/review-responses/RR-0QSEHW.md
+++ b/tickets/entities/review-responses/RR-0QSEHW.md
@@ -1,0 +1,18 @@
+---
+id: RR-0QSEHW
+type: review-response
+title: Stale s.schemas reference in gitcrypt_integration_test.go comment after fileLayout extraction
+finding: gitcrypt_integration_test.go:182 documented the scan-skip invariant as making buildInaccessibleEntity 'safe to assume entityType is always in s.schemas'. The schemas map moved to fileLayout, so s.schemas no longer exists — the only lingering reference to a removed field in the package. The equivalent prose in markdown.go was updated but this one was missed.
+severity: minor
+resolution: Updated the comment to 'in the layout's schemas', matching the wording already used in markdown.go. Verified with a fresh -count=1 run of ./internal/store/... plus comment-lint in the correct worktree.
+status: addressed
+---
+
+Nit from the TKT-Y683LJ code review (cranky-code-reviewer, PR #1465). The
+reviewer's verdict on the PR was sound/merge: tx.go byte-identical;
+emit/notifyPut/notifyDelete/notifyRenamed bodies identical with lock-op count 66
+in base and 66 on branch; the mu-held-across-batch watcher property untouched;
+the purity claim structurally enforced by VALUE receivers (neither new type can
+mutate) with zero references to the guarded state; exported-method set diffed
+identical (33 vs 33, so the store.Store surface is unchanged); max-methods=81
+verified by count; no test files changed.

--- a/tickets/entities/review-responses/RR-Y9C2DP.md
+++ b/tickets/entities/review-responses/RR-Y9C2DP.md
@@ -1,0 +1,18 @@
+---
+id: RR-Y9C2DP
+type: review-response
+title: writeEntity/writeRelation are now pure one-line pass-throughs — 2 free methods for a later arc step
+finding: After the mdCodec extraction, FSStore.writeEntity (entity.go:499) and FSStore.writeRelation (relation.go:242) are one-line pass-throughs to s.codec.*. Inlining their six in-package call sites would remove 2 more methods from the count. Note these were ALREADY pass-throughs before this PR — not a regression introduced here.
+severity: nit
+reason: 'Deliberately deferred: inlining would add non-mechanical churn to a PR whose entire value is being mechanically verifiable against the storetest conformance harness. Reviewer explicitly agreed this was the right call for this PR. Fold into whichever later arc step next touches entity.go/relation.go (a pure sed across six in-package call sites) rather than spending a PR on it.'
+status: deferred
+---
+
+Nit from the TKT-Y683LJ code review (cranky-code-reviewer, PR #1465), logged
+against the TKT-N0IKN9 arc as a cheap follow-on win.
+
+Process note from the same review, worth carrying into later arc steps: verify
+in the worktree that actually has the commit checked out and use `go test
+-count=1`. The reviewer's first run silently tested `develop` because `git
+checkout` failed (branch already checked out elsewhere) and the cached PASS
+looked identical to a real one.

--- a/tickets/entities/tickets/TKT-Y683LJ.md
+++ b/tickets/entities/tickets/TKT-Y683LJ.md
@@ -1,0 +1,44 @@
+---
+id: TKT-Y683LJ
+type: ticket
+title: Extract fileLayout (and mdCodec) off fsstore.FSStore (plimsoll ratchet 95 → ~81)
+kind: refactor
+priority: medium
+effort: m
+status: done
+---
+
+Sub-ticket of [[TKT-N0IKN9]], opening the `fsstore.FSStore` arc (95 methods / 33
+exported; the exported surface is largely the mandated `store.Store` interface,
+so the ratchet target is the unexported set).
+
+## What
+
+**Pure structural extraction, no behavior change, no `store.Store` surface
+change, no locking/event-ordering change.**
+
+Step 1 — `fileLayout`: immutable path/key resolver holding `{entitiesKey,
+relationsKey, attachKey, schemas, rooted}` with `entityFileKey`,
+`relationFileKey`, `propertyOrder`, `absPath` (from fsstore.go) plus
+`buildPluralToTypeMap`, `resolveEntityType` (from index.go). Pure function of
+config fixed at `New`; no lock, no mutable state, no events. −6.
+
+Step 2 (same PR, separate commit, only if step 1's gates are green) — `mdCodec`:
+the markdown read/write seam from markdown.go (`readEntityFile`,
+`writeEntityFile`, `readRelationFile`, `writeRelationFile`,
+`buildInaccessibleEntity`, `buildInaccessibleRelation`, `readDataFile`,
+`writeDataFile`) over `{rooted, layout}`. Touches no mutable index state and no
+lock; the git-crypt inaccessible-shell path moves with it (pinned by gitcrypt
+tests). −8.
+
+Explicit do-not-touch (from the design survey): `tx.go` (DEC-8UIL0 pairing),
+`emit`/observer notification (called under `mu.Lock`; ordering pinned by
+storetest), the watcher/reconciler, `notifyRenamed` single-event semantics.
+
+Ratchet `//plimsoll:max-methods` 95 → 89 (step 1) → 81 (step 2).
+
+## Done when
+
+plimsoll with lowered directive; `go test ./internal/store/...` (the storetest
+conformance harness + fuzz seeds + gitcrypt/recovery/persistence tests) and the
+full suite green; arch-lint/comment-lint/lint clean.

--- a/tickets/relations/TKT-Y683LJ--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-Y683LJ--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y683LJ
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-Y683LJ--has-implementation--IMPL-UCOK9W.md
+++ b/tickets/relations/TKT-Y683LJ--has-implementation--IMPL-UCOK9W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y683LJ
+relation: has-implementation
+to: IMPL-UCOK9W
+---

--- a/tickets/relations/TKT-Y683LJ--has-planning--PLAN-WFLYKO.md
+++ b/tickets/relations/TKT-Y683LJ--has-planning--PLAN-WFLYKO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y683LJ
+relation: has-planning
+to: PLAN-WFLYKO
+---

--- a/tickets/relations/TKT-Y683LJ--has-review--REV-B6YHXP.md
+++ b/tickets/relations/TKT-Y683LJ--has-review--REV-B6YHXP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y683LJ
+relation: has-review
+to: REV-B6YHXP
+---

--- a/tickets/relations/TKT-Y683LJ--has-review-response--RR-0QSEHW.md
+++ b/tickets/relations/TKT-Y683LJ--has-review-response--RR-0QSEHW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y683LJ
+relation: has-review-response
+to: RR-0QSEHW
+---

--- a/tickets/relations/TKT-Y683LJ--has-review-response--RR-Y9C2DP.md
+++ b/tickets/relations/TKT-Y683LJ--has-review-response--RR-Y9C2DP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y683LJ
+relation: has-review-response
+to: RR-Y9C2DP
+---

--- a/tickets/relations/TKT-Y683LJ--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-Y683LJ--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-Y683LJ
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Pure structural first ratchet of `FSStore` (opens the FSStore arc of TKT-N0IKN9). Two package-private collaborators are extracted, both immutable after `New` and touching none of the store's mutable state: `fileLayout` (entity/relation file keys, plural-to-type resolution, property order, absPath — `layout.go`) and `mdCodec` (markdown read/write of entity/relation files, including the git-crypt inaccessible-shell handling, which stays inside the codec — `markdown.go`). Locking (`mu`/`txMu`), event ordering (`emit`/`notifyPut`/`notifyDelete`/`notifyRenamed`), the tx.go wrapper/core pairing, and the `store.Store` surface are untouched; call sites are mechanical `s.layout.*` / `s.codec.*` rewrites. The plimsoll directive ratchets 95 → 81 (exported stays 33). Acceptance proof is the green storetest conformance harness plus fsstore's gitcrypt/recovery/persistence/fuzz suites, full `go test ./...`, `-race`, arch-lint, comment-lint, and golangci-lint.

https://claude.ai/code/session_016Br8QmRwRReoeZx55EfwyQ