### PR TITLE
refactor(mcp): extract lua/schema-resource/prompt handlers off Server (TKT-MGNE5L)

### DIFF
--- a/internal/mcp/acl_test.go
+++ b/internal/mcp/acl_test.go
@@ -110,7 +110,7 @@ func gatedServer(t *testing.T) (*Server, context.Context) {
 	}
 
 	srv := &Server{deps: deps, logger: slog.New(slog.DiscardHandler)}
-	srv.types, srv.trace, srv.export = deps.handlers()
+	srv.handlerSet = deps.handlers()
 	return srv, principal.With(ctx, principal.Principal{User: "alice", Tool: principal.ToolMCP})
 }
 
@@ -345,7 +345,7 @@ func TestACL_Resources_AreGated(t *testing.T) {
 	t.Parallel()
 	s, ctx := gatedServer(t)
 
-	_, err := s.handleReadEntity(ctx, readResourceReq("rela://entity/feature/"+hiddenID))
+	_, err := s.schemaRes.handleReadEntity(ctx, readResourceReq("rela://entity/feature/"+hiddenID))
 	if err == nil {
 		t.Error("LEAK: resource read of a hidden entity succeeded")
 	} else if strings.Contains(err.Error(), hiddenTitle) {
@@ -353,7 +353,7 @@ func TestACL_Resources_AreGated(t *testing.T) {
 	}
 
 	// A readable entity still works, so the gate is not simply refusing all.
-	if _, err := s.handleReadEntity(ctx, readResourceReq("rela://entity/ticket/"+visibleID)); err != nil {
+	if _, err := s.schemaRes.handleReadEntity(ctx, readResourceReq("rela://entity/ticket/"+visibleID)); err != nil {
 		t.Errorf("readable entity denied through resource path: %v", err)
 	}
 }

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -95,9 +95,8 @@ func (h promptHandler) handleAnalyzeTraceabilityPrompt(
 	}
 
 	// Get trace trees
-	tracer := h.tracer
-	traceFrom := tracer.TraceFrom(ctx, id, 0)
-	traceTo := tracer.TraceTo(ctx, id, 0)
+	traceFrom := h.tracer.TraceFrom(ctx, id, 0)
+	traceTo := h.tracer.TraceTo(ctx, id, 0)
 
 	var traceFromText, traceToText string
 	if traceFrom != nil {

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -9,15 +9,31 @@ import (
 
 	mcpgo "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/natsort"
 	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
 )
 
 func (s *Server) registerPrompts() {
-	s.mcp.AddPrompt(promptAnalyzeTraceability(), s.handleAnalyzeTraceabilityPrompt)
-	s.mcp.AddPrompt(promptReviewOrphans(), s.handleReviewOrphansPrompt)
-	s.mcp.AddPrompt(promptSummarizeProject(), s.handleSummarizeProjectPrompt)
-	s.mcp.AddPrompt(promptReviewEntity(), s.handleReviewEntityPrompt)
+	s.mcp.AddPrompt(promptAnalyzeTraceability(), s.prompts.handleAnalyzeTraceabilityPrompt)
+	s.mcp.AddPrompt(promptReviewOrphans(), s.prompts.handleReviewOrphansPrompt)
+	s.mcp.AddPrompt(promptSummarizeProject(), s.prompts.handleSummarizeProjectPrompt)
+	s.mcp.AddPrompt(promptReviewEntity(), s.prompts.handleReviewEntityPrompt)
+}
+
+// promptHandler serves the four registered prompts. A type of its own rather
+// than more methods on [Server] (the urlHelpers pattern, TKT-MGNE5L): a
+// prompt assembles read-only graph context — entity rows via the gated
+// [GraphReader], traversals via the tracer, shape via the metamodel, plus the
+// shared typeResolver for the review-orphans type filter. Identity still
+// arrives on the ctx via Server.principalMiddleware; the handler holds no
+// principal.
+type promptHandler struct {
+	store  GraphReader
+	meta   *metamodel.Metamodel
+	tracer tracer.Tracer
+	types  typeResolver
 }
 
 func promptAnalyzeTraceability() *mcpgo.Prompt {
@@ -59,7 +75,7 @@ func promptReviewEntity() *mcpgo.Prompt {
 
 // --- Prompt Handlers ---
 
-func (s *Server) handleAnalyzeTraceabilityPrompt(
+func (h promptHandler) handleAnalyzeTraceabilityPrompt(
 	ctx context.Context, request *mcpgo.GetPromptRequest,
 ) (*mcpgo.GetPromptResult, error) {
 	id := request.Params.Arguments["id"]
@@ -67,7 +83,7 @@ func (s *Server) handleAnalyzeTraceabilityPrompt(
 		return nil, errors.New("id argument is required")
 	}
 
-	st := s.deps.Store
+	st := h.store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
@@ -79,7 +95,7 @@ func (s *Server) handleAnalyzeTraceabilityPrompt(
 	}
 
 	// Get trace trees
-	tracer := s.deps.Tracer
+	tracer := h.tracer
 	traceFrom := tracer.TraceFrom(ctx, id, 0)
 	traceTo := tracer.TraceTo(ctx, id, 0)
 
@@ -124,17 +140,17 @@ Please analyze:
 	}, nil
 }
 
-func (s *Server) handleReviewOrphansPrompt(
+func (h promptHandler) handleReviewOrphansPrompt(
 	ctx context.Context, request *mcpgo.GetPromptRequest,
 ) (*mcpgo.GetPromptResult, error) {
 	entityType := request.Params.Arguments["type"]
 
-	orphanIDs, _ := s.deps.Tracer.FindOrphans(ctx)
+	orphanIDs, _ := h.tracer.FindOrphans(ctx)
 
-	st := s.deps.Store
+	st := h.store
 	var resolved string
 	if entityType != "" {
-		resolved = s.types.resolveType(entityType)
+		resolved = h.types.resolveType(entityType)
 	}
 
 	type orphanSummary struct {
@@ -163,7 +179,7 @@ func (s *Server) handleReviewOrphansPrompt(
 	}
 
 	// Get available relation types
-	meta := s.deps.Meta
+	meta := h.meta
 	relTypes := meta.RelationTypes()
 	natsort.Strings(relTypes)
 	var relInfo strings.Builder
@@ -204,12 +220,12 @@ For each orphan entity:
 	}, nil
 }
 
-func (s *Server) handleSummarizeProjectPrompt(
+func (h promptHandler) handleSummarizeProjectPrompt(
 	ctx context.Context, _ *mcpgo.GetPromptRequest,
 ) (*mcpgo.GetPromptResult, error) {
 	// Entity counts by type
-	meta := s.deps.Meta
-	st := s.deps.Store
+	meta := h.meta
+	st := h.store
 	entityTypes := meta.EntityTypes()
 	natsort.Strings(entityTypes)
 	var entityCounts strings.Builder
@@ -237,7 +253,7 @@ func (s *Server) handleSummarizeProjectPrompt(
 	}
 
 	// Analysis summary
-	orphanIDs, _ := s.deps.Tracer.FindOrphans(ctx)
+	orphanIDs, _ := h.tracer.FindOrphans(ctx)
 	orphanCount := len(orphanIDs)
 
 	content := fmt.Sprintf(`Generate a comprehensive project summary based on the following data.
@@ -278,7 +294,7 @@ Please provide:
 	}, nil
 }
 
-func (s *Server) handleReviewEntityPrompt(
+func (h promptHandler) handleReviewEntityPrompt(
 	ctx context.Context, request *mcpgo.GetPromptRequest,
 ) (*mcpgo.GetPromptResult, error) {
 	id := request.Params.Arguments["id"]
@@ -286,7 +302,7 @@ func (s *Server) handleReviewEntityPrompt(
 		return nil, errors.New("id argument is required")
 	}
 
-	st := s.deps.Store
+	st := h.store
 	entity, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
@@ -298,7 +314,7 @@ func (s *Server) handleReviewEntityPrompt(
 	}
 
 	// Get entity type schema
-	meta := s.deps.Meta
+	meta := h.meta
 	def, _ := meta.GetEntityDef(entity.Type)
 	var schemaText string
 	if def != nil {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -18,7 +18,7 @@ func (s *Server) registerResources() {
 			Description: "The project's metamodel definition (entity types, relations, properties)",
 			MIMEType:    "application/json",
 		},
-		s.handleReadMetamodel,
+		s.schemaRes.handleReadMetamodel,
 	)
 
 	// Dynamic resource template: entities
@@ -29,7 +29,7 @@ func (s *Server) registerResources() {
 			Description: "Read a specific entity with its properties, content, and relations",
 			MIMEType:    "application/json",
 		},
-		s.handleReadEntity,
+		s.schemaRes.handleReadEntity,
 	)
 
 	// Dynamic resource template: relations
@@ -40,14 +40,14 @@ func (s *Server) registerResources() {
 			Description: "Read a specific relation between two entities",
 			MIMEType:    "application/json",
 		},
-		s.handleReadRelation,
+		s.schemaRes.handleReadRelation,
 	)
 }
 
-func (s *Server) handleReadMetamodel(
+func (h schemaResourceHandler) handleReadMetamodel(
 	_ context.Context, _ *mcpgo.ReadResourceRequest,
 ) (*mcpgo.ReadResourceResult, error) {
-	meta := s.deps.Meta
+	meta := h.meta
 	result := map[string]any{
 		"version":   meta.GetVersion(),
 		"namespace": meta.GetNamespace(),
@@ -73,7 +73,7 @@ func (s *Server) handleReadMetamodel(
 	}, nil
 }
 
-func (s *Server) handleReadEntity(
+func (h schemaResourceHandler) handleReadEntity(
 	ctx context.Context, request *mcpgo.ReadResourceRequest,
 ) (*mcpgo.ReadResourceResult, error) {
 	uri := request.Params.URI
@@ -86,7 +86,7 @@ func (s *Server) handleReadEntity(
 	}
 	entityType, id := segments[0], segments[1]
 
-	st := s.deps.Store
+	st := h.store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return nil, fmt.Errorf("entity not found: %s", id)
@@ -109,7 +109,7 @@ func (s *Server) handleReadEntity(
 	}, nil
 }
 
-func (s *Server) handleReadRelation(
+func (h schemaResourceHandler) handleReadRelation(
 	ctx context.Context, request *mcpgo.ReadResourceRequest,
 ) (*mcpgo.ReadResourceResult, error) {
 	uri := request.Params.URI
@@ -122,7 +122,7 @@ func (s *Server) handleReadRelation(
 	}
 	fromID, relType, toID := segments[0], segments[1], segments[2]
 
-	st := s.deps.Store
+	st := h.store
 	relation, getErr := st.GetRelation(ctx, fromID, relType, toID)
 	if getErr != nil {
 		return nil, fmt.Errorf("relation not found: %s --%s--> %s", fromID, relType, toID)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -199,8 +199,16 @@ type Server struct {
 	handlerSet
 }
 
-// handlerSet is the extracted handler groups a [Server] carries, grouped so
-// Deps.handlers has one return value rather than one per group.
+// handlerSet is the extracted handler groups a [Server] carries.
+//
+// Grouping them in one struct is load-bearing, not cosmetic: every
+// construction site wires them with a SINGLE whole-struct assignment
+// (s.handlerSet = deps.handlers()), so a partially-wired Server cannot be
+// built. Adding a seventh group adds a field here and every site picks it
+// up — with per-field assignment, a site that forgot one would compile and
+// then nil-panic at request time, which is how this was structured before
+// and what the grouping exists to prevent. Keep it one value; do not
+// spread these back out into separate returns.
 type handlerSet struct {
 	types     typeResolver
 	trace     traceHandler

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -160,9 +160,10 @@ type Watcher interface {
 
 // Server wraps the MCP server with rela-specific state.
 //
-// TODO(TKT-N0IKN9): Server is over the 40-method load line (38 methods
-// after the first ratchet). Decompose; ratchet this number down as
-// handlers move out.
+// TODO(TKT-N0IKN9): Server started this arc over the 40-method load line;
+// it is under it now (25 methods). The directive stays pinned to the actual
+// count so extraction gains cannot silently erode; ratchet it further as
+// the remaining handler clusters move out.
 //
 // 48 → 49: [Server.HTTPHandler] (TKT-BDG8U9). It belongs on Server — it
 // exposes THIS server over a second transport, the peer of [Server.Serve] —
@@ -175,31 +176,53 @@ type Watcher interface {
 // traceHandler / exportHandler (store + tracer, and store + resolver,
 // respectively). Each is a field below, wired from Deps in [NewServer];
 // registerTools points the affected AddTool lines at the field's methods.
-// The remaining handlers genuinely span deps — the next TKT-N0IKN9 slice.
 //
-//plimsoll:max-methods=38
+// 38 → 25 (TKT-MGNE5L): the lua tools moved to luaHandler (the sole user of
+// LuaWriteDeps / LuaCache / ProjectRoot), the schema tools + resource reads
+// to schemaResourceHandler (store + metamodel), and the prompt handlers to
+// promptHandler (store + metamodel + tracer + resolver). register* stay on
+// Server and point at the fields' methods. The remaining handlers genuinely
+// span deps — the next TKT-N0IKN9 slice.
+//
+//plimsoll:max-methods=25
 type Server struct {
 	mcp       *mcpgo.Server
 	deps      Deps
 	logger    *slog.Logger
 	principal principal.Principal
 
-	// Extracted handler groups (TKT-YUETL7) — built from deps by
-	// Deps.handlers. Identity is NOT threaded into them: every handler
-	// reads the principal from its ctx, stamped by principalMiddleware.
-	types  typeResolver
-	trace  traceHandler
-	export exportHandler
+	// Extracted handler groups (TKT-YUETL7, TKT-MGNE5L) — built from deps
+	// by Deps.handlers. Embedded so the groups stay addressable as
+	// s.trace/s.export/... Identity is NOT threaded into them: every
+	// handler reads the principal from its ctx, stamped by
+	// principalMiddleware.
+	handlerSet
+}
+
+// handlerSet is the extracted handler groups a [Server] carries, grouped so
+// Deps.handlers has one return value rather than one per group.
+type handlerSet struct {
+	types     typeResolver
+	trace     traceHandler
+	export    exportHandler
+	lua       luaHandler
+	schemaRes schemaResourceHandler
+	prompts   promptHandler
 }
 
 // handlers builds the extracted handler groups a [Server] carries. One
 // derivation shared by [NewServer] and the test helpers that construct
 // Server literals, so the wiring cannot drift between them.
-func (d Deps) handlers() (typeResolver, traceHandler, exportHandler) {
+func (d Deps) handlers() handlerSet {
 	types := typeResolver{meta: d.Meta}
-	return types,
-		traceHandler{store: d.Store, tracer: d.Tracer},
-		exportHandler{store: d.Store, types: types}
+	return handlerSet{
+		types:     types,
+		trace:     traceHandler{store: d.Store, tracer: d.Tracer},
+		export:    exportHandler{store: d.Store, types: types},
+		lua:       luaHandler{writeDeps: d.LuaWriteDeps, cache: d.LuaCache, projectRoot: d.ProjectRoot},
+		schemaRes: schemaResourceHandler{store: d.Store, meta: d.Meta},
+		prompts:   promptHandler{store: d.Store, meta: d.Meta, tracer: d.Tracer, types: types},
+	}
 }
 
 // Option configures a [Server] at construction.
@@ -267,7 +290,7 @@ func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 	if err := deps.validate(); err != nil {
 		return nil, err
 	}
-	s.types, s.trace, s.export = deps.handlers()
+	s.handlerSet = deps.handlers()
 
 	// Capabilities are inferred by the go-sdk from the features actually
 	// registered below (tools/resources/prompts each gain listChanged when

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -30,19 +30,20 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(toolAnalyzeValidations(), s.handleAnalyzeValidations)
 	s.mcp.AddTool(toolAnalyzeSchema(), s.handleAnalyzeSchema)
 
-	// Schema tools
-	s.mcp.AddTool(toolGetSchema(), s.handleGetSchema)
-	s.mcp.AddTool(toolGetMetamodel(), s.handleGetSchema)
-	s.mcp.AddTool(toolListEntityTypes(), s.handleListEntityTypes)
-	s.mcp.AddTool(toolListRelationTypes(), s.handleListRelationTypes)
+	// Schema tools (get_metamodel intentionally shares get_schema's
+	// handler — see toolGetMetamodel)
+	s.mcp.AddTool(toolGetSchema(), s.schemaRes.handleGetSchema)
+	s.mcp.AddTool(toolGetMetamodel(), s.schemaRes.handleGetSchema)
+	s.mcp.AddTool(toolListEntityTypes(), s.schemaRes.handleListEntityTypes)
+	s.mcp.AddTool(toolListRelationTypes(), s.schemaRes.handleListRelationTypes)
 
 	// Utility tools
 	s.mcp.AddTool(toolExport(), s.export.handleExport)
 
 	// Lua scripting tools
-	s.mcp.AddTool(toolLuaEval(), s.handleLuaEval)
-	s.mcp.AddTool(toolLuaRun(), s.handleLuaRun)
-	s.mcp.AddTool(toolLuaList(), s.handleLuaList)
+	s.mcp.AddTool(toolLuaEval(), s.lua.handleLuaEval)
+	s.mcp.AddTool(toolLuaRun(), s.lua.handleLuaRun)
+	s.mcp.AddTool(toolLuaList(), s.lua.handleLuaList)
 }
 
 // --- Tool Definitions ---

--- a/internal/mcp/tools_lua.go
+++ b/internal/mcp/tools_lua.go
@@ -55,7 +55,20 @@ func toolLuaList() *mcpgo.Tool {
 	)
 }
 
-func (s *Server) handleLuaEval(ctx context.Context, req *mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+// luaHandler serves the lua_eval / lua_run / lua_list tools. A type of its
+// own rather than more methods on [Server] (the urlHelpers pattern,
+// TKT-MGNE5L): the lua tools are the ONLY consumers of the write-capable
+// runtime deps, the script cache, and the project root — holding them here
+// means no other handler in the package can reach a Lua write path. Identity
+// still arrives on the ctx via Server.principalMiddleware; the handler holds
+// no principal.
+type luaHandler struct {
+	writeDeps   lua.WriteDeps
+	cache       *lua.Cache
+	projectRoot string
+}
+
+func (h luaHandler) handleLuaEval(ctx context.Context, req *mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	in := newToolRequest(req)
 	code, err := in.RequireString("code")
 	if err != nil {
@@ -75,8 +88,8 @@ func (s *Server) handleLuaEval(ctx context.Context, req *mcpgo.CallToolRequest) 
 	// LuaWriteDeps.Capabilities is the zero value here and must stay that way;
 	// do not "fix" a script that fails with "attempt to index a nil value
 	// (global http)" by granting it here.
-	runtime, err := script.NewWriterRuntime(s.deps.LuaWriteDeps, "",
-		&output, lua.WithContext(ctx), lua.WithCache(s.deps.LuaCache))
+	runtime, err := script.NewWriterRuntime(h.writeDeps, "",
+		&output, lua.WithContext(ctx), lua.WithCache(h.cache))
 	if err != nil {
 		return errorResult("config error: " + err.Error()), nil
 	}
@@ -107,7 +120,7 @@ func (s *Server) handleLuaEval(ctx context.Context, req *mcpgo.CallToolRequest) 
 	return textResult(result), nil
 }
 
-func (s *Server) handleLuaRun(ctx context.Context, req *mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+func (h luaHandler) handleLuaRun(ctx context.Context, req *mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	in := newToolRequest(req)
 	path, err := in.RequireString("path")
 	if err != nil {
@@ -127,7 +140,7 @@ func (s *Server) handleLuaRun(ctx context.Context, req *mcpgo.CallToolRequest) (
 	// Parse args if provided
 	args := in.GetStringSlice("args", nil)
 
-	projectRoot := s.deps.ProjectRoot
+	projectRoot := h.projectRoot
 
 	// Security: Scripts must be in the scripts/ directory
 	// Use os.Root for traversal-resistant path access
@@ -164,8 +177,8 @@ func (s *Server) handleLuaRun(ctx context.Context, req *mcpgo.CallToolRequest) (
 	// lua_run names a file under scripts/, but the CHOICE of file is the MCP
 	// client's, so this inherits the same posture rather than the operator-shell
 	// default `rela script` uses for the very same files.
-	runtime, err := script.NewWriterRuntime(s.deps.LuaWriteDeps, path,
-		&output, lua.WithContext(ctx), lua.WithCache(s.deps.LuaCache))
+	runtime, err := script.NewWriterRuntime(h.writeDeps, path,
+		&output, lua.WithContext(ctx), lua.WithCache(h.cache))
 	if err != nil {
 		return errorResult("config error: " + err.Error()), nil
 	}
@@ -230,9 +243,9 @@ func luaScriptErrorResult(surface lua.Surface, envelopePath, projectRoot string,
 	return errorResult(string(body))
 }
 
-func (s *Server) handleLuaList(_ context.Context, _ *mcpgo.CallToolRequest,
+func (h luaHandler) handleLuaList(_ context.Context, _ *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
-	projectRoot := s.deps.ProjectRoot
+	projectRoot := h.projectRoot
 
 	// Only search the scripts/ directory (security restriction)
 	scriptsPath := filepath.Join(projectRoot, scriptsDir)

--- a/internal/mcp/tools_lua_test.go
+++ b/internal/mcp/tools_lua_test.go
@@ -43,7 +43,7 @@ func TestHandleLuaEval_ReturnsScriptErrorEnvelope(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 
-	result, err := s.handleLuaEval(context.Background(),
+	result, err := s.lua.handleLuaEval(context.Background(),
 		luaCallToolReq(map[string]any{"code": "print('hello')\nerror('kaboom')"}))
 	if err != nil {
 		t.Fatalf("handler returned Go error: %v", err)
@@ -77,7 +77,7 @@ func TestHandleLuaEval_ReturnsScriptErrorEnvelope(t *testing.T) {
 func TestHandleLuaEval_PreservesIsErrorFlag(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, _ := s.handleLuaEval(context.Background(),
+	result, _ := s.lua.handleLuaEval(context.Background(),
 		luaCallToolReq(map[string]any{"code": "error('x')"}))
 	if !result.IsError {
 		t.Error("IsError flag must remain true on Lua failure for MCP clients to branch")

--- a/internal/mcp/tools_schema.go
+++ b/internal/mcp/tools_schema.go
@@ -11,10 +11,22 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-func (s *Server) handleGetSchema(
+// schemaResourceHandler serves the schema tools (get_schema / get_metamodel /
+// list_entity_types / list_relation_types) and the rela:// resource reads in
+// resources.go. One merged type rather than two (the urlHelpers pattern,
+// TKT-MGNE5L): both surfaces answer "describe the graph's shape and read one
+// row of it" from the same two collaborators — the metamodel and the gated
+// [GraphReader]. Identity still arrives on the ctx via
+// Server.principalMiddleware; the handler holds no principal.
+type schemaResourceHandler struct {
+	store GraphReader
+	meta  *metamodel.Metamodel
+}
+
+func (h schemaResourceHandler) handleGetSchema(
 	_ context.Context, _ *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
-	meta := s.deps.Meta
+	meta := h.meta
 	result := map[string]any{
 		"version":   meta.GetVersion(),
 		"namespace": meta.GetNamespace(),
@@ -33,7 +45,7 @@ func (s *Server) handleGetSchema(
 	return textResult(text), nil
 }
 
-func (s *Server) handleListEntityTypes(
+func (h schemaResourceHandler) handleListEntityTypes(
 	ctx context.Context, _ *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
 	type entityTypeInfo struct {
@@ -45,8 +57,8 @@ func (s *Server) handleListEntityTypes(
 		Count      int                              `json:"count"`
 	}
 
-	meta := s.deps.Meta
-	st := s.deps.Store
+	meta := h.meta
+	st := h.store
 	types := meta.EntityTypes()
 	natsort.Strings(types)
 
@@ -74,7 +86,7 @@ func (s *Server) handleListEntityTypes(
 	return textResult(text), nil
 }
 
-func (s *Server) handleListRelationTypes(
+func (h schemaResourceHandler) handleListRelationTypes(
 	ctx context.Context, _ *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
 	type relationTypeInfo struct {
@@ -87,8 +99,8 @@ func (s *Server) handleListRelationTypes(
 		Count       int      `json:"count"`
 	}
 
-	meta := s.deps.Meta
-	st := s.deps.Store
+	meta := h.meta
+	st := h.store
 	types := meta.RelationTypes()
 	natsort.Strings(types)
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -90,7 +90,7 @@ func makeTestServerWithStore(t *testing.T) (*Server, *memstore.MemStore) {
 		deps:   deps,
 		logger: slog.New(slog.DiscardHandler),
 	}
-	srv.types, srv.trace, srv.export = deps.handlers()
+	srv.handlerSet = deps.handlers()
 	return srv, st
 }
 
@@ -941,7 +941,7 @@ func TestHandleAnalyzeValidations_NoRules(t *testing.T) {
 func TestHandleGetMetamodel(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, err := s.handleGetSchema(context.Background(), &mcpgo.CallToolRequest{})
+	result, err := s.schemaRes.handleGetSchema(context.Background(), &mcpgo.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -961,7 +961,7 @@ func TestHandleGetMetamodel(t *testing.T) {
 func TestHandleListEntityTypes(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, err := s.handleListEntityTypes(context.Background(), &mcpgo.CallToolRequest{})
+	result, err := s.schemaRes.handleListEntityTypes(context.Background(), &mcpgo.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -978,7 +978,7 @@ func TestHandleListEntityTypes(t *testing.T) {
 func TestHandleListRelationTypes(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, err := s.handleListRelationTypes(context.Background(), &mcpgo.CallToolRequest{})
+	result, err := s.schemaRes.handleListRelationTypes(context.Background(), &mcpgo.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -999,7 +999,7 @@ func TestHandleReadEntity(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/requirement/REQ-001"
-	contents, err := s.handleReadEntity(context.Background(), req)
+	contents, err := s.schemaRes.handleReadEntity(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1017,7 +1017,7 @@ func TestHandleReadEntity_TypeMismatch(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/decision/REQ-001"
-	_, err := s.handleReadEntity(context.Background(), req)
+	_, err := s.schemaRes.handleReadEntity(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for type mismatch")
 	}
@@ -1031,7 +1031,7 @@ func TestHandleReadEntity_NotFound(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/requirement/REQ-999"
-	_, err := s.handleReadEntity(context.Background(), req)
+	_, err := s.schemaRes.handleReadEntity(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for nonexistent entity")
 	}
@@ -1042,7 +1042,7 @@ func TestHandleReadEntity_InvalidURI(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/onlyone"
-	_, err := s.handleReadEntity(context.Background(), req)
+	_, err := s.schemaRes.handleReadEntity(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for invalid URI")
 	}
@@ -1053,7 +1053,7 @@ func TestHandleReadRelation(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://relation/DEC-001/addresses/REQ-001"
-	contents, err := s.handleReadRelation(context.Background(), req)
+	contents, err := s.schemaRes.handleReadRelation(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1071,7 +1071,7 @@ func TestHandleReadRelation_NotFound(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://relation/REQ-001/nonexistent/REQ-002"
-	_, err := s.handleReadRelation(context.Background(), req)
+	_, err := s.schemaRes.handleReadRelation(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for nonexistent relation")
 	}

--- a/tickets/entities/implementation-checklists/IMPL-CLLMB1.md
+++ b/tickets/entities/implementation-checklists/IMPL-CLLMB1.md
@@ -1,0 +1,54 @@
+---
+id: IMPL-CLLMB1
+type: implementation-checklist
+title: 'Implementation: mcp.Server round 2: lua/schema/resources/prompts handlers (38 → ~25)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no new behavior — receiver-only moves; dispatch/golden/capabilities-posture suites pin the surfaces)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled (toolGetSchema/toolGetMetamodel aliasing onto the same handler preserved on the new receiver)
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A: test changes are mechanical re-points)
+- [x] ~~No hardcoded values in assertions~~ (N/A)
+- [x] ~~Only values that matter~~ (N/A)
+- [x] ~~Interpolated values from objects~~ (N/A)
+- [x] ~~Property comparisons from original object~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (full `go test ./...` green)
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence (PR #1468, branch tkt-mgne5l-mcp-round2):**
+- Server 38 → **25**; directive ratcheted to match.
+- `luaHandler` isolates the Lua deps (WriteDeps/cache/projectRoot) that no
+other handler uses, so no other handler can now reach them;
+`schemaResourceHandler` merges schema tools + resources (identical store+meta
+deps); `promptHandler` takes store+meta+tracer+typeResolver.
+- Coordinator fixes after the implementing agent was interrupted: the
+shared derivation returned 6 positional values (tripping gocritic's
+tooManyResultsChecker); refactored to a named `handlerSet` struct **embedded**
+on Server, so every `s.trace.…` reference still resolves via field promotion and
+NewServer/test-helper wiring still cannot drift. Also fixed a doclink in the new
+godoc (Go cannot link the unexported `Deps.handlers`, so the brackets were
+dropped).
+- Gates: build, full `go test ./...`, `-race ./internal/mcp/`, plimsoll,
+arch-lint, comment-lint, golangci-lint (0 issues) — all green.
+
+## Quality
+
+- [x] Code follows project patterns (mirrors the TKT-YUETL7 handler shape on the base branch)
+- [x] Checked for DRY opportunities (one shared `Deps.handlers` derivation for NewServer + test helpers, so wiring can't drift)
+- [x] No security issues introduced (principalMiddleware untouched; no principal threaded into any handler struct — identity still read from ctx)
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-U67DAY.md
+++ b/tickets/entities/review-checklists/REV-U67DAY.md
@@ -1,0 +1,30 @@
+---
+id: REV-U67DAY
+type: review-checklist
+title: 'Review: mcp.Server round 2: lua/schema/resources/prompts handlers (38 → ~25)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (verified at the branch tip with `-count=1` in the correct worktree; `-race` on internal/mcp)
+- [x] Linters pass (golangci-lint 0 issues, plimsoll at 25, arch-lint, comment-lint clean across 11075 comments)
+- [x] Coverage floors hold
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer, diffed against the STACKED base tkt-yuetl7-mcp-trace-export, not develop)
+- [x] All critical/significant findings addressed (none)
+- [x] Minor/nit findings addressed: [[RR-8TF28O]] (handlerSet godoc now documents the anti-partial-wiring property, not just the gocritic reason), [[RR-046BDE]] (tracer package shadow removed). Third nit — `schemaResourceHandler`'s portmanteau name — deliberately not actioned; the shared dep set is real and splitting would yield two identical structs.
+
+## Verification
+
+- [x] `get_metamodel` / `get_schema` aliasing preserved — and now defended by dispatch_test.go's tool inventory ("deprecated alias, must keep dispatching"), so a future dedup fails a test rather than only contradicting a comment
+- [x] Identity/ACL: principalMiddleware untouched at SDK level; no principal field on any handler; all three types hold the narrow GraphReader, never store.Store. resources/prompts narrowed their *reach* (same gate — Deps.Store was already GraphReader); TestACL_Resources_AreGated passes
+- [x] TestLuaToolsHoldNoAmbientCapabilities remains load-bearing after the move (luaHandler.writeDeps is copied from the exact field it guards) — not orphaned by the extraction
+- [x] handlerSet embedding verified: zero method promotion (so the plimsoll reduction is real, not accounting), no field-name collisions with Server's own four fields, and all four construction sites use a single whole-struct assignment — partial wiring is genuinely closed
+- [x] NewServer validates deps BEFORE calling handlers(), so groups are never built from unvalidated nils
+- [x] Method count verified at 25, matching the directive
+- [x] Tests: receiver re-points only; zero assertion changes, zero deleted tests, zero golden-file changes (capabilities_posture_test.go and golden_test.go byte-identical to base)

--- a/tickets/entities/review-responses/RR-046BDE.md
+++ b/tickets/entities/review-responses/RR-046BDE.md
@@ -1,0 +1,18 @@
+---
+id: RR-046BDE
+type: review-response
+title: tracer local shadowed the tracer package in handleAnalyzeTraceabilityPrompt
+finding: prompts.go:98 did `tracer := h.tracer`, shadowing the imported tracer package inside the function. Pre-existing (was `tracer := s.deps.Tracer`), but the package name is now genuinely needed in the same file for the promptHandler.tracer field declaration, so the shadow moved from merely ugly to one edit away from confusing.
+severity: nit
+resolution: Removed the local entirely — the two uses now call h.tracer.TraceFrom / h.tracer.TraceTo inline. No behavior change; build, tests, lint and comment-lint all green.
+status: addressed
+---
+
+Nit from the TKT-MGNE5L code review (cranky-code-reviewer, PR #1468).
+
+Third nit from the same review, NOT actioned and deliberately so:
+`schemaResourceHandler`'s name is a portmanteau of two surfaces rather than a
+responsibility, which is often the tell that a type is two things. Left as-is
+because the shared `{GraphReader, meta}` dep set is real and splitting would
+produce two structs with identical fields; the reviewer agreed and only flagged
+it as where pressure will show if a third surface ever wants in.

--- a/tickets/entities/review-responses/RR-8TF28O.md
+++ b/tickets/entities/review-responses/RR-8TF28O.md
@@ -1,0 +1,18 @@
+---
+id: RR-8TF28O
+type: review-response
+title: handlerSet godoc documented only the gocritic reason, not the anti-partial-wiring property it protects
+finding: The handlerSet godoc said the grouping exists 'so Deps.handlers has one return value rather than one per group' — the gocritic reason. The load-bearing reason is that whole-struct assignment makes a partially-wired Server unconstructible (the hazard RR-OSJQWC flagged on the parent PR). As written it reads like a style concession a later refactor could reverse without realising what it gives up.
+severity: minor
+resolution: 'Rewrote the godoc to lead with the safety property: single whole-struct assignment at every construction site, adding a seventh group is picked up automatically, and per-field assignment would compile then nil-panic at request time. Ends with an explicit ''keep it one value; do not spread these back out into separate returns.'''
+status: addressed
+---
+
+Nit from the TKT-MGNE5L code review (cranky-code-reviewer, PR #1468). Reviewer
+verified: pure move after normalization; get_metamodel/get_schema aliasing
+preserved AND now defended by dispatch_test.go's inventory test rather than
+prose alone; no principal in any handler struct; all handlers hold the narrow
+GraphReader (resources/prompts narrowed their reach, same gate); handlerSet
+promotes zero methods so the plimsoll reduction is real, not accounting; no
+field-name collisions; TestLuaToolsHoldNoAmbientCapabilities did not get
+orphaned by the move; directive 25 matches; zero assertion/golden changes.

--- a/tickets/entities/tickets/TKT-MGNE5L.md
+++ b/tickets/entities/tickets/TKT-MGNE5L.md
@@ -1,0 +1,39 @@
+---
+id: TKT-MGNE5L
+type: ticket
+title: 'mcp.Server round 2: lua/schema/resources/prompts handlers (38 → ~25)'
+kind: refactor
+priority: medium
+effort: m
+status: done
+---
+
+Sub-ticket of [[TKT-N0IKN9]], second step of the `mcp.Server` arc after
+[[TKT-YUETL7]] (49 → 38). Stacked on TKT-YUETL7's branch.
+
+## What
+
+**Pure structural extraction, no behavior change, no wire-visible change.**
+
+- **`luaHandler`** (−3): `handleLuaEval`, `handleLuaRun`, `handleLuaList`
+(tools_lua.go) over `{lua.WriteDeps, lua cache, projectRoot}` — deps used by
+NOTHING else in the package, so this also stops other handlers from seeing the
+Lua capabilities. capabilities_posture_test.go + tools_lua_test.go pin behavior.
+- **`schemaResourceHandler`** (−6): the schema tools (`handleGetSchema`,
+`handleListEntityTypes`, `handleListRelationTypes`, tools_schema.go) and the
+resources (`handleReadMetamodel`, `handleReadEntity`, `handleReadRelation`,
+resources.go) share the same deps `{store GraphReader, meta}` — one merged type.
+PRESERVE the aliasing: `toolGetSchema()` and `toolGetMetamodel()` both register
+the same handleGetSchema.
+- **`promptHandler`** (−4): the four prompt handlers (prompts.go) over
+`{store GraphReader, meta, tracer}`. golden_test.go pins prompt output.
+
+`registerTools`/`registerResources`/`registerPrompts` stay on Server; affected
+registration lines re-point. principalMiddleware untouched — no principal
+threaded into any handler struct. Ratchet directive 38 → ~25.
+
+## Done when
+
+plimsoll with lowered directive; full suite + `-race ./internal/mcp/` green;
+dispatch/golden/capabilities-posture tests unchanged;
+arch-lint/comment-lint/lint clean.

--- a/tickets/relations/TKT-MGNE5L--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-MGNE5L--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MGNE5L
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-MGNE5L--depends-on--TKT-YUETL7.md
+++ b/tickets/relations/TKT-MGNE5L--depends-on--TKT-YUETL7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MGNE5L
+relation: depends-on
+to: TKT-YUETL7
+---

--- a/tickets/relations/TKT-MGNE5L--has-implementation--IMPL-CLLMB1.md
+++ b/tickets/relations/TKT-MGNE5L--has-implementation--IMPL-CLLMB1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MGNE5L
+relation: has-implementation
+to: IMPL-CLLMB1
+---

--- a/tickets/relations/TKT-MGNE5L--has-review--REV-U67DAY.md
+++ b/tickets/relations/TKT-MGNE5L--has-review--REV-U67DAY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MGNE5L
+relation: has-review
+to: REV-U67DAY
+---

--- a/tickets/relations/TKT-MGNE5L--has-review-response--RR-046BDE.md
+++ b/tickets/relations/TKT-MGNE5L--has-review-response--RR-046BDE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MGNE5L
+relation: has-review-response
+to: RR-046BDE
+---

--- a/tickets/relations/TKT-MGNE5L--has-review-response--RR-8TF28O.md
+++ b/tickets/relations/TKT-MGNE5L--has-review-response--RR-8TF28O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MGNE5L
+relation: has-review-response
+to: RR-8TF28O
+---

--- a/tickets/relations/TKT-MGNE5L--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-MGNE5L--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-MGNE5L
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Second step of the `mcp.Server` arc (TKT-N0IKN9), stacked on #1463. Three more clusters move off Server: `luaHandler` (lua_eval/run/list — its deps are used by nothing else in the package, so no other handler can now see the Lua capabilities), `schemaResourceHandler` (schema tools + resources, which share the same store+meta deps), and `promptHandler`. Directive ratchets **38 → 25**.

The `toolGetSchema`/`toolGetMetamodel` aliasing onto the same handler is preserved. `principalMiddleware` is untouched and no principal is threaded into any handler struct — every handler still reads identity from ctx. The groups are built by one shared `Deps.handlers` derivation and embedded on Server, so `NewServer` and the test helpers cannot drift.

Gates: full `go test ./...`, `-race ./internal/mcp/`, plimsoll, arch-lint, comment-lint, golangci-lint (0 issues) all green.

https://claude.ai/code/session_016Br8QmRwRReoeZx55EfwyQ