### PR TITLE
Secrets hygiene: warn on permissive mode, read systemd credentials (TKT-RX7I97)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -336,6 +336,12 @@ deps:
       - schema
       - script
       - search
+      # `rela secrets credential-name` only DERIVES the systemd credential name
+      # for the project — it reads no secret values. The name embeds a hash of
+      # the project path (so two same-named projects cannot share a credential),
+      # which makes it underivable by hand, so an operator needs a way to print
+      # it for their unit file.
+      - secrets
       - state
       - storage
       - store

--- a/docs-project/entities/guides/GUIDE-lua-scripting.md
+++ b/docs-project/entities/guides/GUIDE-lua-scripting.md
@@ -1061,6 +1061,76 @@ overrides:
 - Keys under `overrides.<script-path>` apply only to that script and override globals
 - All values are plain strings
 
+**Keep the file readable only by its owner:**
+
+```bash
+chmod 700 .rela
+chmod 600 .rela/secrets.yaml
+```
+
+Both matter. `rela init` creates `.rela/` as `0755`, so tightening the file
+alone still leaves the directory listable — and a group-writable parent would
+let another user replace `secrets.yaml` outright.
+
+rela does not create the secrets file, so its permissions are whatever your
+editor and umask produced. When it is group- or world-readable, rela logs a
+warning naming the path and mode and loads it anyway — failing closed would
+break a working deployment on upgrade. The warning repeats only if the mode
+changes, so a fixed-then-regressed file is reported again rather than silently
+passing. It never echoes a key name or value.
+
+The check covers the file, not the directory: `chmod 700 .rela` is on you.
+
+#### systemd credentials
+
+On a server, prefer systemd's credential mechanism over a file in the project.
+rela reads `$CREDENTIALS_DIRECTORY` when systemd passes a credential whose name
+matches the project. Ask rela for the name rather than deriving it:
+
+```bash
+$ rela secrets credential-name
+rela-secrets-acme-6e0bff4c
+```
+
+The name is `rela-secrets-<project>-<hash>`: the readable directory name so you
+can tell which unit-file line belongs to which project, plus a short hash of the
+project's absolute path so two projects that happen to share a directory name
+never resolve to the same credential.
+
+```ini
+[Service]
+LoadCredentialEncrypted=rela-secrets-acme-6e0bff4c:/etc/rela/acme-secrets.cred
+```
+
+Encrypt the file with `systemd-creds` before deploying it:
+
+```bash
+systemd-creds encrypt --name=rela-secrets-acme-6e0bff4c secrets.yaml /etc/rela/acme-secrets.cred
+```
+
+The credential has the same YAML format as `secrets.yaml`. Why this is better
+than a plaintext file or an environment variable:
+
+- It is decrypted into a per-service tmpfs at mode `0400`, owned by the service
+  user — never written to persistent storage in the clear.
+- It is **not inherited by child processes**, unlike an environment variable.
+  That matters because rela runs external converters for attachments and view
+  exports; those inherit rela's environment but cannot see a credential.
+- `systemd-creds` can bind the encryption key to the host TPM, so the file on
+  disk is useless if copied elsewhere.
+
+The credential name is per-project deliberately: `$CREDENTIALS_DIRECTORY` is
+process-global, so a single shared name would hand one project's secrets to
+every other project served by the same process.
+
+The name changes if you move the project directory, since it includes a hash of
+the absolute path. Re-run `rela secrets credential-name` and update the unit
+file after a move.
+
+When systemd passes a credential for the project it wins over
+`.rela/secrets.yaml`. Otherwise rela falls back to the project file — including
+when the unit loads other, unrelated credentials.
+
 #### Usage in Lua
 
 ```lua

--- a/docs-project/entities/guides/GUIDE-mail.md
+++ b/docs-project/entities/guides/GUIDE-mail.md
@@ -72,8 +72,28 @@ That is the same file Lua scripts read. An SMTP password is no different in kind
 from an API token, so it goes in the same place rather than in a mechanism unique
 to mail.
 
+Keep that file readable only by its owner — `chmod 700 .rela && chmod 600
+.rela/secrets.yaml`. rela warns when the file is group- or world-readable; the
+directory mode is not checked, so set it yourself.
+
+**On systemd, prefer a credential.** rela reads `$CREDENTIALS_DIRECTORY` when
+the unit passes a credential named for the project — run `rela secrets
+credential-name` to get it:
+
+```ini
+[Service]
+LoadCredentialEncrypted=rela-secrets-acme-6e0bff4c:/etc/rela/acme-secrets.cred
+```
+
+The credential holds the same YAML as `secrets.yaml`, so `smtp_password` goes in
+it alongside every other key. It is decrypted into a per-service tmpfs at mode
+`0400`, is not inherited by child processes, and can be TPM-bound. See
+[Lua scripting → systemd credentials](lua-scripting.md#systemd-credentials) for
+the full setup.
+
 **Or use an environment variable.** If your deployment injects credentials as
-environment variables — containers, systemd units — name the variable instead:
+environment variables — containers, or systemd units not using credentials —
+name the variable instead:
 
 ```yaml
 # .rela/mail.yaml
@@ -81,6 +101,10 @@ password_env: RELA_SMTP_PASSWORD
 ```
 
 `secrets.yaml` takes precedence when both are present.
+
+Note an environment variable is the weakest of the three: every process rela
+spawns inherits it, including the external converters that run for attachment
+processing and view exports. A systemd credential is not inherited.
 
 Either way, **the password never goes in `mail.yaml`**. Writing a literal
 `password:` key there is refused at load with an error pointing you at the

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -1055,6 +1055,56 @@ overrides:
 - Keys under `overrides.<script-path>` apply only to that script and override globals
 - All values are plain strings
 
+**Keep the file readable only by its owner:**
+
+```bash
+chmod 600 .rela/secrets.yaml
+```
+
+rela does not create this file, so its permissions are whatever your editor and
+umask produced. When it is group- or world-readable, rela logs a warning naming
+the path and mode (once per file, not per script run) and loads it anyway —
+failing closed would break a working deployment on upgrade. The warning never
+echoes a key name or value.
+
+#### systemd credentials
+
+On a server, prefer systemd's credential mechanism over a file in the project.
+rela reads `$CREDENTIALS_DIRECTORY` when systemd passes a credential named
+`rela-secrets-<project>`, where `<project>` is the name of the directory
+containing `.rela/`:
+
+```ini
+[Service]
+# /srv/acme/.rela  ->  credential name "rela-secrets-acme"
+LoadCredentialEncrypted=rela-secrets-acme:/etc/rela/acme-secrets.cred
+```
+
+Encrypt the file with `systemd-creds` before deploying it:
+
+```bash
+systemd-creds encrypt --name=rela-secrets-acme secrets.yaml /etc/rela/acme-secrets.cred
+```
+
+The credential has the same YAML format as `secrets.yaml`. Why this is better
+than a plaintext file or an environment variable:
+
+- It is decrypted into a per-service tmpfs at mode `0400`, owned by the service
+  user — never written to persistent storage in the clear.
+- It is **not inherited by child processes**, unlike an environment variable.
+  That matters because rela runs external converters for attachments and view
+  exports; those inherit rela's environment but cannot see a credential.
+- `systemd-creds` can bind the encryption key to the host TPM, so the file on
+  disk is useless if copied elsewhere.
+
+The credential name is per-project deliberately: `$CREDENTIALS_DIRECTORY` is
+process-global, so a single shared name would hand one project's secrets to
+every other project served by the same process.
+
+When systemd passes a credential for the project it wins over
+`.rela/secrets.yaml`. Otherwise rela falls back to the project file — including
+when the unit loads other, unrelated credentials.
+
 #### Usage in Lua
 
 ```lua

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -1058,26 +1058,42 @@ overrides:
 **Keep the file readable only by its owner:**
 
 ```bash
+chmod 700 .rela
 chmod 600 .rela/secrets.yaml
 ```
 
-rela does not create this file, so its permissions are whatever your editor and
-umask produced. When it is group- or world-readable, rela logs a warning naming
-the path and mode (once per file, not per script run) and loads it anyway —
-failing closed would break a working deployment on upgrade. The warning never
-echoes a key name or value.
+Both matter. `rela init` creates `.rela/` as `0755`, so tightening the file
+alone still leaves the directory listable — and a group-writable parent would
+let another user replace `secrets.yaml` outright.
+
+rela does not create the secrets file, so its permissions are whatever your
+editor and umask produced. When it is group- or world-readable, rela logs a
+warning naming the path and mode and loads it anyway — failing closed would
+break a working deployment on upgrade. The warning repeats only if the mode
+changes, so a fixed-then-regressed file is reported again rather than silently
+passing. It never echoes a key name or value.
+
+The check covers the file, not the directory: `chmod 700 .rela` is on you.
 
 #### systemd credentials
 
 On a server, prefer systemd's credential mechanism over a file in the project.
-rela reads `$CREDENTIALS_DIRECTORY` when systemd passes a credential named
-`rela-secrets-<project>`, where `<project>` is the name of the directory
-containing `.rela/`:
+rela reads `$CREDENTIALS_DIRECTORY` when systemd passes a credential whose name
+matches the project. Ask rela for the name rather than deriving it:
+
+```bash
+$ rela secrets credential-name
+rela-secrets-acme-6e0bff4c
+```
+
+The name is `rela-secrets-<project>-<hash>`: the readable directory name so you
+can tell which unit-file line belongs to which project, plus a short hash of the
+project's absolute path so two projects that happen to share a directory name
+never resolve to the same credential.
 
 ```ini
 [Service]
-# /srv/acme/.rela  ->  credential name "rela-secrets-acme"
-LoadCredentialEncrypted=rela-secrets-acme:/etc/rela/acme-secrets.cred
+LoadCredentialEncrypted=rela-secrets-acme-6e0bff4c:/etc/rela/acme-secrets.cred
 ```
 
 Encrypt the file with `systemd-creds` before deploying it:
@@ -1100,6 +1116,10 @@ than a plaintext file or an environment variable:
 The credential name is per-project deliberately: `$CREDENTIALS_DIRECTORY` is
 process-global, so a single shared name would hand one project's secrets to
 every other project served by the same process.
+
+The name changes if you move the project directory, since it includes a hash of
+the absolute path. Re-run `rela secrets credential-name` and update the unit
+file after a move.
 
 When systemd passes a credential for the project it wins over
 `.rela/secrets.yaml`. Otherwise rela falls back to the project file — including

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -1099,7 +1099,7 @@ LoadCredentialEncrypted=rela-secrets-acme-6e0bff4c:/etc/rela/acme-secrets.cred
 Encrypt the file with `systemd-creds` before deploying it:
 
 ```bash
-systemd-creds encrypt --name=rela-secrets-acme secrets.yaml /etc/rela/acme-secrets.cred
+systemd-creds encrypt --name=rela-secrets-acme-6e0bff4c secrets.yaml /etc/rela/acme-secrets.cred
 ```
 
 The credential has the same YAML format as `secrets.yaml`. Why this is better

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -71,11 +71,12 @@ Keep that file readable only by its owner — `chmod 700 .rela && chmod 600
 directory mode is not checked, so set it yourself.
 
 **On systemd, prefer a credential.** rela reads `$CREDENTIALS_DIRECTORY` when
-the unit passes a credential named `rela-secrets-<project>`:
+the unit passes a credential named for the project — run `rela secrets
+credential-name` to get it:
 
 ```ini
 [Service]
-LoadCredentialEncrypted=rela-secrets-acme:/etc/rela/acme-secrets.cred
+LoadCredentialEncrypted=rela-secrets-acme-6e0bff4c:/etc/rela/acme-secrets.cred
 ```
 
 The credential holds the same YAML as `secrets.yaml`, so `smtp_password` goes in

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -66,8 +66,9 @@ That is the same file Lua scripts read. An SMTP password is no different in kind
 from an API token, so it goes in the same place rather than in a mechanism unique
 to mail.
 
-Keep that file readable only by its owner — `chmod 600 .rela/secrets.yaml`.
-rela warns when it is group- or world-readable.
+Keep that file readable only by its owner — `chmod 700 .rela && chmod 600
+.rela/secrets.yaml`. rela warns when the file is group- or world-readable; the
+directory mode is not checked, so set it yourself.
 
 **On systemd, prefer a credential.** rela reads `$CREDENTIALS_DIRECTORY` when
 the unit passes a credential named `rela-secrets-<project>`:

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -66,8 +66,26 @@ That is the same file Lua scripts read. An SMTP password is no different in kind
 from an API token, so it goes in the same place rather than in a mechanism unique
 to mail.
 
+Keep that file readable only by its owner — `chmod 600 .rela/secrets.yaml`.
+rela warns when it is group- or world-readable.
+
+**On systemd, prefer a credential.** rela reads `$CREDENTIALS_DIRECTORY` when
+the unit passes a credential named `rela-secrets-<project>`:
+
+```ini
+[Service]
+LoadCredentialEncrypted=rela-secrets-acme:/etc/rela/acme-secrets.cred
+```
+
+The credential holds the same YAML as `secrets.yaml`, so `smtp_password` goes in
+it alongside every other key. It is decrypted into a per-service tmpfs at mode
+`0400`, is not inherited by child processes, and can be TPM-bound. See
+[Lua scripting → systemd credentials](lua-scripting.md#systemd-credentials) for
+the full setup.
+
 **Or use an environment variable.** If your deployment injects credentials as
-environment variables — containers, systemd units — name the variable instead:
+environment variables — containers, or systemd units not using credentials —
+name the variable instead:
 
 ```yaml
 # .rela/mail.yaml
@@ -75,6 +93,10 @@ password_env: RELA_SMTP_PASSWORD
 ```
 
 `secrets.yaml` takes precedence when both are present.
+
+Note an environment variable is the weakest of the three: every process rela
+spawns inherits it, including the external converters that run for attachment
+processing and view exports. A systemd credential is not inherited.
 
 Either way, **the password never goes in `mail.yaml`**. Writing a literal
 `password:` key there is refused at load with an error pointing you at the

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -51,11 +51,18 @@ var (
 
 // CLI is the kong-parsed root.
 //
-// TODO(TKT-N0IKN9): CLI has 38 exported fields (kong binds one per subcommand,
+// TODO(TKT-N0IKN9): CLI has 47 exported fields (kong binds one per subcommand,
 // so growth is structural here) — over the 20-field load line. Revisit grouping
 // subcommands into sub-structs; ratchet this number down if/when that lands.
 //
-//plimsoll:max-fields=46
+// Raised 46 → 47 for `secrets` (TKT-RX7I97). Splitting was preferred per
+// CLAUDE.md and rejected: the field count is one-per-subcommand, so the only
+// way to shed fields is to nest EXISTING commands (the history/restore/purge
+// six are the obvious candidates), and that renames user-facing commands —
+// out of scope for a secrets-hygiene change. `secrets` is itself a sub-struct
+// holding its subcommand, so it adds one field rather than one per verb.
+//
+//plimsoll:max-fields=47
 type CLI struct {
 	// Global flags.
 	Project string `help:"Project directory (default: auto-detect from cwd)." env:"RELA_PROJECT"`
@@ -109,6 +116,7 @@ type CLI struct {
 	Scheduler            SchedulerCmd            `cmd:"" help:"Run scheduled Lua tasks."`
 	Renumber             RenumberCmd             `cmd:"" help:"Renumber managed order properties on orderable relations."`
 	Sync                 SyncCmd                 `cmd:"" help:"Sync local changes with a remote rela-server."`
+	Secrets              SecretsCmd              `cmd:"" help:"Inspect how project secrets are supplied."`
 }
 
 // VersionCmd needs no services.
@@ -230,7 +238,7 @@ func requiresProject(cmd string) bool {
 		"template", "create", "update", "delete", "link", "unlink",
 		"detach", "import", "normalize", "script", "scheduler",
 		"rename", "analyze", "acl", "attach", "attachments", "gc", "renumber",
-		"sync", "history", "restore",
+		"sync", "history", "restore", "secrets",
 		"relation-history", "relation-restore", "history-purge", "relation-history-purge":
 		return true
 	case "migrate":

--- a/internal/cli/secrets.go
+++ b/internal/cli/secrets.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
+)
+
+// SecretsCmd groups the secrets helpers.
+type SecretsCmd struct {
+	CredentialName SecretsCredentialNameCmd `cmd:"" name:"credential-name" help:"Print the systemd credential name for this project."`
+}
+
+// SecretsCredentialNameCmd prints the systemd credential name for the project.
+//
+// The name embeds a hash of the project's absolute path so two projects sharing
+// a directory name cannot resolve to one credential, which makes it something
+// an operator cannot derive by hand — hence this command. It writes the bare
+// name so it can be substituted straight into a unit file.
+type SecretsCredentialNameCmd struct{}
+
+// Run dispatches `rela secrets credential-name`.
+func (c *SecretsCredentialNameCmd) Run(svc *readServices) error {
+	name := secrets.CredentialName(svc.Paths.CacheDir)
+	if name == "" {
+		return fmt.Errorf("secrets: cannot derive a credential name for %q", svc.Paths.CacheDir)
+	}
+	fmt.Println(name)
+	return nil
+}

--- a/internal/cli/secrets_test.go
+++ b/internal/cli/secrets_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/secrets"
+)
+
+func TestSecretsCredentialNameCmd(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, project.CacheDir)
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	svc := &readServices{Paths: &project.Context{CacheDir: cacheDir}}
+
+	out, err := captureStdout(t, func() error {
+		cmd := &SecretsCredentialNameCmd{}
+		return cmd.Run(svc)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := strings.TrimSpace(out)
+	// The operator pastes this into a unit file, so it must equal exactly what
+	// the loader will look for — not merely resemble it.
+	if want := secrets.CredentialName(cacheDir); got != want {
+		t.Errorf("printed %q, but the loader looks for %q", got, want)
+	}
+	if !strings.HasPrefix(got, "rela-secrets-") {
+		t.Errorf("printed %q, want a rela-secrets- prefix", got)
+	}
+}
+
+func TestSecretsCredentialNameCmd_UnderivableIsAnError(t *testing.T) {
+	// A path that is not a <project>/.rela directory names no project. Printing
+	// an empty or invented name would send the operator to a unit-file line
+	// that can never match.
+	svc := &readServices{Paths: &project.Context{CacheDir: ""}}
+	cmd := &SecretsCredentialNameCmd{}
+	if err := cmd.Run(svc); err == nil {
+		t.Fatal("expected an error for an underivable credential name")
+	}
+}

--- a/internal/mail/config.go
+++ b/internal/mail/config.go
@@ -3,6 +3,7 @@ package mail
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -238,7 +239,21 @@ func (c *Config) hasPassword() bool {
 func (c *Config) resolvePassword() string {
 	// secrets.yaml first: it is where an operator keeps every other credential,
 	// so it is where they will look for this one.
-	if sec, err := secrets.Load(c.relaDir, ""); err == nil {
+	sec, err := secrets.Load(c.relaDir, "")
+	switch {
+	case errors.Is(err, secrets.ErrNotFound):
+		// No secrets configured at all — the ordinary case for a deployment
+		// using password_env. Fall through silently.
+	case err != nil:
+		// A malformed or unreadable secrets source is NOT the same as an
+		// absent one. Swallowing it here would send the caller on to
+		// password_env and, when that is unset, produce "password_env is
+		// empty or unset" — an error naming the wrong cause entirely. The
+		// send still falls back, because refusing to send mail over a
+		// secrets-file syntax error is worse than trying, but the real fault
+		// is on the record. The error names the path, never the contents.
+		slog.Warn("mail: secrets source unreadable, falling back to password_env", "error", err)
+	default:
 		if v := sec[SecretKey]; v != "" {
 			return v
 		}

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -1,9 +1,11 @@
 package mail_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -844,6 +846,57 @@ func TestOutbox_ConcurrentEnqueue(t *testing.T) {
 }
 
 // --- credential sources ------------------------------------------------------
+
+// TestConfig_MalformedSecretsFallsBackAndWarns pins the distinction between an
+// ABSENT secrets source and a BROKEN one. Both fall back to password_env so a
+// syntax error cannot stop mail entirely, but a broken source must leave a
+// record: without it the operator sees only "password_env is empty or unset",
+// which names the wrong cause and is a genuinely hard bug to chase when the
+// real fault is inside a TPM-encrypted credential they cannot easily read.
+func TestConfig_MalformedSecretsFallsBackAndWarns(t *testing.T) {
+	// No t.Parallel: t.Setenv and slog.SetDefault below.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secrets.yaml"),
+		[]byte("{{ this is not yaml\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, mail.ConfigFile),
+		[]byte("transport: smtp\nhost: h\nfrom: f@e.com\nusername: relay\npassword_env: RELA_TEST_SMTP_PW\n"), 0o600))
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg, err := mail.LoadConfig(dir)
+	require.NoError(t, err)
+
+	t.Setenv("RELA_TEST_SMTP_PW", "from-env")
+	require.Equal(t, "from-env", mail.ExportResolvePassword(cfg),
+		"a broken secrets source must still fall back to password_env")
+	require.Contains(t, buf.String(), "secrets source unreadable",
+		"a broken secrets source must be logged, not swallowed")
+	require.NotContains(t, buf.String(), "from-env", "the warning must not echo a credential")
+}
+
+// TestConfig_AbsentSecretsIsSilent is the counterpart: no secrets.yaml at all is
+// the ordinary password_env deployment and must not produce a warning.
+func TestConfig_AbsentSecretsIsSilent(t *testing.T) {
+	// No t.Parallel: t.Setenv and slog.SetDefault below.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, mail.ConfigFile),
+		[]byte("transport: smtp\nhost: h\nfrom: f@e.com\nusername: relay\npassword_env: RELA_TEST_SMTP_PW2\n"), 0o600))
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg, err := mail.LoadConfig(dir)
+	require.NoError(t, err)
+
+	t.Setenv("RELA_TEST_SMTP_PW2", "from-env")
+	require.Equal(t, "from-env", mail.ExportResolvePassword(cfg))
+	require.Empty(t, buf.String(), "an absent secrets source is not a fault")
+}
 
 // TestConfig_PasswordFromSecretsYAML covers the primary source: the SMTP
 // password lives beside every other credential an operator keeps, rather than

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -15,14 +15,32 @@
 //	    jira_api_key: sk-different-key
 //
 // The file lives in .rela/ which is gitignored by convention.
+//
+// # Sources
+//
+// Secrets come from one of two places, checked in order:
+//
+//  1. systemd's credentials directory, when the unit passed one for THIS
+//     project (see [CredentialName]). Preferred because those files live in a
+//     per-service tmpfs, are mode 0400 and owned by the service user, are not
+//     inherited by child processes, and may be encrypted at rest against the
+//     TPM via LoadCredentialEncrypted=.
+//  2. The project's .rela/secrets.yaml.
+//
+// The environment variable is only ever read as a DIRECTORY path; the file
+// name inside it is derived from rela's own constants and the project
+// directory, never from request input.
 package secrets
 
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -30,21 +48,58 @@ import (
 // ConfigFile is the name of the secrets file inside .rela/.
 const ConfigFile = "secrets.yaml"
 
-// ErrNotFound indicates that .rela/secrets.yaml does not exist.
+// credentialsDirEnv is the environment variable systemd sets for a unit using
+// LoadCredential= / LoadCredentialEncrypted=. systemd owns the directory and
+// its modes.
+const credentialsDirEnv = "CREDENTIALS_DIRECTORY"
+
+// ErrNotFound indicates that no secrets source exists for the project.
 var ErrNotFound = errors.New("secrets: no .rela/secrets.yaml")
 
-// Load reads .rela/secrets.yaml and returns the resolved secrets for
-// the given script path. Global values are merged with per-script
-// overrides (overrides take precedence).
+// warnedPaths records the secrets files already reported as over-permissive.
 //
-// Returns ErrNotFound (wrapped) when the file does not exist — callers
-// should treat this as "no secrets configured" and pass an empty map.
+// Keyed by path rather than a single [sync.Once] because one process can serve
+// several projects (appbuild.SharedBase assembles one Services per store), and
+// a process-wide latch would silence every project after the first. Load runs
+// per script execution and twice per mail send, so without this the warning
+// would repeat on every document render.
+var warnedPaths sync.Map
+
+// Load reads the project's secrets and returns the resolved values for the
+// given script path. Global values are merged with per-script overrides
+// (overrides take precedence).
+//
+// Returns ErrNotFound (wrapped) when no source exists — callers should treat
+// this as "no secrets configured" and pass an empty map.
 func Load(relaDir, scriptPath string) (map[string]string, error) {
 	raw, err := readFile(relaDir)
 	if err != nil {
 		return nil, err
 	}
 	return resolve(raw, scriptPath), nil
+}
+
+// CredentialName returns the systemd credential name that supplies secrets for
+// the project whose .rela directory is relaDir.
+//
+// The name is project-scoped ("rela-secrets-<project>") because
+// CREDENTIALS_DIRECTORY is process-global while secrets are per-project: a
+// single fixed name would hand one tenant's credential to every other project
+// in the same process. The project component is the name of the directory
+// CONTAINING .rela, which is what an operator sees as the project.
+//
+// Returns "" when relaDir is empty, which disables the credentials source.
+func CredentialName(relaDir string) string {
+	if relaDir == "" {
+		return ""
+	}
+	project := filepath.Base(filepath.Dir(filepath.Clean(relaDir)))
+	// Base can yield "." or a separator for degenerate inputs; those name no
+	// project, so there is nothing to scope a credential to.
+	if project == "." || project == string(filepath.Separator) {
+		return ""
+	}
+	return "rela-secrets-" + project
 }
 
 // rawConfig is the on-disk YAML structure. Top-level keys (except
@@ -55,8 +110,19 @@ type rawConfig struct {
 	Overrides map[string]map[string]string `yaml:"overrides"`
 }
 
+// readFile locates the active secrets source and parses it.
 func readFile(relaDir string) (*rawConfig, error) {
-	path := filepath.Join(relaDir, ConfigFile)
+	path, fromCredentials := sourcePath(relaDir)
+	if path == "" {
+		return nil, fmt.Errorf("%w", ErrNotFound)
+	}
+
+	// systemd owns the modes inside its credentials directory (0400 already),
+	// so only the operator-authored file is worth policing.
+	if !fromCredentials {
+		warnIfPermissive(path)
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -70,6 +136,83 @@ func readFile(relaDir string) (*rawConfig, error) {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 	return &raw, nil
+}
+
+// sourcePath picks the secrets file to read, reporting whether it came from the
+// systemd credentials directory.
+//
+// A credential is used only when it exists for THIS project; otherwise the
+// project file is used. systemd sets CREDENTIALS_DIRECTORY for any unit loading
+// any credential, so its mere presence says nothing about rela.
+//
+// Returns "" when neither source exists.
+func sourcePath(relaDir string) (path string, fromCredentials bool) {
+	if dir := os.Getenv(credentialsDirEnv); dir != "" {
+		if name := CredentialName(relaDir); name != "" {
+			// gosec flags the environment variable reaching a path. It is
+			// systemd-supplied, not request input, and the file name is
+			// rela's own constant plus the project directory — so there is
+			// no attacker-controlled component to traverse with.
+			candidate := filepath.Join(dir, name)
+			//nolint:gosec // G703: path is systemd-supplied config, not request input
+			if st, err := os.Stat(candidate); err == nil && st.Mode().IsRegular() {
+				return candidate, true
+			}
+		}
+	}
+	if relaDir == "" {
+		return "", false
+	}
+	return filepath.Join(relaDir, ConfigFile), false
+}
+
+// warnIfPermissive logs once per path when the secrets file is readable beyond
+// its owner.
+//
+// Advisory only: the file is operator-authored, and refusing to load it would
+// break working deployments on upgrade. Because nothing is granted or denied on
+// the result, the gap between this Stat and the later ReadFile is not a
+// security-relevant TOCTOU — an attacker who can swap the file already has
+// write access to it.
+//
+// Logs the path and mode only, never a key name or value.
+func warnIfPermissive(path string) {
+	// Windows reports synthetic permission bits, so the check would fire on a
+	// condition no operator can fix.
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		// Missing or unreadable is the read path's problem to report, with a
+		// better error than this advisory check could give.
+		return
+	}
+
+	perm := info.Mode().Perm()
+	if perm&0o077 == 0 {
+		return
+	}
+	if _, loaded := warnedPaths.LoadOrStore(path, struct{}{}); loaded {
+		return
+	}
+
+	slog.Warn("secrets: file is readable by other users",
+		"path", path,
+		"mode", fmt.Sprintf("%04o", perm),
+		"fix", "chmod 600 "+path)
+}
+
+// resetPermissionWarnings clears the warn-once cache.
+//
+// Test-only: package-level state would otherwise make warning assertions
+// depend on test execution order.
+func resetPermissionWarnings() {
+	warnedPaths.Range(func(k, _ any) bool {
+		warnedPaths.Delete(k)
+		return true
+	})
 }
 
 // resolve merges global secrets with per-script overrides.

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -33,6 +33,7 @@
 package secrets
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -41,6 +42,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"gopkg.in/yaml.v3"
 )
@@ -48,22 +50,48 @@ import (
 // ConfigFile is the name of the secrets file inside .rela/.
 const ConfigFile = "secrets.yaml"
 
+// cacheDirName is the project cache directory holding the secrets file.
+//
+// Duplicated from project.CacheDir rather than imported: internal/secrets is a
+// leaf in .go-arch-lint.yml with no declared dependencies, and depending on
+// internal/project to read one constant would invert that.
+const cacheDirName = ".rela"
+
 // credentialsDirEnv is the environment variable systemd sets for a unit using
 // LoadCredential= / LoadCredentialEncrypted=. systemd owns the directory and
 // its modes.
 const credentialsDirEnv = "CREDENTIALS_DIRECTORY"
 
 // ErrNotFound indicates that no secrets source exists for the project.
-var ErrNotFound = errors.New("secrets: no .rela/secrets.yaml")
+var ErrNotFound = errors.New("secrets: no secrets source (no .rela/secrets.yaml, no systemd credential)")
 
-// warnedPaths records the secrets files already reported as over-permissive.
+// warnedPaths records the (file, mode) pairs already reported as
+// over-permissive, and warnedCount bounds it.
 //
-// Keyed by path rather than a single [sync.Once] because one process can serve
-// several projects (appbuild.SharedBase assembles one Services per store), and
-// a process-wide latch would silence every project after the first. Load runs
-// per script execution and twice per mail send, so without this the warning
-// would repeat on every document render.
-var warnedPaths sync.Map
+// Keyed per entry rather than a single [sync.Once] because one process can
+// serve several projects (appbuild.SharedBase assembles one Services per
+// store), and a process-wide latch would silence every project after the first.
+// Load runs per script execution and twice per mail send, so without this the
+// warning would repeat on every document render.
+//
+// The cap keeps this from growing without bound: entries are never evicted, and
+// the key set is "projects this process has served" — a cardinality the package
+// does not control. Past the cap the warning is simply dropped, which is
+// acceptable for an advisory diagnostic and preferable to unbounded retention.
+var (
+	warnedPaths sync.Map
+	warnedCount atomic.Int64
+)
+
+// maxWarnedPaths caps the warn-once cache. Far above any realistic project
+// count, so a normal deployment never reaches it.
+const maxWarnedPaths = 1024
+
+// warnKey identifies one (file, mode) pair already reported.
+type warnKey struct {
+	path string
+	perm os.FileMode
+}
 
 // Load reads the project's secrets and returns the resolved values for the
 // given script path. Global values are merged with per-script overrides
@@ -82,24 +110,66 @@ func Load(relaDir, scriptPath string) (map[string]string, error) {
 // CredentialName returns the systemd credential name that supplies secrets for
 // the project whose .rela directory is relaDir.
 //
-// The name is project-scoped ("rela-secrets-<project>") because
-// CREDENTIALS_DIRECTORY is process-global while secrets are per-project: a
-// single fixed name would hand one tenant's credential to every other project
-// in the same process. The project component is the name of the directory
-// CONTAINING .rela, which is what an operator sees as the project.
+// The name is "rela-secrets-<project>-<hash>", where <project> is the directory
+// CONTAINING .rela and <hash> is the first 4 bytes of the SHA-256 of that
+// directory's ABSOLUTE path.
 //
-// Returns "" when relaDir is empty, which disables the credentials source.
+// # Why both halves are needed
+//
+// CREDENTIALS_DIRECTORY is process-global while secrets are per-project, so a
+// single fixed name would hand one tenant's credential to every other project
+// in the same process. The project component alone does not fix that: two
+// tenants laid out as /srv/a/proj and /srv/b/proj share a basename, and
+// "/srv/<tenant>/<project>" is exactly the layout appbuild.SharedBase exists to
+// serve. A basename-only name would silently serve one tenant's live
+// credentials to the other, failing OPEN. The path hash restores uniqueness;
+// the readable project component is kept so an operator can still recognize
+// which unit-file line belongs to which project.
+//
+// Print the name with `rela secrets credential-name` rather than deriving it by
+// hand.
+//
+// # Rejected inputs
+//
+// Returns "" — disabling the credentials source — when relaDir is empty, is not
+// a <project>/.rela path, or names no project (a bare ".rela", a filesystem
+// root, a path that walks upward). A caller passing something else is a bug,
+// and minting a credential name for it would let an unrelated file in the
+// credentials directory be adopted on the strength of a path artifact.
 func CredentialName(relaDir string) string {
 	if relaDir == "" {
 		return ""
 	}
-	project := filepath.Base(filepath.Dir(filepath.Clean(relaDir)))
-	// Base can yield "." or a separator for degenerate inputs; those name no
-	// project, so there is nothing to scope a credential to.
-	if project == "." || project == string(filepath.Separator) {
+	// Relative paths must be resolved before hashing: "proj/.rela" and
+	// "/srv/a/proj/.rela" would otherwise hash differently per working
+	// directory, or collide with each other.
+	abs, err := filepath.Abs(filepath.Clean(relaDir))
+	if err != nil {
 		return ""
 	}
-	return "rela-secrets-" + project
+	// Resolve symlinks too. project.Discover only calls filepath.Abs, so the
+	// same project reached through a symlinked parent (a /srv/current ->
+	// /srv/releases/N deploy layout) would otherwise hash to a DIFFERENT name
+	// than the one the operator printed — the credential would silently stop
+	// being found after a switchover. Best-effort: a path that does not exist
+	// yet keeps the unresolved form rather than losing the credential entirely.
+	if resolved, resErr := filepath.EvalSymlinks(abs); resErr == nil {
+		abs = resolved
+	}
+	// The last segment must actually be the cache directory. Accepting any
+	// path would return a credential name for a project that does not exist.
+	if filepath.Base(abs) != cacheDirName {
+		return ""
+	}
+
+	parent := filepath.Dir(abs)
+	project := filepath.Base(parent)
+	if project == "." || project == ".." || project == string(filepath.Separator) {
+		return ""
+	}
+
+	sum := sha256.Sum256([]byte(parent))
+	return fmt.Sprintf("rela-secrets-%s-%x", project, sum[:4])
 }
 
 // rawConfig is the on-disk YAML structure. Top-level keys (except
@@ -114,7 +184,7 @@ type rawConfig struct {
 func readFile(relaDir string) (*rawConfig, error) {
 	path, fromCredentials := sourcePath(relaDir)
 	if path == "" {
-		return nil, fmt.Errorf("%w", ErrNotFound)
+		return nil, ErrNotFound
 	}
 
 	// systemd owns the modes inside its credentials directory (0400 already),
@@ -126,7 +196,7 @@ func readFile(relaDir string) (*rawConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("%w", ErrNotFound)
+			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
@@ -145,7 +215,10 @@ func readFile(relaDir string) (*rawConfig, error) {
 // project file is used. systemd sets CREDENTIALS_DIRECTORY for any unit loading
 // any credential, so its mere presence says nothing about rela.
 //
-// Returns "" when neither source exists.
+// The returned project-file path is NOT checked for existence — that is
+// os.ReadFile's job, which distinguishes "absent" from "unreadable" with a
+// better error than a bool could. Returns "" only when there is no project
+// directory and no credential, i.e. nothing to read at all.
 func sourcePath(relaDir string) (path string, fromCredentials bool) {
 	if dir := os.Getenv(credentialsDirEnv); dir != "" {
 		if name := CredentialName(relaDir); name != "" {
@@ -194,7 +267,18 @@ func warnIfPermissive(path string) {
 	if perm&0o077 == 0 {
 		return
 	}
-	if _, loaded := warnedPaths.LoadOrStore(path, struct{}{}); loaded {
+	// Key on path AND mode: a file fixed to 0600 and later regressed to 0666
+	// must warn again, or the log would still name the mode it had the first
+	// time. A mode that simply stays wrong stays quiet.
+	if _, loaded := warnedPaths.LoadOrStore(warnKey{path: path, perm: perm}, struct{}{}); loaded {
+		return
+	}
+	// Count AFTER the store so each distinct entry is counted once. Racing
+	// goroutines may overshoot the cap slightly; the bound is to stop unbounded
+	// growth, not to be exact.
+	if warnedCount.Add(1) > maxWarnedPaths {
+		warnedPaths.Delete(warnKey{path: path, perm: perm})
+		warnedCount.Add(-1)
 		return
 	}
 
@@ -213,6 +297,7 @@ func resetPermissionWarnings() {
 		warnedPaths.Delete(k)
 		return true
 	})
+	warnedCount.Store(0)
 }
 
 // resolve merges global secrets with per-script overrides.

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -1,9 +1,13 @@
 package secrets
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -127,5 +131,364 @@ func writeYAML(t *testing.T, dir, content string) {
 	err := os.WriteFile(filepath.Join(dir, ConfigFile), []byte(content), 0600)
 	if err != nil {
 		t.Fatalf("write secrets.yaml: %v", err)
+	}
+}
+
+// --- Permission warning (TKT-RX7I97) ---
+
+// captureWarnings redirects slog to a buffer for the duration of the test and
+// clears the warn-once cache, which is package-level state that would
+// otherwise make these assertions depend on test execution order.
+func captureWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	resetPermissionWarnings()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() {
+		slog.SetDefault(prev)
+		resetPermissionWarnings()
+	})
+	return &buf
+}
+
+// writeMode writes a secrets file at an explicit mode, defeating umask.
+func writeMode(t *testing.T, dir, content string, mode os.FileMode) {
+	t.Helper()
+	path := filepath.Join(dir, ConfigFile)
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write secrets.yaml: %v", err)
+	}
+	// WriteFile applies umask, so set the mode explicitly.
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+}
+
+func TestLoad_WarnsOnPermissiveMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	for _, tc := range []struct {
+		name     string
+		mode     os.FileMode
+		wantWarn bool
+	}{
+		{"owner only", 0o600, false},
+		{"owner rw, group r", 0o640, true},
+		{"world readable", 0o644, true},
+		{"world writable", 0o666, true},
+		{"owner read only", 0o400, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := captureWarnings(t)
+			dir := t.TempDir()
+			writeMode(t, dir, "api_key: sk-abc123\n", tc.mode)
+
+			sec, err := Load(dir, "s.lua")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// The warning is advisory: secrets must still load.
+			if sec["api_key"] != "sk-abc123" {
+				t.Errorf("secrets not returned: got %q", sec["api_key"])
+			}
+
+			got := strings.Contains(buf.String(), "readable by other users")
+			if got != tc.wantWarn {
+				t.Errorf("warning present = %v, want %v (mode %04o)\nlog: %s",
+					got, tc.wantWarn, tc.mode, buf.String())
+			}
+		})
+	}
+}
+
+func TestLoad_WarningNeverEchoesSecrets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	buf := captureWarnings(t)
+	dir := t.TempDir()
+	writeMode(t, dir, "api_key: sk-super-secret\ntoken: tok-confidential\n", 0o644)
+
+	if _, err := Load(dir, "s.lua"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	log := buf.String()
+	if !strings.Contains(log, "readable by other users") {
+		t.Fatalf("expected a warning, got: %s", log)
+	}
+	// A log line that quoted the file would defeat the point of the check.
+	for _, leak := range []string{"sk-super-secret", "tok-confidential", "api_key", "token"} {
+		if strings.Contains(log, leak) {
+			t.Errorf("warning leaked %q into the log: %s", leak, log)
+		}
+	}
+}
+
+func TestLoad_WarnsOncePerPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	buf := captureWarnings(t)
+	dir := t.TempDir()
+	writeMode(t, dir, "api_key: sk-abc123\n", 0o644)
+
+	// Load runs per script execution and twice per mail send; a warning per
+	// call would spam a document-rendering server (RR-V1G22E).
+	for range 3 {
+		if _, err := Load(dir, "s.lua"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if n := strings.Count(buf.String(), "readable by other users"); n != 1 {
+		t.Errorf("warning count = %d, want 1\nlog: %s", n, buf.String())
+	}
+}
+
+func TestLoad_WarnsPerProjectNotGlobally(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	buf := captureWarnings(t)
+	// One process can serve several projects; a global latch would silence
+	// every project after the first.
+	dirA, dirB := t.TempDir(), t.TempDir()
+	writeMode(t, dirA, "api_key: a\n", 0o644)
+	writeMode(t, dirB, "api_key: b\n", 0o644)
+
+	for _, d := range []string{dirA, dirB} {
+		if _, err := Load(d, "s.lua"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if n := strings.Count(buf.String(), "readable by other users"); n != 2 {
+		t.Errorf("warning count = %d, want 2 (one per project)\nlog: %s", n, buf.String())
+	}
+}
+
+// --- systemd credentials directory (TKT-RX7I97) ---
+
+// writeCredential places a project-scoped credential in a fake systemd
+// credentials directory.
+func writeCredential(t *testing.T, credDir, relaDir, content string, mode os.FileMode) {
+	t.Helper()
+	name := CredentialName(relaDir)
+	if name == "" {
+		t.Fatalf("CredentialName(%q) is empty", relaDir)
+	}
+	path := filepath.Join(credDir, name)
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write credential: %v", err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod credential: %v", err)
+	}
+}
+
+// projectRelaDir builds a realistic <project>/.rela layout, which
+// CredentialName derives the project name from.
+func projectRelaDir(t *testing.T, project string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), project, ".rela")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return dir
+}
+
+func TestLoad_PrefersCredentialsDirectory(t *testing.T) {
+	captureWarnings(t)
+	relaDir := projectRelaDir(t, "acme")
+	credDir := t.TempDir()
+	t.Setenv(credentialsDirEnv, credDir)
+
+	// Distinct values prove which source won.
+	writeMode(t, relaDir, "api_key: from-project-file\n", 0o600)
+	writeCredential(t, credDir, relaDir, "api_key: from-systemd\n", 0o400)
+
+	sec, err := Load(relaDir, "s.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec["api_key"] != "from-systemd" {
+		t.Errorf("api_key = %q, want from-systemd", sec["api_key"])
+	}
+}
+
+func TestLoad_FallsBackWhenNoCredentialForProject(t *testing.T) {
+	captureWarnings(t)
+	relaDir := projectRelaDir(t, "acme")
+	credDir := t.TempDir()
+	// systemd sets the variable for ANY unit loading ANY credential, so an
+	// unrelated credential must not shadow the project file.
+	if err := os.WriteFile(filepath.Join(credDir, "unrelated-thing"), []byte("x: y\n"), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv(credentialsDirEnv, credDir)
+	writeMode(t, relaDir, "api_key: from-project-file\n", 0o600)
+
+	sec, err := Load(relaDir, "s.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec["api_key"] != "from-project-file" {
+		t.Errorf("api_key = %q, want from-project-file", sec["api_key"])
+	}
+}
+
+func TestLoad_CredentialsAreProjectScoped(t *testing.T) {
+	captureWarnings(t)
+	// The regression this guards: CREDENTIALS_DIRECTORY is process-global but
+	// secrets are per-project, so an unscoped lookup would serve one tenant's
+	// credential to every other project in the process (RR-Y2O7C6).
+	credDir := t.TempDir()
+	t.Setenv(credentialsDirEnv, credDir)
+
+	relaA := projectRelaDir(t, "alpha")
+	relaB := projectRelaDir(t, "beta")
+	writeCredential(t, credDir, relaA, "api_key: alpha-secret\n", 0o400)
+	writeCredential(t, credDir, relaB, "api_key: beta-secret\n", 0o400)
+
+	for _, tc := range []struct{ relaDir, want string }{
+		{relaA, "alpha-secret"},
+		{relaB, "beta-secret"},
+	} {
+		sec, err := Load(tc.relaDir, "s.lua")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sec["api_key"] != tc.want {
+			t.Errorf("api_key = %q, want %q — projects saw each other's secrets",
+				sec["api_key"], tc.want)
+		}
+	}
+}
+
+func TestLoad_NoPermissionWarningForCredentials(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	buf := captureWarnings(t)
+	relaDir := projectRelaDir(t, "acme")
+	credDir := t.TempDir()
+	t.Setenv(credentialsDirEnv, credDir)
+	// systemd owns these modes; policing them would be noise the operator
+	// cannot act on.
+	writeCredential(t, credDir, relaDir, "api_key: k\n", 0o644)
+
+	if _, err := Load(relaDir, "s.lua"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(buf.String(), "readable by other users") {
+		t.Errorf("warned about a systemd-owned credential: %s", buf.String())
+	}
+}
+
+func TestLoad_CredentialsDirectoryEdgeCases(t *testing.T) {
+	captureWarnings(t)
+	relaDir := projectRelaDir(t, "acme")
+	writeMode(t, relaDir, "api_key: from-project-file\n", 0o600)
+
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T)
+	}{
+		{"unset", func(t *testing.T) {
+			t.Helper()
+			// Genuinely absent, not set-to-empty: Getenv cannot tell them
+			// apart, but Unsetenv is what a non-systemd process actually sees.
+			t.Setenv(credentialsDirEnv, "")
+			if err := os.Unsetenv(credentialsDirEnv); err != nil {
+				t.Fatalf("unsetenv: %v", err)
+			}
+		}},
+		{"empty string", func(t *testing.T) {
+			t.Helper()
+			t.Setenv(credentialsDirEnv, "")
+		}},
+		{"nonexistent directory", func(t *testing.T) {
+			t.Helper()
+			t.Setenv(credentialsDirEnv, filepath.Join(t.TempDir(), "does-not-exist"))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup(t)
+			sec, err := Load(relaDir, "s.lua")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sec["api_key"] != "from-project-file" {
+				t.Errorf("api_key = %q, want from-project-file", sec["api_key"])
+			}
+		})
+	}
+}
+
+func TestLoad_CredentialsDirectoryIgnoresNonRegularFile(t *testing.T) {
+	captureWarnings(t)
+	relaDir := projectRelaDir(t, "acme")
+	credDir := t.TempDir()
+	t.Setenv(credentialsDirEnv, credDir)
+	writeMode(t, relaDir, "api_key: from-project-file\n", 0o600)
+
+	// A directory where the credential should be must not be read as YAML.
+	if err := os.MkdirAll(filepath.Join(credDir, CredentialName(relaDir)), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	sec, err := Load(relaDir, "s.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sec["api_key"] != "from-project-file" {
+		t.Errorf("api_key = %q, want from-project-file", sec["api_key"])
+	}
+}
+
+func TestLoad_InvalidYAMLInCredentialDoesNotFallBack(t *testing.T) {
+	captureWarnings(t)
+	relaDir := projectRelaDir(t, "acme")
+	credDir := t.TempDir()
+	t.Setenv(credentialsDirEnv, credDir)
+	// Falling back here would let a corrupt credential silently resolve to a
+	// stale project file, hiding the misconfiguration.
+	writeMode(t, relaDir, "api_key: from-project-file\n", 0o600)
+	writeCredential(t, credDir, relaDir, "{{invalid", 0o400)
+
+	if _, err := Load(relaDir, "s.lua"); err == nil {
+		t.Fatal("expected an error for invalid YAML in the credential")
+	}
+}
+
+func TestCredentialName(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		relaDir string
+		want    string
+	}{
+		{"typical project", filepath.Join(string(filepath.Separator), "srv", "acme", ".rela"), "rela-secrets-acme"},
+		{"trailing separator", filepath.Join(string(filepath.Separator), "srv", "acme", ".rela") + string(filepath.Separator), "rela-secrets-acme"},
+		{"empty disables the source", "", ""},
+		{"relative bare .rela", ".rela", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CredentialName(tc.relaDir); got != tc.want {
+				t.Errorf("CredentialName(%q) = %q, want %q", tc.relaDir, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoad_EmptyRelaDirWithoutCredentials(t *testing.T) {
+	captureWarnings(t)
+	t.Setenv(credentialsDirEnv, "")
+	// script.cacheDirFor passes "" for a zero-value deps; that must stay a
+	// clean ErrNotFound rather than reading the process's working directory.
+	if _, err := Load("", "s.lua"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -248,6 +249,42 @@ func TestLoad_WarnsOncePerPath(t *testing.T) {
 	}
 }
 
+func TestLoad_WarnsAgainWhenModeChanges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	buf := captureWarnings(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, ConfigFile)
+	writeMode(t, dir, "api_key: sk-abc123\n", 0o640)
+
+	if _, err := Load(dir, "s.lua"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Fixed, then regressed to something WORSE. Suppressing the second warning
+	// would leave the log naming 0640 while the file is world-writable.
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if _, err := Load(dir, "s.lua"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if _, err := Load(dir, "s.lua"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	log := buf.String()
+	if n := strings.Count(log, "readable by other users"); n != 2 {
+		t.Errorf("warning count = %d, want 2 (0640 then 0666)\nlog: %s", n, log)
+	}
+	if !strings.Contains(log, "0666") {
+		t.Errorf("the regressed mode was not reported\nlog: %s", log)
+	}
+}
+
 func TestLoad_WarnsPerProjectNotGlobally(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission bits are synthetic on Windows")
@@ -293,7 +330,14 @@ func writeCredential(t *testing.T, credDir, relaDir, content string, mode os.Fil
 // CredentialName derives the project name from.
 func projectRelaDir(t *testing.T, project string) string {
 	t.Helper()
-	dir := filepath.Join(t.TempDir(), project, ".rela")
+	return projectRelaDirUnder(t, t.TempDir(), project)
+}
+
+// projectRelaDirUnder builds <root>/<project>/.rela, so two projects can share
+// a basename under different roots.
+func projectRelaDirUnder(t *testing.T, root, project string) string {
+	t.Helper()
+	dir := filepath.Join(root, project, ".rela")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -365,6 +409,64 @@ func TestLoad_CredentialsAreProjectScoped(t *testing.T) {
 			t.Errorf("api_key = %q, want %q — projects saw each other's secrets",
 				sec["api_key"], tc.want)
 		}
+	}
+}
+
+func TestLoad_SameBasenameProjectsDoNotShareACredential(t *testing.T) {
+	captureWarnings(t)
+	// End-to-end form of TestCredentialName_DistinctProjectsSharingABasename:
+	// two tenants each with a project directory named "proj".
+	credDir := t.TempDir()
+	t.Setenv(credentialsDirEnv, credDir)
+
+	relaA := projectRelaDirUnder(t, t.TempDir(), "proj")
+	relaB := projectRelaDirUnder(t, t.TempDir(), "proj")
+
+	// Only tenant A has a credential; B must fall back to its own file rather
+	// than adopt A's secrets.
+	writeCredential(t, credDir, relaA, "api_key: tenant-a-secret\n", 0o400)
+	writeMode(t, relaB, "api_key: tenant-b-own-file\n", 0o600)
+
+	secA, err := Load(relaA, "s.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secA["api_key"] != "tenant-a-secret" {
+		t.Errorf("tenant A api_key = %q, want tenant-a-secret", secA["api_key"])
+	}
+
+	secB, err := Load(relaB, "s.lua")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secB["api_key"] != "tenant-b-own-file" {
+		t.Errorf("tenant B api_key = %q, want tenant-b-own-file — it received another tenant's credential",
+			secB["api_key"])
+	}
+}
+
+func TestLoad_ConcurrentLoadsWarnOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are synthetic on Windows")
+	}
+	buf := captureWarnings(t)
+	dir := t.TempDir()
+	writeMode(t, dir, "api_key: sk-abc123\n", 0o644)
+
+	// Emitting exactly one warning is the whole reason warnedPaths is a
+	// sync.Map; parallel script executions are the realistic caller.
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			if _, err := Load(dir, "s.lua"); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	if n := strings.Count(buf.String(), "readable by other users"); n != 1 {
+		t.Errorf("warning count = %d, want 1 under concurrency\nlog: %s", n, buf.String())
 	}
 }
 
@@ -465,21 +567,98 @@ func TestLoad_InvalidYAMLInCredentialDoesNotFallBack(t *testing.T) {
 }
 
 func TestCredentialName(t *testing.T) {
+	sep := string(filepath.Separator)
+
+	t.Run("names the project and is stable", func(t *testing.T) {
+		dir := filepath.Join(sep, "srv", "acme", ".rela")
+		got := CredentialName(dir)
+		if !strings.HasPrefix(got, "rela-secrets-acme-") {
+			t.Errorf("CredentialName(%q) = %q, want a rela-secrets-acme- prefix", dir, got)
+		}
+		// The operator writes this into a unit file; it must not move between
+		// runs or a working deployment would break on restart.
+		if again := CredentialName(dir); again != got {
+			t.Errorf("not stable: %q then %q", got, again)
+		}
+	})
+
+	t.Run("trailing separator is the same project", func(t *testing.T) {
+		base := filepath.Join(sep, "srv", "acme", ".rela")
+		if CredentialName(base) != CredentialName(base+sep) {
+			t.Error("a trailing separator changed the credential name")
+		}
+	})
+
+	t.Run("symlinked path resolves to the same name as its target", func(t *testing.T) {
+		// A /srv/current -> /srv/releases/N deploy layout must not change the
+		// credential name on switchover, or the credential silently stops
+		// being found.
+		root := t.TempDir()
+		target := filepath.Join(root, "real", "acme", ".rela")
+		if err := os.MkdirAll(target, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		link := filepath.Join(root, "link")
+		if err := os.Symlink(filepath.Join(root, "real"), link); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		viaLink := filepath.Join(link, "acme", ".rela")
+		if got, want := CredentialName(viaLink), CredentialName(target); got != want {
+			t.Errorf("via symlink %q != via target %q", got, want)
+		}
+	})
+
+	t.Run("relative path resolves to the same name as its absolute form", func(t *testing.T) {
+		// Otherwise the name would depend on the working directory.
+		root := t.TempDir()
+		abs := filepath.Join(root, "acme", ".rela")
+		if err := os.MkdirAll(abs, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		t.Chdir(root)
+		if got, want := CredentialName(filepath.Join("acme", ".rela")), CredentialName(abs); got != want {
+			t.Errorf("relative %q != absolute %q", got, want)
+		}
+	})
+
 	for _, tc := range []struct {
 		name    string
 		relaDir string
-		want    string
 	}{
-		{"typical project", filepath.Join(string(filepath.Separator), "srv", "acme", ".rela"), "rela-secrets-acme"},
-		{"trailing separator", filepath.Join(string(filepath.Separator), "srv", "acme", ".rela") + string(filepath.Separator), "rela-secrets-acme"},
-		{"empty disables the source", "", ""},
-		{"relative bare .rela", ".rela", ""},
+		{"empty disables the source", ""},
+		{"filesystem root", filepath.Join(sep, ".rela")},
+		{"not a .rela directory", filepath.Join(sep, "srv", "acme")},
+		{"deep path that is not a project", filepath.Join(sep, "some", "deep", "path")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := CredentialName(tc.relaDir); got != tc.want {
-				t.Errorf("CredentialName(%q) = %q, want %q", tc.relaDir, got, tc.want)
+			if got := CredentialName(tc.relaDir); got != "" {
+				t.Errorf("CredentialName(%q) = %q, want \"\" (source disabled)", tc.relaDir, got)
 			}
 		})
+	}
+}
+
+// TestCredentialName_DistinctProjectsSharingABasename guards the cross-tenant
+// leak: /srv/a/proj and /srv/b/proj are different projects, and
+// "/srv/<tenant>/<project>" is the layout appbuild.SharedBase serves. A
+// basename-only name would give both the same credential, failing OPEN — one
+// tenant would receive the other's live secrets.
+func TestCredentialName_DistinctProjectsSharingABasename(t *testing.T) {
+	sep := string(filepath.Separator)
+	a := CredentialName(filepath.Join(sep, "srv", "tenant-a", "proj", ".rela"))
+	b := CredentialName(filepath.Join(sep, "srv", "tenant-b", "proj", ".rela"))
+
+	if a == "" || b == "" {
+		t.Fatalf("expected names for both projects, got %q and %q", a, b)
+	}
+	if a == b {
+		t.Fatalf("distinct projects collided on %q — one tenant would receive the other's secrets", a)
+	}
+	// Both should still be recognizable to the operator.
+	for _, got := range []string{a, b} {
+		if !strings.HasPrefix(got, "rela-secrets-proj-") {
+			t.Errorf("%q lost the readable project component", got)
+		}
 	}
 }
 

--- a/tickets/entities/docs-checklists/DOCS-M0SVP6.md
+++ b/tickets/entities/docs-checklists/DOCS-M0SVP6.md
@@ -1,0 +1,75 @@
+---
+id: DOCS-M0SVP6
+type: docs-checklist
+title: 'Docs: Secrets hygiene: enforce 0600 on .rela/secrets.yaml and support systemd LoadCredentialEncrypted'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Godoc on new exported symbols
+- [x] Rationale captured where a decision is non-obvious
+
+`CredentialName` is the one new exported symbol. Its godoc states the name
+format, why *both* halves are needed (a "# Why both halves are needed" section
+naming the fail-open cross-tenant leak a basename-only name would cause), which
+inputs are rejected and why, and points at `rela secrets credential-name`
+instead of hand-derivation.
+
+The package doc gained a "# Sources" section listing the two sources in
+precedence order and why the systemd one is preferred (per-service tmpfs, 0400,
+not inherited by children, TPM-bindable).
+
+Unexported but load-bearing rationale is also recorded: `warnIfPermissive`
+documents why the Stat/ReadFile TOCTOU is not security-relevant here (the check
+gates nothing), why it warns rather than refuses, and why Windows is skipped;
+`warnedPaths` documents the per-entry keying and the cap; `cacheDirName`
+documents why the constant is duplicated rather than imported from
+`internal/project` (arch-lint leaf rule).
+
+## Project Documentation
+
+- [x] `docs/lua-scripting.md` updated
+- [x] `docs/mail.md` updated
+- [x] ~~`docs/metamodel.md`~~ (N/A: no metamodel change)
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no such file in this repo — CLI help is
+generated from kong tags, and the new command carries its own `help:`)
+- [x] ~~`docs/data-entry.md`~~ (N/A: no UI change)
+- [x] ~~`CLAUDE.md`~~ (N/A: introduces no new pattern or convention; it follows
+the existing `slog.Warn`-for-degraded-config and leaf-package rules)
+- [x] ~~`README.md`~~ (N/A: no project-level change)
+
+`docs/lua-scripting.md` — the Secrets section now covers file permissions
+(`chmod 700 .rela` **and** `chmod 600 .rela/secrets.yaml`, with the reason both
+matter and an explicit statement that rela checks only the file), and gained a
+"systemd credentials" subsection: how to get the name, `systemd-creds encrypt`,
+the unit-file line, why it beats a plaintext file or an env var, and the note
+that the name changes if the project directory moves.
+
+`docs/mail.md` — the same permission correction in short form, plus a pointer to
+the systemd section, and an explicit statement that `password_env` is the
+weakest of the three because every spawned process inherits it.
+
+## External Documentation
+
+- [x] ~~Changelog~~ (N/A: not maintained in this repo)
+- [x] ~~Migration notes~~ (N/A: purely additive — an existing
+`.rela/secrets.yaml` keeps working unchanged. The only new user-visible
+behaviour is a warning on an over-permissive file, which is advisory and does
+not fail the load.)
+
+## Accuracy
+
+- [x] Examples were run, not written from memory
+
+The `chmod`/warning behaviour and the credential precedence were exercised
+end-to-end and the actual output is quoted in the implementation checklist. The
+`rela secrets credential-name` example output was taken from a real run against
+this repo's `tickets/` project and verified to equal what the loader derives.
+
+**One example is NOT verified:** the `systemd-creds encrypt` command and the
+`LoadCredentialEncrypted=` unit-file line. No systemd on this machine, so those
+two lines come from systemd's documentation. Flagged on the ticket and in the
+review checklist for validation on a Linux host.

--- a/tickets/entities/implementation-checklists/IMPL-WBKVF3.md
+++ b/tickets/entities/implementation-checklists/IMPL-WBKVF3.md
@@ -1,0 +1,105 @@
+---
+id: IMPL-WBKVF3
+type: implementation-checklist
+title: 'Implementation: Secrets hygiene: enforce 0600 on .rela/secrets.yaml and support systemd LoadCredentialEncrypted'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Helpers added: `captureWarnings` (slog capture + warn-cache reset via
+`t.Cleanup`), `writeMode` (explicit chmod, defeating umask), `writeCredential`
+and `projectRelaDir` (realistic `<project>/.rela` layout, since `CredentialName`
+derives the project from the parent directory). Credential filenames come from
+`CredentialName(relaDir)` rather than a hardcoded string, so the tests cannot
+drift from the implementation's naming.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Ran a temporary end-to-end program against a real `/tmp/relaverify/acme/.rela`
+layout (removed afterwards):
+
+```
+--- 1) world-readable project file: expect a WARN ---
+WARN secrets: file is readable by other users
+  path=/tmp/relaverify/acme/.rela/secrets.yaml mode=0644
+  fix="chmod 600 /tmp/relaverify/acme/.rela/secrets.yaml"
+   loaded: map[demo_key:from-project-file] err=<nil>
+--- 2) second load of same path: NO further warning ---   (none emitted)
+--- 3) systemd credential for this project wins ---
+   credential name: rela-secrets-acme
+   loaded: map[demo_key:from-systemd]
+--- 4) unrelated credential present: falls back to project file ---
+   loaded: map[demo_key:from-project-file]
+```
+
+Confirms AC1 (warn + still loads), AC3 (credential wins), AC4 (unrelated
+credential does not shadow), AC6 (warn-once).
+
+Automated checks:
+- `go test ./...` — full suite green
+- `go test -race ./internal/{secrets,lua,mail,script}/...` — clean (the
+warn-once cache is shared mutable state, so the race detector matters here)
+- `just lint` — clean (9 findings fixed, none suppressed except one documented
+gosec G703 `//nolint`; see Quality below)
+- `just arch-lint` — OK, no warnings
+- `just comment-lint` — clean across 11,077 comments
+- `just plimsoll` — clean
+- Coverage: `internal/secrets` at **96.1%** (floor is the default 50)
+
+**Not verified:** systemd itself. This is a macOS box with no `systemd-creds`,
+so `LoadCredentialEncrypted=` was exercised by simulating the contract
+(`CREDENTIALS_DIRECTORY` + a file named `rela-secrets-<project>`) rather than by
+a real unit. The rela-side code is a plain env-var + directory read, but the
+unit-file syntax in the docs is from documentation, not a live run. Flagged on
+the ticket for validation on a Linux host.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Patterns followed: `slog.Warn` for degraded-but-working config matches
+`internal/appbuild/mail.go:47`. `internal/secrets` stays a stdlib-only leaf
+(`log/slog`, `sync`, `runtime` are stdlib), so `.go-arch-lint.yml` needed no
+change.
+
+Security notes:
+- The warning logs path + octal mode only. `TestLoad_WarningNeverEchoesSecrets`
+asserts no key name or value reaches the log.
+- One `//nolint:gosec` on the `os.Stat` of the credentials path (G703, path
+traversal via taint analysis). Read before suppressing: the taint source is
+`CREDENTIALS_DIRECTORY`, which is systemd-supplied, and the filename is rela's
+own constant plus the project directory — no request-controlled component. The
+comment states this at the site.
+- The `Stat`-then-`ReadFile` TOCTOU shape is documented as deliberate: the
+check is advisory logging, gating nothing.
+
+Scratch file `zz_manual_verify_test.go` was used for the evidence above and
+deleted; `git status` confirms only the four intended files are modified.

--- a/tickets/entities/planning-checklists/PLAN-YJVG3F.md
+++ b/tickets/entities/planning-checklists/PLAN-YJVG3F.md
@@ -1,0 +1,255 @@
+---
+id: PLAN-YJVG3F
+type: planning-checklist
+title: 'Planning: Secrets hygiene: enforce 0600 on .rela/secrets.yaml and support systemd LoadCredentialEncrypted'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN:
+1. Warn (not refuse) when `.rela/secrets.yaml` is group- or world-readable.
+2. Read `$CREDENTIALS_DIRECTORY` (systemd `LoadCredentialEncrypted=`) as a
+secrets source, **scoped per project** (see RR-Y2O7C6).
+3. Document both in `docs/lua-scripting.md` and `docs/mail.md`.
+
+OUT:
+- Encrypting `secrets.yaml` at rest (sops/age) — rejected on the ticket.
+- macOS Keychain backend.
+- Refusing to load a permissive file (warn only; failing closed would break
+working deployments on upgrade).
+- Changing `.rela/` from 0755 — it holds cache/index files that are not
+secret, and tightening it is a separate blast radius.
+
+**Acceptance Criteria:**
+
+1. A `secrets.yaml` with mode 0644 logs exactly one `slog.Warn` naming the path
+and the mode; `Load` still returns the secrets.
+2. A `secrets.yaml` with mode 0600 logs nothing.
+3. With `CREDENTIALS_DIRECTORY` set and a matching credential file inside,
+`Load` reads from there and ignores the project file.
+4. With `CREDENTIALS_DIRECTORY` set but no matching file inside, `Load` falls
+back to the project file (systemd sets the var for any unit using
+`LoadCredential*`, including units loading unrelated credentials).
+5. The permission warning is skipped for the credentials directory (systemd
+owns those modes; 0400 is already correct and not ours to police).
+6. Repeated `Load` calls against the same permissive path warn **once**, not
+once per call (RR-V1G22E).
+7. Two different projects in one process with one `CREDENTIALS_DIRECTORY` do
+**not** receive each other's secrets (RR-Y2O7C6).
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — small change; the investigation is recorded on the
+ticket body.
+
+**Existing Solutions:**
+
+- **sops** (`github.com/getsops/sops/v3`; the `go.mozilla.org/sops` path is dead
+— the module declares the getsops path and Go refuses the old one). Rejected:
+links all five KMS backends unconditionally (139 modules, ~58 MB, roughly
+doubling the binary), and the ENV-key deployment model is not an improvement.
+- **filippo.io/age** (5 modules, +1.2 MB). Rejected for *this* ticket: whole-file
+encryption whose key still has to live somewhere local. Already adopted for repo
+data encryption — see DEC-D5P4X / [[repo-encryption]], whose threat model
+explicitly names "subprocess inheritance of `$RELA_KEY_FILE`" as a reason to
+prefer a key file over an env var. Same reasoning drives this ticket.
+- **systemd credentials** (`LoadCredentialEncrypted=`): per-service tmpfs,
+mode 0400, service-user-owned, NOT inherited by child processes, keys optionally
+TPM2-backed. No dependency — it is an env var and a directory.
+- Codebase prior art: `slog.Warn` for degraded-but-working config is the
+established pattern (`internal/appbuild/mail.go:47`,
+`internal/appbuild/appbuild_fs.go:92`).
+
+**Verified during design review:**
+- `os/exec` inheritance: `internal/cmdexec/cmdexec.go:264` never sets `ec.Env`,
+so children inherit the full parent environment. Reproduced with a standalone
+program — a child `sh -c` printed a parent-set variable. This is what makes the
+credentials-directory source materially better than `password_env`.
+- Mode bitmask: `mode.Perm()&0o077` is nonzero for 0644 (0044) and 0640 (0040),
+zero for 0600. Verified by running it.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+`readFile` in `internal/secrets/secrets.go` already isolates "where the bytes
+come from" from "how they are parsed". Both changes land there, so the two
+callers (`internal/lua/context.go:35`, `internal/mail/config.go:241`) are
+untouched.
+
+1. **Source selection, project-scoped.** If `CREDENTIALS_DIRECTORY` is set AND
+contains a credential file for *this project*, use it; else the project
+`.rela/`. The credential filename is derived from the project so a
+process-global directory cannot serve one tenant's secrets to another
+(RR-Y2O7C6). Absent that file, fall back silently.
+2. **Permission warning, de-duplicated.** `os.Stat` the chosen path; if
+`mode.Perm()&0o077 != 0`, emit one `slog.Warn` with the path, octal mode, and
+the fixing command. Suppressed after the first observation of a given path via a
+package-level `sync.Map` (RR-V1G22E), with an unexported reset hook for tests
+(RR-8Z97UM). Skipped for the credentials directory.
+
+`internal/secrets` is a leaf with no `deps` entry in `.go-arch-lint.yml`, so it
+stays stdlib-only. `log/slog` and `sync` are stdlib; no new dependency and no
+arch-lint change.
+
+Windows is a no-op case: Go reports synthetic modes there, so gate the check on
+`runtime.GOOS != "windows"` to avoid a warning nobody can act on.
+
+**Files to modify:**
+- `internal/secrets/secrets.go` — source selection + permission check
+- `internal/secrets/secrets_test.go` — new tests
+- `docs/lua-scripting.md` — secrets Configuration section
+- `docs/mail.md` — systemd guidance beside the existing `password_env` text
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- `CREDENTIALS_DIRECTORY` — set by systemd, trusted to the same degree as the
+process environment generally (anything that can set it can already set
+`LD_PRELOAD`). Used as a directory path only; the filename is derived from our
+own constant plus the project identity, never from request input, so there is no
+traversal vector. Absent file → fall back, not fail.
+- `secrets.yaml` contents — unchanged; still operator-authored YAML.
+
+**Security-Sensitive Operations:**
+
+- **The warning must never echo a secret.** It logs the path and the octal mode
+only — no key names, no values. Existing `Load` errors already wrap the path and
+not the content; that stays.
+- **No mode-fixing.** `Chmod`-ing the operator's file on read would be a
+surprising side effect from a read path, and would mask the misconfiguration
+rather than surfacing it.
+- **TOCTOU considered and dismissed.** The `Stat`-then-`ReadFile` pair is a
+classic TOCTOU shape, but the check is *advisory logging*, not an access
+decision — nothing is granted or denied on its result. An attacker who can swap
+the file between the two calls already has write access to the secrets file,
+which is game over independently. Explicitly NOT worth an `O_NOFOLLOW`
+/`Fstat`-on-handle rewrite here; that would be justified only if the check ever
+gates access.
+- Note the *real* win is the credentials directory: `password_env` puts a
+credential in the environment, which `internal/cmdexec` children provably
+inherit (verified above). Credentials-directory secrets are not inherited.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+Warning assertions capture `slog` output via a
+`slog.New(slog.NewTextHandler(&buf, ...))` installed with `slog.SetDefault` and
+restored by `t.Cleanup`. Every such test also calls the warn-cache reset hook in
+`t.Cleanup`. **No `t.Parallel()` in tests using `t.Setenv`** — the runtime
+panics on that pair (RR-8Z97UM).
+
+1. AC1 — 0644 file → exactly one warn, secrets still returned.
+2. AC2 — 0600 file → no warn.
+3. AC3 — `CREDENTIALS_DIRECTORY` with a matching file → values come from it; a
+deliberately different value in the project file proves precedence.
+4. AC4 — `CREDENTIALS_DIRECTORY` set, no matching file → project file used.
+5. AC5 — credentials-dir file at 0644 → no warn.
+6. AC6 — three consecutive `Load` calls on one permissive path → exactly one
+warn line.
+7. AC7 — two distinct relaDirs + one `CREDENTIALS_DIRECTORY` → each project
+gets its own secrets, neither sees the other's.
+
+**Edge Cases:**
+
+- `CREDENTIALS_DIRECTORY` set to empty string → treat as unset.
+- `CREDENTIALS_DIRECTORY` pointing at a nonexistent dir → fall back, no error.
+- Neither source exists → `ErrNotFound` as today (regression-guarded by the
+existing `TestLoad_FileNotFound`).
+- Symlinked secrets.yaml → `os.Stat` follows the link and reports the target's
+mode, which is the mode that matters.
+- `Stat` fails but `ReadFile` succeeds (race, or unreadable dir) → skip the
+warning, do not fail the load.
+- Windows → check skipped.
+
+**Negative Tests:**
+
+- Invalid YAML in the credentials dir must error, not silently fall back to the
+project file — a fallback there would let a corrupt credential mask a working
+file and produce confusing behaviour.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Warning fatigue.* `secrets.Load` runs per script execution and twice per mail
+send — far more often than the original plan assumed (RR-V1G22E). Mitigated by
+per-path warn-once, so a document-rendering server emits one line, not one per
+render.
+- *Cross-tenant secret bleed.* A process-global credentials directory served to
+every project would hand one tenant another's secrets (RR-Y2O7C6). Mitigated by
+project-scoping the credential filename.
+- *Refusing would be safer but breaks deployments.* Chose warn; recorded as out
+of scope rather than forgotten.
+- *systemd behaviour unverified on this machine.* macOS dev box, no systemd. The
+`$CREDENTIALS_DIRECTORY` contract is documented behaviour, and the code path is
+a plain env-var + directory read that is fully unit-testable without systemd.
+Docs will not claim a TPM2-backed setup was tested end-to-end.
+- *Coverage floor.* `internal/secrets` has no override in `.testcoverage.yml`, so
+it sits at the default 50. New error branches need tests (RR-8Z97UM).
+
+**Effort:** s
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] `docs/lua-scripting.md` — secrets Configuration section: file permissions
+and the credentials-directory source
+- [x] `docs/mail.md` — systemd `LoadCredentialEncrypted=` beside the existing
+`password_env` guidance, noting why it is preferable
+- [ ] N/A for metamodel.md / cli-reference.md / data-entry.md / CLAUDE.md /
+README.md — no metamodel, command, UI, convention, or project-level change
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+- RR-V1G22E (significant) — warning fires per script execution / twice per mail
+send; needs per-path warn-once. Plan updated.
+- RR-Y2O7C6 (significant) — process-global `CREDENTIALS_DIRECTORY` would leak
+secrets across tenants; needs project-scoped credential naming. Plan updated.
+- RR-8Z97UM (minor) — warn cache is global mutable state; needs a test reset
+hook, and `t.Setenv` forbids `t.Parallel`. Plan updated.

--- a/tickets/entities/planning-checklists/PLAN-YJVG3F.md
+++ b/tickets/entities/planning-checklists/PLAN-YJVG3F.md
@@ -238,8 +238,10 @@ For enhancements: identify what documentation needs updating.
 and the credentials-directory source
 - [x] `docs/mail.md` — systemd `LoadCredentialEncrypted=` beside the existing
 `password_env` guidance, noting why it is preferable
-- [ ] N/A for metamodel.md / cli-reference.md / data-entry.md / CLAUDE.md /
-README.md — no metamodel, command, UI, convention, or project-level change
+- [x] ~~metamodel.md / cli-reference.md / data-entry.md / CLAUDE.md /
+README.md~~ (N/A: no metamodel, UI, convention, or project-level change. The
+`rela secrets credential-name` command added during implementation carries its
+own kong `help:` text, and this repo has no cli-reference.md.)
 
 ## Design Review
 

--- a/tickets/entities/review-checklists/REV-BQL197.md
+++ b/tickets/entities/review-checklists/REV-BQL197.md
@@ -2,82 +2,140 @@
 id: REV-BQL197
 type: review-checklist
 title: 'Review: Secrets hygiene: enforce 0600 on .rela/secrets.yaml and support systemd LoadCredentialEncrypted'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Comment lint gate clean (`just comment-lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
 
-**Comment findings.** `just comment-report` lists the advisory rules
-(duplication, nil-contract, param-contract, restatement). They are not a merge
-gate, but a finding your diff *introduces* should be fixed or suppressed — don't
-grow the backlog.
+Results on the final commit:
 
-Every rule is a heuristic over prose, so false positives are expected. To
-suppress one, prefer the inline form on the declaration line, which travels with
-the code and is reviewed in this diff:
+- `go test ./...` — green; `-race` green on secrets/mail/cli/lua/script
+- `just lint` — clean. 12 findings were raised and **fixed, not suppressed**
+(gosec, nolintlint, perfsprint, thelper ×3, unparam, gocritic ×2, modernize,
+misspell, revive redefines-builtin-id). One `//nolint:gosec` survives and was
+verified load-bearing by deleting it and re-running: G703 does fire on that
+line.
+- `just comment-lint` — clean across 11,090 comments
+- `just arch-lint` — OK (needed a rule change; see below)
+- `just plimsoll` — clean (needed a pin bump; see below)
+- `just coverage-check` — **PASS**: package floor 50% satisfied, total
+threshold 65% satisfied, total 78.3%. `internal/secrets` 90.8%, `internal/mail`
+92.6%, `internal/cli` 37.9% against its floor of 30.
 
-```go
-func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
-```
-
-Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
-same prose recurs across many sites. A reason is required either way — an
-unexplained suppression is a finding nobody can re-evaluate later.
+Two config changes, both deliberate and annotated at the site:
+- `.go-arch-lint.yml` grants `cli → secrets`. The allowlist was previously only
+`mail` and `lua` — packages that read secret *values*. `rela secrets
+credential-name` reads none; it derives a name. Rationale recorded in the file.
+- `internal/cli/kong.go` plimsoll pin 46 → 47. CLAUDE.md prefers splitting to
+raising, and that was considered: kong binds one field per subcommand, so
+shedding fields means nesting *existing* commands (history/restore/purge), which
+renames user-facing commands — out of scope here. `SecretsCmd` is itself a
+sub-struct, so it costs one field rather than one per verb.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+
+Design review (before implementation):
+- RR-V1G22E (significant) — warning fired per script execution / twice per mail
+send. Fixed: per-path warn-once.
+- RR-Y2O7C6 (significant) — process-global `CREDENTIALS_DIRECTORY` leaked across
+tenants. Fixed: project-scoped credential name.
+- RR-8Z97UM (minor) — global warn cache leaks between tests. Fixed: reset hook.
+
+Code review (cranky-code-reviewer) and self-review:
+- **RR-IB0LVR (critical)** — `CredentialName` collided on basename, a fail-open
+cross-tenant secret leak, and the doc comment asserted the property it lacked.
+Fixed: hash of the resolved absolute path + `rela secrets credential-name`.
+- **RR-MHW4HZ (significant)** — the path hash then broke symlink-swap deploys
+(`/srv/current` → `/srv/releases/N`), silently orphaning the credential. Found
+by testing against a symlinked layout. Fixed: `filepath.EvalSymlinks`.
+- **RR-WEKA7E (significant)** — mail's `err == nil` swallowed the new
+corrupt-credential error and reported "password_env is empty or unset", naming
+the wrong cause. Fixed: three-way switch + warning; two new tests.
+- **RR-6DAEXY (significant)** — warn cache never re-warned after a mode
+regression and grew unbounded. Fixed: `(path, mode)` key, capped at 1024.
+- RR-MVKA2W (minor) — `CredentialName("../.rela")` returned `rela-secrets-..`.
+- RR-DAXMUE (minor) — docs gave incomplete `chmod` advice; `.rela` is 0755.
+- RR-9FQLT8 (minor) — stale `ErrNotFound` message, no-op `%w`, and a
+`sourcePath` comment that misdescribed the code.
+
+One reviewer suggestion was **declined with reasoning** rather than silently
+dropped: replacing the `runtime.GOOS == "windows"` branch with a build-tagged
+file pair. Correct that the repo uses build tags heavily, but a two-file split
+to save one comparison on a cold path costs more in navigability than it
+returns. Recorded on RR-9FQLT8.
+
+Diff self-review: 8 files, all in scope. No unrelated changes, no debug code, no
+leftover scratch files (`zz_manual_verify_test.go` was used for manual evidence
+and deleted; `git status` is clean apart from the intended files).
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+1. 0644 file logs exactly one warn, still loads — **PASS**
+(`TestLoad_WarnsOnPermissiveMode`, manual run showed the warning with a `chmod
+600` fix hint)
+2. 0600 file logs nothing — **PASS** (same table; also covers 0400, 0640, 0666)
+3. Credential for the project wins over the project file — **PASS**
+(`TestLoad_PrefersCredentialsDirectory`; manual run confirmed)
+4. Credentials dir present but no matching file → project file — **PASS**
+(`TestLoad_FallsBackWhenNoCredentialForProject`, with an *unrelated* credential
+present, which is the realistic systemd case)
+5. No permission warning for credentials-dir files — **PASS**
+(`TestLoad_NoPermissionWarningForCredentials`)
+6. Repeated loads warn once — **PASS** (`TestLoad_WarnsOncePerPath`, plus
+`TestLoad_ConcurrentLoadsWarnOnce` under `-race`)
+7. Two projects in one process don't cross-read — **PASS**
+(`TestLoad_CredentialsAreProjectScoped`, and the harder
+`TestLoad_SameBasenameProjectsDoNotShareACredential`)
+
+Added beyond the original criteria, from review: mode-change re-warning, the
+symlink-stability case, credential-name derivation properties, and the mail
+absent-vs-broken distinction.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** see `has-docs` link.
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+The one TODO touched is the pre-existing `TODO(TKT-N0IKN9)` on the `CLI` struct;
+its field count was updated and the pin bump explained rather than left to be
+rediscovered.
+
+**Known limitation, deliberately not closed:** systemd itself was never
+exercised. This is a macOS box with no `systemd-creds`, so the
+`$CREDENTIALS_DIRECTORY` contract was simulated. The rela-side logic is a plain
+env-var + directory read and is fully unit-tested, but the unit-file syntax in
+the docs comes from documentation, not a live run. Recorded on the ticket for
+validation on a Linux host before anyone relies on the
+`LoadCredentialEncrypted=` examples verbatim.
 
 ## Pull Request
 
 - [ ] Run `/pr` command to create PR and monitor CI
-
-<!--
-Deliberately NOT tracked here: the PR URL and whether CI passed.
-
-Both post-date this checklist. `/pr` requires the ticket to be `done` and
-validating clean before it opens the PR, and a `done` review-checklist may have
-no unchecked items — so an item asking for the PR URL can only be satisfied by a
-PR that does not exist yet. Checking it early would mean asserting "CI passed"
-before CI ran, which turns the checklist from evidence into a formality.
-
-GitHub records both authoritatively, and the branch and commit messages carry
-the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
-here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-BQL197.md
+++ b/tickets/entities/review-checklists/REV-BQL197.md
@@ -138,4 +138,18 @@ validation on a Linux host before anyone relies on the
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M.
+-->

--- a/tickets/entities/review-checklists/REV-BQL197.md
+++ b/tickets/entities/review-checklists/REV-BQL197.md
@@ -1,0 +1,83 @@
+---
+id: REV-BQL197
+type: review-checklist
+title: 'Review: Secrets hygiene: enforce 0600 on .rela/secrets.yaml and support systemd LoadCredentialEncrypted'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-6DAEXY.md
+++ b/tickets/entities/review-responses/RR-6DAEXY.md
@@ -9,6 +9,7 @@ finding: |-
 
     (2) The sync.Map never evicts. In the SharedBase multi-tenant case it retains one entry per project path forever, keyed by a value whose cardinality the package does not control. Small, but it is the shape of leak that matters later — and keying on (path, mode) to fix (1) makes it marginally worse.
 severity: significant
+resolution: '(1) The cache key is now a warnKey{path, perm} struct rather than the path alone, so a changed mode warns again while a stable wrong mode stays quiet. Pinned by TestLoad_WarnsAgainWhenModeChanges, which walks 0640 -> 0600 -> 0666 and asserts two warnings with the second naming 0666. (2) The map is bounded at maxWarnedPaths = 1024, tracked with an atomic.Int64; past the cap the entry is rolled back and the warning dropped, which is acceptable for an advisory diagnostic. Concurrency was confirmed rather than assumed: TestLoad_ConcurrentLoadsWarnOnce fires 16 concurrent Loads at one permissive file and asserts exactly one warning under -race.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-6DAEXY.md
+++ b/tickets/entities/review-responses/RR-6DAEXY.md
@@ -1,0 +1,34 @@
+---
+id: RR-6DAEXY
+type: review-response
+title: Warn-once cache never re-warned after a mode regression, and grew unbounded
+finding: |-
+    Two defects in the warn-once cache.
+
+    (1) Keyed on path alone, so once a file warned at 0640 the entry was permanent. An operator who chmods to 0600 and later regresses to 0666 — world-WRITABLE, strictly worse than first reported — got no second warning for the process lifetime, and the log still named 0640. "Don't spam" and "warn once ever" are not the same requirement.
+
+    (2) The sync.Map never evicts. In the SharedBase multi-tenant case it retains one entry per project path forever, keyed by a value whose cardinality the package does not control. Small, but it is the shape of leak that matters later — and keying on (path, mode) to fix (1) makes it marginally worse.
+severity: significant
+status: addressed
+---
+
+## Resolution
+
+**(1)** Introduced a `warnKey{path, perm}` struct as the cache key. A changed
+mode warns again; a mode that simply stays wrong stays quiet — which is the
+requirement the original comment was reaching for.
+
+`TestLoad_WarnsAgainWhenModeChanges` walks 0640 → 0600 → 0666 and asserts two
+warnings, with the second naming `0666`. That test fails against the old
+path-only key.
+
+**(2)** Bounded the map at `maxWarnedPaths = 1024`, tracked with an
+`atomic.Int64`. Past the cap the entry is rolled back and the warning dropped —
+acceptable for an advisory diagnostic, and preferable to unbounded retention.
+The counter increments after `LoadOrStore` so each distinct entry counts once;
+racing goroutines may overshoot slightly, which the comment states, because the
+bound exists to stop growth rather than to be exact.
+
+Concurrency was separately confirmed correct rather than assumed:
+`TestLoad_ConcurrentLoadsWarnOnce` fires 16 concurrent `Load` calls at one
+permissive file and asserts exactly one warning, under `-race`.

--- a/tickets/entities/review-responses/RR-8Z97UM.md
+++ b/tickets/entities/review-responses/RR-8Z97UM.md
@@ -1,0 +1,30 @@
+---
+id: RR-8Z97UM
+type: review-response
+title: Per-path warn-once cache is global mutable state that leaks between tests
+finding: |-
+    The de-duplication fix required by RR-V1G22E introduces package-level mutable state (a sync.Map of already-warned paths). That creates two problems the plan must address before implementation.
+
+    First, test isolation: the acceptance criteria include "a 0644 file logs exactly one warn" and "a 0600 file logs nothing". With a package-level cache these tests become order-dependent — a path warned in an earlier test stays suppressed. t.TempDir() gives each test a unique path which mostly avoids collisions, but relying on that is implicit and fragile.
+
+    Second, the tests need t.Setenv for CREDENTIALS_DIRECTORY, which panics if the test calls t.Parallel(). internal/mail/mail_test.go uses t.Parallel() liberally, so the convention in neighbouring packages is not automatically safe here.
+severity: minor
+resolution: 'Added unexported resetPermissionWarnings(), called from the captureWarnings test helper both up-front and via t.Cleanup, so warning assertions cannot depend on test execution order. No t.Parallel() in any test using t.Setenv. Coverage concern resolved: internal/secrets is at 96.1% against the default floor of 50, with the new error branches (stat failure, non-regular credential, invalid credential YAML, empty relaDir) all covered.'
+status: addressed
+---
+
+## Fix
+
+Expose an unexported reset hook used only from tests (`func resetWarnCache()`),
+called via `t.Cleanup` in every test that asserts on warning output. This is the
+standard Go approach for package-level caches and keeps the cache unexported.
+
+Do not add `t.Parallel()` to the new tests that call `t.Setenv`; the Go runtime
+panics on that combination. Existing non-env tests in the package are
+unaffected.
+
+Coverage note: `internal/secrets` has **no override** in `.testcoverage.yml`, so
+it sits at the default package floor of 50. The package is small, so the added
+branches (stat error, windows skip, credentials-dir fallback) need tests or the
+floor could be threatened — the error paths are the easiest ones to leave
+uncovered.

--- a/tickets/entities/review-responses/RR-9FQLT8.md
+++ b/tickets/entities/review-responses/RR-9FQLT8.md
@@ -11,6 +11,7 @@ finding: |-
 
     (3) sourcePath's doc said "Returns \"\" when neither source exists", which is false: it never checks whether the project file exists, only whether relaDir is empty. In a codebase whose comments are load-bearing, a comment that misdescribes its function is a defect.
 severity: minor
+resolution: '(1) ErrNotFound is now "secrets: no secrets source (no .rela/secrets.yaml, no systemd credential)" so a grep on the message leads somewhere. (2) Both fmt.Errorf("%w", ErrNotFound) sites return the bare sentinel; errors.Is still matches, covered by the existing TestLoad_FileNotFound. (3) sourcePath''s doc now says what the code does — the project-file path is returned without an existence check because os.ReadFile distinguishes absent from unreadable better than a bool could, and "" is returned only when there is no project directory and no credential. Also verified in this pass: the //nolint:gosec is load-bearing (removed it, G703 fired on that exact line, restored it), and resetPermissionWarnings is genuinely test-only. Declined the build-tag split for the Windows check, with reasoning recorded in the body.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-9FQLT8.md
+++ b/tickets/entities/review-responses/RR-9FQLT8.md
@@ -1,0 +1,38 @@
+---
+id: RR-9FQLT8
+type: review-response
+title: Stale ErrNotFound message, no-op %w wrapping, and a sourcePath doc comment that misdescribed the code
+finding: |-
+    Three small correctness-of-description defects.
+
+    (1) ErrNotFound's message stayed "secrets: no .rela/secrets.yaml" although it now also fires when no systemd credential exists and when relaDir is empty. An operator greps the message, finds the file present, and is stuck.
+
+    (2) `fmt.Errorf("%w", ErrNotFound)` at two sites wraps a sentinel in nothing — it adds no context and allocates. Returning the sentinel is identical in behaviour and clearer.
+
+    (3) sourcePath's doc said "Returns \"\" when neither source exists", which is false: it never checks whether the project file exists, only whether relaDir is empty. In a codebase whose comments are load-bearing, a comment that misdescribes its function is a defect.
+severity: minor
+status: addressed
+---
+
+## Resolution
+
+1. Message is now `"secrets: no secrets source (no .rela/secrets.yaml, no
+systemd credential)"` — it names both sources, so a grep leads somewhere.
+2. Both sites return the bare `ErrNotFound`. `errors.Is` still matches (it is
+the same sentinel), which the existing `TestLoad_FileNotFound` covers.
+3. The comment now says what the code does: the project-file path is returned
+without an existence check because that is `os.ReadFile`'s job — it
+distinguishes "absent" from "unreadable" with a better error than a bool could —
+and `""` is returned only when there is no project directory and no credential.
+
+Also from this review pass, verified rather than assumed:
+- The `//nolint:gosec` was tested by removing it: G703 does fire, on the
+`os.Stat` line it is attached to. It is load-bearing and correctly placed.
+- `resetPermissionWarnings` really is test-only (unexported, referenced only
+from `secrets_test.go`).
+
+Not taken: the reviewer's suggestion to replace the `runtime.GOOS == "windows"`
+runtime branch with a build-tagged file pair. It is correct that the repo uses
+build tags heavily and that the compiler would drop the dead branch, but a
+two-file split to save one comparison on a cold path costs more in navigability
+than it returns. Noted as a preference, not a defect.

--- a/tickets/entities/review-responses/RR-DAXMUE.md
+++ b/tickets/entities/review-responses/RR-DAXMUE.md
@@ -1,0 +1,34 @@
+---
+id: RR-DAXMUE
+type: review-response
+title: Docs gave incomplete chmod advice — .rela is created 0755 and is not checked
+finding: |-
+    The permission check stats the file only. A 0600 secrets.yaml inside a 0755 .rela/ is reported clean — correct for reading, but project.Initialize (internal/project/context.go:142) creates .rela with MkdirAll(0755), so rela itself produces a world-readable, world-executable directory, and a group-writable parent would let another user replace secrets.yaml wholesale.
+
+    On its own this would be out of scope for a file-mode check. It matters because the new docs tell operators `chmod 600 .rela/secrets.yaml` is the fix. Incomplete security advice is worse than none: the operator now believes they are done.
+severity: minor
+status: addressed
+---
+
+## Resolution
+
+Fixed the docs rather than extending the check.
+
+`docs/lua-scripting.md` now shows both commands and says why:
+
+```bash
+chmod 700 .rela
+chmod 600 .rela/secrets.yaml
+```
+
+with an explicit note that `rela init` creates `.rela/` as `0755`, that a
+group-writable parent allows outright replacement of the file, and — stated
+plainly so the guarantee is not overread — that **the check covers the file, not
+the directory**. `docs/mail.md` carries the same correction in shorter form.
+
+Extending `warnIfPermissive` to the directory was considered and left out. The
+ticket's stated scope is the secrets file, `.rela/` also holds non-secret cache
+and index files whose `0755` is not itself a fault, and tightening the directory
+mode is a change to what `project.Initialize` *writes* rather than what
+`secrets` *reads* — a different package and a different blast radius. The doc
+now describes the actual boundary instead of implying a wider one.

--- a/tickets/entities/review-responses/RR-DAXMUE.md
+++ b/tickets/entities/review-responses/RR-DAXMUE.md
@@ -7,6 +7,7 @@ finding: |-
 
     On its own this would be out of scope for a file-mode check. It matters because the new docs tell operators `chmod 600 .rela/secrets.yaml` is the fix. Incomplete security advice is worse than none: the operator now believes they are done.
 severity: minor
+resolution: 'Fixed the docs rather than extending the check. docs/lua-scripting.md now shows both `chmod 700 .rela` and `chmod 600 .rela/secrets.yaml`, explains that rela init creates .rela as 0755 and that a group-writable parent allows outright replacement of the file, and states plainly that the check covers the file, not the directory. docs/mail.md carries the same correction in short form. Extending warnIfPermissive to the directory was considered and left out: .rela also holds non-secret cache and index files whose 0755 is not itself a fault, and tightening the mode is a change to what project.Initialize writes rather than what secrets reads — a different package and blast radius. The doc now describes the actual boundary instead of implying a wider one.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-IB0LVR.md
+++ b/tickets/entities/review-responses/RR-IB0LVR.md
@@ -9,6 +9,7 @@ finding: |-
 
     Raised from minor to critical after code review. My original assessment leaned on NewSharedBase having no production caller yet, but a latent fail-open credential leak in the topology the code is being built for is not a minor defect.
 severity: critical
+resolution: 'CredentialName now returns rela-secrets-<project>-<hash>, hashing the symlink-resolved ABSOLUTE path (SHA-256, first 4 bytes) instead of using the bare basename, so two projects sharing a directory name can no longer collide onto one credential. filepath.Abs runs before hashing so a relative relaDir cannot hash per working directory, and the last path segment must be .rela or the source is disabled. Because the name is no longer hand-derivable, added `rela secrets credential-name` (internal/cli/secrets.go) and pointed the docs at it. Pinned by TestCredentialName_DistinctProjectsSharingABasename and the end-to-end TestLoad_SameBasenameProjectsDoNotShareACredential. Supporting: .go-arch-lint.yml grants cli->secrets (name derivation only, no secret values read), kong.go adds secrets to requiresProject, CLI plimsoll pin 46->47.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-IB0LVR.md
+++ b/tickets/entities/review-responses/RR-IB0LVR.md
@@ -1,0 +1,59 @@
+---
+id: RR-IB0LVR
+type: review-response
+title: CredentialName collided on basename — cross-tenant secret leak, and the doc comment denied it
+finding: |-
+    CredentialName reduced the whole project path to its last segment, so /srv/tenant-a/proj/.rela and /srv/tenant-b/proj/.rela both derived "rela-secrets-proj". Two tenants whose project directories share a name — proj, app, data, main are all likely in a /srv/<tenant>/<project> layout, which is exactly what appbuild.SharedBase exists to serve — would be served the single credential the operator declared. The failure is silent and fails OPEN: tenant B gets no error, it gets tenant A's live SMTP password and API keys.
+
+    Worse, the doc comment asserted the scoping property it did not provide, which is precisely how this survives review. TestLoad_CredentialsAreProjectScoped used basenames alpha/beta, so it passed while the real collision went untested.
+
+    Raised from minor to critical after code review. My original assessment leaned on NewSharedBase having no production caller yet, but a latent fail-open credential leak in the topology the code is being built for is not a minor defect.
+severity: critical
+status: addressed
+---
+
+## Resolution
+
+Reversed my earlier "document it" decision and hashed the path, which is what
+the finding required.
+
+`CredentialName` now returns `rela-secrets-<project>-<hash>`, where `<hash>` is
+the first 4 bytes of SHA-256 over the project's **absolute** path:
+
+```go
+abs, err := filepath.Abs(filepath.Clean(relaDir))
+...
+sum := sha256.Sum256([]byte(parent))
+return fmt.Sprintf("rela-secrets-%s-%x", project, sum[:4])
+```
+
+The readable project component is kept so an operator can tell which unit-file
+line belongs to which project; the hash restores injectivity.
+
+I had rejected this on ergonomics — the operator cannot derive the name by hand.
+That objection was right, and the answer was to solve it rather than to accept a
+fail-open leak: **`rela secrets credential-name`** prints the name for the
+current project. The docs now tell operators to run it instead of constructing
+the string.
+
+Also fixed here, from the same review finding:
+- `filepath.Abs` before hashing, so a relative `relaDir` cannot hash differently
+per working directory or collide with its own absolute form.
+- The last path segment must be `.rela`; anything else returns `""`. Previously
+`some/deep/path` yielded `rela-secrets-deep` — a credential name for a project
+that does not exist.
+- The doc comment no longer claims a scoping property the code lacks; it states
+exactly what the two name components are for.
+
+Tests:
+- `TestCredentialName_DistinctProjectsSharingABasename` — the inverse of the old
+test; two tenants both named `proj` must NOT collide.
+- `TestLoad_SameBasenameProjectsDoNotShareACredential` — end-to-end: tenant A
+has a credential, tenant B has only its own file, and B must not adopt A's.
+- `TestCredentialName` subtests for relative-equals-absolute, stability across
+calls, trailing separator, and the four rejected-input shapes.
+
+Supporting changes: `.go-arch-lint.yml` grants `cli → secrets` (the command
+derives a NAME and reads no secret values — noted at the rule), `secrets` is
+added to `requiresProject` in kong.go, and the `CLI` plimsoll field pin goes 46
+→ 47 with the reasoning recorded at the declaration.

--- a/tickets/entities/review-responses/RR-MHW4HZ.md
+++ b/tickets/entities/review-responses/RR-MHW4HZ.md
@@ -1,0 +1,29 @@
+---
+id: RR-MHW4HZ
+type: review-response
+title: Credential name changed across a symlinked path, breaking symlink-swap deploys
+finding: |-
+    Hashing the absolute path fixed the basename collision but introduced a new failure: filepath.Abs does not resolve symlinks, and project.Discover (internal/project/context.go:86) only calls Abs, so Context.CacheDir carries whatever path the user supplied.
+
+    Verified by running the binary from both sides of a symlink: the two paths stayed unresolved and hashed differently. A /srv/current -> /srv/releases/N deploy layout — the standard symlink-swap pattern — would therefore change the credential name on every release. The operator's unit file keeps the old name, no credential matches, and rela silently falls back to the project file or to password_env. Silent fallback on a credential is exactly the failure mode this ticket set out to remove.
+
+    Found by testing the new code against a symlinked layout rather than by reading it; neither my own review nor the code review caught it, because it only appears once the name became path-derived.
+severity: significant
+status: addressed
+---
+
+## Resolution
+
+`CredentialName` now calls `filepath.EvalSymlinks` after `filepath.Abs`, so a
+project reached through a symlinked parent hashes to the same name as its
+target.
+
+Best-effort by design: if `EvalSymlinks` fails — most likely because the
+directory does not exist yet — the unresolved absolute path is kept rather than
+returning `""`. Losing the credential entirely over an unresolvable path would
+be a worse failure than a name that is merely stable-but-unresolved, and the
+`.rela` directory exists in every real deployment.
+
+`TestCredentialName/symlinked path resolves to the same name as its target`
+builds a real symlinked layout and asserts both paths agree. It skips rather
+than fails where symlinks are unavailable.

--- a/tickets/entities/review-responses/RR-MHW4HZ.md
+++ b/tickets/entities/review-responses/RR-MHW4HZ.md
@@ -9,6 +9,7 @@ finding: |-
 
     Found by testing the new code against a symlinked layout rather than by reading it; neither my own review nor the code review caught it, because it only appears once the name became path-derived.
 severity: significant
+resolution: 'CredentialName calls filepath.EvalSymlinks after filepath.Abs, so a project reached through a symlinked parent hashes to the same name as its target and a /srv/current -> /srv/releases/N switchover does not orphan the credential. Best-effort: if EvalSymlinks fails (most likely a not-yet-created directory) the unresolved absolute path is kept rather than returning "", since losing the credential entirely would be the worse failure. Pinned by TestCredentialName/symlinked path resolves to the same name as its target, which builds a real symlinked layout and skips where symlinks are unavailable.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-MVKA2W.md
+++ b/tickets/entities/review-responses/RR-MVKA2W.md
@@ -1,0 +1,12 @@
+---
+id: RR-MVKA2W
+type: review-response
+title: CredentialName produced "rela-secrets-.." for an upward relative path
+finding: |-
+    CredentialName("../.rela") returned "rela-secrets-.." — filepath.Base(filepath.Dir(filepath.Clean("../.rela"))) is "..", which was not in the guard alongside "." and the separator. The result is a credential name that names no project and that an operator would never deliberately declare, so any file matching it in $CREDENTIALS_DIRECTORY would be picked up on the strength of a path artifact rather than an operator decision.
+
+    Found by running CredentialName over a table of degenerate inputs rather than by reading it; the original guard covered the two cases I had thought of and missed the third.
+severity: minor
+resolution: 'Added ".." to the guard so the credentials source is disabled (returns "") rather than deriving a nonsense name. Covered by two new TestCredentialName subtests: "upward relative path names no project" and "filesystem root".'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-V1G22E.md
+++ b/tickets/entities/review-responses/RR-V1G22E.md
@@ -1,0 +1,28 @@
+---
+id: RR-V1G22E
+type: review-response
+title: Warning fires per script execution and twice per mail send, not once
+finding: |-
+    The plan's mitigation for warning fatigue says the warning is emitted "once per load, not per key" — but a load is not a rare event. secrets.Load is called from lua.LoadContextOptions (internal/lua/context.go:35), which runs inside script.NewWriterRuntime — constructed per document render (internal/script/list_document.go:85), per action (internal/script/action.go:68), and per executor run (internal/script/executor.go:201). On the mail side, Config.resolvePassword calls Load and is invoked twice per send: once via hasPassword (internal/mail/smtp.go:78) and again directly (smtp.go:111).
+
+    A data-entry server rendering documents would emit this warning on every page render, which is log spam severe enough that operators will filter the logger — destroying the value of the warning and any other warning from the same package. The plan's stated mitigation does not address this because it misidentifies the call frequency.
+severity: significant
+resolution: Added a package-level sync.Map (warnedPaths) keyed by resolved path; warnIfPermissive uses LoadOrStore so a given file warns once per process. Keyed per path rather than a single sync.Once so a multi-project process still warns for each project. Pinned by TestLoad_WarnsOncePerPath (3 loads -> 1 warning) and TestLoad_WarnsPerProjectNotGlobally (2 projects -> 2 warnings).
+status: addressed
+---
+
+## Fix
+
+De-duplicate the warning per resolved path for the process lifetime, using a
+`sync.Map` (or a mutex-guarded `map[string]struct{}`) keyed by the absolute
+path. First observation of a permissive file warns; subsequent loads of the same
+path stay silent.
+
+Per-path rather than a single `sync.Once` because a process can legitimately
+serve multiple projects (`appbuild.SharedBase` assembles one `Services` per
+tenant), and a global once would silence the warning for every project after the
+first — the exact failure the ceiling-guard reasoning in CLAUDE.md warns about,
+where a shared object leaks state across tenants.
+
+This keeps the warning actionable (it still fires once per misconfigured file)
+without coupling it to render frequency.

--- a/tickets/entities/review-responses/RR-WEKA7E.md
+++ b/tickets/entities/review-responses/RR-WEKA7E.md
@@ -9,6 +9,7 @@ finding: |-
 
     That message is now actively false: the credential is present, password_env is irrelevant, and the real fault is a YAML syntax error inside a TPM-encrypted blob the operator cannot easily inspect.
 severity: significant
+resolution: 'resolvePassword (internal/mail/config.go) now switches on the error instead of discarding it: errors.Is(err, secrets.ErrNotFound) falls through silently (the ordinary password_env deployment), a non-nil error logs slog.Warn "mail: secrets source unreadable, falling back to password_env", and only the default branch reads the key. This matches what internal/lua/context.go already did. The fallback is deliberately kept — refusing to send mail over a secrets-file syntax error is worse than trying the other source — but the real fault is now on the record rather than surfacing as a misleading message about password_env. Covered by TestConfig_MalformedSecretsFallsBackAndWarns (fallback works, warning emitted, credential not echoed) and TestConfig_AbsentSecretsIsSilent (an absent file must stay quiet so the warning keeps its signal).'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-WEKA7E.md
+++ b/tickets/entities/review-responses/RR-WEKA7E.md
@@ -1,0 +1,41 @@
+---
+id: RR-WEKA7E
+type: review-response
+title: mail resolvePassword swallowed the new corrupt-credential error and reported the wrong cause
+finding: |-
+    internal/mail/config.go:241 was `if sec, err := secrets.Load(...); err == nil`, discarding every error identically. This change made that pre-existing looseness materially worse by adding a new, likelier, harder-to-diagnose error to the set it swallows.
+
+    With a malformed systemd credential: Load returns a parse error, it is discarded, resolvePassword falls through to os.Getenv(PasswordVar) — reintroducing one layer up the very fallback the credential path deliberately refuses (TestLoad_InvalidYAMLInCredentialDoesNotFallBack) — and if PasswordVar is unset, smtp.go:78 reports "username is set but the environment variable named by password_env is empty or unset".
+
+    That message is now actively false: the credential is present, password_env is irrelevant, and the real fault is a YAML syntax error inside a TPM-encrypted blob the operator cannot easily inspect.
+severity: significant
+status: addressed
+---
+
+## Resolution
+
+`resolvePassword` now distinguishes the three cases, matching what
+`internal/lua/context.go` already did:
+
+```go
+sec, err := secrets.Load(c.relaDir, "")
+switch {
+case errors.Is(err, secrets.ErrNotFound):
+    // ordinary password_env deployment — silent
+case err != nil:
+    slog.Warn("mail: secrets source unreadable, falling back to password_env", "error", err)
+default:
+    if v := sec[SecretKey]; v != "" { return v }
+}
+```
+
+Kept the fallback rather than returning an error: refusing to send mail over a
+secrets-file syntax error is worse than trying the other source. But the real
+fault is now on the record instead of surfacing as a misleading message about a
+variable that has nothing to do with it.
+
+Two tests, in a package that previously had none for this interaction:
+- `TestConfig_MalformedSecretsFallsBackAndWarns` — asserts the fallback still
+works, that the warning is emitted, and that it does not echo the credential.
+- `TestConfig_AbsentSecretsIsSilent` — the counterpart: no secrets file at all
+is the ordinary case and must stay quiet, so the warning keeps its signal.

--- a/tickets/entities/review-responses/RR-Y2O7C6.md
+++ b/tickets/entities/review-responses/RR-Y2O7C6.md
@@ -1,0 +1,39 @@
+---
+id: RR-Y2O7C6
+type: review-response
+title: Process-global CREDENTIALS_DIRECTORY silently overrides every project in a multi-tenant process
+finding: |-
+    The plan gives CREDENTIALS_DIRECTORY precedence over the project file, but CREDENTIALS_DIRECTORY is process-global while secrets.Load is per-project — it takes a relaDir argument, and callers pass different directories (internal/mail/config.go:241 passes c.relaDir; internal/lua/context.go:35 passes the script's cacheDir).
+
+    Multi-project-per-process is a real supported topology, not hypothetical: appbuild.SharedBase exists precisely so one process can Assemble one Services per tenant store (internal/appbuild/appbuild.go:1116-1122), and CLAUDE.md documents several rela-server processes and schema-per-tenant scoping.
+
+    With the planned precedence, a single systemd credential would be served to EVERY project in the process, silently replacing each tenant's own secrets. Tenant B would receive tenant A's credentials. That is a confidentiality failure, and it fails in the dangerous direction: the operator sees secrets "working" and cannot tell they are the wrong ones.
+severity: significant
+resolution: 'Took option 1: the exported CredentialName(relaDir) derives a project-scoped credential name ("rela-secrets-<project>", from the directory containing .rela), and sourcePath only uses $CREDENTIALS_DIRECTORY when a file of that exact name exists. A process-global directory can therefore never serve one project''s credential to another. Pinned by TestLoad_CredentialsAreProjectScoped (two projects, one credentials dir, each gets only its own) and TestLoad_FallsBackWhenNoCredentialForProject (an unrelated credential does not shadow the project file).'
+status: addressed
+---
+
+## Fix
+
+Scope the credentials-directory lookup so it cannot cross tenants. Two options,
+in preference order:
+
+**1. Namespace the credential by project (preferred).** systemd's
+`LoadCredentialEncrypted=rela-<name>:<path>` lets an operator name each
+credential, and they land as separate files in `$CREDENTIALS_DIRECTORY`. Derive
+the expected filename from the project rather than using one fixed
+`secrets.yaml`. Falls back cleanly when the per-project name is absent.
+
+**2. Restrict to the single-project case.** Only consult
+`$CREDENTIALS_DIRECTORY` when the process serves one project.
+
+Given effort `s` and that the multi-tenant deployment is the postgres/server
+tier, the pragmatic v1 is option 1's mechanism with a documented single-project
+assumption — but the precedence must NOT be "global credential beats every
+project's own file" as written.
+
+The plan's justification for the current precedence ("an operator who has moved
+to systemd credentials cannot be silently shadowed by a stale project file") is
+sound for one project and actively harmful for several. Whichever option is
+taken, add a test with two distinct relaDirs and one `CREDENTIALS_DIRECTORY`
+asserting they do not receive each other's values.

--- a/tickets/entities/tickets/TKT-OMCAAW.md
+++ b/tickets/entities/tickets/TKT-OMCAAW.md
@@ -1,0 +1,68 @@
+---
+id: TKT-OMCAAW
+type: ticket
+title: Investigate flaky TestMemoryQueue_Conformance/IdempotencyKeyFreedAfterCompletion
+kind: test
+priority: low
+effort: s
+tags:
+    - needs-investigation
+status: backlog
+---
+
+## Observed
+
+During `just ci` (`go test -race -cover -shuffle=on`):
+
+```
+--- FAIL: TestMemoryQueue_Conformance (68.01s)
+    --- FAIL: TestMemoryQueue_Conformance/IdempotencyKeyFreedAfterCompletion (0.00s)
+        jobstest.go:100:
+            Error Trace: internal/jobs/jobstest/jobstest.go:686
+                         internal/jobs/jobstest/jobstest.go:100
+            Error: Received unexpected error:
+                   jobs: an identical job is already pending
+FAIL	github.com/Sourcehaven-BV/rela/internal/jobs	69.174s
+```
+
+The subtest reports 0.00s while the parent takes 68s, so the enqueue appears to
+race something in the surrounding suite rather than time out on its own.
+
+## Not reproducible in isolation
+
+- `go test ./internal/jobs/ -run '.../IdempotencyKeyFreedAfterCompletion' -count=5` — passes
+- `go test ./internal/jobs/ -count=1` on `develop` — passes (68s)
+- `go test -race -shuffle=on ./internal/jobs/ -count=1` on the branch — passes (69s)
+
+It needs the full-suite ordering, and `-shuffle=on` varies that per run.
+
+## Filed as a ticket, not a bug
+
+The `bug` type requires `fixes` and `adds-measure` relations, which presuppose a
+diagnosed root cause and a chosen prevention. Neither exists yet — this is an
+observation awaiting triage. Convert it to a `bug` once the cause is known and
+the 5-whys can be filled in honestly.
+
+## Not caused by the branch that found it
+
+Found while running `just ci` for TKT-RX7I97, which touches `internal/secrets`,
+`internal/mail`, `internal/cli` and docs — nothing in `internal/jobs`, and no
+shared state with it. Confirmed by running the jobs package on `develop`.
+
+## Suspected area
+
+The name says the key should be released once the job completes, and the error
+is the still-pending guard firing — so a completion/release step may not be
+synchronized with the next enqueue, letting a fast re-enqueue observe the prior
+job as still pending.
+
+Per CLAUDE.md, `IdempotencyKey` semantics are load-bearing for recurring tasks
+("one of these pending at a time is enough"), so a genuine
+release-after-completion race is worth understanding rather than papering over
+with a longer wait in the test.
+
+## Next step
+
+`go test -race -shuffle=on -count=20 ./internal/jobs/`, and when it reproduces
+note the shuffle seed the failing run prints so it can be replayed
+deterministically.

--- a/tickets/entities/tickets/TKT-RX7I97.md
+++ b/tickets/entities/tickets/TKT-RX7I97.md
@@ -1,0 +1,80 @@
+---
+id: TKT-RX7I97
+type: ticket
+title: 'Secrets hygiene: enforce 0600 on .rela/secrets.yaml and support systemd LoadCredentialEncrypted'
+kind: enhancement
+priority: medium
+effort: s
+tags:
+    - security
+status: review
+---
+
+## Problem
+
+Two gaps in how `.rela/secrets.yaml` is protected, found while evaluating sops
+for rela secrets.
+
+**1. No permission enforcement.** `internal/secrets/secrets.go` reads the file
+with a plain `os.ReadFile` and never checks or sets its mode. There is no
+`Chmod` and no `Stat` mode check anywhere in the package — the `0600` only
+appears in a test fixture (`secrets_test.go:127`). rela never writes the file
+itself (it is operator-authored), so the mode is whatever the operator's editor
+and umask produced. On a permissive umask it can land group- or world-readable
+and nothing says so. `.rela/` itself is created `0755`
+(`internal/project/context.go:142`).
+
+**2. No documented story for injecting secrets on a server.** `docs/mail.md`
+mentions systemd units only in the context of `password_env`, which puts the
+credential in the process environment — inherited by every child process,
+including the third-party converters `internal/cmdexec` runs over
+attacker-influenceable bytes. systemd's `LoadCredentialEncrypted=` is strictly
+better on that axis and is currently undocumented.
+
+## Why not sops / at-rest encryption
+
+Investigated and rejected for this ticket (see the investigation notes below).
+Encrypting `secrets.yaml` and handing the process a key via `SOPS_AGE_KEY` does
+not strictly improve hygiene: it trades N secrets in a file for one master key
+in the environment, which is a worse location because env vars are inherited by
+subprocesses and appear in `/proc/PID/environ`. Using `SOPS_AGE_KEY_FILE`
+instead lands back at "a plaintext credential in a 0600 file" — exactly what we
+already have.
+
+Note the `go.mozilla.org/sops` import path is dead regardless: the module
+declares itself as `github.com/getsops/sops/v3` and Go refuses the old path. The
+real library links all five KMS backends unconditionally (AWS, Azure, GCP,
+Vault) — 139 modules, ~58 MB of linked code, roughly doubling the `rela` binary.
+
+At-rest encryption of repo *data* remains covered by [[repo-encryption]] /
+DEC-D5P4X; this ticket is only about the secrets file's hygiene.
+
+## Scope
+
+**1. Permission check on load.** In `internal/secrets`, `Stat` the file before
+reading and warn when it is group- or world-readable. Warn rather than refuse:
+the file is operator-authored and failing closed would break existing working
+deployments on upgrade. Where rela does create the file's directory, prefer
+`0700`.
+
+**2. systemd credentials support.** Read `$CREDENTIALS_DIRECTORY` as a secrets
+source when set, so `LoadCredentialEncrypted=` works without materializing a
+plaintext file in the project. Secrets land in a per-service tmpfs, mode 0400,
+owned by the service user, not inherited by children, with keys optionally
+TPM2-backed. Document it in `docs/mail.md` and `docs/lua-scripting.md`.
+
+The `secrets.Load` seam has only two non-test callers
+(`internal/lua/context.go:35`, `internal/mail/config.go:241`), so the source of
+the bytes stays an implementation detail.
+
+## Out of scope
+
+- Encrypting `secrets.yaml` at rest (rejected above).
+- macOS Keychain as a third backend.
+- Refusing to load a world-readable file (warn only, for now).
+
+## Verification
+
+`systemd-creds` behaviour has not been verified hands-on — the investigation ran
+on macOS. The `$CREDENTIALS_DIRECTORY` plumbing must be validated on a real
+Linux host before the docs claim it works.

--- a/tickets/entities/tickets/TKT-RX7I97.md
+++ b/tickets/entities/tickets/TKT-RX7I97.md
@@ -7,7 +7,7 @@ priority: medium
 effort: s
 tags:
     - security
-status: review
+status: done
 ---
 
 ## Problem
@@ -15,66 +15,80 @@ status: review
 Two gaps in how `.rela/secrets.yaml` is protected, found while evaluating sops
 for rela secrets.
 
-**1. No permission enforcement.** `internal/secrets/secrets.go` reads the file
-with a plain `os.ReadFile` and never checks or sets its mode. There is no
-`Chmod` and no `Stat` mode check anywhere in the package — the `0600` only
-appears in a test fixture (`secrets_test.go:127`). rela never writes the file
-itself (it is operator-authored), so the mode is whatever the operator's editor
-and umask produced. On a permissive umask it can land group- or world-readable
-and nothing says so. `.rela/` itself is created `0755`
-(`internal/project/context.go:142`).
+**1. No permission enforcement.** `internal/secrets/secrets.go` read the file
+with a plain `os.ReadFile` and never checked its mode. There was no `Chmod` and
+no `Stat` mode check anywhere in the package — the `0600` appeared only in a
+test fixture. rela never writes the file itself (it is operator-authored), so
+the mode is whatever the operator's editor and umask produced. On a permissive
+umask it can land group- or world-readable and nothing said so. `.rela/` itself
+is created `0755` (`internal/project/context.go:142`).
 
 **2. No documented story for injecting secrets on a server.** `docs/mail.md`
-mentions systemd units only in the context of `password_env`, which puts the
+mentioned systemd units only in the context of `password_env`, which puts the
 credential in the process environment — inherited by every child process,
 including the third-party converters `internal/cmdexec` runs over
-attacker-influenceable bytes. systemd's `LoadCredentialEncrypted=` is strictly
-better on that axis and is currently undocumented.
+attacker-influenceable bytes. That inheritance was confirmed empirically:
+`cmdexec` never sets `ec.Env` (`internal/cmdexec/cmdexec.go:264`), so children
+receive the full parent environment. systemd's `LoadCredentialEncrypted=` is
+better on exactly that axis and was undocumented.
 
 ## Why not sops / at-rest encryption
 
-Investigated and rejected for this ticket (see the investigation notes below).
-Encrypting `secrets.yaml` and handing the process a key via `SOPS_AGE_KEY` does
-not strictly improve hygiene: it trades N secrets in a file for one master key
-in the environment, which is a worse location because env vars are inherited by
-subprocesses and appear in `/proc/PID/environ`. Using `SOPS_AGE_KEY_FILE`
-instead lands back at "a plaintext credential in a 0600 file" — exactly what we
-already have.
+Investigated and rejected. Encrypting `secrets.yaml` and handing the process a
+key via `SOPS_AGE_KEY` does not strictly improve hygiene: it trades N secrets in
+a file for one master key in the environment, which is a worse location for the
+inheritance reason above. Using `SOPS_AGE_KEY_FILE` instead lands back at "a
+plaintext credential in a 0600 file" — what we already have.
 
-Note the `go.mozilla.org/sops` import path is dead regardless: the module
-declares itself as `github.com/getsops/sops/v3` and Go refuses the old path. The
-real library links all five KMS backends unconditionally (AWS, Azure, GCP,
-Vault) — 139 modules, ~58 MB of linked code, roughly doubling the `rela` binary.
+The `go.mozilla.org/sops` import path is dead regardless: the module declares
+itself as `github.com/getsops/sops/v3` and Go refuses the old path. The real
+library links all five KMS backends unconditionally (AWS, Azure, GCP, Vault) —
+139 modules, ~58 MB of linked code, roughly doubling the `rela` binary.
 
 At-rest encryption of repo *data* remains covered by [[repo-encryption]] /
 DEC-D5P4X; this ticket is only about the secrets file's hygiene.
 
-## Scope
+## What shipped
 
-**1. Permission check on load.** In `internal/secrets`, `Stat` the file before
-reading and warn when it is group- or world-readable. Warn rather than refuse:
-the file is operator-authored and failing closed would break existing working
-deployments on upgrade. Where rela does create the file's directory, prefer
-`0700`.
+**1. Permission warning.** `internal/secrets` stats the file and logs one
+`slog.Warn` naming the path, octal mode, and the `chmod 600` fix when it is
+group- or world-readable. Advisory: the file still loads, because failing closed
+would break working deployments on upgrade. De-duplicated on `(path, mode)` and
+capped at 1024 entries — `Load` runs per script execution and twice per mail
+send, so a naive warning would fire on every document render, while a path-only
+key would miss a fixed-then-regressed file.
 
-**2. systemd credentials support.** Read `$CREDENTIALS_DIRECTORY` as a secrets
-source when set, so `LoadCredentialEncrypted=` works without materializing a
-plaintext file in the project. Secrets land in a per-service tmpfs, mode 0400,
-owned by the service user, not inherited by children, with keys optionally
-TPM2-backed. Document it in `docs/mail.md` and `docs/lua-scripting.md`.
+**2. systemd credentials.** `Load` prefers `$CREDENTIALS_DIRECTORY` when it
+holds a credential for *this* project. The name is
+`rela-secrets-<project>-<hash>`, hashing the symlink-resolved absolute path:
+`CREDENTIALS_DIRECTORY` is process-global while secrets are per-project, and a
+basename-only name would serve one tenant's credentials to another, failing
+open. Since the name is no longer derivable by hand, **`rela secrets
+credential-name`** prints it.
 
-The `secrets.Load` seam has only two non-test callers
-(`internal/lua/context.go:35`, `internal/mail/config.go:241`), so the source of
-the bytes stays an implementation detail.
+**3. Docs.** `docs/lua-scripting.md` (permissions + a systemd-credentials
+section) and `docs/mail.md`.
+
+Both callers of the `secrets.Load` seam were left in place, so the source of the
+bytes stayed an implementation detail — except in `internal/mail`, where
+`resolvePassword` was discarding every error identically and would have reported
+"password_env is empty or unset" for a corrupt credential. It now distinguishes
+an absent source from a broken one.
 
 ## Out of scope
 
 - Encrypting `secrets.yaml` at rest (rejected above).
 - macOS Keychain as a third backend.
-- Refusing to load a world-readable file (warn only, for now).
+- Refusing to load a world-readable file (warn only).
+- Checking the mode of `.rela/` itself — the docs now tell operators to
+`chmod 700 .rela` and state plainly that rela checks only the file.
 
-## Verification
+## Verification gap
 
-`systemd-creds` behaviour has not been verified hands-on — the investigation ran
-on macOS. The `$CREDENTIALS_DIRECTORY` plumbing must be validated on a real
-Linux host before the docs claim it works.
+**`systemd-creds` was never run.** The investigation and implementation happened
+on macOS, so the `$CREDENTIALS_DIRECTORY` contract was simulated (an env var
+plus a correctly-named file) rather than exercised through a real unit. The
+rela-side path is a plain env-var + directory read and is fully unit-tested, but
+the `systemd-creds encrypt` and `LoadCredentialEncrypted=` lines in the docs
+come from systemd's documentation. Validate them on a Linux host before relying
+on them verbatim.

--- a/tickets/relations/TKT-OMCAAW--affects--background-jobs.md
+++ b/tickets/relations/TKT-OMCAAW--affects--background-jobs.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OMCAAW
+relation: affects
+to: background-jobs
+---

--- a/tickets/relations/TKT-OMCAAW--implements--FEAT-QAOV6.md
+++ b/tickets/relations/TKT-OMCAAW--implements--FEAT-QAOV6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OMCAAW
+relation: implements
+to: FEAT-QAOV6
+---

--- a/tickets/relations/TKT-RX7I97--affects--lua-scripting.md
+++ b/tickets/relations/TKT-RX7I97--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-RX7I97--has-docs--DOCS-M0SVP6.md
+++ b/tickets/relations/TKT-RX7I97--has-docs--DOCS-M0SVP6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-docs
+to: DOCS-M0SVP6
+---

--- a/tickets/relations/TKT-RX7I97--has-implementation--IMPL-WBKVF3.md
+++ b/tickets/relations/TKT-RX7I97--has-implementation--IMPL-WBKVF3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-implementation
+to: IMPL-WBKVF3
+---

--- a/tickets/relations/TKT-RX7I97--has-planning--PLAN-YJVG3F.md
+++ b/tickets/relations/TKT-RX7I97--has-planning--PLAN-YJVG3F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-planning
+to: PLAN-YJVG3F
+---

--- a/tickets/relations/TKT-RX7I97--has-review--REV-BQL197.md
+++ b/tickets/relations/TKT-RX7I97--has-review--REV-BQL197.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review
+to: REV-BQL197
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-6DAEXY.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-6DAEXY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-6DAEXY
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-8Z97UM.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-8Z97UM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-8Z97UM
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-9FQLT8.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-9FQLT8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-9FQLT8
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-DAXMUE.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-DAXMUE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-DAXMUE
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-IB0LVR.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-IB0LVR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-IB0LVR
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-MHW4HZ.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-MHW4HZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-MHW4HZ
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-MVKA2W.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-MVKA2W.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-MVKA2W
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-V1G22E.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-V1G22E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-V1G22E
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-WEKA7E.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-WEKA7E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-WEKA7E
+---

--- a/tickets/relations/TKT-RX7I97--has-review-response--RR-Y2O7C6.md
+++ b/tickets/relations/TKT-RX7I97--has-review-response--RR-Y2O7C6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: has-review-response
+to: RR-Y2O7C6
+---

--- a/tickets/relations/TKT-RX7I97--implements--FEAT-i5ji.md
+++ b/tickets/relations/TKT-RX7I97--implements--FEAT-i5ji.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RX7I97
+relation: implements
+to: FEAT-i5ji
+---


### PR DESCRIPTION
Closes TKT-RX7I97.

Two gaps in how `.rela/secrets.yaml` is protected, found while evaluating sops for rela secrets.

## What this does

**1. Warns when the secrets file is readable by others.** `internal/secrets` stats the file and logs one `slog.Warn` naming the path, octal mode, and the `chmod 600` fix. Advisory — the file still loads, because failing closed would break working deployments on upgrade. De-duplicated on `(path, mode)` and capped, because `Load` runs per script execution and twice per mail send; a naive warning would fire on every document render, while a path-only key would miss a file that was fixed and later regressed.

**2. Reads systemd credentials.** `Load` prefers `$CREDENTIALS_DIRECTORY` when it holds a credential for *this* project. Those live in a per-service tmpfs at mode 0400, are **not inherited by child processes**, and can be TPM-bound.

That inheritance point is the actual motivation, and it was verified rather than assumed: `internal/cmdexec` never sets `ec.Env` (cmdexec.go:264), so the third-party converters it runs over attacker-influenceable bytes receive rela's full environment. `password_env` puts a credential there; a systemd credential is not inherited.

**3. `rela secrets credential-name`** prints the credential name, since it is no longer derivable by hand.

## Why not sops

Rejected. Encrypting `secrets.yaml` and handing the process a key via `SOPS_AGE_KEY` trades N secrets in a file for one master key in the environment — a worse location, for the inheritance reason above. `SOPS_AGE_KEY_FILE` lands back at "a plaintext credential in a 0600 file", which is what we already have.

Separately, `go.mozilla.org/sops` is a dead import path (the module declares `github.com/getsops/sops/v3`), and the real library links all five KMS backends unconditionally — 139 modules, ~58 MB, roughly doubling the binary.

At-rest encryption of repo *data* remains DEC-D5P4X's territory; this is only about the secrets file.

## The credential name

`rela-secrets-<project>-<hash>`, hashing the symlink-resolved absolute path.

Both halves are load-bearing. `CREDENTIALS_DIRECTORY` is process-global while secrets are per-project, so an unscoped name would serve one tenant's credentials to every other project in the process. A **basename**-only name doesn't fix that either: `/srv/a/proj` and `/srv/b/proj` collide, and `/srv/<tenant>/<project>` is exactly the layout `appbuild.SharedBase` exists to serve. That failure is silent and fails *open*. The hash restores uniqueness; the readable component keeps unit-file lines recognizable.

Symlinks are resolved because `project.Discover` only calls `filepath.Abs` — without it a `/srv/current -> /srv/releases/N` switchover would change the name and silently orphan the credential.

## Also fixed

`internal/mail`'s `resolvePassword` was discarding every `secrets.Load` error identically. With a malformed credential it would fall through to `password_env` and report *"password_env is empty or unset"* — naming the wrong cause entirely. It now distinguishes an absent source from a broken one.

## Review

Design review raised 3 findings, code review raised 6, and 1 more came from testing against a symlinked layout. All addressed; see the RR-* entities on the ticket. 12 lint findings were fixed rather than suppressed; the one surviving `//nolint:gosec` was verified load-bearing by removing it and re-running.

`.go-arch-lint.yml` grants `cli → secrets` (the command derives a *name* and reads no secret values) and the `CLI` plimsoll field pin goes 46 → 47, both annotated at the site.

## Not verified

**systemd itself was never run** — this was developed on macOS, so the `$CREDENTIALS_DIRECTORY` contract was simulated. The rela-side path is a plain env-var + directory read and is fully unit-tested, but the `systemd-creds encrypt` and `LoadCredentialEncrypted=` lines in the docs come from systemd's documentation. Worth validating on a Linux host before relying on them verbatim.

Separately, `just ci` surfaced a flaky `internal/jobs` idempotency test unrelated to this branch (passes on `develop` and in isolation) — filed as TKT-OMCAAW rather than fixed here.

https://claude.ai/code/session_01Vv87ooBaKccSTreyVHAVd1