### PR TITLE
refactor(dataentry): extract query/search leaf off App (TKT-SJ0LRS)

### DIFF
--- a/internal/dataentry/acl_search_test.go
+++ b/internal/dataentry/acl_search_test.go
@@ -267,7 +267,7 @@ func TestACLSearch_ScopeErrorMapping(t *testing.T) {
 	}
 
 	// Sentinel wrapping (AC7b): the _position consumer relies on it.
-	_, qErr := app.executeQuery(gateCtxFor(aliceCtx(), t, d), "alpha")
+	_, qErr := app.queries.executeQuery(gateCtxFor(aliceCtx(), t, d), "alpha")
 	if !errors.Is(qErr, errACLListQuery) {
 		t.Errorf("executeQuery scope error = %v, want errACLListQuery wrap", qErr)
 	}
@@ -325,7 +325,7 @@ func TestACLSearch_BackendErrorMapping(t *testing.T) {
 		t.Errorf("raw backend error leaked to the wire: %s", body)
 	}
 
-	_, qErr := app.executeQuery(context.Background(), "alpha")
+	_, qErr := app.queries.executeQuery(context.Background(), "alpha")
 	if qErr == nil || errors.Is(qErr, errACLListQuery) {
 		t.Errorf("backend error = %v, want non-nil and NOT errACLListQuery", qErr)
 	}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -323,7 +323,7 @@ func (a *App) scopedSortedEntities(
 	// over relevance ranking, same approach SearchView uses for filtering.
 	// Backend errors surface as HTTP 500 rather than rendering an empty list
 	// and pretending the search succeeded.
-	searchResult, err := a.freeTextIDsForType(ctx, queryGet(query, "q"), typeName)
+	searchResult, err := a.queries.freeTextIDsForType(ctx, queryGet(query, "q"), typeName)
 	if err != nil {
 		return nil, err
 	}
@@ -1533,7 +1533,7 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 	// executeQuery is read-gated (TKT-BA8BSX): only entities the
 	// request principal may read come back, and gate/load/search
 	// failures surface instead of silently truncating.
-	entities, err := a.executeQuery(r.Context(), query)
+	entities, err := a.queries.executeQuery(r.Context(), query)
 	if err != nil {
 		writeListPipelineError(w, r, err)
 		return

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -113,7 +113,12 @@ const userPaletteFile = "palette.yaml"
 // /_theme export/import pair, and the /_settings + /_palette CRUD) moved to
 // appearanceHandler (TKT-8AJ1PM, 104 → 92).
 //
-//plimsoll:max-methods=92
+// The search-query pipeline (5 methods — executeQuery and its free-text
+// branch, the list `?q=` id-set helper, and the sort / property-filter passes
+// they share) moved to queryService, and the dead isRelationLinked was deleted
+// (TKT-SJ0LRS, 92 → 86).
+//
+//plimsoll:max-methods=86
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -239,10 +244,15 @@ type App struct {
 	// Pure glue over the self-synchronized logo/palette/settings services
 	// — no writeMu.
 	appearance *appearanceHandler
-	templater  templating.Templater
-	cfgLoader  config.Loader
-	kv         state.KV
-	acl        acl.ACL
+	// queries owns the search-query pipeline: executeQuery (shared by
+	// /_search, the `_position` search scope and the next-action engine),
+	// the list endpoint's `?q=` id-set helper, and the sort / property-filter
+	// passes those share (TKT-SJ0LRS). Read-only; no writeMu.
+	queries   *queryService
+	templater templating.Templater
+	cfgLoader config.Loader
+	kv        state.KV
+	acl       acl.ACL
 
 	// attachmentRunner drives external scan/transform commands for uploads.
 	// nil out-of-box → uploads get native MIME validation only (Phase 2 wires
@@ -969,6 +979,11 @@ func NewApp(
 	// appearanceHandler owns the theme/settings/palette routes; wired after
 	// the logo/palette/settings services and viewReader it captures.
 	app.appearance = newAppearanceHandler(app)
+
+	// queryService owns the search-query pipeline. Its searcher and
+	// affordance handles are closures because tests reassign both after
+	// construction — see the type's doc comment.
+	app.queries = newQueryService(app)
 
 	// commandHandler owns the user-configured command surface. Its
 	// collaborators are narrow closures over App: the schema snapshot (command/

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"errors"
 	"fmt"
 	"html/template"
 	"iter"
@@ -266,23 +265,6 @@ func applyFilters(entities []*entity.Entity, filters []FilterConfig) []*entity.E
 	return result
 }
 
-// sortEntitiesMulti sorts entities by multiple sort specs using type-aware comparison.
-func (a *App) sortEntitiesMulti(entities []*entity.Entity, specs []filter.SortSpec) {
-	if len(specs) == 0 {
-		return
-	}
-	s := a.State()
-	entityDefs := make(map[string]*metamodel.EntityDef)
-	for _, e := range entities {
-		if _, ok := entityDefs[e.Type]; !ok {
-			if def, ok := s.Meta.GetEntityDef(e.Type); ok {
-				entityDefs[e.Type] = def
-			}
-		}
-	}
-	filter.SortMulti(entities, entityRecord, specs, entityDefs, s.Meta)
-}
-
 // resolvePropertyValues returns allowed values for a property from its definition or custom type.
 func resolvePropertyValues(prop metamodel.PropertyDef, meta *metamodel.Metamodel) []string {
 	if len(prop.Values) > 0 {
@@ -396,145 +378,6 @@ func addCheckboxIndices(s string) string {
 		idx++
 		return result
 	})
-}
-
-// executeQuery parses a search query and returns all matching entities.
-// It supports the same query syntax as the search page: type:, prop:, status:,
-// and free text. Free-text words use OR logic with fuzzy matching via Bleve;
-// results are ranked by score.
-// executeQuery runs the search-view pipeline under the ctx principal's
-// read scope (TKT-BA8BSX). Both consumers — handleV1Search and the
-// _position search scope (resolveScope) — inherit the gate from here,
-// so no future consumer can run an ungated search by accident.
-//
-// Ordering of the gate: the scope resolves FIRST, and an
-// all-effective-DenyAll scope returns before any backend work — a
-// denied principal must not be able to probe search-backend latency
-// (RR-X56H pattern, pinned with a recording searcher in
-// acl_search_test.go). The free-text branch then runs through
-// search.VisibleSearcher so hidden hits never have their bodies
-// loaded; the type-listing branch resolves the per-type verdict
-// against the store directly.
-//
-// The maxFreeTextSearchResults bound counts entities that survived
-// BOTH visibility and property filters (post-visibility truncation —
-// a pre-visibility cap starves restricted principals; a pre-filter
-// cap would starve filtered queries the same way).
-//
-// Errors: visibility-scope failures wrap errACLListQuery (mapped by
-// writeGateError: cancel-silent / 504 / 500 acl_query_failed with
-// constant detail), store-load failures wrap errListLoad, and plain
-// search-backend failures pass through (500 search_failed). The
-// pre-TKT-BA8BSX version swallowed both error classes into silently
-// truncated results.
-func (a *App) executeQuery(ctx context.Context, query string) ([]*entity.Entity, error) {
-	sq := searchparser.ParseQuery(query)
-	if sq.IsEmpty() {
-		return nil, nil
-	}
-
-	svc := a.Services()
-	typeNames := make([]string, 0, len(svc.Meta.Entities))
-	for name := range svc.Meta.Entities {
-		typeNames = append(typeNames, name)
-	}
-	slices.Sort(typeNames)
-	scope := readGateFromContext(ctx).SearchScope(ctx, typeNames)
-	if len(scope) == 0 {
-		return []*entity.Entity{}, nil
-	}
-
-	var candidates []*entity.Entity
-	var err error
-	if sq.HasFreeText() {
-		// Hits arrive in relevance order. Scores are dropped because
-		// executeQuery never sorted by them.
-		candidates, err = a.runVisibleFreeTextSearch(ctx, svc, sq, scope)
-	} else {
-		// Push the equality filters into the store as a PRE-FILTER, cutting
-		// the rows loaded. The Go pass below still evaluates every filter,
-		// including the pushed ones, and remains authoritative.
-		//
-		// That belt-and-braces is deliberate rather than redundant.
-		// store.PropPredicate compares by STRING FORM; filter.MatchAll is
-		// metamodel-aware. On a typed property they disagree — `count!=03`
-		// against an integer 3 is a non-match typed and a match as strings,
-		// and an enum filter naming an undeclared value ERRORS in Go
-		// (surfacing the operator's typo) while the store silently returns
-		// nothing. Dropping a pushed filter from the Go pass would let the
-		// looser of the two decide, WIDENING results on a path /_search and
-		// scope navigation share.
-		//
-		// Keeping both makes the outcome provably identical to the
-		// pre-pushdown behavior — the store can only ever remove rows the Go
-		// pass would also have removed — while still winning the I/O.
-		pushed := pushdownPrefilters(sq.PropertyFilters, svc.Meta, sq.EntityTypes)
-		candidates, err = visibleListByTypes(ctx, svc, sq.EntityTypes, scope, pushed)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	results := make([]*entity.Entity, 0, len(candidates))
-	for _, e := range candidates {
-		if !a.matchesPropertyFilters(e, sq.PropertyFilters) {
-			continue
-		}
-		results = append(results, e)
-		if sq.HasFreeText() && len(results) >= maxFreeTextSearchResults {
-			break
-		}
-	}
-
-	// Apply sort from query syntax (free-text results are already ranked by relevance)
-	if sq.HasSort() {
-		a.sortEntitiesMulti(results, sq.SortClauses)
-	}
-
-	return results, nil
-}
-
-// runVisibleFreeTextSearch is executeQuery's free-text branch: the
-// same phrase re-quoting as runFreeTextSearchE, routed through the
-// ACL-scoped searcher. The backend-side limit is only set when no
-// property filters remain — with Go-side filters pending, truncation
-// happens in executeQuery after them, or the filter gap would re-open
-// the starvation the post-visibility limit closes.
-func (a *App) runVisibleFreeTextSearch(
-	ctx context.Context, svc Services, sq *searchparser.SearchQuery, scope map[string]search.TypeScope,
-) ([]*entity.Entity, error) {
-	parts := make([]string, 0, len(sq.FreeTextWords)+len(sq.FreeTextPhrases))
-	parts = append(parts, sq.FreeTextWords...)
-	for _, p := range sq.FreeTextPhrases {
-		parts = append(parts, `"`+p+`"`)
-	}
-	limit := 0
-	if len(sq.PropertyFilters) == 0 {
-		limit = maxFreeTextSearchResults
-	}
-	q := search.Query{
-		Text:  strings.Join(parts, " "),
-		Types: sq.EntityTypes,
-		Limit: limit,
-	}
-	out := make([]*entity.Entity, 0)
-	for hit, err := range searchVisibleHits(ctx, a.visibleSearcher, a.affordances, q, scope) {
-		if err != nil {
-			if errors.Is(err, search.ErrScope) {
-				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
-			}
-			return nil, fmt.Errorf("free-text search: %w", err)
-		}
-		e, getErr := svc.Store.GetEntity(ctx, hit.ID)
-		if getErr != nil {
-			// Stale index hit (entity deleted between index query and
-			// store read). Skip silently — the result stays a coherent
-			// set of currently-existing entities.
-			continue
-		}
-		out = append(out, e)
-	}
-	return out, nil
 }
 
 // searchVisibleHits runs the ACL-scoped search with property-level redaction
@@ -696,39 +539,6 @@ type freeTextIDsForTypeResult struct {
 	HasFilter bool
 }
 
-// freeTextIDsForType runs a free-text search constrained to the given entity
-// type and returns the matching ids. Empty / whitespace queries (and queries
-// like `prop:status=open` that have no free-text words) return HasFilter=false
-// so the caller skips intersection entirely. Searcher errors are surfaced —
-// the list handler converts them to HTTP 500 rather than rendering an empty
-// list and pretending the search succeeded.
-//
-// Used by the list endpoint to support `?q=` without going through the full
-// executeQuery path: a list is already type-scoped, so any `type:` token from
-// the query string is intentionally ignored — we always pin the type to the
-// list's type to keep the surface predictable.
-func (a *App) freeTextIDsForType(ctx context.Context, query, typeName string) (freeTextIDsForTypeResult, error) {
-	query = strings.TrimSpace(query)
-	if query == "" {
-		return freeTextIDsForTypeResult{}, nil
-	}
-	sq := searchparser.ParseQuery(query)
-	if sq.IsEmpty() || !sq.HasFreeText() {
-		return freeTextIDsForTypeResult{}, nil
-	}
-	sq.EntityTypes = []string{typeName}
-
-	hits, err := runFreeTextSearchE(ctx, a.Services(), sq, maxFreeTextSearchResults)
-	if err != nil {
-		return freeTextIDsForTypeResult{}, err
-	}
-	ids := make(map[string]struct{}, len(hits))
-	for _, e := range hits {
-		ids[e.ID] = struct{}{}
-	}
-	return freeTextIDsForTypeResult{IDs: ids, HasFilter: true}, nil
-}
-
 // maxFreeTextSearchResults caps the number of hits the searcher is asked to
 // return. Hoisted to a package constant so executeQuery and the list-search
 // path stay in lockstep on the bound.
@@ -821,8 +631,6 @@ func relationDirection(d dataentryconfig.Direction) store.Direction {
 	return store.DirectionOutgoing
 }
 
-// matchesPropertyFilters checks whether an entity matches the given property filters.
-// Returns true if no filters are specified or all filters match.
 // pushdownPrefilters returns the store-evaluable subset of the property
 // filters, as a PRE-FILTER only — the caller must still run every filter
 // through the metamodel-aware Go pass.
@@ -856,43 +664,6 @@ func pushdownPrefilters(
 	filters []*filter.Filter, meta *metamodel.Metamodel, types []string,
 ) []store.PropPredicate {
 	return queryplan.PushdownPrefilters(filters, meta, types)
-}
-
-func (a *App) matchesPropertyFilters(e *entity.Entity, filters []*filter.Filter) bool {
-	if len(filters) == 0 {
-		return true
-	}
-	s := a.State()
-	entDef, ok := s.Meta.GetEntityDef(e.Type)
-	if !ok {
-		return false
-	}
-	matched, err := filter.MatchAll(entityRecord(e), filters, entDef, s.Meta)
-	return err == nil && matched
-}
-
-// isRelationLinked checks whether a form relation field (formRel) corresponds
-// to a link relation (linkRel) coming from a view's "Add" button. It returns
-// true when the link relation's inverse matches the form relation, when the
-// form relation's inverse matches the link relation, or when they are equal.
-func (a *App) isRelationLinked(formRel, linkRel string) bool {
-	if formRel == linkRel {
-		return true
-	}
-	s := a.State()
-	// Check if linkRel has an inverse that equals formRel.
-	if def, ok := s.Meta.GetRelationDef(linkRel); ok && def.Inverse != nil {
-		if def.Inverse.GetID() == formRel {
-			return true
-		}
-	}
-	// Check if formRel has an inverse that equals linkRel.
-	if def, ok := s.Meta.GetRelationDef(formRel); ok && def.Inverse != nil {
-		if def.Inverse.GetID() == linkRel {
-			return true
-		}
-	}
-	return false
 }
 
 // propertyElements returns the property value as the list of elements a filter

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -281,7 +281,7 @@ func TestSortEntitiesMulti(t *testing.T) {
 
 	t.Run("nil specs does nothing", func(t *testing.T) {
 		entities := makeEntities()
-		app.sortEntitiesMulti(entities, nil)
+		app.queries.sortEntitiesMulti(entities, nil)
 		if entities[0].ID != "E-003" {
 			t.Errorf("expected no reorder, got %s first", entities[0].ID)
 		}
@@ -289,7 +289,7 @@ func TestSortEntitiesMulti(t *testing.T) {
 
 	t.Run("empty specs does nothing", func(t *testing.T) {
 		entities := makeEntities()
-		app.sortEntitiesMulti(entities, []filter.SortSpec{})
+		app.queries.sortEntitiesMulti(entities, []filter.SortSpec{})
 		if entities[0].ID != "E-003" {
 			t.Errorf("expected no reorder, got %s first", entities[0].ID)
 		}
@@ -297,7 +297,7 @@ func TestSortEntitiesMulti(t *testing.T) {
 
 	t.Run("ascending sort", func(t *testing.T) {
 		entities := makeEntities()
-		app.sortEntitiesMulti(entities, []filter.SortSpec{{Property: "name", Direction: "asc"}})
+		app.queries.sortEntitiesMulti(entities, []filter.SortSpec{{Property: "name", Direction: "asc"}})
 		if entities[0].ID != "E-001" || entities[1].ID != "E-002" || entities[2].ID != "E-003" {
 			t.Errorf("expected Alice, Bob, Charlie; got %s, %s, %s",
 				entities[0].Properties["name"], entities[1].Properties["name"], entities[2].Properties["name"])
@@ -306,7 +306,7 @@ func TestSortEntitiesMulti(t *testing.T) {
 
 	t.Run("descending sort", func(t *testing.T) {
 		entities := makeEntities()
-		app.sortEntitiesMulti(entities, []filter.SortSpec{{Property: "name", Direction: "desc"}})
+		app.queries.sortEntitiesMulti(entities, []filter.SortSpec{{Property: "name", Direction: "desc"}})
 		if entities[0].ID != "E-003" || entities[1].ID != "E-002" || entities[2].ID != "E-001" {
 			t.Errorf("expected Charlie, Bob, Alice; got %s, %s, %s",
 				entities[0].Properties["name"], entities[1].Properties["name"], entities[2].Properties["name"])
@@ -320,7 +320,7 @@ func TestSortEntitiesMulti(t *testing.T) {
 			testutil.Entity("item").ID("E-002").Build(),
 			testutil.Entity("item").ID("E-003").With("name", "Alice").Build(),
 		}
-		app.sortEntitiesMulti(entities, []filter.SortSpec{{Property: "name", Direction: "asc"}})
+		app.queries.sortEntitiesMulti(entities, []filter.SortSpec{{Property: "name", Direction: "asc"}})
 		// With type-aware sorting, nil values sort to end
 		if entities[0].ID != "E-003" {
 			t.Errorf("expected Alice first, got %s", entities[0].ID)
@@ -748,67 +748,6 @@ func TestResolveRelationColumnValue(t *testing.T) {
 			t.Errorf("got %v, want empty slice", got)
 		}
 	})
-}
-
-func TestIsRelationLinked(t *testing.T) {
-	meta := &metamodel.Metamodel{
-		Relations: map[string]metamodel.RelationDef{
-			"assessedBy": {
-				Label:   "assessed by",
-				From:    []string{"annex_a_control"},
-				To:      []string{"iso_control_assessment"},
-				Inverse: &metamodel.InverseDef{ID: "assesses"},
-			},
-			"depends_on": {
-				Label: "depends on",
-				From:  []string{"ticket"},
-				To:    []string{"ticket"},
-			},
-		},
-	}
-	app := newAppFromParts(nil, meta, nil)
-
-	tests := []struct {
-		name     string
-		formRel  string
-		linkRel  string
-		expected bool
-	}{
-		{
-			name:     "direct match",
-			formRel:  "depends_on",
-			linkRel:  "depends_on",
-			expected: true,
-		},
-		{
-			name:     "inverse of link relation matches form relation",
-			formRel:  "assesses",
-			linkRel:  "assessedBy",
-			expected: true,
-		},
-		{
-			name:     "no match",
-			formRel:  "assesses",
-			linkRel:  "depends_on",
-			expected: false,
-		},
-		{
-			name:     "unknown relations",
-			formRel:  "unknown_a",
-			linkRel:  "unknown_b",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := app.isRelationLinked(tt.formRel, tt.linkRel)
-			if got != tt.expected {
-				t.Errorf("isRelationLinked(%q, %q) = %v, want %v",
-					tt.formRel, tt.linkRel, got, tt.expected)
-			}
-		})
-	}
 }
 
 func TestResolveFilterVariable(t *testing.T) {

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -63,7 +63,7 @@ func (a *App) nextActionCandidates() nextaction.CandidateFunc {
 // SPA: a client-side fetch would be a second read surface to gate.
 func (a *App) nextActionOptions() nextaction.OptionFunc {
 	return func(ctx context.Context, query string, limit int) ([]nextaction.PickOption, error) {
-		entities, err := a.executeQuery(ctx, query)
+		entities, err := a.queries.executeQuery(ctx, query)
 		if err != nil {
 			return nil, fmt.Errorf("next-action pick_one query %q: %w", query, err)
 		}
@@ -104,7 +104,7 @@ func (a *App) nextActionOptions() nextaction.OptionFunc {
 // a type whose title is hidden by `visible:` would put the hidden value on
 // the wire — the BUG-R9EHKV leak class, through a new door.
 func (a *App) queryCandidates(ctx context.Context, query string) ([]nextaction.Candidate, error) {
-	entities, err := a.executeQuery(ctx, query)
+	entities, err := a.queries.executeQuery(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("next-action query %q: %w", query, err)
 	}

--- a/internal/dataentry/nextaction_handler_test.go
+++ b/internal/dataentry/nextaction_handler_test.go
@@ -432,7 +432,7 @@ func TestQueryPushdown_MatchesGoSideFiltering(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := app.executeQuery(aliceCtx(), tc.query)
+			got, err := app.queries.executeQuery(aliceCtx(), tc.query)
 			require.NoError(t, err)
 
 			ids := make([]string, 0, len(got))
@@ -541,7 +541,7 @@ func TestQueryPushdown_PreservesTypedSemantics(t *testing.T) {
 
 	// Typed comparison accepts the zero-padded form; a string comparison does
 	// not. The Go pass must remain authoritative.
-	got, err := app.executeQuery(aliceCtx(), "type:ticket prop:count=03")
+	got, err := app.queries.executeQuery(aliceCtx(), "type:ticket prop:count=03")
 	require.NoError(t, err)
 	require.Len(t, got, 1,
 		"an integer property must compare numerically, not by string form")

--- a/internal/dataentry/queryservice.go
+++ b/internal/dataentry/queryservice.go
@@ -36,8 +36,10 @@ import (
 // The searcher seam is deliberately [search.VisibleSearcher], never a plain
 // search.Searcher: executeQuery's free-text branch must only ever see hits
 // the request principal may read (TKT-BA8BSX). This type also holds NO
-// store.Store — the store reads it needs arrive through the Services bundle,
-// whose gating is applied by the free functions in helpers.go
+// store.Store FIELD — it never carries an independent store handle, so a
+// read cannot bypass the request-scoped bundle. The store reads it does
+// perform arrive through the Services bundle passed in per call, whose
+// gating is applied by the free functions in helpers.go
 // (visibleListByTypes / visibleEntitiesOfType) against the resolved scope.
 type queryService struct {
 	// schema is the reloadable snapshot; the sort and property-filter passes
@@ -70,7 +72,8 @@ func newQueryService(app *App) *queryService {
 // It supports the same query syntax as the search page: type:, prop:, status:,
 // and free text. Free-text words use OR logic with fuzzy matching via Bleve;
 // results are ranked by score.
-// executeQuery runs the search-view pipeline under the ctx principal's
+//
+// It runs the search-view pipeline under the ctx principal's
 // read scope (TKT-BA8BSX). Every consumer — handleV1Search, the
 // _position search scope (resolveScope), and the next-action engine —
 // inherits the gate from here, so no future consumer can run an ungated

--- a/internal/dataentry/queryservice.go
+++ b/internal/dataentry/queryservice.go
@@ -1,0 +1,274 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
+)
+
+// queryService owns the search-query pipeline: the `/_search` and
+// `_position`-scope entry point (executeQuery), its free-text branch, the
+// list endpoint's `?q=` id-set helper, and the metamodel-aware sort and
+// property-filter passes those share. Extracted from App (TKT-SJ0LRS, part
+// of the TKT-R68TV8 decomposition arc).
+//
+// Consolidating them here is the point of the extraction: the read handlers,
+// the next-action engine (nextaction.go) and the `_position` scope resolver
+// (scope.go) now share ONE collaborator instead of each reaching back into
+// App for the same closures.
+//
+// Collaborator rationale differs from the sibling handlers in one respect
+// that is load-bearing. The ACL-scoped searcher and the affordance service
+// are held as CLOSURES rather than values, because tests reassign
+// `app.visibleSearcher` (see rebindVisibleSearcher) and `app.affordances`
+// after construction; a captured value would silently keep the searcher from
+// construction time and a test injecting a recording/denying searcher would
+// exercise the wrong one.
+//
+// The searcher seam is deliberately [search.VisibleSearcher], never a plain
+// search.Searcher: executeQuery's free-text branch must only ever see hits
+// the request principal may read (TKT-BA8BSX). This type also holds NO
+// store.Store — the store reads it needs arrive through the Services bundle,
+// whose gating is applied by the free functions in helpers.go
+// (visibleListByTypes / visibleEntitiesOfType) against the resolved scope.
+type queryService struct {
+	// schema is the reloadable snapshot; the sort and property-filter passes
+	// resolve entity definitions against it per call so a metamodel reload
+	// propagates.
+	schema func() *Schema
+	// services returns the read bundle (store + searcher + metamodel).
+	services func() Services
+	// visibleSearcher is the ACL-scoped search seam. Late-bound: tests
+	// reassign App.visibleSearcher after construction.
+	visibleSearcher func() search.VisibleSearcher
+	// affordances supplies the per-hit field-verdict source used to drop
+	// hits that matched only a `visible:`-hidden property. Late-bound for
+	// the same reason as visibleSearcher.
+	affordances func() affordanceService
+}
+
+// newQueryService wires the leaf over the App's current collaborators.
+// Called from NewApp and from the test rebind path.
+func newQueryService(app *App) *queryService {
+	return &queryService{
+		schema:          app.State,
+		services:        app.Services,
+		visibleSearcher: func() search.VisibleSearcher { return app.visibleSearcher },
+		affordances:     func() affordanceService { return app.affordances },
+	}
+}
+
+// executeQuery parses a search query and returns all matching entities.
+// It supports the same query syntax as the search page: type:, prop:, status:,
+// and free text. Free-text words use OR logic with fuzzy matching via Bleve;
+// results are ranked by score.
+// executeQuery runs the search-view pipeline under the ctx principal's
+// read scope (TKT-BA8BSX). Every consumer — handleV1Search, the
+// _position search scope (resolveScope), and the next-action engine —
+// inherits the gate from here, so no future consumer can run an ungated
+// search by accident.
+//
+// Ordering of the gate: the scope resolves FIRST, and an
+// all-effective-DenyAll scope returns before any backend work — a
+// denied principal must not be able to probe search-backend latency
+// (RR-X56H pattern, pinned with a recording searcher in
+// acl_search_test.go). The free-text branch then runs through
+// search.VisibleSearcher so hidden hits never have their bodies
+// loaded; the type-listing branch resolves the per-type verdict
+// against the store directly.
+//
+// The maxFreeTextSearchResults bound counts entities that survived
+// BOTH visibility and property filters (post-visibility truncation —
+// a pre-visibility cap starves restricted principals; a pre-filter
+// cap would starve filtered queries the same way).
+//
+// Errors: visibility-scope failures wrap errACLListQuery (mapped by
+// writeGateError: cancel-silent / 504 / 500 acl_query_failed with
+// constant detail), store-load failures wrap errListLoad, and plain
+// search-backend failures pass through (500 search_failed). The
+// pre-TKT-BA8BSX version swallowed both error classes into silently
+// truncated results.
+func (q *queryService) executeQuery(ctx context.Context, query string) ([]*entity.Entity, error) {
+	sq := searchparser.ParseQuery(query)
+	if sq.IsEmpty() {
+		return nil, nil
+	}
+
+	svc := q.services()
+	typeNames := make([]string, 0, len(svc.Meta.Entities))
+	for name := range svc.Meta.Entities {
+		typeNames = append(typeNames, name)
+	}
+	slices.Sort(typeNames)
+	scope := readGateFromContext(ctx).SearchScope(ctx, typeNames)
+	if len(scope) == 0 {
+		return []*entity.Entity{}, nil
+	}
+
+	var candidates []*entity.Entity
+	var err error
+	if sq.HasFreeText() {
+		// Hits arrive in relevance order. Scores are dropped because
+		// executeQuery never sorted by them.
+		candidates, err = q.runVisibleFreeTextSearch(ctx, svc, sq, scope)
+	} else {
+		// Push the equality filters into the store as a PRE-FILTER, cutting
+		// the rows loaded. The Go pass below still evaluates every filter,
+		// including the pushed ones, and remains authoritative.
+		//
+		// That belt-and-braces is deliberate rather than redundant.
+		// store.PropPredicate compares by STRING FORM; filter.MatchAll is
+		// metamodel-aware. On a typed property they disagree — `count!=03`
+		// against an integer 3 is a non-match typed and a match as strings,
+		// and an enum filter naming an undeclared value ERRORS in Go
+		// (surfacing the operator's typo) while the store silently returns
+		// nothing. Dropping a pushed filter from the Go pass would let the
+		// looser of the two decide, WIDENING results on a path /_search and
+		// scope navigation share.
+		//
+		// Keeping both makes the outcome provably identical to the
+		// pre-pushdown behavior — the store can only ever remove rows the Go
+		// pass would also have removed — while still winning the I/O.
+		pushed := pushdownPrefilters(sq.PropertyFilters, svc.Meta, sq.EntityTypes)
+		candidates, err = visibleListByTypes(ctx, svc, sq.EntityTypes, scope, pushed)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]*entity.Entity, 0, len(candidates))
+	for _, e := range candidates {
+		if !q.matchesPropertyFilters(e, sq.PropertyFilters) {
+			continue
+		}
+		results = append(results, e)
+		if sq.HasFreeText() && len(results) >= maxFreeTextSearchResults {
+			break
+		}
+	}
+
+	// Apply sort from query syntax (free-text results are already ranked by relevance)
+	if sq.HasSort() {
+		q.sortEntitiesMulti(results, sq.SortClauses)
+	}
+
+	return results, nil
+}
+
+// runVisibleFreeTextSearch is executeQuery's free-text branch: the
+// same phrase re-quoting as runFreeTextSearchE, routed through the
+// ACL-scoped searcher. The backend-side limit is only set when no
+// property filters remain — with Go-side filters pending, truncation
+// happens in executeQuery after them, or the filter gap would re-open
+// the starvation the post-visibility limit closes.
+func (q *queryService) runVisibleFreeTextSearch(
+	ctx context.Context, svc Services, sq *searchparser.SearchQuery, scope map[string]search.TypeScope,
+) ([]*entity.Entity, error) {
+	parts := make([]string, 0, len(sq.FreeTextWords)+len(sq.FreeTextPhrases))
+	parts = append(parts, sq.FreeTextWords...)
+	for _, p := range sq.FreeTextPhrases {
+		parts = append(parts, `"`+p+`"`)
+	}
+	limit := 0
+	if len(sq.PropertyFilters) == 0 {
+		limit = maxFreeTextSearchResults
+	}
+	sQuery := search.Query{
+		Text:  strings.Join(parts, " "),
+		Types: sq.EntityTypes,
+		Limit: limit,
+	}
+	out := make([]*entity.Entity, 0)
+	for hit, err := range searchVisibleHits(ctx, q.visibleSearcher(), q.affordances(), sQuery, scope) {
+		if err != nil {
+			if errors.Is(err, search.ErrScope) {
+				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
+			}
+			return nil, fmt.Errorf("free-text search: %w", err)
+		}
+		e, getErr := svc.Store.GetEntity(ctx, hit.ID)
+		if getErr != nil {
+			// Stale index hit (entity deleted between index query and
+			// store read). Skip silently — the result stays a coherent
+			// set of currently-existing entities.
+			continue
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// freeTextIDsForType runs a free-text search constrained to the given entity
+// type and returns the matching ids. Empty / whitespace queries (and queries
+// like `prop:status=open` that have no free-text words) return HasFilter=false
+// so the caller skips intersection entirely. Searcher errors are surfaced —
+// the list handler converts them to HTTP 500 rather than rendering an empty
+// list and pretending the search succeeded.
+//
+// Used by the list endpoint to support `?q=` without going through the full
+// executeQuery path: a list is already type-scoped, so any `type:` token from
+// the query string is intentionally ignored — we always pin the type to the
+// list's type to keep the surface predictable.
+func (q *queryService) freeTextIDsForType(
+	ctx context.Context, query, typeName string,
+) (freeTextIDsForTypeResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return freeTextIDsForTypeResult{}, nil
+	}
+	sq := searchparser.ParseQuery(query)
+	if sq.IsEmpty() || !sq.HasFreeText() {
+		return freeTextIDsForTypeResult{}, nil
+	}
+	sq.EntityTypes = []string{typeName}
+
+	hits, err := runFreeTextSearchE(ctx, q.services(), sq, maxFreeTextSearchResults)
+	if err != nil {
+		return freeTextIDsForTypeResult{}, err
+	}
+	ids := make(map[string]struct{}, len(hits))
+	for _, e := range hits {
+		ids[e.ID] = struct{}{}
+	}
+	return freeTextIDsForTypeResult{IDs: ids, HasFilter: true}, nil
+}
+
+// sortEntitiesMulti sorts entities by multiple sort specs using type-aware comparison.
+func (q *queryService) sortEntitiesMulti(entities []*entity.Entity, specs []filter.SortSpec) {
+	if len(specs) == 0 {
+		return
+	}
+	s := q.schema()
+	entityDefs := make(map[string]*metamodel.EntityDef)
+	for _, e := range entities {
+		if _, ok := entityDefs[e.Type]; !ok {
+			if def, ok := s.Meta.GetEntityDef(e.Type); ok {
+				entityDefs[e.Type] = def
+			}
+		}
+	}
+	filter.SortMulti(entities, entityRecord, specs, entityDefs, s.Meta)
+}
+
+// matchesPropertyFilters checks whether an entity matches the given property
+// filters. Returns true if no filters are specified or all filters match.
+func (q *queryService) matchesPropertyFilters(e *entity.Entity, filters []*filter.Filter) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	s := q.schema()
+	entDef, ok := s.Meta.GetEntityDef(e.Type)
+	if !ok {
+		return false
+	}
+	matched, err := filter.MatchAll(entityRecord(e), filters, entDef, s.Meta)
+	return err == nil && matched
+}

--- a/internal/dataentry/scope.go
+++ b/internal/dataentry/scope.go
@@ -107,7 +107,7 @@ func scopeFromParam(raw string, meta entityTypeChecker) (scope ScopeDescriptor, 
 func (a *App) resolveScope(ctx context.Context, scope ScopeDescriptor) ([]*entityPkg.Entity, error) {
 	switch scope.Source {
 	case "search":
-		entities, err := a.executeQuery(ctx, scope.Q)
+		entities, err := a.queries.executeQuery(ctx, scope.Q)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -211,6 +211,10 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 	// appearanceHandler mirrors production wiring (see NewApp): built after
 	// the logo/palette/settings services and viewReader it captures.
 	app.appearance = newAppearanceHandler(app)
+	// queryService mirrors production wiring (see NewApp). Its searcher and
+	// affordance handles are closures, so the rebinds tests perform after this
+	// point (rebindVisibleSearcher, app.affordances = ...) are picked up.
+	app.queries = newQueryService(app)
 	// commandHandler holds closures over App methods, which read the fields
 	// rebound above — so it stays valid after this rebind. (Rebuilt rather than
 	// relying on a nil zero value, since newHandlerTestApp bypasses NewApp.)

--- a/tickets/entities/implementation-checklists/IMPL-S85VKS.md
+++ b/tickets/entities/implementation-checklists/IMPL-S85VKS.md
@@ -1,0 +1,64 @@
+---
+id: IMPL-S85VKS
+type: implementation-checklist
+title: 'Implementation: Extract dataentry query/search leaf off App (92 → ~87), de-risking the read-pipeline steps'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no new behavior — receiver-only moves; existing handler/ACL-search suites drive every moved helper)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — see the closure/value decision below
+- [x] Error handling in place
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A: call-site re-points, plus one deleted test whose subject was deleted)
+- [x] ~~No hardcoded values in assertions~~ (N/A)
+- [x] ~~Only values that matter~~ (N/A)
+- [x] ~~Interpolated values from objects~~ (N/A)
+- [x] ~~Property comparisons from original object~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (dataentry package + full suite, `-count=1`)
+- [x] Each acceptance criterion verified
+- [x] Edge cases manually verified
+
+**Verification Evidence (PR #1470), re-checked by the coordinator:**
+- App 92 → **86**; directive lowered to 86 with a history line. Count
+verified excluding the one `*App` method that lives in watcher_test.go.
+- `just plimsoll` green; `go test -count=1 ./internal/dataentry/` green;
+`just coverage-check` PASS at 78.2%.
+- **ACL invariant verified:** `queryservice.go` holds no `store.Store` and
+no plain `search.Searcher` — the only mentions of those types in the file are in
+the doc comment explaining why it holds neither. Store reads still arrive via
+the `Services` bundle through the unchanged `visibleListByTypes` /
+`visibleEntitiesOfType` free functions, gated by the same `readGateFromContext`
+scope.
+- `isRelationLinked` confirmed dead in production: the only caller was
+`TestIsRelationLinked`, a test exercising otherwise-unreachable code, so method
+and test were deleted together.
+
+**Deliberate deviation from the sibling pattern, and why it is correct:** the
+sibling handlers hold fixed service handles BY VALUE, but this leaf holds
+`visibleSearcher` and `affordances` as **closures**. Verified: tests reassign
+`app.visibleSearcher` after construction (acl_search_test.go:251, 290, 304;
+test_helpers_test.go) specifically to inject denying/recording searchers. A
+by-value capture would have kept the construction-time searcher, so those ACL
+tests would have exercised the wrong one and **passed vacuously**. The reasoning
+is recorded in the type's doc comment. `schema`/`services` follow the sibling
+pattern; a planned `gateRead` field was dropped since nothing rebinds it
+(`readGateFromContext` is called directly, as the App method did).
+
+## Quality
+
+- [x] Code follows project patterns (leaf-service shape; deviation justified and documented in-code)
+- [x] Checked for DRY opportunities — this IS the DRY step: next-action, scope and the read pipeline now share one collaborator instead of each threading its own closure later
+- [x] No security issues introduced (ACL-scoped searcher preserved; no ungated search path introduced)
+- [x] No silent failures
+- [x] No debug code left behind

--- a/tickets/entities/review-checklists/REV-FK6U62.md
+++ b/tickets/entities/review-checklists/REV-FK6U62.md
@@ -1,0 +1,83 @@
+---
+id: REV-FK6U62
+type: review-checklist
+title: 'Review: Extract dataentry query/search leaf off App (92 → ~87), de-risking the read-pipeline steps'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-FK6U62.md
+++ b/tickets/entities/review-checklists/REV-FK6U62.md
@@ -2,82 +2,29 @@
 id: REV-FK6U62
 type: review-checklist
 title: 'Review: Extract dataentry query/search leaf off App (92 → ~87), de-risking the read-pipeline steps'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Comment lint gate clean (`just comment-lint`)
-- [ ] Coverage maintained (`just coverage-check`)
-
-**Comment findings.** `just comment-report` lists the advisory rules
-(duplication, nil-contract, param-contract, restatement). They are not a merge
-gate, but a finding your diff *introduces* should be fixed or suppressed — don't
-grow the backlog.
-
-Every rule is a heuristic over prose, so false positives are expected. To
-suppress one, prefer the inline form on the declaration line, which travels with
-the code and is reviewed in this diff:
-
-```go
-func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
-```
-
-Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
-same prose recurs across many sites. A reason is required either way — an
-unexplained suppression is a finding nobody can re-evaluate later.
+- [x] All tests pass (`-count=1` and `-race` on dataentry, verified in the correct worktree with branch identity echoed alongside)
+- [x] Linters pass (golangci-lint 0 issues, plimsoll at 86, arch-lint, comment-lint clean across 11081 comments, go vet)
+- [x] Coverage floors hold (78.2%)
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] `/code-review` run (cranky-code-reviewer, diffed against the STACKED base tkt-8aj1pm-dataentry-appearance)
+- [x] All critical/significant findings addressed: [[RR-LJHL3F]] — the reviewer's "plimsoll is inert on App" claim was investigated and **refuted**; the gate fires correctly (verified twice, exit status 3 in both the main checkout and the PR worktree)
+- [x] Minor/nit findings addressed: [[RR-RYTNDG]] (overstated no-store claim precised; doubled godoc lead merged)
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+## Verification
 
-## Acceptance Verification
-
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
-
-**Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
-
-## Documentation (enhancements only)
-
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
-
-## Final Checks
-
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
-
-## Pull Request
-
-- [ ] Run `/pr` command to create PR and monitor CI
-
-<!--
-Deliberately NOT tracked here: the PR URL and whether CI passed.
-
-Both post-date this checklist. `/pr` requires the ticket to be `done` and
-validating clean before it opens the PR, and a `done` review-checklist may have
-no unchecked items — so an item asking for the PR URL can only be satisfied by a
-PR that does not exist yet. Checking it early would mean asserting "CI passed"
-before CI ran, which turns the checklist from evidence into a formality.
-
-GitHub records both authoritatively, and the branch and commit messages carry
-the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
-here. See TKT-UFV01M. -->
+- [x] **ACL invariant intact and NOT vacuous.** The seam is `search.VisibleSearcher` throughout; no path to a plain `search.Searcher`; `readGateFromContext` consulted identically with the deny-all short-circuit still ordered before any backend work. `TestACLSearch_DenyAllShortCircuit` carries a positive control asserting the backend runs exactly once for a granted search, so it cannot pass by never reaching the searcher. All 10 `TestACLSearch_*` pass under `-race`
+- [x] **The closure deviation was proven empirically, not argued.** The reviewer implemented the rejected by-value design and ran the suite: four ACL tests fail, most damningly `TestACLSearch_ScopeErrorMapping` returning 200 with entity data where a 500 ACL failure was expected. A by-value capture keeps the construction-time searcher, so the injected failing searcher is never consulted and the test passes vacuously. The closures are load-bearing
+- [x] `isRelationLinked` genuinely dead: only references were its definition and its own test; unexported, so no external dispatch; no reflection in the package. Deleted with its test
+- [x] All five moved methods are pure moves — only substantive edits are a forced local rename (`q` → `sQuery`, since `q` now names the receiver) and one signature line-wrap
+- [x] All call sites re-pointed (api_v1.go:326,1536; nextaction.go:66,107; scope.go:110); no survivors, none double-wrapped
+- [x] Directive exact: 86 declared, 86 actual; the 92→86 delta reconciles precisely (5 moved + 1 deleted)
+- [x] Zero lint suppressions added; test changes are mechanical re-points plus the one deletion, no assertion weakened

--- a/tickets/entities/review-responses/RR-LJHL3F.md
+++ b/tickets/entities/review-responses/RR-LJHL3F.md
@@ -1,0 +1,25 @@
+---
+id: RR-LJHL3F
+type: review-response
+title: Reviewer's claim that plimsoll is inert on App is incorrect — gate verified firing
+finding: 'The review closed with: ''just plimsoll is inert on this receiver — I set max-methods=1 and it still exited 0, so the god-object gate is not actually enforcing the App directive.'' If true this would invalidate every count in the TKT-N0IKN9 arc, since the ratchet would be unenforced and the numbers would rest purely on hand-verification.'
+severity: significant
+reason: 'NOT REPRODUCIBLE — the claim is wrong. Tested twice: in the main checkout (directive 104 → 1) plimsoll failed with ''type App has 104 methods, over the load line of 1'', exit status 3; and independently in the PR worktree (directive 86 → 1), also exit status 3, recipe failed. The gate enforces the App directive correctly in both. Most likely cause is the very worktree hazard the reviewer flagged one paragraph earlier: `cd` resets between Bash calls, so the edit and the linter run can land in different checkouts. No action needed; recorded so the false ''gate is inert'' belief is not carried into later arc steps.'
+status: wont-fix
+---
+
+Claim from the TKT-SJ0LRS code review (cranky-code-reviewer, PR #1470),
+investigated and refuted by the coordinator.
+
+The rest of that review was excellent and its central finding was verified
+empirically by the reviewer rather than argued: they implemented the REJECTED
+by-value design for `visibleSearcher`/`affordances` and ran the suite, producing
+four ACL test failures — most damningly `TestACLSearch_ScopeErrorMapping`
+returning 200 with entity data where a 500 ACL failure was expected. That is
+direct proof the closures are load-bearing and that a by-value capture would
+have made those tests pass vacuously.
+
+The reviewer also confirmed the gate tests are not vacuous in the other
+direction: `TestACLSearch_DenyAllShortCircuit` carries a positive control
+asserting the backend runs exactly once for a granted search, so it cannot pass
+by never reaching the searcher.

--- a/tickets/entities/review-responses/RR-RYTNDG.md
+++ b/tickets/entities/review-responses/RR-RYTNDG.md
@@ -1,0 +1,26 @@
+---
+id: RR-RYTNDG
+type: review-response
+title: 'queryService godoc: overstated ''holds NO store.Store'' and a doubled executeQuery lead paragraph'
+finding: (1) The type doc said the leaf 'holds NO store.Store', which is true of its FIELDS but reads as absolute — executeQuery still reaches the store via svc.Store.GetEntity through the per-call Services bundle. A future reader taking the sentence literally would be confused by that line. (2) The moved executeQuery godoc carried two '// executeQuery ...' lead paragraphs, an artifact inherited verbatim from helpers.go that predates this PR.
+severity: minor
+resolution: '(1) Reworded to ''holds NO store.Store FIELD — it never carries an independent store handle, so a read cannot bypass the request-scoped bundle'', then states that the reads it does perform arrive through the per-call Services bundle. (2) Merged the doubled lead into one paragraph. Gates re-run on the correct branch (identity echoed alongside): build, dataentry tests, comment-lint, golangci-lint 0 issues, plimsoll.'
+status: addressed
+---
+
+Minor + nit findings from the TKT-SJ0LRS code review (cranky-code-reviewer, PR
+#1470).
+
+Reviewer's deferred leverage note, NOT actioned here: the `func() T`
+late-binding pattern now recurs across viewsHandler, commandHandler,
+attachmentHandler and queryService, and exists solely because tests mutate App
+fields post-construction — production structure shaped by test wiring. The
+durable fix is a test helper that builds the App with its final collaborators,
+letting every leaf hold values. Worth considering as the decomposition arc
+lands; explicitly not a blocker.
+
+Process note confirmed and worth repeating: `cd` resets between Bash calls, so a
+measurement can silently land in the wrong checkout. Echo `git rev-parse
+--abbrev-ref HEAD` in the SAME command as any count or gate run. This bit the
+reviewer once (measuring develop's 104 instead of the branch's 86) and is the
+likely cause of their incorrect 'plimsoll is inert' claim (see [[RR-LJHL3F]]).

--- a/tickets/entities/tickets/TKT-SJ0LRS.md
+++ b/tickets/entities/tickets/TKT-SJ0LRS.md
@@ -5,7 +5,7 @@ title: Extract dataentry query/search leaf off App (92 → ~87), de-risking the 
 kind: refactor
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 Sub-ticket of the [[TKT-R68TV8]] `dataentry.App` decomposition arc, following

--- a/tickets/entities/tickets/TKT-SJ0LRS.md
+++ b/tickets/entities/tickets/TKT-SJ0LRS.md
@@ -1,0 +1,46 @@
+---
+id: TKT-SJ0LRS
+type: ticket
+title: Extract dataentry query/search leaf off App (92 → ~87), de-risking the read-pipeline steps
+kind: refactor
+priority: medium
+effort: s
+status: review
+---
+
+Sub-ticket of the [[TKT-R68TV8]] `dataentry.App` decomposition arc, following
+[[TKT-8AJ1PM]] (104 → 92).
+
+The App survey ranked this as the step to do **before** next-action, scope and
+the read pipeline: those three clusters all *borrow* these helpers, so
+extracting the leaf first turns three later closure-threading problems into one
+shared collaborator.
+
+## What
+
+**Pure structural extraction, no behavior change, no ACL change.**
+
+Move the search/query/sort helpers from `helpers.go` onto a focused
+`queryService` leaf (the `entityReader`/`visibleReader` value-type shape):
+
+- `executeQuery`, `runVisibleFreeTextSearch`, `freeTextIDsForType`,
+`sortEntitiesMulti`, `matchesPropertyFilters`
+- **Delete `isRelationLinked`** — the survey found zero callers. Verify
+repo-wide before deleting.
+
+Deps: `visibleSearcher` (the ACL-scoped searcher — it stays the ACL-scoped one;
+this extraction must not introduce an ungated search path), plus the affordance
+service and the schema/Services closures the helpers already use.
+
+`executeQuery` has callers in `nextaction.go` and `scope.go` as well as the read
+pipeline — they become `a.queries.executeQuery(...)` (or take the leaf), which
+is exactly the point: one collaborator instead of three closures later.
+
+Ratchet `//plimsoll:max-methods` on App 92 → the real count (~87 after the 5
+moves plus the dead-method deletion).
+
+## Done when
+
+plimsoll with the lowered directive; full suite + `-race` on dataentry green;
+the ACL search tests (the `search.VisibleSearcher` contract) pass unchanged;
+coverage floors hold; arch-lint/comment-lint/lint clean.

--- a/tickets/relations/TKT-SJ0LRS--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-SJ0LRS--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SJ0LRS
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-SJ0LRS--depends-on--TKT-8AJ1PM.md
+++ b/tickets/relations/TKT-SJ0LRS--depends-on--TKT-8AJ1PM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SJ0LRS
+relation: depends-on
+to: TKT-8AJ1PM
+---

--- a/tickets/relations/TKT-SJ0LRS--has-implementation--IMPL-S85VKS.md
+++ b/tickets/relations/TKT-SJ0LRS--has-implementation--IMPL-S85VKS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SJ0LRS
+relation: has-implementation
+to: IMPL-S85VKS
+---

--- a/tickets/relations/TKT-SJ0LRS--has-review--REV-FK6U62.md
+++ b/tickets/relations/TKT-SJ0LRS--has-review--REV-FK6U62.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SJ0LRS
+relation: has-review
+to: REV-FK6U62
+---

--- a/tickets/relations/TKT-SJ0LRS--has-review-response--RR-LJHL3F.md
+++ b/tickets/relations/TKT-SJ0LRS--has-review-response--RR-LJHL3F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SJ0LRS
+relation: has-review-response
+to: RR-LJHL3F
+---

--- a/tickets/relations/TKT-SJ0LRS--has-review-response--RR-RYTNDG.md
+++ b/tickets/relations/TKT-SJ0LRS--has-review-response--RR-RYTNDG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SJ0LRS
+relation: has-review-response
+to: RR-RYTNDG
+---

--- a/tickets/relations/TKT-SJ0LRS--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-SJ0LRS--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-SJ0LRS
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Pure structural refactor, no behavior change. Moves the five search-query methods off `dataentry.App` onto a new focused `queryService` leaf (`queryservice.go`): `executeQuery`, its free-text branch `runVisibleFreeTextSearch`, the list-endpoint `?q=` helper `freeTextIDsForType`, and the `sortEntitiesMulti` / `matchesPropertyFilters` passes they share. `isRelationLinked` was verified dead repo-wide (only caller was its own unit test) and deleted along with `TestIsRelationLinked`.

The ACL invariant is preserved exactly: the leaf holds a `search.VisibleSearcher` seam and no `store.Store`, so there is no new path to an ungated searcher; store reads still arrive through the `Services` bundle and the same scope-resolved `visibleListByTypes` free functions. The searcher and affordance handles are closures rather than values because tests reassign `app.visibleSearcher` / `app.affordances` after construction — a captured value would silently exercise the construction-time searcher. All ACL-scoped search tests pass unchanged.

All five `executeQuery` call sites (`nextaction.go`, `scope.go`, `api_v1.go`) now share one collaborator, which is the point: it de-risks the follow-on next-action, scope, and read-pipeline extraction steps by giving them a single shared seam instead of each threading its own closure. Plimsoll directive ratcheted 92 → 86 with the usual history line in `app.go`.

STACKED on #1464 (`tkt-8aj1pm-dataentry-appearance`) — both touch the same plimsoll directive line. GitHub will retarget when the base merges.

https://claude.ai/code/session_016Br8QmRwRReoeZx55EfwyQ