### PR TITLE
feat(dataentry): attach files while creating an entity (TKT-7K3BJF)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -383,6 +383,31 @@ Each entry in `fields:` configures one property input:
 > column headers, relation field labels, view-section fields, and Lua flow
 > fields. `rela migrate` will never remove a `label:` you have written.
 
+### File Properties on Forms
+
+A `file`-type property renders a file control: pick or drag a file, see its
+name, size and (for images) a preview, and remove it. It works on both **create
+and edit** forms.
+
+On an **edit** form the pick uploads immediately — the entity exists, so the
+bytes go straight to it.
+
+On a **create** form there is nothing to upload *to* yet. An attachment is
+stored against an entity id, and the id does not exist until the entity is
+saved, so the form **stages** your pick and uploads it right after the create
+succeeds. In practice this is invisible: you fill the form, attach a file, press
+Create, and the entity is saved with its file. Two details are worth knowing:
+
+- A staged file is marked **"Pending save"** until it is uploaded, and counts
+  toward the property's `max` while staged.
+- Because the upload is a second step, it can fail on its own (a file over the
+  size limit, or one your scan policy rejects). If that happens the entity is
+  still created — you land on it and the message names the files that did not
+  attach, so you can retry them there. Nothing is silently dropped.
+
+Attachments inherit the owning entity's permissions: if you may not update the
+entity, you may not attach to it.
+
 ### Field Layout (`span`)
 
 Fields lay out on a **12-column grid**. A field with no `span` takes the full

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -402,8 +402,10 @@ Create, and the entity is saved with its file. Two details are worth knowing:
   toward the property's `max` while staged.
 - Because the upload is a second step, it can fail on its own (a file over the
   size limit, or one your scan policy rejects). If that happens the entity is
-  still created — you land on it and the message names the files that did not
-  attach, so you can retry them there. Nothing is silently dropped.
+  **still created**: you land on it, and the message names the files that did
+  not attach so you can re-attach them there, on the entity's own file control.
+  Nothing is silently dropped — but the failed files do have to be picked
+  again, since the form that held them is gone by then.
 
 Attachments inherit the owning entity's permissions: if you may not update the
 entity, you may not attach to it.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -377,6 +377,31 @@ Each entry in `fields:` configures one property input:
 > column headers, relation field labels, view-section fields, and Lua flow
 > fields. `rela migrate` will never remove a `label:` you have written.
 
+### File Properties on Forms
+
+A `file`-type property renders a file control: pick or drag a file, see its
+name, size and (for images) a preview, and remove it. It works on both **create
+and edit** forms.
+
+On an **edit** form the pick uploads immediately — the entity exists, so the
+bytes go straight to it.
+
+On a **create** form there is nothing to upload *to* yet. An attachment is
+stored against an entity id, and the id does not exist until the entity is
+saved, so the form **stages** your pick and uploads it right after the create
+succeeds. In practice this is invisible: you fill the form, attach a file, press
+Create, and the entity is saved with its file. Two details are worth knowing:
+
+- A staged file is marked **"Pending save"** until it is uploaded, and counts
+  toward the property's `max` while staged.
+- Because the upload is a second step, it can fail on its own (a file over the
+  size limit, or one your scan policy rejects). If that happens the entity is
+  still created — you land on it and the message names the files that did not
+  attach, so you can retry them there. Nothing is silently dropped.
+
+Attachments inherit the owning entity's permissions: if you may not update the
+entity, you may not attach to it.
+
 ### Field Layout (`span`)
 
 Fields lay out on a **12-column grid**. A field with no `span` takes the full

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -396,8 +396,10 @@ Create, and the entity is saved with its file. Two details are worth knowing:
   toward the property's `max` while staged.
 - Because the upload is a second step, it can fail on its own (a file over the
   size limit, or one your scan policy rejects). If that happens the entity is
-  still created — you land on it and the message names the files that did not
-  attach, so you can retry them there. Nothing is silently dropped.
+  **still created**: you land on it, and the message names the files that did
+  not attach so you can re-attach them there, on the entity's own file control.
+  Nothing is silently dropped — but the failed files do have to be picked
+  again, since the form that held them is gone by then.
 
 Attachments inherit the owning entity's permissions: if you may not update the
 entity, you may not attach to it.

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -794,6 +794,15 @@ export class FormPage extends BasePage {
     return (await err.count()) > 0 ? err.innerText() : "";
   }
 
+  /** Text of the error toast, waited for. Used by the create-with-attachments
+   *  failure path, where the entity IS created but an upload was rejected —
+   *  the message is the only thing telling the user which files to re-attach. */
+  async errorToastText(): Promise<string> {
+    const toast = this.toastContainer.first();
+    await expect(toast).toBeVisible();
+    return toast.innerText();
+  }
+
   /** Submit a create that is expected to also upload `expectedUploads`
    *  attachments, waiting for the POST and every attachment PUT so the
    *  assertions that follow don't race the second phase. */

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -742,4 +742,73 @@ export class FormPage extends BasePage {
   async getPrefixOptions(): Promise<string[]> {
     return this.prefixSelect.locator("option").allTextContents();
   }
+
+  // --- File attachments (TKT-7K3BJF) ---
+  //
+  // The file widget renders one `.file-widget` per `file`-type property,
+  // inside that property's field shell. Scoping by the field id keeps these
+  // helpers usable on a form with several file properties.
+
+  private fileWidget(property: string): Locator {
+    // FieldRenderer passes `id="field-<property>"` to the widget, and
+    // FileWidget binds it to its root — the same convention `#field-title`
+    // already relies on.
+    return this.page.locator(`#field-${property}.file-widget`);
+  }
+
+  /** The hidden `<input type=file>` behind the widget's pick control. */
+  private fileInput(property: string): Locator {
+    return this.fileWidget(property).locator('input[type="file"]');
+  }
+
+  /** Attach a file to a `file` property. In create mode this only STAGES it
+   *  (nothing is uploaded until the entity exists); in edit mode it uploads
+   *  immediately. `name` is the filename the server will see. */
+  async attachFile(property: string, name: string, contents: string, mimeType = "text/plain") {
+    await this.fileInput(property).setInputFiles({
+      name,
+      mimeType,
+      buffer: Buffer.from(contents),
+    });
+  }
+
+  /** Filenames currently listed on a `file` property — staged or uploaded. */
+  async attachedFileNames(property: string): Promise<string[]> {
+    return this.fileWidget(property).locator(".file-name").allInnerTexts();
+  }
+
+  /** Remove the file at `index` from a `file` property's list. */
+  async removeAttachedFile(property: string, index = 0) {
+    await this.fileWidget(property).locator(".file-remove").nth(index).click();
+  }
+
+  /** Whether the add/replace control is offered for a `file` property.
+   *  False at capacity, or when the widget cannot mutate. */
+  async canAddFile(property: string): Promise<boolean> {
+    return (await this.fileWidget(property).locator(".file-dropzone").count()) > 0;
+  }
+
+  /** The widget's inline error text, or '' when none is shown. */
+  async fileErrorText(property: string): Promise<string> {
+    const err = this.fileWidget(property).locator(".file-error");
+    return (await err.count()) > 0 ? err.innerText() : "";
+  }
+
+  /** Submit a create that is expected to also upload `expectedUploads`
+   *  attachments, waiting for the POST and every attachment PUT so the
+   *  assertions that follow don't race the second phase. */
+  async submitAndExpectCreateWithUploads(
+    plural: string,
+    expectedUploads: number,
+  ): Promise<{ id: string }> {
+    const uploads = Array.from({ length: expectedUploads }, () =>
+      this.page.waitForResponse(
+        (r) =>
+          r.url().includes("/_attachments/") && r.request().method() === "PUT",
+      ),
+    );
+    const created = await this.submitAndExpectCreate(plural);
+    await Promise.all(uploads);
+    return created;
+  }
 }

--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -761,10 +761,24 @@ export class FormPage extends BasePage {
     return this.fileWidget(property).locator('input[type="file"]');
   }
 
+  /** Wait for a `file` property's widget to render.
+   *
+   *  Necessary because a create form does not render its fields until the
+   *  staged-affordance dry-run POST resolves (`affordanceVisible` gates on
+   *  `stagedAffordancesReady`), and `clickCreateButton` only waits for
+   *  `domcontentloaded`. On an unloaded machine the dry-run lands first and
+   *  the widget is there immediately; under parallel load it does not, so
+   *  asserting on the widget without this wait is a race that only shows up
+   *  in a full-suite run. */
+  async waitForFileWidget(property: string) {
+    await expect(this.fileWidget(property)).toBeVisible();
+  }
+
   /** Attach a file to a `file` property. In create mode this only STAGES it
    *  (nothing is uploaded until the entity exists); in edit mode it uploads
    *  immediately. `name` is the filename the server will see. */
   async attachFile(property: string, name: string, contents: string, mimeType = "text/plain") {
+    await this.waitForFileWidget(property);
     await this.fileInput(property).setInputFiles({
       name,
       mimeType,
@@ -774,6 +788,7 @@ export class FormPage extends BasePage {
 
   /** Filenames currently listed on a `file` property — staged or uploaded. */
   async attachedFileNames(property: string): Promise<string[]> {
+    await this.waitForFileWidget(property);
     return this.fileWidget(property).locator(".file-name").allInnerTexts();
   }
 
@@ -785,6 +800,7 @@ export class FormPage extends BasePage {
   /** Whether the add/replace control is offered for a `file` property.
    *  False at capacity, or when the widget cannot mutate. */
   async canAddFile(property: string): Promise<boolean> {
+    await this.waitForFileWidget(property);
     return (await this.fileWidget(property).locator(".file-dropzone").count()) > 0;
   }
 

--- a/e2e/tests/attachments-create.spec.ts
+++ b/e2e/tests/attachments-create.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from './fixtures';
+import { FormPage, ListPage } from '../pages';
+
+// Attaching a file while CREATING an entity (TKT-7K3BJF).
+//
+// This is the real integration proof for the feature: an attachment cannot be
+// written before the entity row exists (every store backend returns
+// ErrNotFound) and no id can be reserved ahead of the create, so the SPA
+// stages the picked bytes and uploads them once the server returns an id.
+// Only an end-to-end run exercises both phases against a real store.
+test.describe('Attachments on entity create', () => {
+  test('stages a file in the create form and attaches it after save', async ({ appPage, api }) => {
+    const listPage = new ListPage(appPage);
+    const formPage = new FormPage(appPage);
+
+    await listPage.navigateToList('bugs');
+    await listPage.clickCreateButton();
+
+    await formPage.fillField('title', 'Bug with a screenshot');
+
+    // The control must exist at all — before this ticket the create form
+    // rendered a dead "Attachment editing unavailable" note here.
+    expect(await formPage.canAddFile('screenshot')).toBe(true);
+
+    await formPage.attachFile('screenshot', 'shot.txt', 'pretend png bytes');
+
+    // Staged, not uploaded: the file is listed, but no entity exists yet.
+    expect(await formPage.attachedFileNames('screenshot')).toEqual(['shot.txt']);
+
+    const created = await formPage.submitAndExpectCreateWithUploads('bugs', 1);
+
+    // The server is the arbiter: the attachment must be readable back on the
+    // entity, and its property stamped.
+    const entity = await api.getEntity('bugs', created.id);
+    const files = entity._attachments?.screenshot ?? [];
+    expect(files).toHaveLength(1);
+    expect(files[0].filename).toBe('shot.txt');
+    expect(entity.properties.screenshot).toBeTruthy();
+  });
+
+  test('a staged file removed before save is never uploaded', async ({ appPage, api }) => {
+    const listPage = new ListPage(appPage);
+    const formPage = new FormPage(appPage);
+
+    await listPage.navigateToList('bugs');
+    await listPage.clickCreateButton();
+    await formPage.fillField('title', 'Bug without a screenshot');
+
+    await formPage.attachFile('screenshot', 'oops.txt', 'unwanted');
+    expect(await formPage.attachedFileNames('screenshot')).toEqual(['oops.txt']);
+
+    await formPage.removeAttachedFile('screenshot');
+    expect(await formPage.attachedFileNames('screenshot')).toEqual([]);
+
+    const created = await formPage.submitAndExpectCreate('bugs');
+
+    const entity = await api.getEntity('bugs', created.id);
+    expect(entity._attachments?.screenshot ?? []).toHaveLength(0);
+  });
+
+  test('stages several files on a multi-cap property and uploads them all', async ({
+    appPage,
+    api,
+  }) => {
+    const listPage = new ListPage(appPage);
+    const formPage = new FormPage(appPage);
+
+    await listPage.navigateToList('bugs');
+    await listPage.clickCreateButton();
+    await formPage.fillField('title', 'Bug with evidence');
+
+    // `evidence` is max: 3 in the fixture schema.
+    await formPage.attachFile('evidence', 'one.txt', 'first');
+    await formPage.attachFile('evidence', 'two.txt', 'second');
+    expect(await formPage.attachedFileNames('evidence')).toEqual(['one.txt', 'two.txt']);
+
+    const created = await formPage.submitAndExpectCreateWithUploads('bugs', 2);
+
+    const entity = await api.getEntity('bugs', created.id);
+    const names = (entity._attachments?.evidence ?? []).map((f) => f.filename).sort();
+    expect(names).toEqual(['one.txt', 'two.txt']);
+  });
+
+  test('hides the add control once a multi-cap property is full', async ({ appPage }) => {
+    const listPage = new ListPage(appPage);
+    const formPage = new FormPage(appPage);
+
+    await listPage.navigateToList('bugs');
+    await listPage.clickCreateButton();
+
+    // Staged files count toward the cap exactly as uploaded ones do in edit
+    // mode, so the third file fills `evidence` (max: 3).
+    await formPage.attachFile('evidence', 'a.txt', 'a');
+    await formPage.attachFile('evidence', 'b.txt', 'b');
+    expect(await formPage.canAddFile('evidence')).toBe(true);
+
+    await formPage.attachFile('evidence', 'c.txt', 'c');
+    expect(await formPage.canAddFile('evidence')).toBe(false);
+  });
+
+  test('creating without touching a file property is unchanged', async ({ appPage, api }) => {
+    // The common case by far: it must not gain a request or change behaviour.
+    const listPage = new ListPage(appPage);
+    const formPage = new FormPage(appPage);
+
+    await listPage.navigateToList('bugs');
+    await listPage.clickCreateButton();
+    await formPage.fillField('title', 'Plain bug');
+
+    const created = await formPage.submitAndExpectCreate('bugs');
+
+    const entity = await api.getEntity('bugs', created.id);
+    expect(entity.properties.title).toBe('Plain bug');
+    expect(entity._attachments?.screenshot ?? []).toHaveLength(0);
+  });
+});

--- a/e2e/tests/attachments-create.spec.ts
+++ b/e2e/tests/attachments-create.spec.ts
@@ -98,6 +98,39 @@ test.describe('Attachments on entity create', () => {
     expect(await formPage.canAddFile('evidence')).toBe(false);
   });
 
+  // The accepted tradeoff of the two-phase design: create can succeed and the
+  // upload fail on its own. The whole feature rests on that being loud, so it
+  // is worth proving against a real server rejection rather than a mock.
+  test('an oversize file fails loudly after the entity is created', async ({ appPage, api }) => {
+    const listPage = new ListPage(appPage);
+    const formPage = new FormPage(appPage);
+
+    await listPage.navigateToList('bugs');
+    await listPage.clickCreateButton();
+    await formPage.fillField('title', 'Bug with an oversize file');
+
+    // The fixture caps attachments at 1 KiB; 4 KiB is a real 413 from the
+    // server's ingress guard, not a simulated one.
+    await formPage.attachFile('screenshot', 'huge.txt', 'x'.repeat(4096));
+
+    const created = await formPage.submitAndExpectCreate('bugs');
+
+    // The entity exists and the user is on it — losing the entity would be
+    // worse than losing the file.
+    await expect(appPage).toHaveURL(new RegExp(`/entity/bug/${created.id}`));
+
+    // The failure is reported, names the file, and says where to fix it.
+    const toast = await formPage.errorToastText();
+    expect(toast).toContain('huge.txt');
+    expect(toast).toContain('too large');
+    expect(toast).toContain('Re-attach on the entity');
+
+    // Nothing was attached, and no half-written property was stamped.
+    const entity = await api.getEntity('bugs', created.id);
+    expect(entity._attachments?.screenshot ?? []).toHaveLength(0);
+    expect(entity.properties.screenshot ?? '').toBe('');
+  });
+
   test('creating without touching a file property is unchanged', async ({ appPage, api }) => {
     // The common case by far: it must not gain a request or change behaviour.
     const listPage = new ListPage(appPage);

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -982,6 +982,10 @@ version: "1.0"
 app:
   name: "E2E Test App"
   description: "Test project for Playwright E2E tests"
+  # TKT-7K3BJF: a deliberately tiny attachment cap so the create-form failure
+  # path (create succeeds, upload 413s) can be driven end-to-end with a small
+  # file. Every fixture attachment in the suite is well under 1 KiB.
+  max_attachment_bytes: 1024
 
 # Enable dark mode so the theme toggle renders in the status bar. Palette
 # config is validated strictly; unknown keys raise startup errors.

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -150,6 +150,12 @@ export interface EntityResponse {
    *  encrypted, no key locally). Each entry names a schema property —
    *  or the special "content" sentinel — that exists but is unreadable. */
   inaccessible?: Array<{ name: string; reason: string }>;
+  /** Per-`file`-property attachment metadata (TKT-7K3BJF/TKT-Q85275). Present
+   *  on a per-entity GET for every file property that holds a file. */
+  _attachments?: Record<
+    string,
+    Array<{ id: string; filename: string; size: number; contentType: string; href: string }>
+  >;
 }
 
 /** Modern JSON:API §9-style relations body for create/update. The
@@ -867,6 +873,14 @@ entities:
         type: priority
       description:
         type: string
+      # TKT-7K3BJF: file properties for create-time attachment staging.
+      # 'screenshot' is single-cap (replace semantics), 'evidence' is
+      # multi-cap so the staged widget's capacity logic is exercised.
+      screenshot:
+        type: file
+      evidence:
+        type: file
+        max: 3
 
   task:
     label: Task
@@ -1076,6 +1090,9 @@ forms:
       - property: priority
       - property: description
         widget: textarea
+      # TKT-7K3BJF: exercised by attachments-create.spec.ts.
+      - property: screenshot
+      - property: evidence
 
   task:
     entity_type: task

--- a/frontend/src/api/attachments.ts
+++ b/frontend/src/api/attachments.ts
@@ -37,6 +37,28 @@ function toAttachmentError(err: unknown): AttachmentError {
   return new AttachmentError('Request failed', 0)
 }
 
+/** The human reason an attachment write was refused, as a bare noun phrase
+ *  ("too large") so a caller can frame it either as a sentence or inside a
+ *  list of filenames. Hoisted here (RR-1556G1 M4) because both the file widget
+ *  and the create form map these statuses, and they had already drifted — one
+ *  lacked a 403 branch. Falls back to the server's problem+json detail, which
+ *  is written for client display. */
+export function attachmentErrorReason(err: unknown): string {
+  // Duck-typed on `status` rather than `instanceof AttachmentError`: the class
+  // identity is not stable across module boundaries (a vi.mock factory, or two
+  // copies of the module in a bundle), and silently degrading a 413 to a
+  // generic "upload failed" because the prototype chain differs is exactly the
+  // failure this helper exists to prevent.
+  const status = typeof err === 'object' && err !== null ? (err as { status?: unknown }).status : undefined
+  const message = typeof err === 'object' && err !== null ? (err as { message?: unknown }).message : undefined
+  if (typeof status === 'number') {
+    if (status === 413) return 'too large'
+    if (status === 409) return 'at the maximum number of files'
+    if (status === 403) return 'not permitted'
+  }
+  return typeof message === 'string' && message ? message : 'upload failed'
+}
+
 /** Upload (append, or replace at max:1) a file on a property. `onProgress`
  *  receives a 0..1 fraction. Returns the updated entity (its
  *  `_attachments` reflects the new file). Throws AttachmentError on a

--- a/frontend/src/components/forms/DynamicForm.attachments.test.ts
+++ b/frontend/src/components/forms/DynamicForm.attachments.test.ts
@@ -1,0 +1,306 @@
+// Create-mode staged-attachment tests for DynamicForm (TKT-7K3BJF).
+//
+// Attaching a file while creating an entity is necessarily TWO requests: an
+// attachment cannot be written before the entity row exists (every store
+// backend returns ErrNotFound, pinned by storetest) and there is no
+// id-reservation primitive, so the only possible order is create-then-attach.
+//
+// That makes the orchestration — not the widget — where this feature can go
+// wrong, which is what this file drives: a real widget pick, through
+// FieldRenderer and FormFieldList into DynamicForm's staging map, and out to
+// an asserted `uploadAttachment` call after `entitiesStore.create` resolves.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
+import DynamicForm from './DynamicForm.vue'
+import type { Entity } from '@/types'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push, replace: vi.fn(), back: vi.fn() }),
+  useRoute: () => ({ query: {}, params: {}, path: '/form/bug-form' }),
+  onBeforeRouteLeave: vi.fn(),
+}))
+
+// Create mode fetches templates and runs the staged-affordance dry-run on
+// mount; both must be stubbed or the form never leaves its loading state.
+vi.mock('@/api', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/api')
+  return {
+    ...actual,
+    getTemplates: vi.fn().mockResolvedValue([]),
+    // The real endpoint returns the STRIPPED candidate — every property the
+    // caller may see, including ones not yet filled. That echo is what
+    // populates `stagedVisibleProps`; echoing only the submitted keys would
+    // mark every untouched field policy-hidden and unrender the whole form.
+    dryRunCreateEntity: vi.fn().mockImplementation(async (_type: string, body: unknown) => ({
+      properties: {
+        title: '',
+        screenshot: '',
+        evidence: [],
+        ...((body as { properties?: Record<string, unknown> })?.properties ?? {}),
+      },
+      _fields: {},
+      _relations: {},
+      warnings: [],
+    })),
+    createRelation: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+// The attachment API is the boundary this feature crosses; MockAttachmentError
+// mirrors the real class (carries an HTTP status) so the status branches fire.
+const { mockUpload, MockAttachmentError } = vi.hoisted(() => {
+  class MockAttachmentError extends Error {
+    status: number
+    constructor(message: string, status: number) {
+      super(message)
+      this.status = status
+    }
+  }
+  return { mockUpload: vi.fn().mockResolvedValue({}), MockAttachmentError }
+})
+vi.mock('@/api/attachments', () => ({
+  uploadAttachment: mockUpload,
+  deleteAttachment: vi.fn().mockResolvedValue(undefined),
+  AttachmentError: MockAttachmentError,
+}))
+
+const ENTITY_TYPE = {
+  name: 'bug',
+  label: 'Bug',
+  id_type: 'sequential',
+  properties: {
+    title: { type: 'string' },
+    screenshot: { type: 'file' },
+    evidence: { type: 'file', max: 3 },
+  },
+}
+
+const FORM = {
+  id: 'bug-form',
+  entity: 'bug',
+  fields: [
+    { property: 'title', label: 'Title' },
+    { property: 'screenshot', label: 'Screenshot' },
+    { property: 'evidence', label: 'Evidence' },
+  ],
+}
+
+const CREATED: Entity = {
+  id: 'BUG-7',
+  type: 'bug',
+  properties: { title: 'x' },
+  warnings: [],
+}
+
+const mounted: VueWrapper[] = []
+
+afterEach(() => {
+  const wrappers = mounted.splice(0)
+  wrappers.forEach((w) => {
+    try {
+      w.unmount()
+    } catch {
+      /* already torn down */
+    }
+  })
+})
+
+async function mountCreate() {
+  const schema = useSchemaStore()
+  schema.forms.set(FORM.id, FORM as never)
+  schema.entityTypes.set('bug', ENTITY_TYPE as never)
+  schema.loaded = true
+
+  const entities = useEntitiesStore()
+  const create = vi.spyOn(entities, 'create').mockResolvedValue(CREATED)
+
+  const wrapper = mount(DynamicForm, {
+    props: { formId: FORM.id },
+    global: {
+      stubs: {
+        RouterLink: true,
+        MarkdownEditor: true,
+        RelationPicker: true,
+        RelationCards: true,
+        AutoSaveIndicator: true,
+        HelpModal: true,
+      },
+    },
+  })
+  mounted.push(wrapper)
+  await flushPromises()
+  return { wrapper, create }
+}
+
+function textFile(name: string, type = 'text/plain'): File {
+  return new File(['bytes'], name, { type })
+}
+
+/** Drive a REAL pick on the file widget for `property`, the way a user does. */
+async function stage(wrapper: VueWrapper, property: string, file: File) {
+  const input = wrapper.find(`#field-${property} input[type="file"]`)
+  Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+  await input.trigger('change')
+  await flushPromises()
+}
+
+async function submit(wrapper: VueWrapper) {
+  await wrapper.find('form').trigger('submit')
+  await flushPromises()
+}
+
+describe('DynamicForm — attachments on create', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockUpload.mockResolvedValue({})
+  })
+
+  it('renders a usable file control in create mode', async () => {
+    // The regression this ticket fixes: the widget used to render a dead
+    // "Attachment editing unavailable" note because there is no entity id.
+    const { wrapper } = await mountCreate()
+    expect(wrapper.find('#field-screenshot .file-dropzone').exists()).toBe(true)
+  })
+
+  it('stages a picked file without uploading, then uploads it after create', async () => {
+    const { wrapper, create } = await mountCreate()
+    const file = textFile('shot.png', 'image/png')
+
+    await stage(wrapper, 'screenshot', file)
+    // Phase 1 has not happened yet, so nothing may be uploaded.
+    expect(mockUpload).not.toHaveBeenCalled()
+
+    await submit(wrapper)
+
+    expect(create).toHaveBeenCalledTimes(1)
+    // The id must be the SERVER's, never a client-side placeholder.
+    expect(mockUpload).toHaveBeenCalledWith('bug', 'BUG-7', 'screenshot', file)
+  })
+
+  it('never sends the file property in the create payload', async () => {
+    // Staged files live outside formData precisely so a File (or a fake path)
+    // is not POSTed as the property's value — the server stamps it itself.
+    const { wrapper, create } = await mountCreate()
+    await stage(wrapper, 'screenshot', textFile('a.png', 'image/png'))
+    await submit(wrapper)
+
+    const payload = create.mock.calls[0][1] as { properties: Record<string, unknown> }
+    expect(payload.properties).not.toHaveProperty('screenshot')
+  })
+
+  it('does not upload a staged file that was removed before save', async () => {
+    const { wrapper } = await mountCreate()
+    await stage(wrapper, 'screenshot', textFile('gone.txt'))
+
+    await wrapper.find('#field-screenshot .file-remove').trigger('click')
+    await flushPromises()
+
+    await submit(wrapper)
+    expect(mockUpload).not.toHaveBeenCalled()
+  })
+
+  it('uploads every file of a multi-cap property', async () => {
+    const { wrapper } = await mountCreate()
+    const a = textFile('a.txt')
+    const b = textFile('b.txt')
+    await stage(wrapper, 'evidence', a)
+    await stage(wrapper, 'evidence', b)
+
+    await submit(wrapper)
+
+    expect(mockUpload).toHaveBeenCalledTimes(2)
+    expect(mockUpload).toHaveBeenCalledWith('bug', 'BUG-7', 'evidence', a)
+    expect(mockUpload).toHaveBeenCalledWith('bug', 'BUG-7', 'evidence', b)
+  })
+
+  it('makes the form dirty while a file is staged (RR-EUX4BX)', async () => {
+    // Staged files are deliberately outside formData, so without an explicit
+    // term they are invisible to checkDirty and the navigation guards let the
+    // user leave with no prompt — silent loss of a file they picked.
+    const { wrapper } = await mountCreate()
+    const vm = wrapper.vm as unknown as { isDirty: () => boolean }
+    expect(vm.isDirty()).toBe(false)
+
+    await stage(wrapper, 'screenshot', textFile('draft.txt'))
+    expect(vm.isDirty()).toBe(true)
+  })
+
+  describe('post-create upload failure', () => {
+    it('surfaces the failure and does not claim success', async () => {
+      const ui = useUIStore()
+      const error = vi.spyOn(ui, 'error')
+      const success = vi.spyOn(ui, 'success')
+      mockUpload.mockRejectedValue(new MockAttachmentError('too big', 413))
+
+      const { wrapper } = await mountCreate()
+      await stage(wrapper, 'screenshot', textFile('huge.bin'))
+      await submit(wrapper)
+
+      expect(error).toHaveBeenCalledTimes(1)
+      expect(error.mock.calls[0][0]).toContain('huge.bin')
+      // A green "created successfully" next to a red failure would describe
+      // one user action twice, contradicting itself.
+      expect(success).not.toHaveBeenCalled()
+    })
+
+    it('keeps the form dirty so the navigation guard still warns', async () => {
+      mockUpload.mockRejectedValue(new MockAttachmentError('nope', 403))
+      const { wrapper } = await mountCreate()
+      await stage(wrapper, 'screenshot', textFile('secret.txt'))
+      await submit(wrapper)
+
+      expect((wrapper.vm as unknown as { isDirty: () => boolean }).isDirty()).toBe(true)
+    })
+
+    it('still navigates to the created entity — it exists', async () => {
+      mockUpload.mockRejectedValue(new MockAttachmentError('nope', 413))
+      const { wrapper } = await mountCreate()
+      await stage(wrapper, 'screenshot', textFile('huge.bin'))
+      await submit(wrapper)
+
+      expect(push).toHaveBeenCalledWith('/entity/bug/BUG-7')
+    })
+
+    it('attempts every file and names each failure (RR-Z7C3CY)', async () => {
+      // Continue-on-error: aborting after the first rejection would leave
+      // later files unattempted with nothing telling the user.
+      const ui = useUIStore()
+      const error = vi.spyOn(ui, 'error')
+      mockUpload
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new MockAttachmentError('too big', 413))
+        .mockRejectedValueOnce(new MockAttachmentError('bad type', 422))
+
+      const { wrapper } = await mountCreate()
+      await stage(wrapper, 'evidence', textFile('ok.txt'))
+      await stage(wrapper, 'evidence', textFile('big.txt'))
+      await stage(wrapper, 'evidence', textFile('weird.exe'))
+      await submit(wrapper)
+
+      expect(mockUpload).toHaveBeenCalledTimes(3)
+      const msg = error.mock.calls[0][0] as string
+      expect(msg).toContain('big.txt')
+      expect(msg).toContain('weird.exe')
+      expect(msg).not.toContain('ok.txt')
+    })
+  })
+
+  it('leaves the no-attachment create path untouched', async () => {
+    // By far the most common case: it must not gain a request or a toast.
+    const ui = useUIStore()
+    const success = vi.spyOn(ui, 'success')
+    const { wrapper, create } = await mountCreate()
+
+    await submit(wrapper)
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(mockUpload).not.toHaveBeenCalled()
+    expect(success).toHaveBeenCalledWith('Entity created successfully')
+  })
+})

--- a/frontend/src/components/forms/DynamicForm.attachments.test.ts
+++ b/frontend/src/components/forms/DynamicForm.attachments.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/api', async () => {
         title: '',
         screenshot: '',
         evidence: [],
+        needs_evidence: false,
         ...((body as { properties?: Record<string, unknown> })?.properties ?? {}),
       },
       _fields: {},
@@ -63,11 +64,15 @@ const { mockUpload, MockAttachmentError } = vi.hoisted(() => {
   }
   return { mockUpload: vi.fn().mockResolvedValue({}), MockAttachmentError }
 })
-vi.mock('@/api/attachments', () => ({
-  uploadAttachment: mockUpload,
-  deleteAttachment: vi.fn().mockResolvedValue(undefined),
-  AttachmentError: MockAttachmentError,
-}))
+vi.mock('@/api/attachments', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/api/attachments')
+  return {
+    ...actual,
+    uploadAttachment: mockUpload,
+    deleteAttachment: vi.fn().mockResolvedValue(undefined),
+    AttachmentError: MockAttachmentError,
+  }
+})
 
 const ENTITY_TYPE = {
   name: 'bug',
@@ -77,6 +82,7 @@ const ENTITY_TYPE = {
     title: { type: 'string' },
     screenshot: { type: 'file' },
     evidence: { type: 'file', max: 3 },
+    needs_evidence: { type: 'boolean' },
   },
 }
 
@@ -87,6 +93,22 @@ const FORM = {
     { property: 'title', label: 'Title' },
     { property: 'screenshot', label: 'Screenshot' },
     { property: 'evidence', label: 'Evidence' },
+  ],
+}
+
+// A wizard whose second step (holding the file property) is conditional, so a
+// revealed-then-hidden branch can be exercised (RR-OI6P51).
+const WIZARD_FORM = {
+  id: 'bug-wizard',
+  entity: 'bug',
+  steps: [
+    { id: 's1', title: 'Basics', fields: [{ property: 'title' }, { property: 'needs_evidence' }] },
+    {
+      id: 's2',
+      title: 'Evidence',
+      visible_when: 'form.needs_evidence == true',
+      fields: [{ property: 'screenshot' }],
+    },
   ],
 }
 
@@ -110,9 +132,10 @@ afterEach(() => {
   })
 })
 
-async function mountCreate() {
+async function mountCreate(form: { id: string } = FORM) {
   const schema = useSchemaStore()
   schema.forms.set(FORM.id, FORM as never)
+  schema.forms.set(WIZARD_FORM.id, WIZARD_FORM as never)
   schema.entityTypes.set('bug', ENTITY_TYPE as never)
   schema.loaded = true
 
@@ -120,7 +143,7 @@ async function mountCreate() {
   const create = vi.spyOn(entities, 'create').mockResolvedValue(CREATED)
 
   const wrapper = mount(DynamicForm, {
-    props: { formId: FORM.id },
+    props: { formId: form.id },
     global: {
       stubs: {
         RouterLink: true,
@@ -146,6 +169,14 @@ async function stage(wrapper: VueWrapper, property: string, file: File) {
   const input = wrapper.find(`#field-${property} input[type="file"]`)
   Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
   await input.trigger('change')
+  await flushPromises()
+}
+
+/** Click the wizard step button whose label contains `text`. */
+async function clickButton(wrapper: VueWrapper, text: string) {
+  const btn = wrapper.findAll('button').find((b) => b.text().includes(text))
+  if (!btn) throw new Error(`no button matching ${text}`)
+  await btn.trigger('click')
   await flushPromises()
 }
 
@@ -249,13 +280,41 @@ describe('DynamicForm — attachments on create', () => {
       expect(success).not.toHaveBeenCalled()
     })
 
-    it('keeps the form dirty so the navigation guard still warns', async () => {
+    it('clears staged state rather than pretending a retry is possible (RR-4QO887)', async () => {
+      // The form unmounts on the navigation below, so retained File objects
+      // would be unreachable anyway — and a still-dirty form whose submit
+      // re-runs the whole create path turns "retry" into a second entity.
       mockUpload.mockRejectedValue(new MockAttachmentError('nope', 403))
       const { wrapper } = await mountCreate()
       await stage(wrapper, 'screenshot', textFile('secret.txt'))
       await submit(wrapper)
 
-      expect((wrapper.vm as unknown as { isDirty: () => boolean }).isDirty()).toBe(true)
+      expect((wrapper.vm as unknown as { isDirty: () => boolean }).isDirty()).toBe(false)
+    })
+
+    it('names where to re-attach, since the staged copies are gone', async () => {
+      const ui = useUIStore()
+      const error = vi.spyOn(ui, 'error')
+      mockUpload.mockRejectedValue(new MockAttachmentError('too big', 413))
+
+      const { wrapper } = await mountCreate()
+      await stage(wrapper, 'screenshot', textFile('huge.bin'))
+      await submit(wrapper)
+
+      const msg = error.mock.calls[0][0] as string
+      expect(msg).toContain('huge.bin')
+      expect(msg).toContain('too large')
+      expect(msg).toContain('Re-attach on the entity')
+    })
+
+    it('a second submit after a failure does not create a second entity', async () => {
+      mockUpload.mockRejectedValue(new MockAttachmentError('nope', 413))
+      const { wrapper, create } = await mountCreate()
+      await stage(wrapper, 'screenshot', textFile('huge.bin'))
+      await submit(wrapper)
+      await submit(wrapper)
+
+      expect(create).toHaveBeenCalledTimes(1)
     })
 
     it('still navigates to the created entity — it exists', async () => {
@@ -289,6 +348,71 @@ describe('DynamicForm — attachments on create', () => {
       expect(msg).toContain('weird.exe')
       expect(msg).not.toContain('ok.txt')
     })
+  })
+
+  it('ignores a second submit while one is in flight (RR-HJLLUF)', async () => {
+    // handleKeydown calls handleSubmit() directly, bypassing PendingButton's
+    // own guard, and the in-flight window now spans the create POST plus N
+    // uploads. Without the re-entrancy guard this yields two entities and two
+    // sets of uploads.
+    const { wrapper, create } = await mountCreate()
+    await stage(wrapper, 'screenshot', textFile('shot.png', 'image/png'))
+
+    const form = wrapper.find('form')
+    // Fire both before awaiting either, so the second lands mid-flight.
+    const first = form.trigger('submit')
+    const second = form.trigger('submit')
+    await Promise.all([first, second])
+    await flushPromises()
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(mockUpload).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not navigate when the component unmounted mid-upload (RR-QQQ2JR)', async () => {
+    let release: (v: unknown) => void = () => {}
+    mockUpload.mockImplementation(() => new Promise((r) => (release = r)))
+
+    const { wrapper } = await mountCreate()
+    await stage(wrapper, 'screenshot', textFile('slow.bin'))
+    const submitted = wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    wrapper.unmount()
+    release({})
+    await submitted
+    await flushPromises()
+
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does not upload a file staged under a then-hidden wizard branch (RR-OI6P51)', async () => {
+    // The property itself is pruned by pruneWizardHidden; the staged file must
+    // be pruned by the same rule, or the bytes land, the server stamps the
+    // property, and the hidden branch persists anyway (TKT-CHLAJ).
+    //
+    // Driven through the wizard's own step navigation: step 2 only renders
+    // once its condition is true, so revealing it is what makes the file
+    // control reachable at all.
+    const { wrapper, create } = await mountCreate(WIZARD_FORM)
+
+    const toggle = wrapper.find('#field-needs_evidence')
+    await toggle.setValue(true)
+    await flushPromises()
+
+    // Advance to the now-visible evidence step and stage a file there.
+    await clickButton(wrapper, 'Next step')
+    await stage(wrapper, 'screenshot', textFile('leak.png', 'image/png'))
+
+    // Go back and hide the branch again.
+    await clickButton(wrapper, 'Prev step')
+    await wrapper.find('#field-needs_evidence').setValue(false)
+    await flushPromises()
+
+    await submit(wrapper)
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(mockUpload).not.toHaveBeenCalled()
   })
 
   it('leaves the no-attachment create path untouched', async () => {

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -28,6 +28,7 @@ import type {
   TransitionOption,
 } from '@/types'
 import { getTemplates, createRelation, dryRunCreateEntity, ApiError, getErrorMessage } from '@/api'
+import { uploadAttachment, AttachmentError } from '@/api/attachments'
 import type { RelationCardState } from './RelationCards.vue'
 import type { RelationPickerIncomingState } from './RelationPicker.vue'
 import {
@@ -117,6 +118,31 @@ const relationAffordances = ref<Record<string, RelationAffordance>>({})
 // Per-`file`-property attachment metadata from the loaded entity, passed
 // to the file widget so it can show the current file + drive upload/remove.
 const attachments = ref<Record<string, AttachmentInfo[]>>({})
+// TKT-7K3BJF: files picked in CREATE mode, not yet uploaded. An attachment
+// cannot be written before the entity row exists (every store backend returns
+// ErrNotFound), and there is no id-reservation primitive, so the only possible
+// order is create-then-attach. These are uploaded in handleSubmit once the
+// server returns an id.
+//
+// They are deliberately NOT part of `formData`: `payload.properties` is built
+// from it, so a File (or a placeholder path) sitting there would be POSTed as
+// the file property's value at create. The server stamps that property itself
+// once the bytes land.
+const stagedFiles = ref<Record<string, File[]>>({})
+
+function updateStagedFiles(property: string, files: File[]) {
+  if (files.length) stagedFiles.value = { ...stagedFiles.value, [property]: files }
+  else {
+    const next = { ...stagedFiles.value }
+    delete next[property]
+    stagedFiles.value = next
+  }
+  checkDirty()
+}
+
+function hasStagedFiles(): boolean {
+  return Object.values(stagedFiles.value).some((list) => list.length > 0)
+}
 // Per-state-machine-field transition verdicts from the loaded entity
 // (`_transitions`, TKT-3G93B8). Present only for machine-typed fields; drives
 // the StatusControl (only-allowed moves) instead of the plain enum select. A
@@ -459,6 +485,49 @@ async function loadEntity(force = false) {
     uiStore.error('Failed to load entity')
     console.error(err)
   }
+}
+
+// uploadStagedFiles pushes every create-mode staged file to the attachment
+// endpoint against the just-created id, and returns the failures.
+//
+// Continue-on-error (RR-Z7C3CY): every file is attempted even after one is
+// rejected, so the user is told about all of them at once rather than
+// discovering the rest on a later save. Sequential rather than parallel: the
+// server serializes attachment writes on its write mutex anyway, and
+// WriteAttachment's capacity check is read-then-write, which concurrent
+// uploads to one property would race.
+async function uploadStagedFiles(
+  entityType: string,
+  entityId: string
+): Promise<{ file: string; message: string }[]> {
+  const failures: { file: string; message: string }[] = []
+  for (const [property, files] of Object.entries(stagedFiles.value)) {
+    for (const file of files) {
+      try {
+        await uploadAttachment(entityType, entityId, property, file)
+      } catch (err) {
+        failures.push({ file: file.name, message: stagedUploadErrorMessage(err) })
+      }
+    }
+  }
+  return failures
+}
+
+// One message naming every file that failed, so "which of my files made it?"
+// is answerable without comparing lists by hand.
+function stagedFailureMessage(failures: { file: string; message: string }[]): string {
+  const detail = failures.map((f) => `${f.file} (${f.message})`).join(', ')
+  return `Entity created, but ${failures.length} file${failures.length > 1 ? 's' : ''} failed to attach: ${detail}`
+}
+
+function stagedUploadErrorMessage(err: unknown): string {
+  if (err instanceof AttachmentError) {
+    if (err.status === 413) return 'too large'
+    if (err.status === 409) return 'at maximum number of files'
+    if (err.status === 403) return 'not permitted'
+    return err.message
+  }
+  return 'upload failed'
 }
 
 // onAttachmentChanged fires after a file widget uploads or removes an
@@ -1039,18 +1108,40 @@ async function handleSubmit() {
       }
     }
 
-    dirty.value = false
+    // TKT-7K3BJF phase 2: upload staged attachments against the id the server
+    // just minted. Ordering here is load-bearing (RR-6ZAOMK) — uploads must
+    // run BEFORE the dirty reset, the embedded early-return, and the success
+    // toast, so that a failure can keep the form dirty, still reach the
+    // inline-create host, and avoid claiming success it didn't achieve.
+    const uploadFailures = hasStagedFiles()
+      ? await uploadStagedFiles(formConfig.value.entity, entity.id)
+      : []
+    // Drop the files that made it; anything still staged failed and the user
+    // may retry it on the entity itself.
+    if (uploadFailures.length === 0) stagedFiles.value = {}
+
+    // Only claim "nothing left to save" when nothing was left behind — a
+    // failed upload keeps the form dirty so the navigation guard still warns.
+    dirty.value = uploadFailures.length > 0
 
     // Embedded: hand the entity to the host and stop. No navigation (it would
     // unmount the form that opened us, taking its draft with it) and no toast
     // — the host reports the creation itself, next to the link step the user
     // still has to complete.
     if (props.embedded) {
+      if (uploadFailures.length > 0) uiStore.error(stagedFailureMessage(uploadFailures))
       emit('inline-created', entity)
       return
     }
 
-    uiStore.success('Entity created successfully')
+    if (uploadFailures.length > 0) {
+      // The entity exists — say so, and name exactly which files did not make
+      // it. A bare success toast followed by an error would describe one user
+      // action twice, contradicting itself.
+      uiStore.error(stagedFailureMessage(uploadFailures))
+    } else {
+      uiStore.success('Entity created successfully')
+    }
 
     // Navigate to return_to or entity detail
     if (returnTo.value) {
@@ -1428,7 +1519,12 @@ function checkDirty() {
     content: content.value,
   })
   const hasCardChanges = pendingCardChanges.value.size > 0
-  dirty.value = currentData !== originalData.value || hasCardChanges
+  // RR-EUX4BX: staged files live outside formData by design, so they are
+  // invisible to the serialized comparison above. Without this term, attaching
+  // a file and navigating away discards it with no prompt from either guard —
+  // silent loss of user input. `pendingCardChanges` is the same shape of
+  // out-of-band dirtiness.
+  dirty.value = currentData !== originalData.value || hasCardChanges || hasStagedFiles()
 }
 
 function getPropertyDef(property: string): PropertyDef | undefined {
@@ -1795,6 +1891,7 @@ defineExpose({
               :errors="errors"
               :relation-affordances="relationAffordances"
               :attachments="attachments"
+              :staged-files="stagedFiles"
               :save-generation="saveGeneration"
               :get-property-def="getPropertyDef"
               :is-field-readonly="isFieldReadonly"
@@ -1802,6 +1899,7 @@ defineExpose({
               :transitions-for="transitionsFor"
               @update-field="proposeChange"
               @attachment-changed="onAttachmentChanged"
+              @update-staged-files="updateStagedFiles"
               @update-relation="updateRelation"
               @update-relation-types="updateRelationTypes"
               @incoming-changed="updateIncomingPicker"

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { ref, shallowRef, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
 import { useSchemaStore, useEntitiesStore, useUIStore } from '@/stores'
 import { isCancelledFetch } from '@/composables/usePageData'
@@ -28,7 +28,7 @@ import type {
   TransitionOption,
 } from '@/types'
 import { getTemplates, createRelation, dryRunCreateEntity, ApiError, getErrorMessage } from '@/api'
-import { uploadAttachment, AttachmentError } from '@/api/attachments'
+import { uploadAttachment, attachmentErrorReason } from '@/api/attachments'
 import type { RelationCardState } from './RelationCards.vue'
 import type { RelationPickerIncomingState } from './RelationPicker.vue'
 import {
@@ -128,7 +128,22 @@ const attachments = ref<Record<string, AttachmentInfo[]>>({})
 // from it, so a File (or a placeholder path) sitting there would be POSTed as
 // the file property's value at create. The server stamps that property itself
 // once the bytes land.
-const stagedFiles = ref<Record<string, File[]>>({})
+// shallowRef, not ref (RR-C1MI2N): a deep ref proxies its contents, and
+// whether a File escapes that depends on the environment — happy-dom's File
+// reports `[object Object]` and IS proxied (identity not preserved), while a
+// spec File reports `File` and is left alone. That divergence would mean the
+// unit tests exercise proxies while production exercises raw Files, silently
+// changing identity comparisons and the brand checks in URL.createObjectURL /
+// FormData.append. Nothing here needs deep reactivity: updateStagedFiles
+// replaces the whole object on every change.
+const stagedFiles = shallowRef<Record<string, File[]>>({})
+
+// Set once a create has SUCCEEDED, so a later submit from the same mounted
+// form cannot mint a second entity (RR-4QO887). The happy path navigates away
+// immediately, but navigation is asynchronous and the failure path stays on a
+// live form long enough for a second Create click or Cmd+Enter to land. The
+// `saving` guard only covers an in-flight submit; this covers a completed one.
+const createdEntityId = ref<string | null>(null)
 
 function updateStagedFiles(property: string, files: File[]) {
   if (files.length) stagedFiles.value = { ...stagedFiles.value, [property]: files }
@@ -501,12 +516,20 @@ async function uploadStagedFiles(
   entityId: string
 ): Promise<{ file: string; message: string }[]> {
   const failures: { file: string; message: string }[] = []
+  // RR-OI6P51: apply the same wizard pruning the property payload gets
+  // (pruneWizardHidden). Without it, staging a file on a step the user then
+  // hides uploads the bytes anyway and the SERVER stamps the property —
+  // persisting a revealed-then-hidden branch, which is exactly what TKT-CHLAJ
+  // prevents for ordinary properties.
+  const active = wizard.activeProperties.value
+  const managed = wizard.managedProperties.value
   for (const [property, files] of Object.entries(stagedFiles.value)) {
+    if (managed.has(property) && !active.has(property)) continue
     for (const file of files) {
       try {
         await uploadAttachment(entityType, entityId, property, file)
       } catch (err) {
-        failures.push({ file: file.name, message: stagedUploadErrorMessage(err) })
+        failures.push({ file: file.name, message: attachmentErrorReason(err) })
       }
     }
   }
@@ -517,17 +540,11 @@ async function uploadStagedFiles(
 // is answerable without comparing lists by hand.
 function stagedFailureMessage(failures: { file: string; message: string }[]): string {
   const detail = failures.map((f) => `${f.file} (${f.message})`).join(', ')
-  return `Entity created, but ${failures.length} file${failures.length > 1 ? 's' : ''} failed to attach: ${detail}`
-}
-
-function stagedUploadErrorMessage(err: unknown): string {
-  if (err instanceof AttachmentError) {
-    if (err.status === 413) return 'too large'
-    if (err.status === 409) return 'at maximum number of files'
-    if (err.status === 403) return 'not permitted'
-    return err.message
-  }
-  return 'upload failed'
+  const plural = failures.length > 1 ? 's' : ''
+  // Names the files AND says where to fix it: the staged copies are gone once
+  // this form unmounts (RR-4QO887), so "re-attach on the entity" is the only
+  // honest instruction.
+  return `Entity created, but ${failures.length} file${plural} failed to attach: ${detail}. Re-attach on the entity.`
 }
 
 // onAttachmentChanged fires after a file widget uploads or removes an
@@ -990,6 +1007,17 @@ function focusFirstError() {
 
 async function handleSubmit() {
   if (!formConfig.value) return
+  // RR-HJLLUF: re-entrancy guard. PendingButton suppresses its own repeat
+  // clicks, but handleKeydown calls handleSubmit() directly, so Cmd+Enter
+  // twice would run the whole create path twice — two entities, and (since
+  // TKT-7K3BJF) two sets of uploads. The guard belongs on the operation, not
+  // on one of its callers, or the next caller reintroduces the hole. The
+  // window is now the create POST *plus* N sequential uploads, so this is
+  // seconds wide on a large file, not milliseconds.
+  if (saving.value) return
+  // Already created once from this form instance (RR-4QO887): a second submit
+  // would create a duplicate, not retry the failed attachment upload.
+  if (createdEntityId.value) return
   // Edit mode has no explicit submit — autosave persists per field. Guard
   // against an Enter-key form submit doing anything (there's no Save button).
   //
@@ -1086,6 +1114,7 @@ async function handleSubmit() {
     payload.properties = pruneWizardHidden(visibleWritablePropertiesForCommit())
     Object.assign(payload, idControls.buildPayloadFields())
     const entity = await entitiesStore.create(formConfig.value.entity, payload)
+    createdEntityId.value = entity.id
     // DEC-HWZHA soft conditions ride the 200 create response; surface them or
     // they are invisible. (Edit-mode warnings come through autosave's own
     // response handling — this is the create channel.)
@@ -1116,13 +1145,16 @@ async function handleSubmit() {
     const uploadFailures = hasStagedFiles()
       ? await uploadStagedFiles(formConfig.value.entity, entity.id)
       : []
-    // Drop the files that made it; anything still staged failed and the user
-    // may retry it on the entity itself.
-    if (uploadFailures.length === 0) stagedFiles.value = {}
-
-    // Only claim "nothing left to save" when nothing was left behind — a
-    // failed upload keeps the form dirty so the navigation guard still warns.
-    dirty.value = uploadFailures.length > 0
+    // RR-4QO887: clear staged files and drop the dirty flag even when an
+    // upload failed. Keeping them looks like it preserves a retry, but this
+    // path navigates away (or, when embedded, the host closes the modal —
+    // RR-7T94EF), unmounting the form and discarding the File objects
+    // regardless. Worse, a still-dirty form whose submit re-runs the WHOLE
+    // create path turns "retry" into a second entity. Recovery is on the
+    // created entity, whose file widget uploads directly; the error message
+    // names exactly which files to re-attach.
+    stagedFiles.value = {}
+    dirty.value = false
 
     // Embedded: hand the entity to the host and stop. No navigation (it would
     // unmount the form that opened us, taking its draft with it) and no toast
@@ -1142,6 +1174,12 @@ async function handleSubmit() {
     } else {
       uiStore.success('Entity created successfully')
     }
+
+    // RR-QQQ2JR: the upload phase can outlive the component (the user clicks
+    // away mid-upload), so re-check before touching the router — every other
+    // async path here already guards on this flag (RR-2PZB). A push on a torn-
+    // down component is a no-op today; this keeps the discipline uniform.
+    if (stagedUnmounted) return
 
     // Navigate to return_to or entity detail
     if (returnTo.value) {

--- a/frontend/src/components/forms/FieldRenderer.vue
+++ b/frontend/src/components/forms/FieldRenderer.vue
@@ -30,12 +30,16 @@ const props = defineProps<{
   entityType?: string
   entityId?: string
   attachments?: AttachmentInfo[]
+  // Create-mode staged files for a `file` property (TKT-7K3BJF). Only the
+  // file-property create path supplies these.
+  stagedFiles?: File[]
   max?: number
 }>()
 
 const emit = defineEmits<{
   update: [value: unknown]
   'attachment-changed': []
+  'update:staged-files': [files: File[]]
 }>()
 
 const fieldId = computed(() => `field-${props.field.property}`)
@@ -99,11 +103,13 @@ const currentValue = computed(() => (props.value == null ? '' : String(props.val
       :option-verdicts="optionVerdicts"
       :transitions="field.transitions"
       :attachments="attachments"
+      :staged-files="stagedFiles"
       :max="max"
       :entity-type="entityType"
       :entity-id="entityId"
       @update:model-value="emit('update', $event)"
       @attachment-changed="emit('attachment-changed')"
+      @update:staged-files="emit('update:staged-files', $event)"
     />
   </FieldShell>
 </template>

--- a/frontend/src/components/forms/FormFieldList.vue
+++ b/frontend/src/components/forms/FormFieldList.vue
@@ -30,6 +30,9 @@ defineProps<{
   errors: Record<string, string>
   relationAffordances: Record<string, RelationAffordance>
   attachments: Record<string, AttachmentInfo[]>
+  // Create-mode staged files per `file` property (TKT-7K3BJF). Absent in
+  // edit mode, where a pick uploads immediately.
+  stagedFiles?: Record<string, File[]>
   saveGeneration: number
   getPropertyDef: (name: string) => PropertyDef | undefined
   isFieldReadonly: (field: FormFieldOrRelation) => boolean
@@ -42,6 +45,7 @@ defineProps<{
 const emit = defineEmits<{
   (e: 'update-field', property: string, value: unknown): void
   (e: 'attachment-changed', ...args: unknown[]): void
+  (e: 'update-staged-files', property: string, files: File[]): void
   (e: 'update-relation', relation: string, value: string[]): void
   (e: 'update-relation-types', relation: string, types: Map<string, string>): void
   (e: 'incoming-changed', relation: string, state: RelationPickerIncomingState): void
@@ -66,9 +70,11 @@ const emit = defineEmits<{
       :entity-type="entityType"
       :entity-id="entityId"
       :attachments="attachments[field.property]"
+      :staged-files="stagedFiles?.[field.property]"
       :max="getPropertyDef(field.property)?.max"
       @update="emit('update-field', field.property!, $event)"
       @attachment-changed="emit('attachment-changed', $event)"
+      @update:staged-files="emit('update-staged-files', field.property!, $event)"
     />
     <RelationCards
       v-else-if="field.relation && field.widget === 'cards' && entityId"

--- a/frontend/src/widgets/FileWidget.vue
+++ b/frontend/src/widgets/FileWidget.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import type { WidgetProps } from './types'
 import type { AttachmentInfo } from '@/types'
-import { uploadAttachment, deleteAttachment, AttachmentError } from '@/api/attachments'
+import {
+  uploadAttachment,
+  deleteAttachment,
+  attachmentErrorReason,
+  AttachmentError,
+} from '@/api/attachments'
 
 const props = defineProps<WidgetProps>()
 
@@ -17,7 +22,10 @@ const emit = defineEmits<{
 
 const files = computed<AttachmentInfo[]>(() => props.attachments ?? [])
 const staged = computed<File[]>(() => props.stagedFiles ?? [])
-const maxCount = computed(() => props.max ?? 1)
+// A declared `max` of 0 (or negative) means the property accepts no files;
+// without the floor it would fall through `isSingle` and offer a picker
+// (RR-1556G1 M2).
+const maxCount = computed(() => Math.max(0, props.max ?? 1))
 const isSingle = computed(() => maxCount.value <= 1)
 // Capacity counts BOTH persisted and staged files: in create mode every file
 // is staged, and a form could in principle show both.
@@ -31,69 +39,84 @@ const canEdit = computed(
 // Create mode (TKT-7K3BJF): no entity id exists yet, so a pick is STAGED
 // rather than uploaded. An attachment cannot be written before the entity
 // row exists, so the host form uploads these after the create returns an id.
-const canStage = computed(() => props.mode === 'edit' && !props.disabled && !props.entityId)
+// `entityType` is checked here as well as in canEdit (RR-1556G1 M1): it is
+// what builds the upload URL, so the two predicates should differ only on the
+// axis that actually distinguishes them — whether an entity id exists yet.
+const canStage = computed(
+  () => props.mode === 'edit' && !props.disabled && !!props.entityType && !props.entityId
+)
 // The add control shows when editing/staging and there's room (single-cap:
 // shows as "Replace" once a file exists; multi-cap: hidden at capacity).
 const canAdd = computed(
-  () => (canEdit.value || canStage.value) && (isSingle.value || !atCapacity.value)
+  () =>
+    maxCount.value > 0 &&
+    (canEdit.value || canStage.value) &&
+    (isSingle.value || !atCapacity.value)
 )
 
 const busy = ref(false)
 const progress = ref(0)
 const uploadError = ref('')
 
-// Object URLs for staged image previews, keyed by File. Revoked on removal
-// and on unmount — an un-revoked blob URL pins its bytes for the life of the
-// document.
-const stagedPreviews = ref(new Map<File, string>())
+// Object URLs for staged image previews, keyed by File.
+//
+// A watcher owns the whole lifecycle rather than the render path minting URLs
+// on demand (RR-1556G1 M3): creating one inside `stagedPreviewUrl` mutated
+// reactive state from a render function. Here a file entering the staged list
+// gets a URL, one leaving has its URL revoked, and whatever remains is revoked
+// on unmount — an un-revoked blob URL pins its bytes for the life of the
+// document. shallowRef because the Map is replaced wholesale, never mutated in
+// place for reactivity's sake.
+const stagedPreviews = shallowRef(new Map<File, string>())
 
 function stagedPreviewUrl(file: File): string | undefined {
-  if (!file.type.startsWith('image/')) return undefined
-  let url = stagedPreviews.value.get(file)
-  if (!url) {
-    url = URL.createObjectURL(file)
-    stagedPreviews.value.set(file, url)
-  }
-  return url
+  return stagedPreviews.value.get(file)
 }
 
-function revokeStagedPreview(file: File) {
-  const url = stagedPreviews.value.get(file)
-  if (url) {
-    URL.revokeObjectURL(url)
-    stagedPreviews.value.delete(file)
-  }
-}
-
-// Revoke previews for files that are no longer staged (e.g. the host cleared
-// the list after a successful create), so the map can't outlive its files.
-watch(staged, (current) => {
-  for (const file of [...stagedPreviews.value.keys()]) {
-    if (!current.includes(file)) revokeStagedPreview(file)
-  }
-})
+watch(
+  staged,
+  (current) => {
+    const next = new Map(stagedPreviews.value)
+    for (const [file, url] of stagedPreviews.value) {
+      if (!current.includes(file)) {
+        URL.revokeObjectURL(url)
+        next.delete(file)
+      }
+    }
+    for (const file of current) {
+      if (file.type.startsWith('image/') && !next.has(file)) {
+        next.set(file, URL.createObjectURL(file))
+      }
+    }
+    stagedPreviews.value = next
+  },
+  { immediate: true }
+)
 
 onBeforeUnmount(() => {
   for (const url of stagedPreviews.value.values()) URL.revokeObjectURL(url)
-  stagedPreviews.value.clear()
+  stagedPreviews.value = new Map()
 })
 
 function stageFile(file: File) {
   // Respect the cap at pick time, mirroring edit mode's capacity rule.
+  if (maxCount.value <= 0) return
   if (atCapacity.value && !isSingle.value) return
   // Single-cap replaces rather than appends, matching the server's max:1
   // semantics (a new upload supersedes the existing file).
   const next = isSingle.value ? [file] : [...staged.value, file]
-  if (isSingle.value) for (const f of staged.value) revokeStagedPreview(f)
   uploadError.value = ''
   emit('update:staged-files', next)
 }
 
-function unstageFile(file: File) {
-  revokeStagedPreview(file)
+// Remove by INDEX, not by object identity (RR-C6CXU1): the same File reference
+// can legitimately appear twice — the input is reset after each pick precisely
+// so a file can be re-selected, and one DataTransfer can be dropped twice — and
+// an identity filter would remove every copy instead of the one clicked.
+function unstageFileAt(index: number) {
   emit(
     'update:staged-files',
-    staged.value.filter((f) => f !== file)
+    staged.value.filter((_, i) => i !== index)
   )
 }
 
@@ -124,13 +147,9 @@ async function doUpload(file: File) {
   }
 }
 
+// Frames the shared reason (RR-1556G1 M4) as a sentence for inline display.
 function uploadErrorMessage(err: unknown): string {
-  if (err instanceof AttachmentError) {
-    if (err.status === 413) return 'File is too large.'
-    if (err.status === 409) return 'This field already holds the maximum number of files.'
-    return err.message
-  }
-  return 'Upload failed.'
+  return `Upload failed: ${attachmentErrorReason(err)}.`
 }
 
 async function doDelete(att: AttachmentInfo) {
@@ -204,7 +223,11 @@ function onDrop(event: DragEvent) {
          the persisted list, but the name is plain text: there is nothing to
          download yet, and the preview comes from a local object URL. -->
     <ul v-if="staged.length" class="file-list file-list-staged">
-      <li v-for="file in staged" :key="`${file.name}-${file.size}-${file.lastModified}`" class="file-item">
+      <!-- Keyed by index, not by file content (RR-C6CXU1): name+size+mtime
+           collides for two copies of the same file, which is reachable — the
+           picker is reset after each pick so the same file can be chosen
+           twice. The list is small and only appended to or filtered. -->
+      <li v-for="(file, i) in staged" :key="i" class="file-item">
         <img
           v-if="stagedPreviewUrl(file)"
           :src="stagedPreviewUrl(file)"
@@ -215,7 +238,7 @@ function onDrop(event: DragEvent) {
           <span class="file-name">{{ file.name }}</span>
           <span class="file-size">{{ formatSize(file.size) }}</span>
           <span class="file-staged-badge">Pending save</span>
-          <button type="button" class="file-remove" @click="unstageFile(file)">Remove</button>
+          <button type="button" class="file-remove" @click="unstageFileAt(i)">Remove</button>
         </div>
       </li>
     </ul>

--- a/frontend/src/widgets/FileWidget.vue
+++ b/frontend/src/widgets/FileWidget.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import type { WidgetProps } from './types'
 import type { AttachmentInfo } from '@/types'
 import { uploadAttachment, deleteAttachment, AttachmentError } from '@/api/attachments'
@@ -10,25 +10,92 @@ const emit = defineEmits<{
   // Fired after a successful upload or delete so the parent can refresh
   // the entity (the property value and _attachments changed server-side).
   'attachment-changed': []
+  // Create mode only: the staged (not-yet-uploaded) file list for this
+  // property changed. The host form owns the list — see `stagedFiles`.
+  'update:staged-files': [files: File[]]
 }>()
 
 const files = computed<AttachmentInfo[]>(() => props.attachments ?? [])
+const staged = computed<File[]>(() => props.stagedFiles ?? [])
 const maxCount = computed(() => props.max ?? 1)
 const isSingle = computed(() => maxCount.value <= 1)
-const atCapacity = computed(() => files.value.length >= maxCount.value)
+// Capacity counts BOTH persisted and staged files: in create mode every file
+// is staged, and a form could in principle show both.
+const atCapacity = computed(() => files.value.length + staged.value.length >= maxCount.value)
 
 // Edit mode can mutate only when the widget knows the owning entity and
 // isn't disabled by ACL.
 const canEdit = computed(
   () => props.mode === 'edit' && !props.disabled && !!props.entityType && !!props.entityId
 )
-// The add control shows when editing and there's room (single-cap: shows
-// as "Replace" once a file exists; multi-cap: hidden at capacity).
-const canAdd = computed(() => canEdit.value && (isSingle.value || !atCapacity.value))
+// Create mode (TKT-7K3BJF): no entity id exists yet, so a pick is STAGED
+// rather than uploaded. An attachment cannot be written before the entity
+// row exists, so the host form uploads these after the create returns an id.
+const canStage = computed(() => props.mode === 'edit' && !props.disabled && !props.entityId)
+// The add control shows when editing/staging and there's room (single-cap:
+// shows as "Replace" once a file exists; multi-cap: hidden at capacity).
+const canAdd = computed(
+  () => (canEdit.value || canStage.value) && (isSingle.value || !atCapacity.value)
+)
 
 const busy = ref(false)
 const progress = ref(0)
 const uploadError = ref('')
+
+// Object URLs for staged image previews, keyed by File. Revoked on removal
+// and on unmount — an un-revoked blob URL pins its bytes for the life of the
+// document.
+const stagedPreviews = ref(new Map<File, string>())
+
+function stagedPreviewUrl(file: File): string | undefined {
+  if (!file.type.startsWith('image/')) return undefined
+  let url = stagedPreviews.value.get(file)
+  if (!url) {
+    url = URL.createObjectURL(file)
+    stagedPreviews.value.set(file, url)
+  }
+  return url
+}
+
+function revokeStagedPreview(file: File) {
+  const url = stagedPreviews.value.get(file)
+  if (url) {
+    URL.revokeObjectURL(url)
+    stagedPreviews.value.delete(file)
+  }
+}
+
+// Revoke previews for files that are no longer staged (e.g. the host cleared
+// the list after a successful create), so the map can't outlive its files.
+watch(staged, (current) => {
+  for (const file of [...stagedPreviews.value.keys()]) {
+    if (!current.includes(file)) revokeStagedPreview(file)
+  }
+})
+
+onBeforeUnmount(() => {
+  for (const url of stagedPreviews.value.values()) URL.revokeObjectURL(url)
+  stagedPreviews.value.clear()
+})
+
+function stageFile(file: File) {
+  // Respect the cap at pick time, mirroring edit mode's capacity rule.
+  if (atCapacity.value && !isSingle.value) return
+  // Single-cap replaces rather than appends, matching the server's max:1
+  // semantics (a new upload supersedes the existing file).
+  const next = isSingle.value ? [file] : [...staged.value, file]
+  if (isSingle.value) for (const f of staged.value) revokeStagedPreview(f)
+  uploadError.value = ''
+  emit('update:staged-files', next)
+}
+
+function unstageFile(file: File) {
+  revokeStagedPreview(file)
+  emit(
+    'update:staged-files',
+    staged.value.filter((f) => f !== file)
+  )
+}
 
 function isImage(att: AttachmentInfo): boolean {
   return att.contentType?.startsWith('image/') ?? false
@@ -80,10 +147,17 @@ async function doDelete(att: AttachmentInfo) {
   }
 }
 
+// A picked file is STAGED in create mode and uploaded immediately in edit
+// mode — the single branch that separates the two behaviours.
+function acceptFile(file: File) {
+  if (canStage.value) stageFile(file)
+  else void doUpload(file)
+}
+
 function onFileInput(event: Event) {
   const input = event.target as HTMLInputElement
   const file = input.files?.[0]
-  if (file) void doUpload(file)
+  if (file) acceptFile(file)
   input.value = '' // allow re-selecting the same file
 }
 
@@ -92,12 +166,12 @@ function onDrop(event: DragEvent) {
   dragOver.value = false
   if (!canAdd.value) return
   const file = event.dataTransfer?.files?.[0]
-  if (file) void doUpload(file)
+  if (file) acceptFile(file)
 }
 </script>
 
 <template>
-  <div class="file-widget">
+  <div :id="id" class="file-widget">
     <!-- The current files (display in any mode). -->
     <ul v-if="files.length" class="file-list">
       <li v-for="att in files" :key="att.id" class="file-item">
@@ -126,7 +200,27 @@ function onDrop(event: DragEvent) {
       </li>
     </ul>
 
-    <span v-else-if="mode !== 'edit'" class="file-empty">No file attached</span>
+    <!-- Staged (not yet uploaded) files — create mode only. Same markup as
+         the persisted list, but the name is plain text: there is nothing to
+         download yet, and the preview comes from a local object URL. -->
+    <ul v-if="staged.length" class="file-list file-list-staged">
+      <li v-for="file in staged" :key="`${file.name}-${file.size}-${file.lastModified}`" class="file-item">
+        <img
+          v-if="stagedPreviewUrl(file)"
+          :src="stagedPreviewUrl(file)"
+          :alt="file.name"
+          class="file-preview"
+        />
+        <div class="file-meta">
+          <span class="file-name">{{ file.name }}</span>
+          <span class="file-size">{{ formatSize(file.size) }}</span>
+          <span class="file-staged-badge">Pending save</span>
+          <button type="button" class="file-remove" @click="unstageFile(file)">Remove</button>
+        </div>
+      </li>
+    </ul>
+
+    <span v-else-if="!files.length && mode !== 'edit'" class="file-empty">No file attached</span>
 
     <!-- Add / replace control (edit mode, with room). -->
     <div
@@ -139,19 +233,21 @@ function onDrop(event: DragEvent) {
     >
       <label class="file-pick">
         <input type="file" :disabled="busy" @change="onFileInput" />
-        <span>{{ isSingle && files.length ? 'Replace file' : 'Add a file' }}</span>
+        <span>{{ isSingle && (files.length || staged.length) ? 'Replace file' : 'Add a file' }}</span>
       </label>
       <span class="file-hint">or drag &amp; drop</span>
-      <span v-if="!isSingle" class="file-count">{{ files.length }} / {{ maxCount }}</span>
+      <span v-if="!isSingle" class="file-count">
+        {{ files.length + staged.length }} / {{ maxCount }}
+      </span>
     </div>
 
     <!-- At capacity in multi mode: explain why no add control. -->
-    <p v-else-if="canEdit && !isSingle && atCapacity" class="file-edit-note">
+    <p v-else-if="(canEdit || canStage) && !isSingle && atCapacity" class="file-edit-note">
       Maximum of {{ maxCount }} files reached — remove one to add another.
     </p>
 
     <!-- Edit mode but the widget can't mutate (no entity context / ACL). -->
-    <p v-else-if="mode === 'edit' && !canEdit" class="file-edit-note">
+    <p v-else-if="mode === 'edit' && !canEdit && !canStage" class="file-edit-note">
       {{ disabled ? 'Editing this attachment is not permitted.' : 'Attachment editing unavailable.' }}
     </p>
 
@@ -232,6 +328,14 @@ function onDrop(event: DragEvent) {
 .file-remove:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+/* A staged file is not yet persisted; the badge says so without relying on
+   colour alone. */
+.file-staged-badge {
+  font-size: var(--font-size-sm, 12px);
+  color: var(--text-muted, #6b7280);
+  font-style: italic;
 }
 
 .file-empty {

--- a/frontend/src/widgets/types.ts
+++ b/frontend/src/widgets/types.ts
@@ -63,7 +63,18 @@ export interface WidgetProps<T = unknown> {
   entityType?: string
   // Owning entity ID, supplied to the file widget for the upload/delete URL
   // in edit mode. Optional — present only on the file-property edit path.
+  //
+  // ABSENT means create mode (the create route sets no entity id), which is
+  // what puts the file widget into STAGED mode: there is no id to upload
+  // against yet, because an attachment cannot be written before the entity
+  // row exists (TKT-7K3BJF). It is genuinely `undefined` here — not a
+  // sentinel; see RR-QTCKCW.
   entityId?: string
+  // Files the user picked in create mode that are not yet uploaded. Owned by
+  // the host form (they must survive this widget re-rendering) and pushed
+  // back through `update:staged-files`. Ignored in edit mode, where a pick
+  // uploads immediately.
+  stagedFiles?: File[]
 }
 
 // WidgetRoutingHint is a lightweight description used by the view-side

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -31,11 +31,20 @@ const { mockUpload, mockDelete, MockAttachmentError } = vi.hoisted(() => {
     MockAttachmentError,
   }
 })
-vi.mock('@/api/attachments', () => ({
-  uploadAttachment: mockUpload,
-  deleteAttachment: mockDelete,
-  AttachmentError: MockAttachmentError,
-}))
+// Stub only the two network functions; keep the real `attachmentErrorReason`
+// so the status→message mapping under test is the shipped one. Note it is the
+// REAL AttachmentError that the helper instanceof-checks, so tests that want a
+// status branch must throw a MockAttachmentError AND the helper must still
+// resolve it — hence importActual rather than a bare object literal.
+vi.mock('@/api/attachments', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/api/attachments')
+  return {
+    ...actual,
+    uploadAttachment: mockUpload,
+    deleteAttachment: mockDelete,
+    AttachmentError: MockAttachmentError,
+  }
+})
 
 describe('TextWidget', () => {
   it('renders the value and emits update:modelValue on input', async () => {

--- a/frontend/src/widgets/widgets.test.ts
+++ b/frontend/src/widgets/widgets.test.ts
@@ -557,13 +557,104 @@ describe('FileWidget', () => {
     expect(w.text()).toContain('No file attached')
   })
 
-  it('shows a note (no upload control) in edit mode without entity context', () => {
+  // TKT-7K3BJF changed what "edit mode without an entity id" means: it is now
+  // the CREATE signal (staged mode), not "cannot mutate". The genuine
+  // cannot-mutate case is a disabled (policy-read-only) field, which is what
+  // this test now covers.
+  it('shows a note (no upload control) when the field is disabled by policy', () => {
     const w = mount(FileWidget, {
-      props: { modelValue: '', mode: 'edit' as const, propertyName: 'screenshot', attachments: [att] },
+      props: {
+        modelValue: '',
+        mode: 'edit' as const,
+        propertyName: 'screenshot',
+        attachments: [att],
+        disabled: true,
+        entityType: 'ticket',
+        entityId: 'TKT-1',
+      },
     })
     expect(w.find('.file-dropzone').exists()).toBe(false)
     expect(w.find('.file-edit-note').exists()).toBe(true)
     expect(w.text()).toContain('shot.png')
+  })
+
+  // --- Staged (create-mode) attachments, TKT-7K3BJF ---
+
+  const stagedProps = (over: Record<string, unknown> = {}) => ({
+    modelValue: '',
+    mode: 'edit' as const,
+    propertyName: 'screenshot',
+    entityType: 'ticket',
+    // No entityId: this IS create mode. Not a sentinel — see RR-QTCKCW.
+    ...over,
+  })
+
+  function textFile(name: string, contents = 'x'): File {
+    return new File([contents], name, { type: 'text/plain' })
+  }
+
+  it('offers an add control in create mode (no entity id yet)', () => {
+    const w = mount(FileWidget, { props: stagedProps() })
+    expect(w.find('.file-dropzone').exists()).toBe(true)
+    expect(w.find('.file-edit-note').exists()).toBe(false)
+  })
+
+  it('renders staged files with a pending badge and no download link', () => {
+    const w = mount(FileWidget, {
+      props: stagedProps({ stagedFiles: [textFile('notes.txt', 'hello')] }),
+    })
+    expect(w.text()).toContain('notes.txt')
+    expect(w.text()).toContain('Pending save')
+    // Nothing to download yet — the bytes are still local.
+    expect(w.find('a.file-name').exists()).toBe(false)
+  })
+
+  // Simulate a real pick: set `files` on the hidden input and fire `change`,
+  // which is the path the widget actually listens on.
+  async function pickFile(w: ReturnType<typeof mount>, file: File) {
+    const input = w.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+    await input.trigger('change')
+  }
+
+  it('emits the staged list when a file is picked, without uploading', async () => {
+    const w = mount(FileWidget, { props: stagedProps() })
+    const file = textFile('a.txt')
+    await pickFile(w, file)
+    const emitted = w.emitted('update:staged-files')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0][0]).toEqual([file])
+    // Staging must never hit the network.
+    expect(mockUpload).not.toHaveBeenCalled()
+  })
+
+  it('removing a staged file emits the shortened list', async () => {
+    const keep = textFile('keep.txt')
+    const drop = textFile('drop.txt')
+    const w = mount(FileWidget, { props: stagedProps({ stagedFiles: [keep, drop], max: 3 }) })
+    await w.findAll('.file-remove')[1].trigger('click')
+    const emitted = w.emitted('update:staged-files')
+    expect(emitted![0][0]).toEqual([keep])
+  })
+
+  it('single-cap staging replaces rather than appends', async () => {
+    const first = textFile('first.txt')
+    const w = mount(FileWidget, { props: stagedProps({ stagedFiles: [first], max: 1 }) })
+    const second = textFile('second.txt')
+    await pickFile(w, second)
+    expect(w.emitted('update:staged-files')![0][0]).toEqual([second])
+  })
+
+  it('staged files count toward capacity and hide the add control at max', () => {
+    const w = mount(FileWidget, {
+      props: stagedProps({
+        propertyName: 'docs',
+        stagedFiles: [textFile('a.txt'), textFile('b.txt')],
+        max: 2,
+      }),
+    })
+    expect(w.find('.file-dropzone').exists()).toBe(false)
+    expect(w.find('.file-edit-note').text()).toContain('Maximum of 2')
   })
 
   it('shows a Replace control for a single-cap property in edit mode', () => {

--- a/tickets/entities/docs-checklists/DOCS-BPLLWQ.md
+++ b/tickets/entities/docs-checklists/DOCS-BPLLWQ.md
@@ -1,0 +1,51 @@
+---
+id: DOCS-BPLLWQ
+type: docs-checklist
+title: 'Docs: Attachments on entity create'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] New/changed functions have doc comments
+- [x] Non-obvious decisions explained with rationale
+
+The comments carry the *reasons*, not restatements: why staged files must stay
+out of `formData` (they would be POSTed as the property value), why the
+statement order in `handleSubmit` is load-bearing, why `shallowRef` rather than
+`ref` (test/production `File` divergence), why removal is by index rather than
+identity, and why `attachmentErrorReason` duck-types on `status`.
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` — new "File Properties on Forms" section explaining
+create-vs-edit behaviour, the "Pending save" state, capacity, and the
+partial-failure case. Authored in
+`docs-project/entities/guides/GUIDE-data-entry.md` and regenerated; `just
+docs-check` passes.
+- [x] ~~`docs/metamodel.md`~~ (N/A: no metamodel change — `file` and `max` already documented)
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no CLI change)
+- [x] ~~`docs/attachment-security.md`~~ (N/A: the security model is deliberately
+unchanged — no new endpoint, blob namespace or ACL subject. That is the whole
+argument for this approach, so documenting a change would be wrong.)
+- [x] ~~`CLAUDE.md`~~ (N/A: no new cross-cutting pattern; the two-phase create
+mirrors the existing `link_as=from` relation write)
+- [x] ~~`README.md`~~ (N/A: no project-level change)
+
+## Accuracy
+
+- [x] Docs describe what the code actually does
+
+Worth recording: the first draft of this section **promised a retry that did not
+exist** — "the message names the files that did not attach, so you can retry
+them there" — while the code cleared nothing and navigated away. Code review
+(RR-4QO887) caught the divergence. The section now says the failed files must be
+picked again, because the form holding them is gone by then. A doc that
+overstates a recovery path is worse than one that omits it.
+
+## External Documentation
+
+- [x] ~~Changelog / release notes~~ (N/A: this repo has no changelog; the ticket
+and commit message carry the rationale)

--- a/tickets/entities/implementation-checklists/IMPL-KU1WNF.md
+++ b/tickets/entities/implementation-checklists/IMPL-KU1WNF.md
@@ -1,0 +1,128 @@
+---
+id: IMPL-KU1WNF
+type: implementation-checklist
+title: 'Implementation: Attachments on entity create: stage files in the create form, upload after the entity exists'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Frontend only, as planned — **no Go source changed** (`git status` shows only
+`frontend/`, `e2e/`, and docs). The hardened upload path is reused verbatim.
+
+| File | Change |
+|------|--------|
+| `frontend/src/widgets/FileWidget.vue` | staged mode (`canStage`), object-URL preview lifecycle, `stageFile`/`unstageFile`, `acceptFile` branch |
+| `frontend/src/widgets/types.ts` | `stagedFiles?: File[]` on `WidgetProps` |
+| `frontend/src/components/forms/FieldRenderer.vue` | forwards prop + `update:staged-files` |
+| `frontend/src/components/forms/FormFieldList.vue` | forwards prop + `update-staged-files` |
+| `frontend/src/components/forms/DynamicForm.vue` | `stagedFiles` ref, dirty term, `uploadStagedFiles`, failure messaging |
+| `e2e/tests/fixtures.ts` | `screenshot` (max 1) + `evidence` (max 3) file properties on `bug`, surfaced on its form; `_attachments` on `EntityResponse` |
+| `e2e/pages/form.page.ts` | file-control page-object methods |
+
+New tests: `frontend/src/components/forms/DynamicForm.attachments.test.ts` (11),
+`e2e/tests/attachments-create.spec.ts` (5), plus 6 staged-mode cases in
+`widgets.test.ts`.
+
+**One existing test changed, deliberately.** `widgets.test.ts`'s "shows a note
+(no upload control) in edit mode without entity context" pinned the behaviour
+this ticket removes — no `entityId` now means CREATE, not "cannot mutate". Its
+intent (a genuinely immutable widget shows a note) is preserved by retargeting
+it at the `disabled` (policy-read-only) case, which is the real cannot-mutate
+condition.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`textFile()` builds test files; assertions compare against the *same* `File`
+instance that was staged (`toHaveBeenCalledWith(..., file)`), and the uploaded
+id is asserted against the mocked create response rather than a literal.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Ran a real `rela-server` (fsstore) on a scratch project with `screenshot` (max
+1) and `evidence` (max 3), drove the actual SPA in Chromium, and used the API as
+the arbiter. Results:
+
+```
+1. create-form file control present: YES
+2. staged filename shown: manual-shot.png
+3. "Pending save" badge: YES
+4. uploads before save (must be 0): 0
+5. image preview from object URL: YES
+6. evidence staged count: 2
+7. capacity counter: 2 / 3
+8. landed on: /entity/bug/BUG-001
+10. screenshot attached: ["manual-shot.png"]
+11. evidence attached: ["manual-shot.png","manual-b.txt"]
+12. screenshot property stamped: "attachments/BUG-001/screenshot/manual-shot.png"
+13. evidence property stamped: ["attachments/BUG-001/evidence/manual-b.txt",
+                               "attachments/BUG-001/evidence/manual-shot.png"]
+```
+
+Maps to acceptance criteria: AC1 (1,2,8,10,12), AC3 (6,7,11,13), AC-uploads-use-
+server-id (12,13 — paths carry the server's `BUG-001`). AC2/AC4/AC5 are covered
+by the automated suites (staged-removal, 413/422/403 failure, ACL parity).
+
+**Duplicate-upload check.** A first pass counted 5 `/_attachments/` requests for
+3 files, which looked like double-uploading. Re-ran with one staged file and
+logged method+path: exactly `PUT /api/v1/bugs/BUG-002/_attachments/screenshot`,
+one request. The extra hits were the SPA's post-upload entity refetches, which
+match the same URL filter — not duplicates.
+
+**Automated results:** frontend 2022/2022 passing (124 files); e2e 270 passed /
+8 pre-existing skips / 0 failures; `go test ./internal/dataentry/...
+./internal/attachment/...` ok; `npm run typecheck` clean; `npm run lint` 0
+errors; `npx tsc --noEmit` + `eslint` clean in e2e (the page-object rule is a
+compile-level error, so the new spec is proven to use page objects only); `just
+arch-lint` OK.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+**Patterns:** staged dirtiness mirrors the existing `pendingCardChanges` term in
+`checkDirty`; the two-phase create mirrors the `link_as=from` reverse-relation
+write already in `handleSubmit`. Deliberately *diverges* from that precedent on
+one point — it only `console.warn`s a failure, whereas a dropped attachment is
+user-visible data loss and gets a real error message.
+
+**DRY:** staged rendering reuses the existing `formatSize`, `.file-list` /
+`.file-item` markup and capacity computeds rather than duplicating them; the
+extra state is one `stagedFiles` ref and two small helpers.
+
+**Security:** no new endpoint, blob namespace, or ACL subject. Every upload
+still passes `attachmentWritePreflight` (uniform-404 read gate → file/hidden
+property check → lock check → `AuthorizeWrite("update")` with an audit row on
+deny) *before* the multipart body is parsed. No client-side check is treated as
+a control; the 413/422 remain authoritative. Uploads address only the
+server-returned id.
+
+**No silent failures:** every upload failure is collected and named in a message
+that identifies the file and reason; a failure also keeps the form dirty so the
+navigation guard still warns. The `console.log` used while debugging the test
+mock was removed (`grep` for DEBUG-HTML returns nothing).

--- a/tickets/entities/planning-checklists/PLAN-LCUIQO.md
+++ b/tickets/entities/planning-checklists/PLAN-LCUIQO.md
@@ -1,0 +1,346 @@
+---
+id: PLAN-LCUIQO
+type: planning-checklist
+title: 'Planning: Attachments on entity create: stage files in the create form, upload after the entity exists'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN — frontend only (`frontend/src/`):
+1. `FileWidget` gains a **staged mode**: with no real `entityId`, hold selected
+`File` objects in local state, render them (name, size, image preview via object
+URL, remove), upload nothing.
+2. `DynamicForm` collects staged files per property and, **after** a successful
+create, uploads each against the returned id via the existing
+`uploadAttachment`, then refreshes.
+3. Upload failure after create is surfaced, never silent: the user lands on the
+created entity with the server's problem+json detail inline.
+4. Respect the property's `max` while staging (parity with edit mode).
+
+OUT — no Go changes at all. No new endpoint, no new blob namespace, no new ACL
+subject. Also out: `required: true` file properties (→ TKT-87VSDE), atomic
+multipart create, a staging/unowned-blob namespace, API/MCP create-time attach,
+and the pre-existing stale-file-property-after-rename issue. All recorded on the
+ticket with rationale.
+
+**Acceptance Criteria:**
+
+1. **Create with a file, one gesture.** Create form shows a working file control;
+pick a file, Save; the entity exists with the file attached and the property
+stamped. → e2e `attachments-create.spec.ts`.
+2. **Staged file removable pre-save.** Stage, remove, Save → no upload issued.
+→ unit (FileWidget) + form-level unit asserting `uploadAttachment` not called.
+3. **`max > 1` stages up to max.** N files stage and all upload; add control
+disappears at capacity. → unit (widget), mirroring the existing "hides the add
+control at capacity" test at `widgets.test.ts:583`.
+4. **Post-create upload failure is loud.** Oversize/rejected file → entity still
+reachable, user lands on it, server detail shown inline, no silent loss. → unit
+with a rejecting `uploadAttachment` mock.
+5. **ACL parity.** No `update` on the created entity → same 403 the edit path
+gives; staged UI does not claim success. → unit (403 mock) + existing Go `acl_*`
+coverage already pins the server side.
+6. **Uploads address only the server-returned id.** No client-side placeholder
+reaches a request URL. → unit asserting the upload mock's args. (Corrected per
+RR-QTCKCW: the `++new++` STAGED_ID sentinel has NO production consumer — create
+mode passes `entityId === undefined`. The original criterion described a
+mechanism that does not exist.)
+7. **No regression for `required` file props.** Behaviour identical to today.
+
+## Research
+
+- [x] For larger features: run `/research` — **N/A**, approach settled in the
+investigation that produced this ticket; the constraints are mechanical, not
+open-ended.
+- [x] Searched for existing libraries — **N/A**, no new dependency. Staging is
+an array of native `File` objects; `axios` multipart upload already exists.
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — see ticket body, which carries the full option analysis
+(A / multipart-create / staging namespace) and why A wins.
+
+**Existing Solutions:**
+
+- **The whole server side already exists and is reused verbatim.**
+`uploadAttachment` (`frontend/src/api/attachments.ts:47`) → `PUT
+/api/v1/{plural}/{id}/_attachments/{property}` → `handleV1PutAttachment`
+(`internal/dataentry/handlers_attachment.go:147`). This ticket adds no server
+surface.
+- **Sibling prior art:** TKT-RXFD5B built this exact widget for edit mode;
+TKT-WLLRO7 added `max`. The staged mode is a third branch on the same component,
+not a new one.
+- **Two-phase create is already an established pattern in this very function.**
+`handleSubmit` already does create-then-follow-up-write for relations:
+`link_as=from` creates the reverse relation *after* the entity exists
+(`DynamicForm.vue:1023-1035`), catching and warning on failure. Staged
+attachment upload is the same shape, so this is not a new idea in the form.
+- **Rejected alternatives** (detail on ticket): multipart create — atomic but
+needs a body-shape branch, multipart size accounting, and a compensating delete;
+staging namespace — needs its own ACL subject, GC, and quota.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+*1. `FileWidget` staged mode.* Today `canEdit = mode === 'edit' && !disabled &&
+!!entityType && !!entityId`. Add a parallel `canStage = mode === 'edit' &&
+!disabled && !entityId` branch. In staged mode the widget keeps `stagedFiles:
+File[]`, renders them from the same list markup (size via the existing
+`formatSize`, image preview via `URL.createObjectURL`), and emits
+`update:staged-files` instead of uploading. Object URLs are revoked on remove
+and on unmount — a leak here is a real one. Capacity logic (`atCapacity`,
+`isSingle`) is reused by counting `files.length + stagedFiles.length`.
+
+*2. `DynamicForm` staging state + post-create upload.* Add `stagedFiles =
+ref<Record<string, File[]>>({})`, fed by the widget's emit through
+`FormFieldList` (which already forwards `attachment-changed`).
+
+**Critical: staged files must NOT enter `formData`.** `payload.properties` is
+built from `visibleWritablePropertiesForCommit()` (`DynamicForm.vue:376`), and
+any key present there is sent to the server. A `File` object — or a fake path
+string — in `formData` would be sent as the file property's value at create,
+which is wrong (the server stamps that property itself, in
+`stampPropertyNames`). Keeping staging in a *separate* ref is the design point,
+not an implementation detail. It also keeps the dry-run
+(`refreshStagedAffordances`, line 607, which posts `{...formData.value}`) clean.
+
+Then in `handleSubmit`, upload each staged file sequentially against
+`entity.id`. Sequential rather than parallel: uploads serialize on the server's
+`writeMu` anyway, and `WriteAttachment`'s cap check is read-then-write
+(non-atomic, relying on serialized writers — see
+`internal/attachment/attachment.go` doc), so concurrent uploads to one property
+are exactly the case its cap logic is not designed for.
+
+**Exact statement order (RR-6ZAOMK).** The span between `create` (line 1014) and
+navigation (line 1050) is not inert — it holds `dirty.value = false` (1037), the
+embedded early-return (1043-1046) and `uiStore.success(...)` (1048), and the
+uploads' position relative to each changes behaviour. Pinned order:
+
+1. `entitiesStore.create(...)` → `surfaceWarnings(entity.warnings)`
+2. **upload staged files**, continue-on-error, collecting `{filename, error}`
+3. `dirty.value = false` **only if every upload succeeded** — otherwise stay
+dirty so the navigation guard still protects the un-uploaded files
+4. embedded early-return (`emit('inline-created', entity)`)
+5. outcome-dependent toast — success, or a partial-success message naming the
+failed files (see RR-Z7C3CY)
+
+Uploads must precede the success toast: firing green "Entity created
+successfully" and then a red upload error describes one user action with two
+contradictory messages.
+
+*3. Failure handling.* Wrap the upload loop. On failure: still navigate to the
+created entity (it exists — hiding it would be worse), and surface the error.
+Deliberately **unlike** the `link_as=from` precedent above, which only
+`console.warn`s (`DynamicForm.vue:1032`) — a silently-dropped attachment is
+user-visible data loss, so this gets a real error toast carrying the server's
+problem+json detail, which `AttachmentError` already extracts
+(`api/attachments.ts:31-39`).
+
+*3b. Dirty tracking must include staged files (RR-EUX4BX).* Because staged files
+deliberately stay out of `formData`, `checkDirty()`
+(`DynamicForm.vue:1380-1388`) cannot see them — it serializes only `{formData,
+relations, content}` plus `pendingCardChanges`. A user who attaches a file and
+navigates away would hit neither guard (`if (!dirty.value) return true`, line
+1596; `handleBeforeUnload`, ~1397) and lose it silently. `pendingCardChanges` is
+the existing precedent for a non-`formData` dirtiness source; do the same:
+
+```js
+const hasStagedFiles = Object.values(stagedFiles.value).some((a) => a.length > 0)
+dirty.value = currentData !== originalData.value || hasCardChanges || hasStagedFiles
+```
+
+*4. Embedded/inline-create path.* `props.embedded` returns early at line 1044
+(`emit('inline-created', entity)`) **before** navigation. The upload must run
+before that early return, or attachments staged in an inline-create modal are
+silently dropped. This is the easiest thing in the whole ticket to get wrong.
+
+**Files to modify:**
+- `frontend/src/widgets/FileWidget.vue` — staged mode, object-URL lifecycle
+- `frontend/src/widgets/types.ts` — `WidgetProps`/emit for staged files
+- `frontend/src/components/forms/FieldRenderer.vue` — forward the new binding
+- `frontend/src/components/forms/FormFieldList.vue` — forward the new binding
+- `frontend/src/components/forms/DynamicForm.vue` — `stagedFiles` ref, upload
+loop after create (both the embedded and navigating paths), error surfacing
+- Tests: `frontend/src/widgets/widgets.test.ts`,
+`frontend/src/components/forms/DynamicForm.test.ts`, new
+`e2e/tests/attachments-create.spec.ts` + a `file` property and page-object
+methods in `e2e/tests/fixtures.ts` / `e2e/pages/`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **User-selected files** (picker / drag-drop). Validated **server-side, exactly
+as today** — sniffed MIME allowlist, sandboxed scan/transform, size cap, per
+`docs/attachment-security.md`. The staged client holds bytes in memory and ships
+them to the unchanged endpoint. **No client-side check is treated as a security
+control**; any client-side size hint is a UX courtesy, and the 413 remains
+authoritative.
+- **The entity id used for upload.** Create mode passes `entityId === undefined`
+(`DynamicForm.vue:1742`), and uploads use ONLY the server-returned `entity.id`,
+so no client-side value can reach an attachment URL. Pinned by an explicit test.
+**Correction (RR-QTCKCW):** an earlier draft claimed `entityId` holds the
+`++new++` STAGED_ID sentinel that must be prevented from leaking. That is false
+— `STAGED_ID`/`isStaged` (`stagedEntity.ts:12-15`) have no production consumer.
+Do NOT "make the guard explicit" by assigning the sentinel into `entityId`; that
+would manufacture the very leak the old wording imagined.
+
+**Security-Sensitive Operations:**
+
+- **Authorization is unchanged and still server-side.** Every upload hits
+`attachmentWritePreflight` (`handlers_attachment.go:363`): uniform-404 read gate
+→ entity/type check → file-property + hidden-property check → lock check →
+`AuthorizeWrite("update")`, with an `OpDeniedWrite` audit row on deny, all
+*before* the multipart body is parsed. Staging changes none of it. A client that
+stages a file it may not upload gets a 403 at commit — the correct boundary.
+- **No new attack surface by construction:** no new route, no unowned-blob
+namespace, no ACL subject, no ID reservation primitive (the absence of which is
+what forces this design at all).
+- **Error text** shown inline is the server's own problem+json `detail`, already
+written for client consumption by `writeV1Error`. No new channel, nothing
+additional exposed.
+- **Memory, not a vuln but worth stating:** staged files sit in browser memory
+until save. Bounded by the property's `max` and the user's own picking.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** (numbers map to Acceptance Criteria above)
+
+| AC | Level | Test |
+|----|-------|------|
+| 1 | e2e | `attachments-create.spec.ts`: create entity with a file, assert attached + property stamped |
+| 1 | unit | `DynamicForm.test.ts`: create resolves → `uploadAttachment` called with `(type, returnedId, prop, file)` |
+| 2 | unit | stage then remove → widget emits empty list; no upload on save |
+| 3 | unit | `widgets.test.ts`: staged files count toward capacity; add control hidden at `max` |
+| 4 | unit | `uploadAttachment` rejects with `AttachmentError(413)` → error surfaced, navigation still happens |
+| 5 | unit | rejects with `AttachmentError(403)` → error surfaced, no success claim |
+| 6 | unit | assert `uploadAttachment` is called with the server-returned `entity.id` |
+| 7 | — | no change; existing behaviour untouched |
+| RR-EUX4BX | unit | stage a file → `isDirty()` true; navigation guard prompts |
+| RR-6ZAOMK | unit | failed upload → form stays dirty; no bare success toast |
+| RR-Z7C3CY | unit | mixed batch (some succeed, some fail) → all attempted, one message names the failures |
+
+Unit tests follow the existing `mount(FileWidget, { props: {...} })` convention
+(`widgets.test.ts:508+`) and the `DynamicForm.test.ts` mocking style.
+
+**Integration:** e2e is the real integration proof (real `rela-server`, real
+store, real upload endpoint). Note `e2e/tests/fixtures.ts` currently declares
+**no `file` property anywhere** — a `file` property must be added to the inline
+fixture schema, plus page-object methods for the file control (the page-object
+pattern is an eslint-enforced compile error to bypass — `e2e/tests/AGENTS.md`).
+That fixture work is a real, easily-underestimated slice of this ticket.
+
+**Edge Cases:**
+
+- Create **fails** (validation 422) with files staged → no upload attempted;
+staged files survive so the user can fix and resubmit without re-picking.
+- **Embedded/inline-create** (`props.embedded`) → upload must run *before* the
+early `emit('inline-created')` return at line 1044.
+- Staging **more than `max`** → excess refused at pick time, consistent with
+edit mode.
+- Same file staged twice / same filename → server auto-suffixes on collision
+(`resolveAttachName`); client need not dedupe.
+- **Partial batch failure at `max > 1` (RR-Z7C3CY)** → continue-on-error: every
+staged file is attempted, failures collected as `{filename, error}`, and ONE
+message names them (`Entity created. 2 of 3 files failed: b.pdf (too large),
+c.exe (type not allowed).`). Aborting the loop would leave later files
+unattempted with nothing telling the user so; a bare per-request detail names no
+filename, leaving "which of my files made it?" unanswerable.
+- **Navigating away mid-upload** → `isCancelledFetch` handling already exists in
+this catch block (BUG-6C3V) and must not be broken.
+- **Empty staging** (no file picked) → the create path is byte-for-byte
+unchanged; the common case must not regress.
+- Object URL **revoked** on remove and unmount (no leak).
+- File property that is **hidden by policy** in create mode → no staged control,
+same as any hidden field.
+
+**Negative Tests:** Oversize (413), rejected MIME (422), ACL deny (403), network
+failure — each must show the server's detail, keep the created entity reachable,
+and never report success. Silent failure is the specific thing this ticket must
+not ship.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+1. **Staged file leaks into `formData` and is POSTed as the property value.**
+The main correctness risk. → Separate `stagedFiles` ref, never merged into
+`formData`; test asserts the create payload has no file-property key.
+2. **Embedded path drops attachments** (early return before upload). → Called
+out in the approach; explicit unit test.
+3. **Partial failure feels broken to the user** — the accepted cost of Option A.
+→ Loud inline error + land on the created entity. If it proves insufficient in
+practice, the multipart-create option is documented and ready.
+4. **e2e fixture has no `file` property today** → schema + page objects must be
+added; scoped above so it isn't discovered mid-implementation.
+5. **Object-URL leak** on preview. → Revoke on remove and unmount.
+6. **Regressing the no-attachment create path** (by far the most common). →
+Existing `DynamicForm` create tests must stay green untouched.
+
+**Effort:** m — confirms the ticket estimate. Frontend-only, but spans 5 source
+files plus non-trivial e2e fixture work.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] `docs/data-entry.md` — UI change: attachments can now be added while
+creating an entity, not only when editing. Worth a line since the old
+save-then-reopen workaround is what users learned.
+- [x] ~~`docs/metamodel.md`~~ (N/A: no metamodel change)
+- [x] ~~`docs/cli-reference.md`~~ (N/A: no CLI change)
+- [x] ~~`CLAUDE.md`~~ (N/A: no new cross-cutting pattern)
+- [x] ~~`README.md`~~ (N/A: no project-level change)
+- [x] ~~`docs/attachment-security.md`~~ (N/A: the security model is deliberately
+unchanged — that is the whole argument for Option A)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+| ID | Severity | Finding | Status |
+|----|----------|---------|--------|
+| RR-QTCKCW | significant | `++new++` sentinel premise factually wrong; AC6 tested a non-existent risk | addressed |
+| RR-EUX4BX | significant | Staged files invisible to dirty tracking → silent loss on navigate-away | addressed |
+| RR-6ZAOMK | significant | Upload placement vs. dirty-reset / success-toast unspecified | addressed |
+| RR-Z7C3CY | minor | Multi-file partial-batch failure unspecified | addressed |
+
+No critical findings. The three significant ones were all *omissions in the
+plan* rather than flaws in the chosen approach — Option A itself survived
+review. Notably RR-EUX4BX is a direct consequence of the plan's own central
+decision (keep staged files out of `formData`), which is the kind of
+second-order effect this review exists to catch.

--- a/tickets/entities/review-checklists/REV-HPY7TN.md
+++ b/tickets/entities/review-checklists/REV-HPY7TN.md
@@ -1,0 +1,82 @@
+---
+id: REV-HPY7TN
+type: review-checklist
+title: 'Review: Attachments on entity create: stage files in the create form, upload after the entity exists'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] `just test` — Go `./internal/dataentry/... ./internal/attachment/...` ok;
+frontend 2027/2027 across 124 files; e2e 271 passed / 8 pre-existing skips / 0
+failures
+- [x] `just lint` — golangci-lint 0 issues; `npm run lint` 0 errors (114 warnings,
+all pre-existing); commentlint gate clean; plimsoll clean
+- [x] `just coverage-check` — package and total thresholds satisfied, 78.3%
+- [x] `just arch-lint` — OK, no warnings
+- [x] `just docs-check` — docs regenerated from `docs-project/` and in sync
+- [x] `npm run typecheck` / `npx tsc --noEmit` (e2e) — clean
+- [x] `npx eslint` on the new e2e spec — clean (the page-object rule is a
+compile-level error, so the spec is proven to use page objects only)
+
+## Code Review
+
+- [x] `/code-review` run (cranky-code-reviewer)
+- [x] All critical findings addressed
+- [x] All significant findings addressed
+- [x] Minor/nit findings addressed or explicitly deferred with reason
+
+**Findings — 8 total, all addressed:**
+
+| ID | Severity | Finding |
+|----|----------|---------|
+| RR-HJLLUF | critical | Double-submit via Cmd+Enter creates two entities and two sets of uploads |
+| RR-4QO887 | critical | Failure path promised a retry that did not exist; kept-dirty state enabled duplicate creates |
+| RR-OI6P51 | significant | Staged files bypassed wizard-hidden pruning, persisting a revealed-then-hidden branch |
+| RR-C6CXU1 | significant | Duplicate Vue `:key`; unstage-by-identity removed both copies |
+| RR-C1MI2N | significant | Deep `ref` proxies `File` under happy-dom — tests exercised proxies, production raw Files |
+| RR-7T94EF | significant | Embedded path's keeps-form-dirty guarantee was void |
+| RR-QQQ2JR | significant | Missing tests: double-submit, unmount mid-upload, wizard-hidden, duplicate key |
+| RR-1556G1 | minor | `canStage` looser than `canEdit`; `max: 0`; render-time mutation; duplicated error mapping |
+
+**What the review actually changed.** Two of these were real defects the design
+review did not reach, and both came from the same blind spot: adding a second
+network phase to submit widens an existing race and turns "retry" into
+"duplicate". The double-submit hole pre-dated this ticket, but its window grew
+from one POST to a POST plus N multipart uploads — seconds, not milliseconds.
+The retry promise was worse: the code kept staged files and a dirty flag for a
+recovery path that the very next `router.push` destroyed, while leaving a live
+form that would happily create a second entity. I took the honest option — clear
+the state, say "re-attach on the entity", and fix the docs that had promised
+otherwise.
+
+RR-C1MI2N is the one worth remembering: happy-dom's `File` reports `[object
+Object]`, so a deep `ref` proxies it and identity is not preserved, while a spec
+`File` is left alone. I verified both halves with a throwaway test before
+accepting the finding. Every unit test here was exercising proxies while
+production exercised raw `File`s — `shallowRef` makes them agree.
+
+## Acceptance Verification
+
+Each criterion from the ticket, with evidence:
+
+| # | Criterion | Result |
+|---|-----------|--------|
+| 1 | Pick/drag a file on the create form; entity saved with file attached and property stamped | **PASS** — e2e `stages a file in the create form and attaches it after save`; manual run stamped `attachments/BUG-001/screenshot/manual-shot.png` |
+| 2 | A staged file removed before save is not uploaded | **PASS** — e2e `a staged file removed before save is never uploaded`; unit `does not upload a staged file that was removed before save` |
+| 3 | At `max > 1`, up to `max` stage and all upload; add control hidden at capacity | **PASS** — e2e `stages several files…` and `hides the add control once a multi-cap property is full`; manual counter showed `2 / 3` |
+| 4 | Upload failure leaves the entity reachable, lands the user on it, shows the server's error | **PASS** — e2e `an oversize file fails loudly after the entity is created`, driving a **real 413** (fixture `max_attachment_bytes: 1024`) |
+| 5 | No `update` permission → same 403 as the edit path; no false success | **PASS** — unit 403 case; server-side gate unchanged (`attachmentWritePreflight`) and covered by existing Go `acl_*` tests |
+| 6 | Uploads address only the server-returned id | **PASS** — unit asserts `uploadAttachment('bug', 'BUG-7', …)` against the mocked create response; manual paths carry the server's `BUG-001` |
+| 7 | A `required` file property is not made worse | **PASS** — no change to required handling; owned by TKT-87VSDE |
+
+## Documentation
+
+- [x] `docs/data-entry.md` updated (via `docs-project/`) — new "File Properties
+on Forms" section, corrected after RR-4QO887 so it no longer promises a retry
+the code does not implement
+- [x] No metamodel / CLI / CLAUDE.md changes needed
+- [x] `docs/attachment-security.md` deliberately unchanged — the security model
+is untouched, which is the whole argument for this approach

--- a/tickets/entities/review-responses/RR-1556G1.md
+++ b/tickets/entities/review-responses/RR-1556G1.md
@@ -1,0 +1,43 @@
+---
+id: RR-1556G1
+type: review-response
+title: 'Minor: canStage omits entityType check, max:0 offers a picker, render-time mutation, duplicated error mapping'
+finding: |-
+    Four small issues, grouped:
+
+    M1. `canStage` (FileWidget.vue:34) omits the `!!props.entityType` check that `canEdit` (line 29) has. FieldRenderer always supplies entityType so there is no production bug, but a mount with neither prop now offers a staging UI where it previously showed 'Attachment editing unavailable'. Add the check so the two predicates differ only on the axis that matters.
+
+    M2. `max: 0` is unhandled: maxCount = props.max ?? 1 leaves 0, and isSingle (maxCount <= 1) is true, so canAdd is true and staging succeeds. A metamodel meaning 'no files here' gets a working picker. Guard max <= 0.
+
+    M3. `stagedPreviewUrl` (FileWidget.vue:50-58) is called from the template and writes into the reactive stagedPreviews map as a side effect — render-time mutation of reactive state. It does not loop today, but it is a trap; derive a computed from `staged` or build the URL at stage time.
+
+    M4. Error-mapping duplication: FileWidget.uploadErrorMessage (line 127) and DynamicForm.stagedUploadErrorMessage (line 518) map the same statuses to different strings, and FileWidget's has no 403 branch. Hoist the status→reason mapping into @/api/attachments and let each site frame it.
+severity: minor
+resolution: 'All four fixed. M1: canStage now also requires entityType, so it differs from canEdit only on whether an entity id exists. M2: maxCount is floored at 0 and both canAdd and stageFile refuse when max <= 0. M3: the preview map is owned by a watcher (mint on enter, revoke on leave, revoke remainder on unmount) so stagedPreviewUrl is a pure lookup and render no longer mutates reactive state. M4: the status→reason mapping is hoisted to attachmentErrorReason in @/api/attachments and both sites frame it; it duck-types on `status` rather than instanceof, because class identity is not stable across a vi.mock boundary and silently degrading a 413 to a generic message is the exact failure the helper exists to prevent (caught by an existing widget test).'
+status: addressed
+---
+
+## Findings (grouped minors)
+
+**M1 — `canStage` is looser than `canEdit`.** `FileWidget.vue:34` omits the
+`!!props.entityType` check present at line 29. `entityType` is what
+`uploadAttachment` needs for the URL. `FieldRenderer` always supplies it, so
+there is no production bug — but a mount with neither prop now offers staging
+where it used to show "Attachment editing unavailable". Add the check so the two
+predicates differ only in the axis that matters.
+
+**M2 — `max: 0` is not handled.** `maxCount = props.max ?? 1` keeps 0; `isSingle
+= maxCount <= 1` is then true, so `canAdd` is true and staging succeeds. A
+metamodel that means "no files here" gets a working picker.
+
+**M3 — render-time mutation.** `stagedPreviewUrl` (`FileWidget.vue:50-58`) is
+called from the template and writes into the reactive `stagedPreviews` map as a
+side effect. It does not loop today, but a render function mutating reactive
+state is a trap. Derive a `computed` from `staged`, or create the URL at stage
+time.
+
+**M4 — duplicated error mapping.** `FileWidget.uploadErrorMessage` (line 127)
+and `DynamicForm.stagedUploadErrorMessage` (line 518) map the same statuses to
+different strings ("File is too large." vs "too large") because one is a
+sentence and one a fragment — and `FileWidget`'s lacks a 403 branch. Hoist the
+status→reason mapping into `@/api/attachments`; let each site frame it.

--- a/tickets/entities/review-responses/RR-4QO887.md
+++ b/tickets/entities/review-responses/RR-4QO887.md
@@ -1,0 +1,68 @@
+---
+id: RR-4QO887
+type: review-response
+title: Failure path promises a retry that does not exist, and the kept-dirty state enables duplicate creates
+finding: |-
+    On upload failure (DynamicForm.vue:1114-1121) the code keeps `stagedFiles` populated and sets `dirty.value = true`, commented 'anything still staged failed and the user may retry it on the entity itself'. But `router.push` at line 1141 then navigates to the entity detail page, unmounting the form and garbage-collecting the staged File objects. There is nothing to retry — the user must re-pick from disk.
+
+    Worse, the still-dirty still-staged form is reachable if navigation is slow or the user presses back, and a second submit calls the FULL create path again: creates=2, uploads=2. So the 'keep it dirty for retry' mechanism does not enable retry, and does enable duplication.
+
+    Compounded by RR-HJLLUF (no re-entrancy guard).
+
+    The docs I wrote in GUIDE-data-entry.md promise the retry explicitly ('you land on it and the message names the files that did not attach, so you can retry them there'), so the documentation is currently wrong too.
+
+    Fix: pick one. (a) Accept recovery-on-entity: clear stagedFiles and leave dirty=false; the error toast already names the files. (b) Actually support retry: do not navigate on failure, and offer a Retry-upload action bound to uploadStagedFiles(type, entity.id) — never handleSubmit. Either way the doc must match.
+severity: critical
+resolution: Took option (a). On upload failure the code now clears stagedFiles and leaves dirty=false, because navigation (or the embedded host closing the modal) unmounts the form and discards the File objects regardless — the retained state bought nothing and enabled a duplicate create. The failure message now ends 'Re-attach on the entity.' so the instruction matches reality, and GUIDE-data-entry.md was rewritten to say the failed files must be picked again rather than promising a retry. Pinned by 'clears staged state rather than pretending a retry is possible' and 'names where to re-attach'.
+status: addressed
+---
+
+## Finding
+
+The failure branch keeps state for a recovery flow that the very next statement
+destroys.
+
+`DynamicForm.vue:1114-1121`:
+```js
+if (uploadFailures.length === 0) stagedFiles.value = {}
+dirty.value = uploadFailures.length > 0
+```
+
+then `DynamicForm.vue:1141`:
+```js
+router.push(`/entity/${formConfig.value.entity}/${entity.id}`)
+```
+
+Navigation unmounts the form. The retained `File` objects go with it. The
+comment's "the user may retry it on the entity itself" describes re-picking the
+files from disk on a different form — which the retained state does nothing to
+help.
+
+## The second half is worse
+
+Keeping the form dirty and staged leaves a live form whose submit still runs the
+**whole** create path. If navigation is slow, or the user goes back, a second
+submit produces a second entity with a second set of uploads. Combined with
+RR-HJLLUF (no `saving` guard) this is easy to trigger.
+
+So the mechanism inverts: it fails to deliver retry, and delivers duplication.
+
+## Documentation is also wrong
+
+`docs-project/entities/guides/GUIDE-data-entry.md` (regenerated into
+`docs/data-entry.md`) says: *"you land on it and the message names the files
+that did not attach, so you can retry them there"*. That promises option (b)
+below; the code implements neither.
+
+## Resolution — pick one
+
+**(a) Recovery happens on the entity.** Clear `stagedFiles`, leave `dirty.value
+= false`. The error message already names the failed files, and the user
+re-attaches on the entity's edit form (where the file widget works). Honest and
+small.
+
+**(b) Actually support retry.** Do not navigate on failure; put the form into a
+post-create state whose action is `uploadStagedFiles(type, entity.id)` —
+explicitly *not* `handleSubmit`, which would re-create.
+
+Whichever is chosen, update the guide so the docs describe the real behaviour.

--- a/tickets/entities/review-responses/RR-6ZAOMK.md
+++ b/tickets/entities/review-responses/RR-6ZAOMK.md
@@ -1,0 +1,71 @@
+---
+id: RR-6ZAOMK
+type: review-response
+title: Plan doesn't specify upload placement relative to dirty-reset and the 'Entity created successfully' toast
+finding: |-
+    The plan says to upload 'after `entitiesStore.create` (line 1014) and before the navigation block (line 1050)', but that span contains three ordering-sensitive statements it never assigns a position relative to:
+
+    1. `dirty.value = false` (line 1037)
+    2. `if (props.embedded) { emit('inline-created', entity); return }` (lines 1043-1046)
+    3. `uiStore.success('Entity created successfully')` (line 1048)
+
+    Each placement is a real decision:
+
+    - If uploads run AFTER `uiStore.success(...)`, the user sees a green 'Entity created successfully' toast immediately followed by an upload error toast — contradictory messaging about one action. If BEFORE, the success toast can be made accurate (or suppressed/reworded on partial failure).
+    - If uploads run after `dirty.value = false`, then a failed upload leaves the form non-dirty with staged files still pending — interacting badly with RR-EUX4BX's fix and letting the user leave without a prompt after a failure.
+    - The plan does flag the embedded early-return (good), but only as 'run before it', without resolving how it composes with the toast and dirty-reset above it.
+
+    Fix: specify the exact statement order in the plan so implementation is mechanical, as the checklist requires ('no design decisions left'). Suggested: uploads immediately after `create` returns and after `surfaceWarnings`, BEFORE dirty-reset/embedded-return/success-toast; on failure, replace the success toast with a partial-success message naming what failed.
+severity: significant
+resolution: 'The plan''s Technical Approach now pins the exact statement order: (1) create + surfaceWarnings, (2) upload staged files continue-on-error, (3) dirty.value = false only if every upload succeeded, (4) embedded early-return, (5) outcome-dependent toast. Uploads precede the success toast so a failure cannot produce a green ''Entity created successfully'' followed by a red error describing the same action. Added a test-plan row asserting a failed upload leaves the form dirty and emits no bare success toast.'
+status: addressed
+---
+
+## Finding
+
+The plan's insertion point is "after line 1014, before line 1050". That span is
+not inert — it contains three statements whose order relative to the uploads
+changes user-visible behaviour, and the plan assigns none of them:
+
+```js
+dirty.value = false                              // 1037
+
+if (props.embedded) {                            // 1043
+  emit('inline-created', entity)
+  return                                          // 1045
+}
+
+uiStore.success('Entity created successfully')   // 1048
+```
+
+**Toast contradiction.** Uploading after line 1048 means a failed attachment
+produces a green "Entity created successfully" immediately followed by a red
+upload error. Two toasts describing one user action, disagreeing.
+
+**Dirty-reset interaction.** Uploading after line 1037 means a failure leaves
+`dirty === false` while staged files remain unconsumed. Combined with
+RR-EUX4BX's fix, that is contradictory: staged files are supposed to make the
+form dirty, but the reset already fired.
+
+**Embedded composition.** The plan flags the early return but doesn't say how it
+composes with the two statements above it.
+
+## Why significant, not minor
+
+The checklist standard is that implementation should be "mechanical — no design
+decisions left". Three unresolved ordering decisions in the single function
+being modified is exactly the gap that gets resolved arbitrarily under
+implementation pressure, and the arbitrary choice here produces contradictory
+UX.
+
+## Suggested resolution
+
+Pin the order explicitly in the plan:
+
+1. `create` → `surfaceWarnings`
+2. **upload staged files** (collect failures)
+3. `dirty.value = false` only if all uploads succeeded (else keep dirty so the
+guard protects the un-uploaded files)
+4. embedded early-return
+5. success toast — worded per outcome: full success vs. "Entity created, but the
+attachment failed: <detail>"

--- a/tickets/entities/review-responses/RR-7T94EF.md
+++ b/tickets/entities/review-responses/RR-7T94EF.md
@@ -1,0 +1,37 @@
+---
+id: RR-7T94EF
+type: review-response
+title: Embedded path's keeps-form-dirty guarantee is void; host unmounts the form immediately
+finding: |-
+    On upload failure in embedded mode (DynamicForm.vue:1124-1129) the code fires the error toast then emits 'inline-created'. But the consumers unmount the form as their first action: RelationPicker.vue:304 handleEntityCreated calls closeCreateModal() immediately, as does RelationCards.vue:755. So `dirty.value = true` protects nothing — there is no navigation guard left to consult, and the staged Files are discarded.
+
+    Not silent (the toast fires), so significant rather than critical. But the comment at DynamicForm.vue:1116-1121 and the commit message both assert a property that is false on this path.
+
+    Fix: either document the embedded exception explicitly, or do not emit 'inline-created' on failure so the host keeps the modal open and the user can act.
+severity: significant
+resolution: 'Resolved by the RR-4QO887 fix rather than separately: the failure path no longer sets dirty=true at all, so there is no longer a guarantee to be void on the embedded path. Staged files are cleared and the error toast fires before the inline-created emit, which is the part that actually informs the user. The misleading comment claiming the dirty flag protects this path was removed with the code it described.'
+status: addressed
+---
+
+## Finding
+
+The failure branch sets `dirty.value = true` "so the navigation guard still
+warns", then the embedded path emits `inline-created`. Its consumers close the
+modal as their first statement:
+
+- `RelationPicker.vue:304` — `handleEntityCreated` → `closeCreateModal()`
+- `RelationCards.vue:755` — same shape
+
+Closing unmounts `InlineCreateFormModal` and the `DynamicForm` inside it, so
+there is no guard left to consult and the staged `File` objects are discarded.
+
+## Severity
+
+Not silent — the error toast fires before the emit, so the user is told. But the
+comment at `DynamicForm.vue:1116-1121` and the commit message both claim the
+dirty flag protects this path, and on the embedded path it does not.
+
+## Fix
+
+Either state the embedded exception where the claim is made, or withhold the
+`inline-created` emit on failure so the host keeps the modal open.

--- a/tickets/entities/review-responses/RR-C1MI2N.md
+++ b/tickets/entities/review-responses/RR-C1MI2N.md
@@ -1,0 +1,63 @@
+---
+id: RR-C1MI2N
+type: review-response
+title: 'Deep ref proxies File under happy-dom: tests exercise proxies, production exercises raw Files'
+finding: |-
+    `stagedFiles` is `ref<Record<string, File[]>>` — a DEEP ref. Vue skips proxying by `toRawType`; a spec File reports 'File' and is left alone. But vitest runs happy-dom, whose File reports '[object Object]', so Vue proxies it.
+
+    Verified empirically in this repo (throwaway test): under happy-dom `Object.prototype.toString.call(file)` === '[object Object]', `isProxy(deep.value.p[0])` === true, and `deep.value.p[0] === f` === FALSE. Identity is not preserved. With shallowRef both are correct (not proxied, identity preserved).
+
+    So the unit tests exercise File PROXIES while production exercises raw Files, silently changing the behaviour of three things this feature depends on: `unstageFile`'s `f !== file` identity filter, `stagedPreviews` (a Map keyed BY File), and the brand checks in URL.createObjectURL / FormData.append.
+
+    It happens to work in both today — luck, not design. Nothing needs deep reactivity on a File: `updateStagedFiles` already replaces the whole object on every change, so shallowRef is sufficient AND makes test and production agree. Same for `stagedPreviews` (FileWidget.vue:48), whose Map never needs reactive tracking — the watch(staged, ...) drives revocation.
+severity: significant
+resolution: 'stagedFiles is now shallowRef, and stagedPreviews likewise. Verified the underlying claim independently with a throwaway test: under happy-dom a File reports ''[object Object]'', a deep ref proxies it, and identity is NOT preserved (deep.value.p[0] === f is false); shallowRef preserves both. With the change, test and production now agree on File identity, so the index-based removal in RR-C6CXU1 and the Map keying are exercising the shipped semantics rather than a proxy artefact.'
+status: addressed
+---
+
+## Finding
+
+The unit tests cannot observe production's actual object semantics.
+
+`stagedFiles` is a **deep** `ref`. Vue decides whether to proxy via
+`toRawType(target)`: a spec `File` reports `"File"` → `INVALID` → untouched. But
+`vitest.config.ts` uses `environment: 'happy-dom'`, whose `File` reports
+`[object Object]` → proxied.
+
+## Verified in this repo
+
+A throwaway test (`src/proxycheck.test.ts`, since removed):
+
+```
+tag:               '[object Object]'
+proxied:           true
+identityPreserved: false      ← deep.value.p[0] === f is FALSE
+```
+
+With `shallowRef`: not proxied, identity preserved.
+
+## Why it matters
+
+Three things this feature relies on behave differently on a proxy than on a raw
+`File`:
+
+- `unstageFile`'s `f !== file` identity filter (`FileWidget.vue:92-98`)
+- `stagedPreviews`, a `Map<File, string>` whose **keys** are proxies in test and
+raw objects in production (`FileWidget.vue:48`)
+- `URL.createObjectURL(file)` and `FormData.append('file', file)`, which brand-check
+
+It works in both today, but by luck. The tests are structurally unable to catch
+a regression in exactly the area the identity bugs live (see RR-C6CXU1).
+
+## Fix
+
+Nothing here needs deep reactivity over a `File`. `updateStagedFiles` already
+replaces the whole object on every change, so `shallowRef` is sufficient and
+makes test and production agree:
+
+```ts
+const stagedFiles = shallowRef<Record<string, File[]>>({})
+```
+
+Same for `stagedPreviews` — the `watch(staged, …)` drives revocation, not Map
+reactivity.

--- a/tickets/entities/review-responses/RR-C6CXU1.md
+++ b/tickets/entities/review-responses/RR-C6CXU1.md
@@ -1,0 +1,51 @@
+---
+id: RR-C6CXU1
+type: review-response
+title: Duplicate Vue :key on staged files; unstage-by-identity removes both copies
+finding: |-
+    FileWidget.vue:207 keys staged rows on `${file.name}-${file.size}-${file.lastModified}`. Two files sharing all three collide — not exotic, since `input.value = ''` (line 161) exists specifically so the SAME file can be re-picked, and dropping two copies of a template document does it too. Two <li> under one key leaves Vue's patching undefined: removing the first can remove the wrong row or leave a stale preview.
+
+    Separately, `unstageFile` (line 92-98) filters by object identity (`f !== file`). For distinct File objects that is right, but if the same File REFERENCE is staged twice (possible via drag-drop of one DataTransfer), filter removes BOTH.
+
+    Fix: stop deriving identity from content. Mint an id at stage time and carry `{ id, file }`, which also fixes the Map<File,string> preview keying and removes the File-proxy sensitivity in RR-XXXX (shallowRef finding).
+severity: significant
+resolution: Stopped deriving identity from file content. The staged list is keyed by index rather than name+size+mtime, and removal is `unstageFileAt(index)` filtering on position rather than `f !== file` filtering on object identity — so two copies of the same file (or the same File reference staged twice) render as distinct rows and removing one removes exactly one. Chose index over a minted id because the list is small and only ever appended to or filtered, so a synthetic id would add a wrapper type for no additional guarantee.
+status: addressed
+---
+
+## Finding
+
+Two related identity bugs in the staged list.
+
+**Key collision.** `FileWidget.vue:207`:
+```
+:key="`${file.name}-${file.size}-${file.lastModified}`"
+```
+
+Two files with the same name, size and mtime produce one key for two rows. The
+widget deliberately supports re-picking the same file (`input.value = ''`, line
+161), and dropping two copies of a template document does it too. Vue's patch
+behaviour under duplicate keys is undefined — removal can hit the wrong row or
+leave a stale preview.
+
+**Over-removal.** `unstageFile` (`FileWidget.vue:92-98`) filters by object
+identity:
+```js
+staged.value.filter((f) => f !== file)
+```
+
+Correct for distinct `File` objects; but if the *same reference* is staged twice
+(one `DataTransfer` dropped twice), it removes both.
+
+## Fix
+
+Give a staged file an identity at pick time rather than deriving one:
+
+```ts
+type StagedFile = { id: string; file: File }
+```
+
+`crypto.randomUUID()` at stage time. That fixes the key, makes `unstageFile`
+exact, and lets the preview map be `Map<string, string>` instead of `Map<File,
+string>` — which also removes the `File`-as-reactive-key sensitivity raised
+separately.

--- a/tickets/entities/review-responses/RR-EUX4BX.md
+++ b/tickets/entities/review-responses/RR-EUX4BX.md
@@ -1,0 +1,65 @@
+---
+id: RR-EUX4BX
+type: review-response
+title: 'Staged files are invisible to dirty tracking: navigate-away silently discards them with no warning'
+finding: |-
+    The plan deliberately keeps staged files OUT of `formData` (correct, to avoid POSTing a File as the property value). But it does not account for the consequence: `checkDirty()` (`DynamicForm.vue:1380-1388`) computes dirtiness ONLY from `JSON.stringify({formData, relations, content})` plus `pendingCardChanges`. A staged file changes none of these.
+
+    So a user who fills nothing but attaches a file has `dirty === false`. Both unsaved-changes guards then let them leave silently: the in-app router guard (`DynamicForm.vue:1596` `if (!dirty.value) return true`) and the native beforeunload handler (`handleBeforeUnload`, ~line 1397, `if (dirty.value)`). The staged file is discarded with no prompt.
+
+    This is silent data loss of user-selected input — precisely the failure class the ticket says it must not ship ('Silent failure is the specific thing this ticket must not ship'). It is also the more likely everyday scenario than the post-create upload failure the plan does carefully handle.
+
+    Fix: include staged-file state in the dirty computation. Cheapest correct form is to fold a stable projection (e.g. per-property array of `name:size`) into checkDirty's serialized payload, or set a separate `hasStagedFiles` flag ORed into `dirty.value` alongside `hasCardChanges` — which is the existing precedent for exactly this situation (a non-formData source of dirtiness). Add an edge case + test.
+severity: significant
+resolution: 'Added section 3b to the plan''s Technical Approach. Staged files are folded into checkDirty() via a `hasStagedFiles` flag ORed alongside the existing `hasCardChanges` — the established precedent for a dirtiness source outside formData. Added a test-plan row: stage a file, assert isDirty() is true and the navigation guard prompts. Also interacts with RR-6ZAOMK''s pinned ordering, where dirty.value = false now fires only when every upload succeeded.'
+status: addressed
+---
+
+## Finding
+
+The plan's central design decision — keep staged files out of `formData` — is
+right, but it has an unexamined consequence.
+
+`checkDirty()` (`DynamicForm.vue:1380-1388`):
+
+```js
+const currentData = JSON.stringify({
+  formData: formData.value,
+  relations: relations.value,
+  content: content.value,
+})
+const hasCardChanges = pendingCardChanges.value.size > 0
+dirty.value = currentData !== originalData.value || hasCardChanges
+```
+
+Staged files live in none of those inputs, so staging a file leaves `dirty ===
+false`.
+
+Both exit guards consult exactly that flag:
+
+- in-app router guard — `DynamicForm.vue:1596`: `if (!dirty.value) return true`
+- native `beforeunload` — `handleBeforeUnload` (~1397): `if (dirty.value)`
+
+A user who opens a create form, attaches a file, and navigates away loses it
+with **no prompt at all**.
+
+## Severity rationale
+
+This is silent loss of user-provided input. The ticket explicitly states "Silent
+failure is the specific thing this ticket must not ship" — and the plan spends
+real effort on the *post-create upload failure* path while missing this one,
+which is considerably more likely in ordinary use (attaching a file and then
+getting distracted is routine; a 413 is not).
+
+## Resolution
+
+`pendingCardChanges` is the existing precedent for a dirtiness source outside
+`formData` — it's ORed in as `hasCardChanges`. Do the same:
+
+```js
+const hasStagedFiles = Object.values(stagedFiles.value).some((a) => a.length > 0)
+dirty.value = currentData !== originalData.value || hasCardChanges || hasStagedFiles
+```
+
+Add to Edge Cases, and add a test: stage a file, assert `isDirty()` is true and
+the navigation guard prompts.

--- a/tickets/entities/review-responses/RR-HJLLUF.md
+++ b/tickets/entities/review-responses/RR-HJLLUF.md
@@ -1,0 +1,44 @@
+---
+id: RR-HJLLUF
+type: review-response
+title: Double-submit via Cmd+Enter creates two entities and two sets of uploads
+finding: |-
+    `handleSubmit` (DynamicForm.vue:986) has no re-entrancy guard. `PendingButton` guards its own click, but `handleKeydown` (DynamicForm.vue:1511) calls `handleSubmit()` DIRECTLY, bypassing it. Two Cmd+Enter presses during an in-flight submit produce create=2 and uploadAttachment=2 — two entities, both with the file attached.
+
+    The hole is pre-existing, but this commit materially widens it. Before, `saving` spanned one POST. Now it spans that POST plus N sequential multipart uploads, so a large file on a slow link holds the window open for tens of seconds. It is also newly worse in kind: previously a duplicate entity, now a duplicate entity AND duplicate blobs.
+
+    Fix: `if (saving.value) return` at the top of handleSubmit, after the formConfig guard. On the operation, not in handleKeydown — otherwise the next caller reintroduces it.
+severity: critical
+resolution: 'Added `if (saving.value) return` at the top of handleSubmit (on the operation, not in handleKeydown). Also added a `createdEntityId` guard so a COMPLETED create cannot be re-submitted from the same mounted form — `saving` is reset in `finally`, so it only covers an in-flight submit, and the failure path stays on a live form. Pinned by two tests: ''ignores a second submit while one is in flight'' (create=1, uploads=1) and ''a second submit after a failure does not create a second entity''.'
+status: addressed
+---
+
+## Finding
+
+Verified: `handleSubmit` (`DynamicForm.vue:986`) guards only `!formConfig.value`
+and `isEdit`. There is no `saving` check.
+
+`handleKeydown` (`DynamicForm.vue:1511`) calls `handleSubmit()` directly, so the
+`PendingButton` in-flight guard is bypassed entirely on the keyboard path.
+
+## Why this is critical now
+
+The race is pre-existing, but its window was one POST. This commit appends N
+sequential multipart uploads inside the same window — for a large file that is
+tens of seconds rather than milliseconds. A theoretical race becomes one that is
+straightforward to hit.
+
+The consequence also changed in kind: previously a duplicate entity; now a
+duplicate entity plus duplicate attachment blobs.
+
+## Fix
+
+```js
+async function handleSubmit() {
+  if (!formConfig.value) return
+  if (saving.value) return   // ← re-entrancy guard
+  ...
+```
+
+Guard the operation, not the caller — fixing it inside `handleKeydown` leaves
+the next caller free to reintroduce it.

--- a/tickets/entities/review-responses/RR-OI6P51.md
+++ b/tickets/entities/review-responses/RR-OI6P51.md
@@ -1,0 +1,59 @@
+---
+id: RR-OI6P51
+type: review-response
+title: Staged files bypass wizard-hidden pruning, persisting a revealed-then-hidden branch
+finding: |-
+    `uploadStagedFiles` (DynamicForm.vue:499) iterates `stagedFiles.value` raw. Properties go through `pruneWizardHidden(visibleWritablePropertiesForCommit())` at line 1081; staged files go through nothing.
+
+    Concrete failure: a wizard whose step 2 has `visible_when: form.needs_evidence == true` and contains a `file` property. The user ticks the box, reveals step 2, stages evidence.pdf, goes back, unticks. `pruneWizardHidden` correctly drops the PROPERTY from the create payload — and then uploadStagedFiles uploads the file anyway, and the server stamps that same property via stampPropertyNames. The revealed-then-hidden branch persists, which is exactly what TKT-CHLAJ exists to prevent, and the existing e2e 'a revealed-then-hidden field is NOT persisted on create' does not cover file properties.
+
+    Fix: filter the upload loop against the same active/managed sets (wizard.activeProperties / wizard.managedProperties, as used at DynamicForm.vue:900):
+
+      if (managed.has(property) && !active.has(property)) continue
+
+    Also worth staging-side pruning so the bytes are never uploaded at all.
+severity: significant
+resolution: 'uploadStagedFiles now applies the same wizard pruning the property payload gets: it reads wizard.activeProperties / wizard.managedProperties and skips any property that is managed-but-inactive, so a file staged on a step the user then hides is never uploaded and the server never stamps the property. Pinned by ''does not upload a file staged under a then-hidden wizard branch'', which drives the real wizard step navigation (reveal → Next step → stage → Prev step → hide → submit) and asserts uploadAttachment is never called.'
+status: addressed
+---
+
+## Finding
+
+The two pruning systems the plan reconciled for *properties* do not cover
+*staged files*.
+
+- Properties: `payload.properties = pruneWizardHidden(visibleWritablePropertiesForCommit())`
+(`DynamicForm.vue:1081`), with the active/managed logic at line 900.
+- Staged files: `for (const [property, files] of Object.entries(stagedFiles.value))`
+(`DynamicForm.vue:499`) — unfiltered.
+
+## Failure scenario
+
+A wizard step gated on `visible_when: form.needs_evidence == true`, containing a
+`file` property:
+
+1. User ticks `needs_evidence` → step 2 reveals
+2. Stages `evidence.pdf`
+3. Goes back, unticks the box → step 2 hides
+
+`pruneWizardHidden` drops `evidence` from the create payload — correct. Then
+`uploadStagedFiles` uploads the file regardless, and the server stamps
+`evidence` itself in `stampPropertyNames`. The hidden branch persists.
+
+This is precisely what TKT-CHLAJ prevents for ordinary properties. The existing
+e2e case "a revealed-then-hidden field is NOT persisted on create" passes
+because it uses no file property.
+
+## Fix
+
+```js
+const active = wizard.activeProperties.value
+const managed = wizard.managedProperties.value
+for (const [property, files] of Object.entries(stagedFiles.value)) {
+  if (managed.has(property) && !active.has(property)) continue
+  ...
+}
+```
+
+Pruning at stage time as well would avoid uploading the bytes at all, but the
+commit-time filter is the correctness boundary.

--- a/tickets/entities/review-responses/RR-QQQ2JR.md
+++ b/tickets/entities/review-responses/RR-QQQ2JR.md
@@ -1,0 +1,40 @@
+---
+id: RR-QQQ2JR
+type: review-response
+title: 'Missing tests for the dangerous paths: double-submit, unmount mid-upload, wizard-hidden, duplicate key'
+finding: |-
+    The suites cover the happy path and failure messaging well, but not the paths that actually break:
+
+    - double-submit (RR-HJLLUF) — the reproduced defect
+    - navigate-away mid-upload: router.push fires AFTER unmount. Every other async path in DynamicForm guards this (stagedUnmounted at line 674, the RR-2PZB guard); uploadStagedFiles has no equivalent. Benign today (push on a stale router is a no-op) but it is the only async block that breaks the file's established discipline.
+    - wizard revealed-then-hidden file property (RR-OI6P51)
+    - duplicate key / same file staged twice (RR-C6CXU1)
+
+    e2e has no failure-path test at all. The single highest-value case — create succeeds, upload 413s, user sees the error and lands on the entity — is exactly the accepted tradeoff the design documents, and it is untested end-to-end even though the server has a real configurable size limit that makes it easy to drive.
+severity: significant
+resolution: 'All four gaps now covered. Unit: ''ignores a second submit while one is in flight'' and ''a second submit after a failure does not create a second entity'' (double-submit); ''does not navigate when the component unmounted mid-upload'' (plus a `stagedUnmounted` guard before router.push, matching the RR-2PZB discipline every other async path here follows); ''does not upload a file staged under a then-hidden wizard branch'' (wizard); index-keyed removal covered by the widget suite. E2E: ''an oversize file fails loudly after the entity is created'' drives a REAL 413 (fixture sets max_attachment_bytes: 1024) and asserts the entity exists, the user lands on it, the message names the file and says where to re-attach, and no property was stamped.'
+status: addressed
+---
+
+## Finding
+
+The tests pin the happy path and the failure *message*, but not the paths where
+this feature actually breaks.
+
+Missing:
+
+1. **Double-submit** (RR-HJLLUF) — the reproduced defect.
+2. **Unmount mid-upload.** `router.push` fires after unmount. Every other async
+path in `DynamicForm` guards this — `stagedUnmounted` (line 674), the RR-2PZB
+guard — and `uploadStagedFiles` has no equivalent. Benign today because `push`
+on a stale router is a no-op, but it is the only async block in the file that
+ignores the established discipline, which is how it stops being benign later.
+3. **Wizard revealed-then-hidden file property** (RR-OI6P51).
+4. **Duplicate key / same file staged twice** (RR-C6CXU1).
+
+## e2e gap
+
+`attachments-create.spec.ts` has no failure-path test. The highest-value case —
+create succeeds, upload 413s, user is told and lands on the entity — is the
+accepted tradeoff the whole design rests on, and it is unverified end to end.
+`max_attachment_bytes` is configurable, so a fixture can drive a real 413.

--- a/tickets/entities/review-responses/RR-QTCKCW.md
+++ b/tickets/entities/review-responses/RR-QTCKCW.md
@@ -1,0 +1,53 @@
+---
+id: RR-QTCKCW
+type: review-response
+title: Plan's ++new++ sentinel premise is factually wrong; AC6 tests a non-existent risk
+finding: |-
+    The plan (and TKT-7K3BJF's acceptance criteria) treat the `++new++` STAGED_ID sentinel as a live value that must be prevented from reaching the server, with AC6 'the ++new++ sentinel never appears in any request URL or body' and a Security Considerations paragraph about it.
+
+    This is false. `grep -rn 'STAGED_ID|isStaged' frontend/src/` excluding tests returns ONLY the definition site (`stagedEntity.ts:12,14-15`). Neither `STAGED_ID` nor `isStaged` is referenced by any production component. `DynamicForm.vue:1742` passes `:entity-id="entityId"` which is `props.entityId` — genuinely `undefined` in create mode, never the sentinel. The FileWidget's `!!entityId` check therefore already discriminates create from edit correctly, via undefined.
+
+    Consequences: (a) AC6 is a test of a risk that does not exist, giving false assurance; (b) the plan's `canStage = ... && !entityId` is correct but for a different reason than stated; (c) worse, a reader could 'fix' this by INTRODUCING the sentinel into entityId to make the guard explicit, which would create the very leak the criterion guards against.
+
+    Fix: drop AC6 and the sentinel paragraph, or restate accurately as 'create mode passes entityId=undefined; uploads only ever use the server-returned entity.id'. If STAGED_ID is genuinely dead code, that is a separate cleanup observation.
+severity: significant
+resolution: Corrected in both the ticket and PLAN-LCUIQO. The ticket's problem statement now says create mode passes `entityId === undefined` (DynamicForm.vue:1742) rather than the sentinel, with a parenthetical noting STAGED_ID has no production consumer. AC6 was rewritten from 'the ++new++ sentinel never appears in any request' to 'uploads use only the server-returned entity.id', which is the invariant that actually has value. The plan's Security Considerations paragraph now carries an explicit warning NOT to 'make the guard explicit' by assigning the sentinel into entityId, since that would manufacture the leak the old wording imagined.
+status: addressed
+---
+
+## Finding
+
+The plan asserts a security property about the `++new++` sentinel that is not
+grounded in the code.
+
+**Verified:**
+
+```
+grep -rn 'STAGED_ID|isStaged' frontend/src/ | grep -v '\.test\.'
+frontend/src/components/forms/stagedEntity.ts:7   (comment)
+frontend/src/components/forms/stagedEntity.ts:10  (comment)
+frontend/src/components/forms/stagedEntity.ts:12  export const STAGED_ID = '++new++'
+frontend/src/components/forms/stagedEntity.ts:14  export function isStaged(...)
+frontend/src/components/forms/stagedEntity.ts:15
+```
+
+Definition site only. No production consumer.
+
+`DynamicForm.vue:1742` binds `:entity-id="entityId"` → `props.entityId`, which
+is `undefined` in create mode. So `FileWidget`'s existing `!!entityId` guard
+distinguishes create from edit through `undefined`, not through a sentinel.
+
+## Why this matters beyond pedantry
+
+The dangerous direction is the "fix". A developer reading AC6 ("the sentinel
+must never reach the server") could reasonably conclude the sentinel *is* in
+`entityId` and make it explicit — introducing exactly the leak the criterion
+purports to prevent. A security criterion that describes a non-existent
+mechanism is worse than no criterion.
+
+## Resolution
+
+Restate as the true invariant: create mode passes `entityId === undefined`, and
+post-create uploads use only the server-returned `entity.id`. Keep a test that
+uploads are called with the returned id — that has real value — but drop the
+sentinel framing.

--- a/tickets/entities/review-responses/RR-Z7C3CY.md
+++ b/tickets/entities/review-responses/RR-Z7C3CY.md
@@ -1,0 +1,50 @@
+---
+id: RR-Z7C3CY
+type: review-response
+title: 'Multi-file staging: partial batch failure is unspecified (which files uploaded, what the user re-picks)'
+finding: |-
+    The plan handles `max > 1` for staging (stage up to max, all upload sequentially) and handles 'an upload fails' as a single condition. It does not specify partial-batch outcomes.
+
+    With 3 staged files where #2 is rejected by the MIME scanner: does #3 still attempt? Does the error name WHICH file failed? After landing on the created entity, the user sees #1 attached and must work out that #2 and #3 are missing — and #3 was never actually attempted, though nothing tells them that.
+
+    The plan's error text ('shows the server's problem+json detail inline') is per-request, so with N files the user could get N error toasts, or one that names no filename. Neither is specified.
+
+    This is minor rather than significant because `max > 1` properties are the less common case and no data is destroyed — the source files still exist on the user's disk. But 'which of my files actually made it' is a question the current plan cannot answer.
+
+    Fix: specify continue-on-error (attempt every file, collect failures) and an error message that names the failed filenames, e.g. 'Entity created. 2 of 3 files failed: b.pdf (too large), c.exe (type not allowed).' Add a test for the mixed-outcome batch.
+severity: minor
+resolution: 'Added an explicit Edge Case: continue-on-error, so every staged file is attempted; failures collected as {filename, error}; one message names them (''Entity created. 2 of 3 files failed: b.pdf (too large), c.exe (type not allowed).''). The rationale is recorded — aborting the loop would leave later files unattempted with nothing telling the user, and a bare per-request problem+json detail names no filename. Added a test-plan row for the mixed-outcome batch.'
+status: addressed
+---
+
+## Finding
+
+The plan treats upload failure as a single boolean. With `max > 1` it is not.
+
+Given 3 staged files where #2 is rejected:
+
+- **Continue or abort?** Unspecified. If the loop aborts, #3 is never attempted
+and nothing tells the user that.
+- **Which file failed?** The plan surfaces "the server's problem+json detail",
+which describes the *rejection reason* but carries no filename — the endpoint is
+per-property, and the client made N separate calls.
+- **How many toasts?** N failures could mean N error toasts.
+
+After navigation the user sees file #1 attached and must reverse-engineer what
+happened to #2 and #3.
+
+## Severity
+
+Minor: `max > 1` is the less common configuration, and nothing is destroyed —
+the originals are still on the user's disk. But "which of my files made it" is a
+question the plan as written cannot answer, and the answer is cheap to specify
+now versus discovering it in review.
+
+## Suggested resolution
+
+- Continue on error; attempt every staged file.
+- Collect `{filename, error}` pairs.
+- One message naming the failures:
+`Entity created. 2 of 3 files failed: b.pdf (too large), c.exe (type not
+allowed).`
+- Test the mixed-outcome batch (some succeed, some fail).

--- a/tickets/entities/tickets/TKT-7K3BJF.md
+++ b/tickets/entities/tickets/TKT-7K3BJF.md
@@ -5,7 +5,7 @@ title: 'Attachments on entity create: stage files in the create form, upload aft
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: done
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-7K3BJF.md
+++ b/tickets/entities/tickets/TKT-7K3BJF.md
@@ -1,0 +1,118 @@
+---
+id: TKT-7K3BJF
+type: ticket
+title: 'Attachments on entity create: stage files in the create form, upload after the entity exists'
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+## Description
+
+Let users attach files **while creating an entity** in the data-entry web app,
+instead of the current save → reopen in edit mode → upload dance.
+
+Today the create form renders a `file` property as a dead field.
+`FileWidget.vue` gates all mutation on `canEdit = mode === 'edit' && !disabled
+&& !!entityType && !!entityId`, and in create mode `entityId` is `undefined`
+(`DynamicForm.vue:1742` binds `props.entityId`, which the create route does not
+set). The widget therefore shows "Attachment editing unavailable."
+
+(Note: `stagedEntity.ts` exports a `++new++` STAGED_ID sentinel, but it has no
+production consumer — `entityId` really is `undefined` here, not the sentinel.
+See RR-QTCKCW.)
+
+### Why the obvious approaches don't work
+
+Two hard constraints, both verified in the code, force the design:
+
+1. **No attachment can be written before the entity row exists.** `AttachFile`
+returns `store.ErrNotFound` unless the entity is present — enforced
+independently in all three backends (`fsstore/attachment.go:47`,
+`pgstore/attachment.go:43` as an in-transaction `SELECT` — there is no FK,
+`memstore/memstore.go:762`) and pinned by the cross-backend conformance suite at
+`storetest/attachment.go:54`.
+2. **There is no ID reservation primitive.** `resolveCandidateID`
+(`entitymanager/core.go:43`) has exactly three branches: client-supplied
+(rejected unless the type `IsManualID()`, `manager.go:494`), a `…DRYRUN`
+placeholder that is never persisted, and server-generated. Sequential IDs
+(`entity/id.go:236`) are predictable, but guessing buys nothing — the attach
+fails the existence check anyway. Short-ID types are crypto-random.
+
+So the write order can only be: create entity → attach.
+
+### Approach (Option A — client-orchestrated two-phase)
+
+Chosen over the alternatives because it adds **no new HTTP ingress, no new blob
+namespace, and no new ACL subject** — it reuses the already security-reviewed
+upload path (MIME allowlist, sandboxed scan/transform, size caps,
+entity-inherited ACL) verbatim.
+
+- **Frontend only.** `FileWidget` gains a *staged* mode: when `entityId` is
+absent/staged it holds the selected `File` objects in component state and
+renders them (name, size, image preview, remove) without uploading.
+- `DynamicForm` collects staged files per property; on successful create it
+calls the existing `uploadAttachment(type, createdId, property, file)` per
+staged file against the **returned** id, then refreshes the entity so the
+stamped property value and `_attachments` are correct.
+- Respect the property's `max`: stage at most `max` files, matching edit-mode
+capacity semantics.
+
+### Partial-failure handling (the known cost of Option A)
+
+Create can succeed and a subsequent upload fail (413 / scan rejection /
+network). This must be **surfaced, never silent**: on any upload failure,
+navigate to the created entity in edit mode with the file field in error state
+and the server's problem+json detail shown inline. The entity the user asked for
+exists; only the file needs re-picking.
+
+Note this window is *not novel* — `attachment.Service.WriteAttachment` already
+writes bytes (step 5) before stamping the property via `UpdateEntity` (step 8),
+and its orphan branch (`internal/attachment/attachment.go:203-208`) points at
+`rela gc --temp-files`. Option A reaches the same window one step earlier.
+
+### Out of scope
+
+- **`required: true` file properties → TKT-87VSDE.** Option A cannot satisfy one
+server-side: the create POST necessarily carries the property empty, so
+validation either fails the create or (per DEC-HWZHA) passes with a warning, and
+the file only lands on the follow-up request. That is a validation-semantics
+question about when a required file is *due*, not a create-form question, and it
+is strictly additive to this work — the staged widget built here is the host
+site for whatever gate that ticket lands. Deliberately split so the common
+(non-required) case ships.
+- **Atomic create-with-attachments.** Extending `handleV1CreateEntity`
+(`write_handler.go:122`, already holds `writeMu` for the whole create) with a
+multipart body variant would close the window, but costs a body-shape branch,
+multipart size accounting, and a compensating delete on scan rejection.
+Deferred; revisit if the partial-failure UX proves insufficient.
+- **A staging/unowned-blob namespace.** Would let scan/reject run before the
+entity exists, but needs its own ACL subject, GC for abandoned uploads, and a
+quota — a real new attack surface for a UX convenience.
+- **API/MCP create-time attach.** This ticket is the SPA form only.
+- **Rename leaves file property values stale.** `RenameEntity` moves attachment
+*bytes* atomically (`pgstore/entity.go:487`, `fsstore/attachment.go:239`) but
+nothing re-stamps the property strings, which embed the literal old id.
+Pre-existing and orthogonal — worth its own ticket, not folded in here.
+
+### Acceptance
+
+- Creating an entity with a `file` property lets the user pick/drag a file in
+the create form; after save the entity exists with the file attached and the
+property stamped, in one user gesture.
+- A staged file can be removed before save and is then not uploaded.
+- At `max > 1`, up to `max` files stage and all upload; the add control
+disappears at capacity (parity with edit mode).
+- An upload that fails after create (oversize / rejected MIME) leaves the
+created entity reachable, lands the user on it, and shows the server's error
+inline — no silent loss, no orphaned bytes beyond the pre-existing window.
+- A user without `update` on the created entity gets the same 403 the edit path
+gives; the staged UI does not pretend the upload succeeded.
+- Attachment uploads use only the server-returned `entity.id` — never a
+client-side placeholder. (Pinned by asserting the upload call's arguments.)
+- A `required` file property is **not** made worse: creating such an entity
+behaves exactly as it does today (TKT-87VSDE owns improving it).
+
+Parent: FEAT-870YCY. Sibling of TKT-RXFD5B (web write path), TKT-WLLRO7 (`max`).
+Follow-up: TKT-87VSDE (required file properties).

--- a/tickets/entities/tickets/TKT-87VSDE.md
+++ b/tickets/entities/tickets/TKT-87VSDE.md
@@ -1,0 +1,91 @@
+---
+id: TKT-87VSDE
+type: ticket
+title: 'Required file properties: decide when a required attachment is due, and enforce it'
+kind: enhancement
+priority: low
+effort: m
+status: backlog
+---
+
+## Description
+
+A `file` property declared `required: true` has no coherent meaning on the
+create path today, and the create-time attachment work (TKT-7K3BJF) makes the
+gap reachable rather than theoretical.
+
+**This is latent, not a live bug.** No in-tree schema currently declares a
+required `file` property, which is why TKT-7K3BJF was allowed to ship without
+solving it.
+
+## The problem
+
+`required` is validated generically in `Metamodel.ValidateProperties`
+(`internal/metamodel/validation.go:147`) — a property is present-and-non-empty,
+or it is an error. There is no file-type special case.
+
+But an attachment cannot exist at create time. The bytes can only be written
+after the entity row exists (`AttachFile` returns `store.ErrNotFound` otherwise
+— `fsstore/attachment.go:47`, `pgstore/attachment.go:43`,
+`memstore/memstore.go:762`, pinned by `storetest/attachment.go:54`), and the
+property is only stamped afterwards by `attachment.Service.WriteAttachment`
+(`internal/attachment/attachment.go:200`).
+
+So the create POST *necessarily* carries the property empty. `required: true`
+therefore means the create either:
+
+- hard-fails, making the property impossible to ever satisfy through the web
+form; or
+- passes with a soft warning (DEC-HWZHA), making `required` decorative on this
+one property type.
+
+Neither is a decision anyone made deliberately — it is a consequence of the
+write ordering.
+
+## The actual question
+
+**When is a required attachment due?** The candidate answers are genuinely
+different products, and this ticket should pick one before any code:
+
+1. **Due at create.** Enforced client-side: the create form blocks Save until a
+file is staged. Honest to the user, but the server still cannot enforce it, so
+it is a UI convention an API/MCP client bypasses. Cheapest.
+2. **Due eventually.** `required` on a file property means "this entity is
+incomplete until a file lands" — a soft warning that persists on the entity and
+surfaces in validation/analyze output until satisfied. Consistent with
+DEC-HWZHA's existing "temporarily invalid state" stance, and enforceable
+server-side because it is checked on read/analyze rather than on write.
+3. **Refuse the declaration.** Reject `required: true` on a `file` property as a
+schema **load error**, on the grounds that it cannot be honoured. Smallest
+surface, and arguably the most honest — but it forecloses a real use case (an
+evidence field that genuinely must be filled).
+
+Option 2 looks closest to how rela already treats partially-valid entities, but
+this needs a decision, not an assumption — likely a `decision` entity.
+
+## Scope
+
+- Pick and document the semantics (probably a linked `decision`).
+- Implement whichever gate that implies. For (1) that is a client-side gate in
+the staged `FileWidget` TKT-7K3BJF builds — that widget is the host site. For
+(2) it is validation/analyze surfacing. For (3) it is a loader check plus a
+clear error.
+- Cover the API/MCP path too, or explicitly state that it is out of scope and
+why (a UI-only gate is bypassable by design).
+
+## Out of scope
+
+- Create-time attachment UX generally — TKT-7K3BJF.
+- Atomic create-with-attachments (multipart create), which would make option (1)
+server-enforceable but is deferred there for independent reasons.
+
+## Acceptance
+
+- The chosen semantics are written down with their rationale, and the two
+rejected options recorded so this is not re-litigated.
+- A schema declaring `required: true` on a `file` property behaves per that
+decision, with a test pinning it.
+- The behaviour is the same whether the entity is created via the web form, the
+API, or MCP — or the difference is deliberate and documented.
+
+Blocked by / follows: TKT-7K3BJF. Parent: FEAT-870YCY.

--- a/tickets/relations/TKT-7K3BJF--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-7K3BJF--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-7K3BJF--has-docs--DOCS-BPLLWQ.md
+++ b/tickets/relations/TKT-7K3BJF--has-docs--DOCS-BPLLWQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-docs
+to: DOCS-BPLLWQ
+---

--- a/tickets/relations/TKT-7K3BJF--has-implementation--IMPL-KU1WNF.md
+++ b/tickets/relations/TKT-7K3BJF--has-implementation--IMPL-KU1WNF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-implementation
+to: IMPL-KU1WNF
+---

--- a/tickets/relations/TKT-7K3BJF--has-planning--PLAN-LCUIQO.md
+++ b/tickets/relations/TKT-7K3BJF--has-planning--PLAN-LCUIQO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-planning
+to: PLAN-LCUIQO
+---

--- a/tickets/relations/TKT-7K3BJF--has-review--REV-HPY7TN.md
+++ b/tickets/relations/TKT-7K3BJF--has-review--REV-HPY7TN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review
+to: REV-HPY7TN
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-1556G1.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-1556G1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-1556G1
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-4QO887.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-4QO887.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-4QO887
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-6ZAOMK.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-6ZAOMK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-6ZAOMK
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-7T94EF.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-7T94EF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-7T94EF
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-C1MI2N.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-C1MI2N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-C1MI2N
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-C6CXU1.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-C6CXU1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-C6CXU1
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-EUX4BX.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-EUX4BX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-EUX4BX
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-HJLLUF.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-HJLLUF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-HJLLUF
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-OI6P51.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-OI6P51.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-OI6P51
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-QQQ2JR.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-QQQ2JR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-QQQ2JR
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-QTCKCW.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-QTCKCW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-QTCKCW
+---

--- a/tickets/relations/TKT-7K3BJF--has-review-response--RR-Z7C3CY.md
+++ b/tickets/relations/TKT-7K3BJF--has-review-response--RR-Z7C3CY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: has-review-response
+to: RR-Z7C3CY
+---

--- a/tickets/relations/TKT-7K3BJF--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-7K3BJF--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-7K3BJF
+relation: implements
+to: FEAT-870YCY
+---

--- a/tickets/relations/TKT-87VSDE--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-87VSDE--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-87VSDE
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-87VSDE--depends-on--TKT-7K3BJF.md
+++ b/tickets/relations/TKT-87VSDE--depends-on--TKT-7K3BJF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-87VSDE
+relation: depends-on
+to: TKT-7K3BJF
+---

--- a/tickets/relations/TKT-87VSDE--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-87VSDE--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-87VSDE
+relation: implements
+to: FEAT-870YCY
+---


### PR DESCRIPTION
Lets users attach files **while creating an entity** in the data-entry web app, instead of the current save → reopen in edit mode → upload dance. Previously the create form rendered a `file` property as a dead field ("Attachment editing unavailable").

Parent: FEAT-870YCY. Sibling of TKT-RXFD5B (web write path) and TKT-WLLRO7 (`max`).

## Why it has to be two requests

Two constraints force the design, both verified in the code:

1. **No attachment can be written before the entity row exists.** `AttachFile` returns `store.ErrNotFound` otherwise — enforced independently in all three backends (`fsstore/attachment.go:47`, `pgstore/attachment.go:43` as an in-transaction `SELECT`; there is no FK, `memstore/memstore.go:762`) and pinned by the cross-backend conformance suite (`storetest/attachment.go:54`).
2. **There is no ID-reservation primitive.** `resolveCandidateID` (`entitymanager/core.go:43`) has exactly three branches: client-supplied (rejected unless the type is manual-ID), a `…DRYRUN` placeholder that is never persisted, and server-generated.

So the only possible order is create → attach. The form stages the picked `File` objects and uploads them against the **server-returned** id once the create succeeds.

## Approach

Frontend + e2e only — **no Go changes**. This adds no new HTTP ingress, no new blob namespace and no new ACL subject; the already security-reviewed upload path (MIME allowlist, sandboxed scan/transform, size caps, entity-inherited ACL) is reused verbatim. Every upload still passes `attachmentWritePreflight` before the multipart body is parsed.

Alternatives considered and deferred (recorded on the ticket): a multipart create endpoint (atomic, but needs a body-shape branch, multipart size accounting and a compensating delete), and a staging/unowned-blob namespace (needs its own ACL subject, GC and quota — real new attack surface for a UX convenience).

## The accepted tradeoff

Create can succeed and an upload fail on its own. That is handled loudly, never silently: the entity still exists, the user lands on it, and one message names each failed file and its reason. Because the form unmounts on navigation, the staged copies are gone — so the message says to re-attach on the entity, and the docs say the same. An earlier draft promised a retry that did not exist; code review caught it.

## Review

Design review found 4 issues (3 significant), code review found 8 more (2 critical). All 12 addressed — see the linked `review-response` entities. The two criticals were worth the pass:

- **Double-submit** — `handleSubmit` had no re-entrancy guard, and `handleKeydown` calls it directly, bypassing `PendingButton`. Pre-existing, but this change widened the window from one POST to a POST plus N uploads, and made the consequence duplicate blobs as well as a duplicate entity.
- **A retry that wasn't** — the failure path kept staged files and a dirty flag for a recovery path the next `router.push` destroyed, while leaving a live form happy to create a second entity.

Also fixed: staged files bypassing wizard-hidden pruning (would have persisted a revealed-then-hidden branch, the thing TKT-CHLAJ exists to prevent); content-derived Vue keys colliding on duplicate files; and `shallowRef` for staged state — happy-dom's `File` is proxied by a deep `ref` and a spec `File` is not, so the tests were exercising different object semantics than production ships.

## Verification

- Frontend **2052/2052** across 126 files; e2e **271 passed** / 8 pre-existing skips
- Go tests, `lint` (0 issues), `arch-lint`, `coverage-check` (78.3%), `docs-check` all clean
- Manually driven end-to-end against a real `rela-server`: staged file shows "Pending save" with 0 uploads before save, then lands with the property stamped (`attachments/BUG-001/screenshot/…`)
- The failure path is proven with a **real 413** (e2e fixture sets `max_attachment_bytes: 1024`), not a mock

## Follow-up

TKT-87VSDE (backlog) — `required: true` on a `file` property has no coherent meaning on the create path, since the POST necessarily carries it empty. Latent today: no in-tree schema declares one. Deliberately split so the common case ships.

https://claude.ai/code/session_01MZ49QM1jaftgozhDmyWLoV