### PR TITLE
refactor(docs): extract seed cluster off docRuntime (TKT-N0IKN9)

### DIFF
--- a/internal/docs/api.go
+++ b/internal/docs/api.go
@@ -105,7 +105,7 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 
 	req := APIRequest{
 		ProjectDir: dr.projectDir,
-		Seed:       dr.seedOps,
+		Seed:       dr.seed.ops,
 		Method:     fieldString(ls, tbl, "method"),
 		Path:       path,
 		As:         fieldString(ls, tbl, "as"),
@@ -123,7 +123,7 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 	if identicalTo != nil {
 		other := APIRequest{
 			ProjectDir: dr.projectDir,
-			Seed:       dr.seedOps,
+			Seed:       dr.seed.ops,
 			Method:     fieldStringOf(identicalTo, "method"),
 			Path:       fieldStringOf(identicalTo, "path"),
 			As:         fieldStringOf(identicalTo, "as"),

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -6,8 +6,6 @@ import (
 
 	lua "github.com/yuin/gopher-lua"
 
-	"github.com/Sourcehaven-BV/rela/internal/entity"
-	rlua "github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -37,8 +35,8 @@ func (dr *docRuntime) registerModule() {
 		"roles_matrix": dr.luaRolesMatrix,
 		"description":  dr.luaDescription,
 		// Seed (raw store — no entitymanager, no validation).
-		"create": dr.luaCreate,
-		"link":   dr.luaLink,
+		"create": dr.seed.luaCreate,
+		"link":   dr.seed.luaLink,
 		// Tier B — browser capture (fails loud when no capturer is wired).
 		"screenshot": dr.luaScreenshot,
 
@@ -89,55 +87,4 @@ func (dr *docRuntime) luaCount(ls *lua.LState) int {
 	}
 	ls.Push(lua.LNumber(n))
 	return 1
-}
-
-// luaCreate seeds an entity directly into the memstore (raw store — no
-// validation, no state-machine gate, no ACL). create("risico", {props}, body?)
-// returns the created entity as a table (so the author can `link` it).
-func (dr *docRuntime) luaCreate(ls *lua.LState) int {
-	typ := ls.CheckString(1)
-	props := map[string]any{}
-	if tbl, ok := ls.Get(2).(*lua.LTable); ok {
-		props = luaTableToMap(tbl)
-	}
-	content := ls.OptString(3, "")
-
-	id := dr.mintID(typ, props)
-	e := &entity.Entity{ID: id, Type: typ, Properties: props, Content: content}
-	if err := dr.store.CreateEntity(dr.ctx, e); err != nil {
-		return dr.luaFail(ls, "create(%q): %v", typ, err)
-	}
-	// Record for replay into the screenshot temp project (DR-S2).
-	dr.seedOps = append(dr.seedOps, SeedOp{
-		Kind: "create", Type: typ, ID: id, Properties: props, Content: content,
-	})
-	ls.Push(rlua.EntityToTable(ls, e))
-	return 1
-}
-
-// luaLink seeds a relation into the memstore. link(from, type, to) where from
-// may be an id string or an entity table (as returned by create).
-func (dr *docRuntime) luaLink(ls *lua.LState) int {
-	from := idArg(ls, 1)
-	relType := ls.CheckString(2)
-	to := idArg(ls, 3)
-	if _, err := dr.store.CreateRelation(dr.ctx, from, relType, to, nil); err != nil {
-		return dr.luaFail(ls, "link(%q,%q,%q): %v", from, relType, to, err)
-	}
-	dr.seedOps = append(dr.seedOps, SeedOp{Kind: "link", From: from, RelType: relType, To: to})
-	return 0
-}
-
-// mintID derives a stable id for a seeded entity: an explicit props.id if given,
-// else "<type>-<n>" from a per-type counter. Fixture ids need only be unique
-// within the build; the counter avoids an O(n²) full-store scan per create.
-func (dr *docRuntime) mintID(typ string, props map[string]any) string {
-	if v, ok := props["id"].(string); ok && v != "" {
-		return v
-	}
-	if dr.seedCounts == nil {
-		dr.seedCounts = map[string]int{}
-	}
-	dr.seedCounts[typ]++
-	return fmt.Sprintf("%s-%d", typ, dr.seedCounts[typ])
 }

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -90,13 +90,10 @@ type docRuntime struct {
 	// it through the Lua error channel (which would lose the type + line).
 	pending *BuildError
 
-	// seedCounts is a per-type auto-id counter for the seed's mintID, avoiding a
-	// full-store scan per create().
-	seedCounts map[string]int
-
-	// seedOps records every create/link so a screenshot{} island can replay them
-	// against a fresh fsstore temp project (DR-S2).
-	seedOps []SeedOp
+	// seed owns the doc.create()/doc.link() write side and the state that serves
+	// it (the auto-id counter and the replay op log). Read-side islands reach
+	// the recorded ops through seed.ops; nothing else may touch its internals.
+	seed *seedBindings
 
 	// capturer renders screenshot{} islands. nil ⇒ screenshot{} fails loud (the
 	// Tier-B browser dependency is injected only by the CLI, keeping core docs
@@ -199,6 +196,9 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 		projectDir:   opts.ProjectDir,
 		outDir:       opts.OutDir,
 	}
+	// Wired after dr exists: the seeder reports failures through the runtime's
+	// pending-BuildError channel, which only dr can own.
+	dr.seed = &seedBindings{store: st, ctx: ctx, fail: dr.luaFail}
 
 	// A reader runtime gives us the sandbox (no io/os) plus rela.* read bindings;
 	// we layer the doc.* module (emit + resolvers + raw-store seed) on top. The

--- a/internal/docs/screenshot.go
+++ b/internal/docs/screenshot.go
@@ -105,7 +105,7 @@ func (dr *docRuntime) luaScreenshot(ls *lua.LState) int {
 
 	spec := CaptureSpec{
 		ProjectDir: dr.projectDir,
-		Seed:       dr.seedOps,
+		Seed:       dr.seed.ops,
 		View:       fieldStringDefault(ls, tbl, "view", "form"),
 		Type:       fieldString(ls, tbl, "type"),
 		Entity:     fieldString(ls, tbl, "entity"),

--- a/internal/docs/seed.go
+++ b/internal/docs/seed.go
@@ -2,8 +2,12 @@ package docs
 
 import (
 	"context"
+	"fmt"
+
+	lua "github.com/yuin/gopher-lua"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	rlua "github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -25,6 +29,95 @@ type SeedOp struct {
 	From    string
 	RelType string
 	To      string
+}
+
+// seedWriter is the narrow slice of the store the seed bindings need: raw
+// create-only writes, no reads and no entitymanager. Declared here at the call
+// site rather than taking a whole store.Store, so the seed cluster cannot grow
+// into update/delete without widening this interface first.
+type seedWriter interface {
+	CreateEntity(ctx context.Context, e *entity.Entity) error
+	CreateRelation(ctx context.Context, from, relType, to string, data *store.RelationData) (*entity.Relation, error)
+}
+
+// seedBindings owns the doc.create()/doc.link() write side: the raw-store
+// fixture construction the manual's islands perform, plus the two pieces of
+// state that exist only to serve it. It is deliberately separate from
+// docRuntime, which is read-side graph interrogation and assertion — nothing
+// outside seeding should be able to reach the counter or the op log.
+//
+// docRuntime keeps ownership of registration (a single doc.* binding table), so
+// this type exposes bindings but never installs them.
+type seedBindings struct {
+	store seedWriter
+	// ctx is stored for the same reason docRuntime stores one: these are
+	// gopher-lua callbacks, which cannot take a context parameter.
+	ctx context.Context //nolint:containedctx // request-scoped Lua-binding callbacks
+
+	// fail raises a typed resolve BuildError on the owning runtime and unwinds
+	// the island. Injected as a callback rather than a back-pointer to
+	// docRuntime, which would recreate the coupling this split removes.
+	fail func(ls *lua.LState, format string, args ...any) int
+
+	// counts is a per-type auto-id counter for mintID, avoiding a full-store
+	// scan per create().
+	counts map[string]int
+
+	// ops records every create/link so a screenshot{} or api{} island can replay
+	// them against a fresh fsstore temp project (DR-S2). Read by those islands
+	// via docRuntime.seed.ops.
+	ops []SeedOp
+}
+
+// luaCreate seeds an entity directly into the memstore (raw store — no
+// validation, no state-machine gate, no ACL). create("risico", {props}, body?)
+// returns the created entity as a table (so the author can `link` it).
+func (s *seedBindings) luaCreate(ls *lua.LState) int {
+	typ := ls.CheckString(1)
+	props := map[string]any{}
+	if tbl, ok := ls.Get(2).(*lua.LTable); ok {
+		props = luaTableToMap(tbl)
+	}
+	content := ls.OptString(3, "")
+
+	id := s.mintID(typ, props)
+	e := &entity.Entity{ID: id, Type: typ, Properties: props, Content: content}
+	if err := s.store.CreateEntity(s.ctx, e); err != nil {
+		return s.fail(ls, "create(%q): %v", typ, err)
+	}
+	// Record for replay into the screenshot temp project (DR-S2).
+	s.ops = append(s.ops, SeedOp{
+		Kind: "create", Type: typ, ID: id, Properties: props, Content: content,
+	})
+	ls.Push(rlua.EntityToTable(ls, e))
+	return 1
+}
+
+// luaLink seeds a relation into the memstore. link(from, type, to) where from
+// may be an id string or an entity table (as returned by create).
+func (s *seedBindings) luaLink(ls *lua.LState) int {
+	from := idArg(ls, 1)
+	relType := ls.CheckString(2)
+	to := idArg(ls, 3)
+	if _, err := s.store.CreateRelation(s.ctx, from, relType, to, nil); err != nil {
+		return s.fail(ls, "link(%q,%q,%q): %v", from, relType, to, err)
+	}
+	s.ops = append(s.ops, SeedOp{Kind: "link", From: from, RelType: relType, To: to})
+	return 0
+}
+
+// mintID derives a stable id for a seeded entity: an explicit props.id if given,
+// else "<type>-<n>" from a per-type counter. Fixture ids need only be unique
+// within the build; the counter avoids an O(n²) full-store scan per create.
+func (s *seedBindings) mintID(typ string, props map[string]any) string {
+	if v, ok := props["id"].(string); ok && v != "" {
+		return v
+	}
+	if s.counts == nil {
+		s.counts = map[string]int{}
+	}
+	s.counts[typ]++
+	return fmt.Sprintf("%s-%d", typ, s.counts[typ])
 }
 
 // ApplySeed replays recorded seed ops against a store, using RAW store writes

--- a/tickets/entities/implementation-checklists/IMPL-0CHRO7.md
+++ b/tickets/entities/implementation-checklists/IMPL-0CHRO7.md
@@ -1,0 +1,37 @@
+---
+id: IMPL-0CHRO7
+type: implementation-checklist
+title: 'Implementation: Extract the seed cluster off docRuntime (36 → 33)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no new behavior — receiver-only moves; the existing internal/docs suite drives create/link through Lua)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled (struct embedding rejected: plimsoll v0.2.0 counts only directly-declared methods, so embedding would report 33 while leaving every seed method callable on dr — satisfying the linter without severing the reach it exists to detect)
+- [x] Error handling in place (no error paths changed)
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A: no test changes)
+- [x] ~~No hardcoded values in assertions~~ (N/A: no test changes)
+- [x] ~~Only values that matter~~ (N/A: no test changes)
+- [x] ~~Interpolated values from objects~~ (N/A: no test changes)
+- [x] ~~Property comparisons from original object~~ (N/A: no test changes)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (`go test ./internal/...` green — the acceptance proof for a behavior-preserving refactor)
+- [x] Each acceptance criterion verified (docRuntime at 33 methods, verified by count; minted id values and sequence unchanged)
+- [x] ~~Edge cases manually verified~~ (N/A: the end-to-end screenshot replay needs Chrome + a built SPA and was not run; internal/docscapture passed from cache, legitimate only because ApplySeed/SeedOp are unchanged in shape and signature)
+
+## Quality
+
+- [x] `go build ./...` and `-tags postgres` clean
+- [x] `just arch-lint` OK, `just comment-lint` clean
+- [x] `just plimsoll` exit 0
+- [x] `golangci-lint run internal/docs/...` — 0 issues

--- a/tickets/entities/review-checklists/REV-0CHRO7.md
+++ b/tickets/entities/review-checklists/REV-0CHRO7.md
@@ -1,0 +1,28 @@
+---
+id: REV-0CHRO7
+type: review-checklist
+title: 'Review: Extract the seed cluster off docRuntime (36 → 33)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./internal/...` green; CI green on every job except the Rela Tickets gate these files resolve)
+- [x] Linters pass (golangci-lint 0 issues, arch-lint OK, comment-lint clean, plimsoll exit 0)
+- [x] Coverage floors hold
+
+## Code Review
+
+- [x] ~~`/code-review` run~~ (N/A: pure receiver-only move; the design decision below was independently confirmed)
+- [x] All critical/significant findings addressed (none)
+- [x] Embedding-vs-named-field decision reviewed and endorsed: plimsoll v0.2.0 counts only directly-declared methods, so embedding would have reported 33 while leaving every seed method callable on dr — satisfying the linter without severing the reach it exists to detect
+
+## Verification
+
+- [x] Method count independently verified: docRuntime at 33
+- [x] Minted id values and sequence unchanged (method bodies byte-identical apart from receiver and field renames)
+- [x] `SeedOp` / `ApplySeed` shape and signature unchanged, so internal/docscapture is untouched
+- [x] Cross-boundary edits held to three one-token `dr.seed.ops` reads in the parallel PR's files, no reordering or reformatting
+- [x] ~~End-to-end screenshot replay exercised~~ (N/A: needs Chrome + a built SPA; internal/docscapture passed from cache, legitimate only because ApplySeed/SeedOp are unchanged — argued, not observed)

--- a/tickets/entities/tickets/TKT-0CHRO7.md
+++ b/tickets/entities/tickets/TKT-0CHRO7.md
@@ -1,0 +1,74 @@
+---
+id: TKT-0CHRO7
+type: ticket
+title: Extract the seed cluster off docRuntime (36 → 33)
+kind: refactor
+priority: medium
+effort: s
+status: review
+---
+
+Sub-ticket of [[TKT-N0IKN9]], part of the `internal/docs` `docRuntime` arc.
+
+## What
+
+**Pure structural extraction, no behavior change, no exported-API change, no
+Lua-visible change.**
+
+Two fields and three methods move off `docRuntime` onto a focused seed recorder
+in `seed.go`, keeping registration on the runtime as the wiring seam:
+
+- **Fields**: `seedCounts`, `seedOps`.
+- **Methods** (−3): `luaCreate`, `luaLink`, `mintID` (from `module.go`).
+
+## Why this cluster is a boundary
+
+Seeding is WRITE-side fixture construction; the rest of `docRuntime` is
+READ-side graph interrogation and assertion. Both fields exist for documented,
+self-contained reasons: `seedCounts` is a per-type auto-id counter so `mintID`
+avoids a full-store scan per `create()`, and `seedOps` records every create/link
+so a `screenshot{}` island can replay them against a fresh fsstore temp project
+(DR-S2).
+
+## Embedding was rejected deliberately
+
+The `seedOps` reads in `screenshot.go`/`api.go` could have been left untouched
+by embedding the seed type, so `dr.seedOps` keeps resolving by promotion. Tested
+against plimsoll v0.2.0 in a scratch module: **it counts only directly-declared
+methods, not promoted ones** — a type with 3 promoted and 1 own method passes
+`max-methods=1`.
+
+So embedding would have reported 33 while leaving every seed method callable on
+`dr`, satisfying the linter without removing the reach the linter exists to
+detect. Rejected as gaming the metric. A named field costs three one-token edits
+and actually severs the coupling.
+
+Worth knowing for the rest of the ratchet arc: plimsoll can be satisfied by
+embedding without decoupling anything.
+
+## Preventive, not a gate fix
+
+On `develop` `docRuntime` is at 36 — under the 40-method line, carrying no
+`//plimsoll:max-*` directive. No directive was added: annotating a compliant
+type pins it rather than ratchets it.
+
+Interacts with the parallel Tier-B ticket, which reads `seedOps` through a `seed
+func() []SeedOp` seam. Both branch off develop independently; whichever lands
+second reconciles (mechanical) and settles the final count.
+
+## Not verified
+
+The end-to-end screenshot replay was not exercised (needs Chrome and a built
+SPA). `internal/docscapture` passed from cache, which is legitimate only because
+`ApplySeed` and `SeedOp` are unchanged in shape and signature. The replay
+argument rests on the method bodies being byte-identical apart from the
+receiver.
+
+## Done when
+
+- [x] `docRuntime` at 33 methods
+- [x] `go build ./...` and `-tags postgres` clean
+- [x] `go test ./internal/...` passes
+- [x] `just arch-lint` OK, `just comment-lint` clean
+- [x] `just plimsoll` exit 0
+- [x] PR open (#1475)

--- a/tickets/entities/tickets/TKT-0CHRO7.md
+++ b/tickets/entities/tickets/TKT-0CHRO7.md
@@ -5,7 +5,7 @@ title: Extract the seed cluster off docRuntime (36 → 33)
 kind: refactor
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 Sub-ticket of [[TKT-N0IKN9]], part of the `internal/docs` `docRuntime` arc.

--- a/tickets/relations/TKT-0CHRO7--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-0CHRO7--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0CHRO7
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-0CHRO7--has-implementation--IMPL-0CHRO7.md
+++ b/tickets/relations/TKT-0CHRO7--has-implementation--IMPL-0CHRO7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0CHRO7
+relation: has-implementation
+to: IMPL-0CHRO7
+---

--- a/tickets/relations/TKT-0CHRO7--has-review--REV-0CHRO7.md
+++ b/tickets/relations/TKT-0CHRO7--has-review--REV-0CHRO7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0CHRO7
+relation: has-review
+to: REV-0CHRO7
+---

--- a/tickets/relations/TKT-0CHRO7--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-0CHRO7--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0CHRO7
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Pure structural refactor continuing the TKT-N0IKN9 decomposition arc, following the pattern of #1462 / #1467. This one is **preventive**: on develop `docRuntime` is at 36 methods, under the 40 cap and carrying no `//plimsoll:max-*` directive. Nothing is failing — the point is to take a real seam out before the type reaches the line.

## The cluster

Moves two fields (`seedCounts`, `seedOps`) and three methods (`luaCreate`, `luaLink`, `mintID`) off `docRuntime` onto a new `seedBindings` in `seed.go`, next to `SeedOp`/`ApplySeed` — the seeding machinery they belong with. `docRuntime` goes **36 → 33** methods.

## Why this is a real boundary

Seeding is WRITE-side fixture construction; the rest of `docRuntime` is READ-side graph interrogation and assertion. The two fields exist for documented, self-contained reasons: `seedCounts` is a per-type auto-id counter so `mintID` avoids a full-store scan per `create()`, and `seedOps` records every create/link so a `screenshot{}` island can replay them against a fresh fsstore temp project (DR-S2). Nothing outside seeding should be able to reach either — which is plimsoll's stated rationale: "a receiver with dozens of private helpers is one struct whose fields they can all reach."

Per the interface-at-the-call-site rule, `seedBindings` takes a narrow `seedWriter` (create-only: `CreateEntity` + `CreateRelation`) rather than the whole store, so the seed cluster cannot grow into update/delete without widening that interface first. Failures are reported through an injected `fail` callback rather than a back-pointer to `docRuntime`, which would recreate the coupling the split removes.

Registration stays on `docRuntime` — the `doc.*` table is still one binding table assembled in `registerModule`; only the two map values change to `dr.seed.luaCreate` / `dr.seed.luaLink`.

## The seedOps / replay coupling

`seedOps` is written by seeding but READ by the replay paths: `screenshot.go:108` and `api.go:108,126` build `CaptureSpec.Seed` / `APIRequest.Seed` from it. Those three sites now read `dr.seed.ops`.

I deliberately did **not** use struct embedding, which would have kept `dr.seedOps` resolving via promotion and left those files untouched. I verified against plimsoll v0.2.0 that it counts only directly-declared methods, not promoted ones — so embedding would have satisfied the linter while leaving all three seed methods callable on `dr`. That is gaming the metric rather than removing the reach the metric exists to detect. A named field costs three one-token edits and actually severs the coupling.

`SeedOp` and `ApplySeed` are unchanged in shape and signature, so `internal/docscapture` (the replay consumer) is untouched.

## No behavior, exported-API, or Lua-visible change

The three method bodies are byte-identical apart from the receiver and the two field renames, so minted id values and their sequence are unchanged. `doc.create()` / `doc.link()` behave exactly as before.

## Verification

- `go build ./...` and `go build -tags postgres ./...` — clean
- `go test ./internal/...` — all pass
- `just arch-lint` — OK, no warnings
- `just plimsoll` — clean, exit 0 (note `just ci` does not run it)
- `just comment-lint` — clean (gate)
- `golangci-lint run internal/docs/...` — 0 issues

Refs TKT-N0IKN9.
