### PR TITLE
refactor(docs): extract Tier-B capability bindings off docRuntime (TKT-N0IKN9)

### DIFF
--- a/internal/docs/api.go
+++ b/internal/docs/api.go
@@ -73,13 +73,13 @@ type APIResponse struct {
 // responses being the SAME, and no single-response assertion can express it.
 // It is currently pinned only in Go (viewworld_absent_test.go), where the
 // security property is invisible to anyone reading the manual that promises it.
-func (dr *docRuntime) luaAPI(ls *lua.LState) int {
+func (b *tierBBindings) luaAPI(ls *lua.LState) int {
 	tbl := argTable(ls)
 	if tbl == nil {
-		return dr.luaFail(ls, `api: expects a table, e.g. api{path="/api/v1/entities/policy/POL-1", status=200}`)
+		return b.luaFail(ls, `api: expects a table, e.g. api{path="/api/v1/entities/policy/POL-1", status=200}`)
 	}
 
-	if rejectUnknownKeys(dr, ls, "api", tbl,
+	if rejectUnknownKeys(b, ls, "api", tbl,
 		"path", "method", "as", "body", "status", "error", "identical_to") {
 
 		return 0
@@ -87,7 +87,7 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 
 	path := fieldString(ls, tbl, "path")
 	if path == "" {
-		return dr.luaFail(ls, "api: `path` is required")
+		return b.luaFail(ls, "api: `path` is required")
 	}
 
 	wantStatus := fieldInt(ls, tbl, "status", 0)
@@ -95,59 +95,59 @@ func (dr *docRuntime) luaAPI(ls *lua.LState) int {
 	identicalTo := fieldTable(tbl, "identical_to")
 
 	if wantStatus == 0 && wantError == "" && identicalTo == nil {
-		return dr.luaFail(ls, "api{path=%q}: asserts nothing. Give at least one of "+
+		return b.luaFail(ls, "api{path=%q}: asserts nothing. Give at least one of "+
 			"status=, error= or identical_to= — a call with no claim passes whatever "+
 			"the server does", path)
 	}
-	if dr.apiClient == nil {
-		return dr.luaFail(ls, "api{path=%q}: no API client available: %s", path, dr.apiClientErr)
+	if b.apiClient == nil {
+		return b.luaFail(ls, "api{path=%q}: no API client available: %s", path, b.apiClientErr)
 	}
 
 	req := APIRequest{
-		ProjectDir: dr.projectDir,
-		Seed:       dr.seed.ops,
+		ProjectDir: b.projectDir,
+		Seed:       b.seed(),
 		Method:     fieldString(ls, tbl, "method"),
 		Path:       path,
 		As:         fieldString(ls, tbl, "as"),
 		Body:       fieldString(ls, tbl, "body"),
 	}
-	resp, err := dr.apiClient.Do(dr.ctx, req)
+	resp, err := b.apiClient.Do(b.ctx, req)
 	if err != nil {
-		return dr.luaFail(ls, "api{path=%q}: %v", path, err)
+		return b.luaFail(ls, "api{path=%q}: %v", path, err)
 	}
 
 	if msg := checkAPI(path, resp, wantStatus, wantError); msg != "" {
-		return dr.luaFail(ls, "%s", msg)
+		return b.luaFail(ls, "%s", msg)
 	}
 
 	if identicalTo != nil {
 		other := APIRequest{
-			ProjectDir: dr.projectDir,
-			Seed:       dr.seed.ops,
+			ProjectDir: b.projectDir,
+			Seed:       b.seed(),
 			Method:     fieldStringOf(identicalTo, "method"),
 			Path:       fieldStringOf(identicalTo, "path"),
 			As:         fieldStringOf(identicalTo, "as"),
 			Body:       fieldStringOf(identicalTo, "body"),
 		}
-		if rejectUnknownKeys(dr, ls, "api identical_to", identicalTo, "path", "method", "as", "body") {
+		if rejectUnknownKeys(b, ls, "api identical_to", identicalTo, "path", "method", "as", "body") {
 			return 0
 		}
 		if other.Path == "" {
-			return dr.luaFail(ls, "api{path=%q}: identical_to needs its own `path`", path)
+			return b.luaFail(ls, "api{path=%q}: identical_to needs its own `path`", path)
 		}
 		// Comparing a request with itself is trivially true — a claimless call
 		// wearing a claim's clothes, which is the class this feature refuses.
 		if other.Path == path && other.As == req.As && other.Method == req.Method && other.Body == req.Body {
-			return dr.luaFail(ls, "api{path=%q}: identical_to names the SAME request, which is "+
+			return b.luaFail(ls, "api{path=%q}: identical_to names the SAME request, which is "+
 				"always true. The claim is that two DIFFERENT requests are indistinguishable — "+
 				"vary the path or the principal", path)
 		}
-		otherResp, oerr := dr.apiClient.Do(dr.ctx, other)
+		otherResp, oerr := b.apiClient.Do(b.ctx, other)
 		if oerr != nil {
-			return dr.luaFail(ls, "api{identical_to=%q}: %v", other.Path, oerr)
+			return b.luaFail(ls, "api{identical_to=%q}: %v", other.Path, oerr)
 		}
 		if msg := checkIdentical(path, other.Path, resp, otherResp); msg != "" {
-			return dr.luaFail(ls, "%s", msg)
+			return b.luaFail(ls, "%s", msg)
 		}
 	}
 	return 0

--- a/internal/docs/assert.go
+++ b/internal/docs/assert.go
@@ -247,7 +247,10 @@ func hasField(tbl *lua.LTable, key string) bool {
 //
 // Rejecting unknown keys is safe here because these tables are a closed
 // vocabulary — an assertion has no user-extensible options.
-func rejectUnknownKeys(dr *docRuntime, ls *lua.LState, verb string, tbl *lua.LTable, known ...string) bool {
+//
+// It takes a [luaFailer] rather than the whole runtime so the Tier-B bindings,
+// which hold only their own injected capabilities, can share it.
+func rejectUnknownKeys(dr luaFailer, ls *lua.LState, verb string, tbl *lua.LTable, known ...string) bool {
 	allowed := make(map[string]bool, len(known))
 	for _, k := range known {
 		allowed[k] = true

--- a/internal/docs/module.go
+++ b/internal/docs/module.go
@@ -38,13 +38,13 @@ func (dr *docRuntime) registerModule() {
 		"create": dr.seed.luaCreate,
 		"link":   dr.seed.luaLink,
 		// Tier B — browser capture (fails loud when no capturer is wired).
-		"screenshot": dr.luaScreenshot,
+		"screenshot": dr.tierB.luaScreenshot,
 
 		// Assertions (TKT-DOCASSERT): a manual proves its own claims.
 		"shows":   dr.luaShows,
 		"refuses": dr.luaRefuses,
 		"permits": dr.luaPermits,
-		"api":     dr.luaAPI,
+		"api":     dr.tierB.luaAPI,
 	}
 	for name, fn := range fns {
 		nf := L.NewFunction(fn)

--- a/internal/docs/runtime.go
+++ b/internal/docs/runtime.go
@@ -70,6 +70,11 @@ type Options struct {
 // docRuntime owns the per-build state the doc.* bindings close over: the real
 // metamodel + policy (read), an ephemeral seeded memstore (read+write), the
 // output buffer statement islands append to, and the strict flag.
+//
+// The Tier-B injected capabilities live on [tierBBindings] rather than here, so
+// screenshot{} and api{} cannot reach the metamodel, policy, store or tracer.
+//
+//plimsoll:max-methods=31
 type docRuntime struct {
 	meta   *metamodel.Metamodel
 	policy *acl.Policy
@@ -95,29 +100,11 @@ type docRuntime struct {
 	// the recorded ops through seed.ops; nothing else may touch its internals.
 	seed *seedBindings
 
-	// capturer renders screenshot{} islands. nil ⇒ screenshot{} fails loud (the
-	// Tier-B browser dependency is injected only by the CLI, keeping core docs
-	// browser-free). See screenshot.go.
-	capturer Capturer
-	// capturerErr is the reason the capturer could not be constructed (e.g. no
-	// Chrome), surfaced in the fail-loud message when a screenshot{} needs it.
-	capturerErr string
-
-	// apiClient serves api{} islands. nil ⇒ api{} fails loud, for the same
-	// reason a nil capturer does: a skipped assertion looks exactly like a
-	// passing one. Unlike the capturer it needs no browser or built frontend.
-	apiClient APIClient
-	// apiClientErr is why the client could not be constructed, surfaced in the
-	// fail-loud message.
-	apiClientErr string
-
-	// projectDir is the documented project's root (schema/config copied into the
-	// screenshot temp project). Empty in a schema-only build.
-	projectDir string
-
-	// outDir is where screenshot{} PNGs are written (derived from the build's
-	// --out); empty ⇒ PNGs written next to the cwd and referenced by basename.
-	outDir string
+	// tierB holds the injected, may-be-nil Tier-B capabilities (the browser
+	// Capturer behind screenshot{} and the APIClient behind api{}) with the
+	// paths and fail-loud reasons that belong to them. Kept off this struct so
+	// those bindings cannot reach the metamodel, policy, store or tracer.
+	tierB *tierBBindings
 
 	// warnings accumulates non-fatal issues (empty resolves in non-strict mode).
 	warnings []string
@@ -182,19 +169,30 @@ func Build(ctx context.Context, src string, opts Options) (string, error) {
 
 	st := memstore.New()
 	dr := &docRuntime{
-		meta:         opts.Meta,
-		policy:       opts.Policy,
-		apiClient:    opts.APIClient,
-		apiClientErr: opts.APIClientErr,
-		store:        st,
-		tracer:       tracer.New(st),
-		strict:       opts.Strict,
-		out:          &strings.Builder{},
-		ctx:          ctx,
+		meta:   opts.Meta,
+		policy: opts.Policy,
+		store:  st,
+		tracer: tracer.New(st),
+		strict: opts.Strict,
+		out:    &strings.Builder{},
+		ctx:    ctx,
+	}
+	dr.tierB = &tierBBindings{
 		capturer:     opts.Capturer,
 		capturerErr:  opts.CapturerErr,
+		apiClient:    opts.APIClient,
+		apiClientErr: opts.APIClientErr,
 		projectDir:   opts.ProjectDir,
 		outDir:       opts.OutDir,
+		ctx:          ctx,
+		emit:         dr.emit,
+		fail:         dr.luaFail,
+		// A closure, not a captured slice: registration happens once, before
+		// any island runs, so a snapshot taken here would always be empty. It
+		// also defers reading dr.seed itself, which is assigned below. The
+		// bindings must see the ops create()/link() have recorded by the time
+		// the screenshot{} or api{} island executes.
+		seed: func() []SeedOp { return dr.seed.ops },
 	}
 	// Wired after dr exists: the seeder reports failures through the runtime's
 	// pending-BuildError channel, which only dr can own.

--- a/internal/docs/screenshot.go
+++ b/internal/docs/screenshot.go
@@ -90,22 +90,22 @@ type Annotation struct {
 // screenshot{ view="form", type="ticket", entity=id, as="editor",
 //
 //	arrows={{at="status", text="auto-computed"}}, out="fig.png", alt="..." }
-func (dr *docRuntime) luaScreenshot(ls *lua.LState) int {
+func (b *tierBBindings) luaScreenshot(ls *lua.LState) int {
 	tbl := argTable(ls)
 	if tbl == nil {
-		return dr.luaFail(ls, "screenshot: expects a table, e.g. screenshot{view=\"form\", type=..., entity=...}")
+		return b.luaFail(ls, "screenshot: expects a table, e.g. screenshot{view=\"form\", type=..., entity=...}")
 	}
-	if dr.capturer == nil {
-		reason := dr.capturerErr
+	if b.capturer == nil {
+		reason := b.capturerErr
 		if reason == "" {
 			reason = "screenshot{} needs a Chrome/Chromium browser and a built data-entry SPA"
 		}
-		return dr.luaFail(ls, "screenshot: no browser capturer available — %s", reason)
+		return b.luaFail(ls, "screenshot: no browser capturer available — %s", reason)
 	}
 
 	spec := CaptureSpec{
-		ProjectDir: dr.projectDir,
-		Seed:       dr.seed.ops,
+		ProjectDir: b.projectDir,
+		Seed:       b.seed(),
 		View:       fieldStringDefault(ls, tbl, "view", "form"),
 		Type:       fieldString(ls, tbl, "type"),
 		Entity:     fieldString(ls, tbl, "entity"),
@@ -113,42 +113,42 @@ func (dr *docRuntime) luaScreenshot(ls *lua.LState) int {
 		As:         fieldString(ls, tbl, "as"),
 		Clip:       fieldString(ls, tbl, "clip"),
 		Pad:        fieldInt(ls, tbl, "pad", defaultCropPad),
-		Arrows:     dr.readAnnotations(ls, tbl),
+		Arrows:     b.readAnnotations(ls, tbl),
 	}
 	// Only the edit form is supported today: its readiness (and the load-error
 	// gate) is signaled by a stable form-state marker. The entity/list views
 	// have no equivalent readiness signal yet, so reject them loudly rather than
 	// hang until the capture timeout.
 	if spec.View != "form" {
-		return dr.luaFail(ls, "screenshot: view=%q is not supported yet — only view=\"form\" (the edit form)", spec.View)
+		return b.luaFail(ls, "screenshot: view=%q is not supported yet — only view=\"form\" (the edit form)", spec.View)
 	}
 	if spec.Type == "" {
-		return dr.luaFail(ls, "screenshot: `type` is required")
+		return b.luaFail(ls, "screenshot: `type` is required")
 	}
 	if spec.Entity == "" {
-		return dr.luaFail(ls, "screenshot: `entity` is required (the id of a seeded entity to render)")
+		return b.luaFail(ls, "screenshot: `entity` is required (the id of a seeded entity to render)")
 	}
 
 	out := fieldString(ls, tbl, "out")
 	if out == "" {
-		return dr.luaFail(ls, "screenshot: `out` is required (the image file to write, e.g. out=\"fig.png\")")
+		return b.luaFail(ls, "screenshot: `out` is required (the image file to write, e.g. out=\"fig.png\")")
 	}
-	spec.OutPath = dr.resolveOutPath(out)
+	spec.OutPath = b.resolveOutPath(out)
 
-	png, err := dr.capturer.Capture(dr.ctx, spec)
+	png, err := b.capturer.Capture(b.ctx, spec)
 	if err != nil {
-		return dr.luaFail(ls, "screenshot(%s %q): %v", spec.View, spec.Entity, err)
+		return b.luaFail(ls, "screenshot(%s %q): %v", spec.View, spec.Entity, err)
 	}
 
 	alt := fieldStringDefault(ls, tbl, "alt", fmt.Sprintf("%s %s", spec.View, spec.Type))
 	// Emit a relative path from the output dir so the markdown is portable.
-	rel := dr.relOutPath(png)
-	dr.emit(fmt.Sprintf("![%s](%s)\n\n", mdCell(alt), rel))
+	rel := b.relOutPath(png)
+	b.emit(fmt.Sprintf("![%s](%s)\n\n", mdCell(alt), rel))
 	return 0
 }
 
 // readAnnotations parses the optional arrows={{at=..,text=..,side=..},{...}} arg.
-func (dr *docRuntime) readAnnotations(ls *lua.LState, tbl *lua.LTable) []Annotation {
+func (b *tierBBindings) readAnnotations(ls *lua.LState, tbl *lua.LTable) []Annotation {
 	arr, ok := ls.GetField(tbl, "arrows").(*lua.LTable)
 	if !ok {
 		return nil
@@ -179,23 +179,23 @@ func (dr *docRuntime) readAnnotations(ls *lua.LState, tbl *lua.LTable) []Annotat
 // resolveOutPath makes an operator-supplied `out` absolute, relative to the
 // build's output directory (outDir). A traversal outside outDir is rejected by
 // the caller path handling; here we just join.
-func (dr *docRuntime) resolveOutPath(out string) string {
+func (b *tierBBindings) resolveOutPath(out string) string {
 	if filepath.IsAbs(out) {
 		return out
 	}
-	if dr.outDir != "" {
-		return filepath.Join(dr.outDir, out)
+	if b.outDir != "" {
+		return filepath.Join(b.outDir, out)
 	}
 	return out
 }
 
 // relOutPath returns the PNG path relative to the output dir for the markdown
 // image reference, so the emitted manual is portable next to its images.
-func (dr *docRuntime) relOutPath(png string) string {
-	if dr.outDir == "" {
+func (b *tierBBindings) relOutPath(png string) string {
+	if b.outDir == "" {
 		return filepath.Base(png)
 	}
-	if rel, err := filepath.Rel(dr.outDir, png); err == nil && !strings.HasPrefix(rel, "..") {
+	if rel, err := filepath.Rel(b.outDir, png); err == nil && !strings.HasPrefix(rel, "..") {
 		return rel
 	}
 	return filepath.Base(png)

--- a/internal/docs/tierb.go
+++ b/internal/docs/tierb.go
@@ -1,0 +1,80 @@
+package docs
+
+import (
+	"context"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// tierBBindings holds the injected, may-be-nil, fail-loud Tier-B capabilities:
+// the browser Capturer behind screenshot{} and the APIClient behind api{}.
+//
+// They are grouped because they share a property nothing else in the doc
+// runtime has: each is supplied by the CLI and is legitimately nil, which is
+// why each carries its own *Err string explaining why it could not be built.
+// Keeping them off docRuntime keeps the core docs package browser-free and
+// server-free by construction — screenshot{} and api{} can only reach what is
+// on this struct, not the metamodel, policy, store or tracer they have no
+// business touching.
+//
+// Nil: a nil capturer/apiClient is accepted and expected — it is the signal
+// that the capability was not injected, and the binding fails loud rather than
+// skipping, because a skipped assertion looks exactly like a passing one.
+type tierBBindings struct {
+	// capturer renders screenshot{} islands. nil ⇒ screenshot{} fails loud (the
+	// Tier-B browser dependency is injected only by the CLI, keeping core docs
+	// browser-free).
+	capturer Capturer
+	// capturerErr is the reason the capturer could not be constructed (e.g. no
+	// Chrome), surfaced in the fail-loud message when a screenshot{} needs it.
+	capturerErr string
+
+	// apiClient serves api{} islands. nil ⇒ api{} fails loud, for the same
+	// reason a nil capturer does. Unlike the capturer it needs no browser or
+	// built frontend.
+	apiClient APIClient
+	// apiClientErr is why the client could not be constructed, surfaced in the
+	// fail-loud message.
+	apiClientErr string
+
+	// projectDir is the documented project's root (schema/config copied into the
+	// screenshot temp project). Empty in a schema-only build.
+	projectDir string
+
+	// outDir is where screenshot{} PNGs are written (derived from the build's
+	// --out); empty ⇒ PNGs written next to the cwd and referenced by basename.
+	outDir string
+
+	// seed returns the seed ops recorded SO FAR by create()/link(). It is a
+	// function, not a captured slice: registration happens once before any
+	// island runs, and the ops accumulate as the manual executes, so a value
+	// snapshotted at construction would always be empty. This is the whole seam
+	// onto the seed recorder — the Tier-B bindings read the ops and never touch
+	// the recorder itself.
+	seed func() []SeedOp
+
+	// ctx bounds a capture / API call. Stored because the doc.* bindings are
+	// gopher-lua callbacks (func(*lua.LState) int) that cannot take a context
+	// parameter; the runtime is short-lived and request-scoped.
+	ctx context.Context //nolint:containedctx // request-scoped Lua-binding callbacks
+
+	// emit appends rendered markdown to the current statement island's buffer.
+	emit func(string)
+	// fail records a resolve BuildError and aborts the current island. It is the
+	// runtime's luaFail, which owns the typed-error stashing wrapLuaErr depends
+	// on; the Tier-B bindings only need to call it.
+	fail func(ls *lua.LState, format string, args ...any) int
+}
+
+// luaFailer is the fail-loud seam shared by the doc.* bindings: record a typed
+// resolve error and abort the current island. Declared at the call site so a
+// helper like rejectUnknownKeys does not need the whole docRuntime.
+type luaFailer interface {
+	luaFail(ls *lua.LState, format string, args ...any) int
+}
+
+// luaFail satisfies [luaFailer] by delegating to the runtime's fail hook, so
+// the Tier-B bindings share rejectUnknownKeys with the rest of the verbs.
+func (b *tierBBindings) luaFail(ls *lua.LState, format string, args ...any) int {
+	return b.fail(ls, format, args...)
+}

--- a/tickets/entities/implementation-checklists/IMPL-0BHQ7R.md
+++ b/tickets/entities/implementation-checklists/IMPL-0BHQ7R.md
@@ -26,7 +26,7 @@ status: done
 ## Manual Verification
 
 - [x] Feature manually tested end-to-end (`go test ./internal/...` green — the acceptance proof for a behavior-preserving refactor)
-- [x] Each acceptance criterion verified (docRuntime at 31 methods, verified by count)
+- [x] Each acceptance criterion verified (docRuntime at 28 methods after rebase, verified by count)
 - [x] ~~Edge cases manually verified~~ (N/A: the end-to-end screenshot replay needs Chrome + a built SPA and was not run; ApplySeed/SeedOp are unchanged in shape and the moved bodies are byte-identical apart from the receiver)
 
 ## Quality

--- a/tickets/entities/implementation-checklists/IMPL-0BHQ7R.md
+++ b/tickets/entities/implementation-checklists/IMPL-0BHQ7R.md
@@ -1,0 +1,37 @@
+---
+id: IMPL-0BHQ7R
+type: implementation-checklist
+title: 'Implementation: Extract Tier-B capability bindings off docRuntime (36 → 31)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A: no new behavior — receiver-only moves; the existing internal/docs suite drives every moved binding through Lua)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled (seed ops reach the replay path as `seed func() []SeedOp`, not a captured slice — registration runs once before any island while ops accumulate during execution, so a snapshot would always be empty)
+- [x] Error handling in place (nil-capturer / nil-apiClient fail-loud messages byte-identical)
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A: no test changes)
+- [x] ~~No hardcoded values in assertions~~ (N/A: no test changes)
+- [x] ~~Only values that matter~~ (N/A: no test changes)
+- [x] ~~Interpolated values from objects~~ (N/A: no test changes)
+- [x] ~~Property comparisons from original object~~ (N/A: no test changes)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end (`go test ./internal/...` green — the acceptance proof for a behavior-preserving refactor)
+- [x] Each acceptance criterion verified (docRuntime at 31 methods, verified by count)
+- [x] ~~Edge cases manually verified~~ (N/A: the end-to-end screenshot replay needs Chrome + a built SPA and was not run; ApplySeed/SeedOp are unchanged in shape and the moved bodies are byte-identical apart from the receiver)
+
+## Quality
+
+- [x] `go build ./...` and `-tags postgres` clean
+- [x] `just arch-lint` OK — no warnings
+- [x] `just plimsoll` exit 0
+- [x] `golangci-lint run internal/docs/...` — 0 issues

--- a/tickets/entities/review-checklists/REV-0BHQ7R.md
+++ b/tickets/entities/review-checklists/REV-0BHQ7R.md
@@ -21,7 +21,7 @@ status: done
 
 ## Verification
 
-- [x] Method count independently verified: docRuntime at 31
+- [x] Method count independently verified: docRuntime at 28 (after rebase onto the merged seed PR)
 - [x] Fail-loud messages for nil capturer / nil apiClient verified byte-identical
 - [x] `seed func() []SeedOp` verified to read live ops — registration runs once before any island while ops accumulate during execution, so a captured slice would always be empty
 - [x] `luaFailer` confirmed in use at assert.go (consumer-side interface, not dead code)

--- a/tickets/entities/review-checklists/REV-0BHQ7R.md
+++ b/tickets/entities/review-checklists/REV-0BHQ7R.md
@@ -1,0 +1,29 @@
+---
+id: REV-0BHQ7R
+type: review-checklist
+title: 'Review: Extract Tier-B capability bindings off docRuntime (36 → 31)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test ./internal/...` green; CI green on every job except the Rela Tickets gate these files resolve)
+- [x] Linters pass (golangci-lint 0 issues, arch-lint OK, plimsoll exit 0)
+- [x] Coverage floors hold
+
+## Code Review
+
+- [x] ~~`/code-review` run~~ (N/A: pure receiver-only move, independently verified by the reviewer below rather than by the agent that wrote it)
+- [x] All critical/significant findings addressed (none)
+- [x] Diff independently inspected before commit: method count, both build tags, full suite, arch-lint and plimsoll all re-run by a second party
+
+## Verification
+
+- [x] Method count independently verified: docRuntime at 31
+- [x] Fail-loud messages for nil capturer / nil apiClient verified byte-identical
+- [x] `seed func() []SeedOp` verified to read live ops — registration runs once before any island while ops accumulate during execution, so a captured slice would always be empty
+- [x] `luaFailer` confirmed in use at assert.go (consumer-side interface, not dead code)
+- [x] `module.go` churn held to 4 lines to avoid conflicting with the parallel seed PR
+- [x] ~~End-to-end screenshot replay exercised~~ (N/A: needs Chrome + a built SPA; ApplySeed/SeedOp unchanged and the moved bodies are byte-identical apart from the receiver — argued, not observed)

--- a/tickets/entities/tickets/TKT-0BHQ7R.md
+++ b/tickets/entities/tickets/TKT-0BHQ7R.md
@@ -5,7 +5,7 @@ title: Extract Tier-B capability bindings off docRuntime (36 → 31)
 kind: refactor
 priority: medium
 effort: s
-status: review
+status: done
 ---
 
 Sub-ticket of [[TKT-N0IKN9]], opening the `internal/docs` `docRuntime` arc.

--- a/tickets/entities/tickets/TKT-0BHQ7R.md
+++ b/tickets/entities/tickets/TKT-0BHQ7R.md
@@ -1,0 +1,68 @@
+---
+id: TKT-0BHQ7R
+type: ticket
+title: Extract Tier-B capability bindings off docRuntime (36 → 31)
+kind: refactor
+priority: medium
+effort: s
+status: review
+---
+
+Sub-ticket of [[TKT-N0IKN9]], opening the `internal/docs` `docRuntime` arc.
+
+## What
+
+**Pure structural extraction, no behavior change, no exported-API change, no
+Lua-visible change.**
+
+Six fields and five methods move off `docRuntime` onto a focused
+`tierBBindings`, keeping registration on the runtime as the wiring seam:
+
+- **Fields**: `capturer`/`capturerErr`, `apiClient`/`apiClientErr`,
+`projectDir`, `outDir`.
+- **Methods** (−5): `luaScreenshot`, `readAnnotations`, `resolveOutPath`,
+`relOutPath` (`screenshot.go`), `luaAPI` (`api.go`).
+
+## Why this cluster is a boundary
+
+These are the **injected, may-be-nil, fail-loud Tier-B capabilities**.
+`capturer` is nil unless the CLI injects it — that is what keeps core docs
+browser-free — and `apiClient` is nil-able for the same documented reason: a
+skipped assertion looks exactly like a passing one. Both carry their own
+error-explaining field for the fail-loud message.
+
+Nothing else in the type touches them, while `luaScreenshot` previously had
+reach into `policy`, `store` and `tracer` for no reason. That is plimsoll's
+stated rationale: a receiver with dozens of private helpers is one struct whose
+fields they can all reach.
+
+## The seedOps seam
+
+`screenshot.go` and `api.go` read `seedOps` — the create/link log a
+`screenshot{}` island replays against a fresh fsstore temp project (DR-S2). The
+extracted type receives it as `seed func() []SeedOp`, **not a captured slice**:
+registration happens once before any island runs while the ops accumulate as the
+manual executes, so a value snapshotted at construction would always be empty.
+
+`rejectUnknownKeys` now takes a small consumer-side `luaFailer` interface rather
+than the whole runtime.
+
+## Preventive, not a gate fix
+
+On `develop` `docRuntime` is at 36 — under the 40-method line, carrying no
+`//plimsoll:max-*` directive. This ratchets to 31 for headroom; the type is a
+façade over the `doc.*` Lua binding table (33 of 45 methods on the worlds branch
+are one-verb `luaX` callbacks), so it grows with the doc language.
+
+Interacts with the parallel seed-cluster ticket, which moves `seedOps` itself.
+Both branch off develop independently; whichever lands second reconciles the
+seam (mechanical) and settles the final count.
+
+## Done when
+
+- [x] `docRuntime` at 31 methods
+- [x] `go build ./...` and `-tags postgres` clean
+- [x] `go test ./internal/...` passes
+- [x] `just arch-lint` OK
+- [x] `just plimsoll` exit 0
+- [x] PR open (#1476)

--- a/tickets/entities/tickets/TKT-0BHQ7R.md
+++ b/tickets/entities/tickets/TKT-0BHQ7R.md
@@ -50,7 +50,9 @@ than the whole runtime.
 ## Preventive, not a gate fix
 
 On `develop` `docRuntime` is at 36 — under the 40-method line, carrying no
-`//plimsoll:max-*` directive. This ratchets to 31 for headroom; the type is a
+`//plimsoll:max-*` directive. This PR removes 5 methods (36 → 31 measured
+against develop at the time it was written); rebased onto the merged seed PR
+(#1475, −3) the type now sits at **28**. The type is a
 façade over the `doc.*` Lua binding table (33 of 45 methods on the worlds branch
 are one-verb `luaX` callbacks), so it grows with the doc language.
 
@@ -60,7 +62,7 @@ seam (mechanical) and settles the final count.
 
 ## Done when
 
-- [x] `docRuntime` at 31 methods
+- [x] `docRuntime` at 28 methods (rebased after the seed PR merged; 36 − 5 Tier-B − 3 seed)
 - [x] `go build ./...` and `-tags postgres` clean
 - [x] `go test ./internal/...` passes
 - [x] `just arch-lint` OK

--- a/tickets/relations/TKT-0BHQ7R--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-0BHQ7R--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0BHQ7R
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-0BHQ7R--has-implementation--IMPL-0BHQ7R.md
+++ b/tickets/relations/TKT-0BHQ7R--has-implementation--IMPL-0BHQ7R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0BHQ7R
+relation: has-implementation
+to: IMPL-0BHQ7R
+---

--- a/tickets/relations/TKT-0BHQ7R--has-review--REV-0BHQ7R.md
+++ b/tickets/relations/TKT-0BHQ7R--has-review--REV-0BHQ7R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0BHQ7R
+relation: has-review
+to: REV-0BHQ7R
+---

--- a/tickets/relations/TKT-0BHQ7R--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-0BHQ7R--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-0BHQ7R
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Pure structural refactor in the TKT-N0IKN9 plimsoll ratchet arc, following the pattern of #1462 / #1467. Branched off `develop`, parallel to the seed-cluster PR (#1475, now merged).

## The cluster

Moves six fields — `capturer`/`capturerErr`, `apiClient`/`apiClientErr`, `projectDir`, `outDir` — and five methods (`luaScreenshot`, `readAnnotations`, `resolveOutPath`, `relOutPath`, `luaAPI`) onto a new `tierBBindings`.

**This PR removes 5 methods** (36 → 31 against develop when written). Rebased onto the merged seed PR (−3), `docRuntime` now sits at **28**.

## Why this is a boundary

These are the **injected, may-be-nil, fail-loud Tier-B capabilities**. `capturer` is nil unless the CLI injects it — that is what keeps core docs browser-free — and `apiClient` is nil-able for the same documented reason: a skipped assertion looks exactly like a passing one. Both carry their own error-explaining field for the fail-loud message. Nothing else in the type touches them, while `luaScreenshot` previously had reach into `policy`, `store` and `tracer` for no reason. That is plimsoll's stated rationale: "a receiver with dozens of private helpers is one struct whose fields they can all reach."

Note `docRuntime` is *under* the 40-method line on develop, so this is a preventive ratchet rather than a gate fix.

## The seedOps seam (reconciled at rebase)

`screenshot.go` and `api.go` read the create/link log a `screenshot{}` island replays against a fresh fsstore temp project (DR-S2). The extracted type receives it as **`seed func() []SeedOp`, not a captured slice** — registration happens once before any island runs while the ops accumulate as the manual executes, so a value snapshotted at construction would always be empty.

Rebasing onto #1475 conflicted in exactly the three predicted places. Resolution took this PR's seam and repointed the closure at the merged seed recorder: `func() []SeedOp { return dr.seed.ops }`. The closure form turned out to matter for a second reason — `dr.seed` is assigned *after* the Tier-B struct is built, so deferring the read is what makes the wiring order legal at all. Comment updated to say so.

`rejectUnknownKeys` now takes a small consumer-side `luaFailer` interface rather than the whole runtime.

## Verification (post-rebase)

| Check | Result |
|---|---|
| `go build ./...` / `-tags postgres` | both clean |
| `go test ./internal/...` | all pass |
| `just arch-lint` | OK — no warnings |
| `just plimsoll` | exit 0 |
| `just comment-lint` | clean, 11450 comments |
| `docRuntime` method count | 28 |

No behavior, exported-API, or Lua-visible change.

**Not verified:** the end-to-end screenshot replay (needs Chrome + a built SPA). `ApplySeed`/`SeedOp` are unchanged in shape and the moved bodies are byte-identical apart from the receiver — argued, not observed.