### PR TITLE
refactor: replace producer-side EntityManager with per-consumer interfaces (TKT-IVSJV6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
   a cross-subsystem grab-bag is not.
 - **No repository or transaction abstractions.** Depend directly on
   `store.Store`, `tracer.Tracer`, `search.Searcher`,
-  `entitymanager.EntityManager`. The old `repo` and `tx` layers are gone
+  `entitymanager.Manager`. The old `repo` and `tx` layers are gone
   — do not reintroduce equivalents. The one sanctioned transaction seam
   is `store.Store.Tx` itself (DEC-8UIL0): a contract ON the store with
   per-backend meaning (fs/mem: write mutex, mutual exclusion only;

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -113,7 +113,7 @@ type Services struct {
 	// the pgstore-native implementation on the postgres build.
 	visibleSearcher search.VisibleSearcher
 	userState       userstate.Store
-	entityManager   entitymanager.EntityManager
+	entityManager   *entitymanager.Manager
 	tracer          tracer.Tracer
 	validator       validator.Validator
 	templater       templating.Templater
@@ -230,7 +230,15 @@ func newUserState(st store.Store, kv state.KV) userstate.Store {
 func (s *Services) UserState() userstate.Store { return s.userState }
 
 // EntityManager returns the production write path.
-func (s *Services) EntityManager() entitymanager.EntityManager { return s.entityManager }
+//
+// The concrete *[entitymanager.Manager], not an interface: it is the sole
+// implementation, and handing out the concrete type lets each consumer
+// declare its own narrow write interface at its call site (CLAUDE.md
+// "interfaces at the call site") and be satisfied structurally, with no
+// wiring change here. It is also what lets internal/cli assert the
+// id-preserving sync applier against a concrete type rather than
+// interface-to-interface (TKT-IVSJV6).
+func (s *Services) EntityManager() *entitymanager.Manager { return s.entityManager }
 
 // ACL returns the authorization gate wired into entitymanager. Exposed
 // so entry points (rela-server) can render operator warnings based on
@@ -430,7 +438,7 @@ func scriptTracer(
 
 // LuaWriteDeps materializes the read-write Lua capability bundle with
 // UNRESTRICTED reads (see [Services.LuaReadDeps] for when that is right).
-// EntityManager goes in as the wide entitymanager.EntityManager; the
+// EntityManager goes in as the concrete *entitymanager.Manager; the
 // lua.WriteDeps.EntityManager field is narrower (lua.Mutator) and
 // accepts any structural match.
 func (s *Services) LuaWriteDeps() lua.WriteDeps {
@@ -623,7 +631,7 @@ type Collaborators struct {
 	// correct implementation for every in-process store. Only wire it
 	// explicitly to exercise a native implementation.
 	VisibleSearcher search.VisibleSearcher
-	EntityManager   entitymanager.EntityManager
+	EntityManager   *entitymanager.Manager
 	Tracer          tracer.Tracer
 	Validator       validator.Validator
 	Templater       templating.Templater

--- a/internal/attachment/attachment.go
+++ b/internal/attachment/attachment.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -35,6 +34,24 @@ type Result struct {
 	FileName string
 }
 
+// EntityUpdater is the write surface the attachment service needs: recording
+// an attachment is a whole-entity save of a record this package just read and
+// modified. See the internal/entitymanager package doc for the consumer-side
+// rule this follows (TKT-IVSJV6).
+//
+// One method. Attaching a file never creates, deletes, renames or relates —
+// it updates the attachment properties of an entity that already exists.
+// Taking the whole write interface would let a future edit here reach for a
+// delete or a rename without that showing up as a dependency change
+// (TKT-IVSJV6).
+//
+// UpdateEntity rather than PatchEntity is deliberate: [Service.Attach] holds
+// the entity it read and owns the full record for the duration of the save,
+// which is the case UpdateEntity is for.
+type EntityUpdater interface {
+	UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
+}
+
 // Deps is the dependency bundle [New] requires. Store, Meta and
 // EntityManager are mandatory; [New] returns an error if any is nil.
 // Processor is optional — when nil the service uses [NoopProcessor] and the
@@ -42,7 +59,7 @@ type Result struct {
 type Deps struct {
 	Store         store.Store
 	Meta          *metamodel.Metamodel
-	EntityManager entitymanager.EntityManager
+	EntityManager EntityUpdater
 
 	// Processor inspects/rewrites attachment bytes before they are persisted
 	// (scan, MIME validation, transform). Optional; defaults to [NoopProcessor].

--- a/internal/cli/cli_wiring.go
+++ b/internal/cli/cli_wiring.go
@@ -1,14 +1,16 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Sourcehaven-BV/rela/internal/analysis"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
+	syncclient "github.com/Sourcehaven-BV/rela/internal/cli/sync"
 	"github.com/Sourcehaven-BV/rela/internal/config"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/project"
@@ -53,12 +55,60 @@ type readServices struct {
 // writes to.
 type writeServices struct {
 	readServices
-	EntityManager entitymanager.EntityManager
-	Validator     validator.Validator
-	Audit         audit.Audit
-	LuaCache      *lua.Cache
-	LuaWriteDeps  lua.WriteDeps
-	State         state.KV
+	EntityManager entityWriter
+
+	// SyncApplier is the id-preserving, automation-suppressed write path
+	// `rela sync` needs (syncclient.LocalApplier). It is a SEPARATE typed
+	// field, not a type assertion on EntityManager, for two reasons.
+	//
+	// First, it is a genuinely distinct capability: ApplyEntity/ApplyRelation
+	// land a remote record verbatim, which is not part of the human-intent
+	// write surface the other subcommands use — so it is its own dependency,
+	// declared as one (CLAUDE.md: define a typed dependency rather than a
+	// type-assertion back-channel).
+	//
+	// Second, the assertion it replaces failed OPEN: it set the applier to nil
+	// on a miss, and `sync push` dereferences it on the create-id-adoption path
+	// (push.go, `newID != ch.Key`), so a miss was a panic rather than the
+	// "only breaks pull" the old comment claimed. The wiring site holds the
+	// concrete *entitymanager.Manager, so assigning this field is checked by
+	// the compiler and the failure mode is gone (TKT-IVSJV6).
+	SyncApplier  syncclient.LocalApplier
+	Validator    validator.Validator
+	Audit        audit.Audit
+	LuaCache     *lua.Cache
+	LuaWriteDeps lua.WriteDeps
+	State        state.KV
+}
+
+// entityWriter is the write surface the CLI's mutating subcommands call. See
+// the internal/entitymanager package doc for why each consumer declares its own
+// interface rather than sharing one (TKT-IVSJV6).
+//
+// Eight of the manager's nine write methods. ValidateCreate is absent because
+// no subcommand dry-runs a create — the CLI either writes or it doesn't, and
+// the advisory path exists for the data-entry form.
+//
+// Note `rela sync pull` additionally type-asserts this value to
+// syncclient.LocalApplier for the id-preserving applier — see buildSyncEngine.
+// Those methods stay off this interface deliberately: they are a distinct
+// capability (apply a remote record verbatim), not part of the human-intent
+// write surface the other subcommands use.
+type entityWriter interface {
+	CreateEntity(ctx context.Context, e *entity.Entity, opts entity.CreateOptions) (*entity.CreateResult, error)
+	UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
+	PatchEntity(ctx context.Context, id string, p entity.Patch) (*entity.UpdateResult, error)
+	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
+	RenameEntity(
+		ctx context.Context, oldID, newID string, opts entity.RenameOptions,
+	) (*entity.RenameResult, error)
+	CreateRelation(
+		ctx context.Context, from, relType, to string, opts entity.RelationOptions,
+	) (*entity.Relation, error)
+	UpdateRelation(
+		ctx context.Context, from, relType, to string, opts entity.RelationOptions,
+	) (*entity.Relation, error)
+	DeleteRelation(ctx context.Context, from, relType, to string) error
 }
 
 // cliBundles is everything the kong wiring binds for command Run methods:
@@ -122,6 +172,7 @@ func newCLIBundles(svc *appbuild.Services) (*cliBundles, error) {
 	write := writeServices{
 		readServices:  read,
 		EntityManager: svc.EntityManager(),
+		SyncApplier:   svc.EntityManager(),
 		Validator:     svc.Validator(),
 		Audit:         svc.Audit(),
 		LuaCache:      svc.ScriptEngine().LuaCache(),

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -99,10 +99,10 @@ func (c *SyncPullCmd) Run(ctx context.Context, svc *writeServices) error {
 }
 
 // buildSyncEngine wires the sync engine from the CLI services: it loads the
-// index, constructs the HTTP client, and type-asserts the entity manager to the
-// id-preserving applier (the same consumer-side pattern as the server — these
-// methods are intentionally off the broad EntityManager interface). Returns the
-// engine, the index (so the caller can Save it), and the cache dir.
+// index and constructs the HTTP client. The id-preserving applier comes from
+// the typed [writeServices.SyncApplier] field rather than a type assertion on
+// EntityManager — see that field's doc for why the assertion was fail-open.
+// Returns the engine, the index (so the caller can Save it), and the cache dir.
 func buildSyncEngine(remote, token string, svc *writeServices) (*syncclient.Engine, *syncclient.State, string, error) {
 	client, err := syncclient.NewClient(remote, token, nil)
 	if err != nil {
@@ -113,13 +113,7 @@ func buildSyncEngine(remote, token string, svc *writeServices) (*syncclient.Engi
 	if err != nil {
 		return nil, nil, "", err
 	}
-	applier, ok := svc.EntityManager.(syncclient.LocalApplier)
-	if !ok {
-		// fs/memory builds use *entitymanager.Manager, which satisfies this; a
-		// build that doesn't would only break pull (push needs no applier).
-		applier = nil
-	}
-	eng, err := syncclient.NewEngine(client, svc.Store, applier, idx)
+	eng, err := syncclient.NewEngine(client, svc.Store, svc.SyncApplier, idx)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/internal/cli/sync/engine.go
+++ b/internal/cli/sync/engine.go
@@ -12,8 +12,8 @@ import (
 
 // LocalApplier is the id-preserving, automation-suppressed write path the pull
 // command uses to land remote records locally. Declared at the call site
-// (CLAUDE.md): *entitymanager.Manager satisfies it, but the broad EntityManager
-// interface deliberately omits ApplyEntity/ApplyRelation — sync is their only
+// (CLAUDE.md): *entitymanager.Manager satisfies it, and no other consumer's
+// write interface names ApplyEntity/ApplyRelation — sync is their only
 // consumer, mirroring the server side. Delete uses the manager's standard
 // delete (a mirrored remote delete). Exported so the CLI wiring can type-assert
 // the entity manager to it.
@@ -51,8 +51,17 @@ type Engine struct {
 	local *LocalSchema
 }
 
-// NewEngine constructs a sync engine. applier may be nil for a push-only run
-// (push never writes locally); pull requires it and errors if it is nil.
+// NewEngine constructs a sync engine.
+//
+// applier may be nil, but ONLY for a run that never writes locally. That is
+// narrower than "push-only": pull and force-pull obviously write, and push does
+// too on its id-adoption path (the primary mints an id differing from the local
+// temp id, and adopting it is a local rename). Each of those three checks for
+// nil and returns errLocalApplierRequired; none dereferences it blind.
+//
+// Production always supplies one — the CLI wiring holds it as a typed
+// writeServices.SyncApplier field, so a missing applier is a compile error
+// there. The nil case exists for tests that exercise read-only paths.
 func NewEngine(client *Client, st store.Store, applier LocalApplier, idx *State) (*Engine, error) {
 	if client == nil {
 		return nil, errors.New("sync engine: client is required")

--- a/internal/cli/sync/force.go
+++ b/internal/cli/sync/force.go
@@ -56,7 +56,7 @@ func (e *Engine) ForcePush(ctx context.Context, key string) (*PushRecordResult, 
 // remotely) mirrors as a local delete.
 func (e *Engine) ForcePull(ctx context.Context, key string) (*PullRecordResult, error) {
 	if e.applier == nil {
-		return nil, errRemoteApplierRequired
+		return nil, errLocalApplierRequired
 	}
 	if err := e.ensureSchema(ctx); err != nil {
 		return nil, err

--- a/internal/cli/sync/nil_applier_test.go
+++ b/internal/cli/sync/nil_applier_test.go
@@ -1,0 +1,44 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestRecordCreate_NilApplier_ErrorsNotPanics pins the fix for the contract lie
+// in NewEngine's godoc (TKT-IVSJV6).
+//
+// The doc used to say "applier may be nil for a push-only run (push never
+// writes locally)". Push DOES write locally when the primary mints an id that
+// differs from the local temp id: adopting it is a local rename. Pull and force
+// guarded that with a nil check; recordCreate dereferenced blind, so a nil
+// applier there was a panic on the ORDINARY create path, not a degraded run.
+//
+// The panic was unreachable while the CLI held a concrete *entitymanager.Manager.
+// Narrowing that field to an interface made it reachable, which is why the guard
+// landed with this ticket.
+func TestRecordCreate_NilApplier_ErrorsNotPanics(t *testing.T) {
+	h := newHarness(t)
+
+	// Same client/store/index as the harness, but NO applier.
+	noApplier, err := NewEngine(h.engine.client, h.st, nil, h.idx)
+	if err != nil {
+		t.Fatalf("NewEngine with nil applier: %v", err)
+	}
+
+	// Applied, with a CreatedID differing from the local key: the id-adoption
+	// path, and the exact branch that used to deref a nil applier.
+	_, err = noApplier.recordCreate(
+		context.Background(),
+		LocalChange{Key: "TKT-temp1"},
+		&PushResult{Applied: true, CreatedID: "TKT-minted1"},
+	)
+	if err == nil {
+		t.Fatal("recordCreate with a nil applier on the id-adoption path should " +
+			"error; it must never dereference the applier blind")
+	}
+	if !errors.Is(err, errLocalApplierRequired) {
+		t.Fatalf("want errLocalApplierRequired, got %v", err)
+	}
+}

--- a/internal/cli/sync/pull.go
+++ b/internal/cli/sync/pull.go
@@ -30,9 +30,11 @@ func isLocalNotFound(err error) bool {
 // delete.
 var errRemoteAbsent = errors.New("remote record absent")
 
-// errRemoteApplierRequired is returned when a pull (or force-pull) is attempted
-// without a local applier wired — pull writes locally and cannot run read-only.
-var errRemoteApplierRequired = errors.New("sync: pull requires a local applier")
+// errLocalApplierRequired is returned when an operation that WRITES LOCALLY is
+// attempted without a local applier wired. Pull and force-pull are the obvious
+// cases; push also qualifies on its id-adoption path, where the primary minted
+// an id differing from the local temp id and adopting it is a local rename.
+var errLocalApplierRequired = errors.New("sync: this operation requires a local applier")
 
 // PullOutcome classifies what happened to one record during a pull.
 type PullOutcome int
@@ -76,7 +78,7 @@ type PullReport struct {
 // cursor where a re-run resumes correctly.
 func (e *Engine) Pull(ctx context.Context) (*PullReport, error) {
 	if e.applier == nil {
-		return nil, errRemoteApplierRequired
+		return nil, errLocalApplierRequired
 	}
 	if err := e.ensureSchema(ctx); err != nil {
 		return nil, err

--- a/internal/cli/sync/push.go
+++ b/internal/cli/sync/push.go
@@ -299,6 +299,15 @@ func (e *Engine) recordCreate(ctx context.Context, ch LocalChange, res *PushResu
 	}
 
 	if newID != ch.Key {
+		// Push DOES write locally on this path: the primary minted an id that
+		// differs from the local temp id, and adopting it is a local rename.
+		// So a nil applier is fatal here rather than merely limiting — guard it
+		// like pull and force do, instead of dereferencing into a panic
+		// (TKT-IVSJV6).
+		if e.applier == nil {
+			return PushRecordResult{}, fmt.Errorf(
+				"adopt server id %q for local %q: %w", newID, ch.Key, errLocalApplierRequired)
+		}
 		if _, err := e.applier.RenameEntity(ctx, ch.Key, newID, entity.RenameOptions{}); err != nil {
 			return PushRecordResult{}, fmt.Errorf("adopt server id %q for local %q: %w", newID, ch.Key, err)
 		}

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -47,6 +47,37 @@ const userDefaultsFile = "user-defaults.yaml"
 // userPaletteFile is the filename for user-specific palette overrides within the .rela directory.
 const userPaletteFile = "palette.yaml"
 
+// appEntityWriter is the write surface App itself calls — the CalDAV write
+// path, entity/relation history restore, and the value it hands to the Lua
+// writer runtime. See the internal/entitymanager package doc for the
+// consumer-side rule this follows (TKT-IVSJV6).
+//
+// Exactly the seven methods App invokes. RenameEntity and ValidateCreate are
+// absent: the SPA has no rename affordance (renames are a CLI and MCP
+// operation), and the form's dry-run preview lives on writeHandler, which
+// declares its own narrower entityMutator.
+//
+// This stays minimal because NewApp takes the CONCRETE *entitymanager.Manager
+// and passes that to the sub-handler constructors, rather than distributing
+// this narrowed value. Otherwise App would have to hold the union of its own
+// calls and every child's — ValidateCreate for writeHandler, and so on — which
+// is the "wide because it is a distributor" problem this ticket removed one
+// level up. A composition root taking the concrete type is the right shape;
+// each handler narrows at its own field.
+type appEntityWriter interface {
+	CreateEntity(ctx context.Context, e *entity.Entity, opts entity.CreateOptions) (*entity.CreateResult, error)
+	UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
+	PatchEntity(ctx context.Context, id string, p entity.Patch) (*entity.UpdateResult, error)
+	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
+	CreateRelation(
+		ctx context.Context, from, relType, to string, opts entity.RelationOptions,
+	) (*entity.Relation, error)
+	UpdateRelation(
+		ctx context.Context, from, relType, to string, opts entity.RelationOptions,
+	) (*entity.Relation, error)
+	DeleteRelation(ctx context.Context, from, relType, to string) error
+}
+
 // App is the central application struct for the data-entry server.
 //
 // # Concurrency model
@@ -133,7 +164,7 @@ type App struct {
 	// history endpoints return 501. The history handlers bind the narrow
 	// sub-interface they need rather than type-asserting the store.
 	versions      store.VersionService
-	entityManager entitymanager.EntityManager
+	entityManager appEntityWriter
 
 	// caldavAliases links CalDAV resources to entities. Optional: nil when no
 	// alias service is wired, in which case the CalDAV routes are not served
@@ -710,7 +741,7 @@ func NewApp(
 	meta *metamodel.Metamodel,
 	st store.Store,
 	versions store.VersionService,
-	em entitymanager.EntityManager,
+	em *entitymanager.Manager,
 	searcher search.Searcher,
 	visibleSearcher search.VisibleSearcher,
 	aclImpl acl.ACL,
@@ -1060,9 +1091,12 @@ func NewApp(
 	// store/manager handles are fixed for App's lifetime. writeMu is shared by
 	// pointer so attachment writes serialize with every other mutation handler.
 	app.attachments = &attachmentHandler{
-		schema:     app.State,
-		store:      st,
-		manager:    app.entityManager,
+		schema: app.State,
+		store:  st,
+		// The concrete manager, not app.entityManager: each sub-handler
+		// narrows to its OWN interface at its own field, so App's stays
+		// exactly what App calls (TKT-IVSJV6).
+		manager:    em,
 		runner:     func() attachment.CommandRunner { return app.attachmentRunner },
 		reader:     app.reader,
 		serializer: app.serializer,
@@ -1081,9 +1115,10 @@ func NewApp(
 	// so both paths stay behaviorally identical. writeMu is shared by pointer
 	// so these writes serialize with every other mutation handler.
 	app.write = &writeHandler{
-		schema:             app.State,
-		store:              st,
-		manager:            app.entityManager,
+		schema:  app.State,
+		store:   st,
+		manager: em, // concrete; writeHandler narrows to entityMutator
+
 		reader:             app.reader,
 		serializer:         app.serializer,
 		affordances:        app.affordances,

--- a/internal/dataentry/attachment_handler.go
+++ b/internal/dataentry/attachment_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -16,9 +15,10 @@ import (
 // (/api/v1/{plural}/{id}/_attachments/...): upload, download, detach.
 // Extracted from App (TKT-R68TV8) to shrink the god object.
 //
-// It holds the full store.Store and entitymanager.EntityManager because
-// attachment.New (the shared HTTP/CLI write-policy service) requires both —
-// narrowing them here would just reintroduce them under other names. The
+// It holds the full store.Store because attachment.New (the shared HTTP/CLI
+// write-policy service) requires it. The write handle is NOT the full manager:
+// this handler never calls it, only passes it to attachment.New, so it holds
+// exactly attachment's own one-method attachment.EntityUpdater (TKT-IVSJV6). The
 // swappable collaborators (acl, audit sink, field resolver, command runner) are closures over
 // App so tests that reassign app.acl / app.fieldResolver after construction
 // stay effective — same rationale as affordanceService. gateRead is App's
@@ -32,7 +32,7 @@ import (
 type attachmentHandler struct {
 	schema     func() *Schema
 	store      store.Store
-	manager    entitymanager.EntityManager
+	manager    attachment.EntityUpdater
 	runner     func() attachment.CommandRunner
 	reader     entityReader
 	serializer entitySerializer

--- a/internal/dataentry/provision.go
+++ b/internal/dataentry/provision.go
@@ -53,7 +53,7 @@ import (
 // gated/rejected by normal authorization — fail-closed, never fail-open to a
 // forged identity.
 func maybeProvision(
-	ctx context.Context, d *acl.Declarative, m entitymanager.EntityManager, meta metaView,
+	ctx context.Context, d *acl.Declarative, m entityProvisioner, meta metaView,
 ) context.Context {
 	// Fast path: only a verified-but-unmatched principal under a provision
 	// policy does anything. Both are cheap ctx/field reads.
@@ -158,6 +158,18 @@ func buildStubEntity(pol *acl.Policy, meta metaView, p principal.Principal) *ent
 		props["org_slug"] = p.OrgSlug()
 	}
 	return &entity.Entity{Type: pol.UserEntityType, Properties: props}
+}
+
+// entityProvisioner is the narrow write surface maybeProvision needs: creating
+// the stub entity for a verified-but-unmatched principal. Defined at the call
+// site (CLAUDE.md consumer-side interfaces), same rationale as [metaView]
+// below — provisioning creates one entity and does nothing else, so it has no
+// business holding a delete or a rename (TKT-IVSJV6).
+//
+// The create still routes through the manager, so the stub is validated,
+// audited and runs automations exactly like any other entity.
+type entityProvisioner interface {
+	CreateEntity(ctx context.Context, e *entity.Entity, opts entity.CreateOptions) (*entity.CreateResult, error)
 }
 
 // metaView is the narrow schema query maybeProvision needs: whether a property

--- a/internal/dataentry/services.go
+++ b/internal/dataentry/services.go
@@ -16,8 +16,8 @@ import (
 //
 // The bundle carries only what HTTP handlers actually need: read-side
 // access to the store and tracer, free-text search, and the metamodel.
-// Writes continue to flow through workspace methods (which go through
-// entitymanager.EntityManager so automations and validations fire).
+// Writes continue to flow through the entity manager so automations and
+// validations fire.
 type Services struct {
 	// Store provides entity/relation CRUD. Handlers use it for read
 	// operations; writes go through the workspace's EntityManager.

--- a/internal/dataentry/settings_handlers.go
+++ b/internal/dataentry/settings_handlers.go
@@ -81,11 +81,10 @@ func writeJSONError(w http.ResponseWriter, status int, message string) {
 // — lets the SPA surface the specific rule that fired (the AWS IAM
 // lesson: opaque denials are unsupportable).
 //
-// Every handler that calls a write entry point on
-// [entitymanager.EntityManager] must invoke this *before* falling
-// back to the generic 500 path. The check is cheap (an errors.As
-// type assertion) and centralizing the 403 body shape here keeps the
-// wire contract identical across all handlers.
+// Every handler that calls a write entry point on the entity manager must
+// invoke this *before* falling back to the generic 500 path. The check is
+// cheap (an errors.As type assertion) and centralizing the 403 body shape
+// here keeps the wire contract identical across all handlers.
 func writeForbiddenIfACLDenied(w http.ResponseWriter, err error) bool {
 	var fe *acl.ForbiddenError
 	if !errors.As(err, &fe) {

--- a/internal/dataentry/write_handler.go
+++ b/internal/dataentry/write_handler.go
@@ -25,6 +25,39 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
+// entityMutator is the write surface the data-entry write handlers call. See
+// the internal/entitymanager package doc for the consumer-side rule this
+// follows (TKT-IVSJV6).
+//
+// Seven of the manager's nine write methods. PatchEntity is absent FROM THIS
+// HANDLER because a form save renders every field and therefore legitimately
+// owns the whole record — the UpdateEntity case (see the PatchEntity rule in
+// CLAUDE.md). That is a fact about form saves, not about data-entry writes
+// generally: the CalDAV writer patches, and holds its own wider surface
+// through App. RenameEntity is absent because the SPA has no rename
+// affordance; renames are a CLI and MCP operation.
+//
+// ValidateCreate is here and nowhere else in the tree: it backs the form's
+// dry-run preview, which is advisory only — the real CreateEntity below stays
+// the sole authorization and audit point.
+type entityMutator interface {
+	CreateEntity(
+		ctx context.Context, e *entityPkg.Entity, opts entityPkg.CreateOptions,
+	) (*entityPkg.CreateResult, error)
+	ValidateCreate(
+		ctx context.Context, e *entityPkg.Entity, opts entityPkg.CreateOptions,
+	) (*entityPkg.Entity, []entityPkg.Warning, error)
+	UpdateEntity(ctx context.Context, e *entityPkg.Entity) (*entityPkg.UpdateResult, error)
+	DeleteEntity(ctx context.Context, id string, cascade bool) (*entityPkg.DeleteResult, error)
+	CreateRelation(
+		ctx context.Context, from, relType, to string, opts entityPkg.RelationOptions,
+	) (*entityPkg.Relation, error)
+	UpdateRelation(
+		ctx context.Context, from, relType, to string, opts entityPkg.RelationOptions,
+	) (*entityPkg.Relation, error)
+	DeleteRelation(ctx context.Context, from, relType, to string) error
+}
+
 // writeHandler owns the data-entry write nucleus: the entity/relation CRUD
 // endpoints (create/dry-run-create/update/delete entity, create/update/delete
 // relation), clone, conflict-resolve, the modern relations reconciler they
@@ -51,7 +84,7 @@ import (
 type writeHandler struct {
 	schema      func() *Schema
 	store       store.Store
-	manager     entitymanager.EntityManager
+	manager     entityMutator
 	reader      entityReader
 	serializer  entitySerializer
 	affordances affordanceService

--- a/internal/entitymanager/entitymanager.go
+++ b/internal/entitymanager/entitymanager.go
@@ -1,66 +1,35 @@
-// Package entitymanager defines the EntityManager service — the "human intent"
-// write path that runs automations, validation, and any policy concerns
-// (future: ACL, audit logging, rate limiting).
+// Package entitymanager defines the entity-manager service — the "human intent"
+// write path that runs automations, validation, and policy concerns (ACL,
+// audit logging).
 //
 // This sits above the Store: reads and writes still go through a store.Store
-// backend, but an EntityManager adds workflow concerns that shouldn't live in
-// raw storage. Consumers use the manager; the store stays focused on CRUD.
+// backend, but the manager adds workflow concerns that shouldn't live in raw
+// storage. Consumers use the manager; the store stays focused on CRUD.
 //
 // Not all consumers need a manager. Importers, bulk sync, and formatters
 // bypass automations and talk to the store directly.
+//
+// # No interface here
+//
+// [Manager] is the whole API, and it is a concrete type on purpose. This
+// package deliberately does NOT declare a wide `EntityManager` interface
+// beside it: that was a producer-side interface, which CLAUDE.md's first rule
+// forbids, and every consumer bound to all nine methods while using between
+// one and seven of them. It was removed in TKT-IVSJV6.
+//
+// Each consumer now declares its own narrow interface at its call site, naming
+// only what it invokes — [github.com/Sourcehaven-BV/rela/internal/lua.Mutator]
+// (6 methods), attachment.EntityUpdater (1), mcp.EntityWriter (6), and the
+// unexported ones in internal/cli and internal/dataentry. *Manager satisfies
+// each structurally, so adding a method here breaks nothing and a consumer
+// reaching for a new capability has to say so in its own interface.
+//
+// A composition root that DISTRIBUTES the manager to sub-handlers (dataentry's
+// NewApp) takes the concrete *Manager rather than a narrowed value, so each
+// handler narrows at its own field. Otherwise the root would have to hold the
+// union of every child's needs — the same "wide because it is a distributor"
+// shape, one level down.
+//
+// Read operations are intentionally absent from all of them — consumers read
+// directly from store.Store.
 package entitymanager
-
-import (
-	"context"
-
-	"github.com/Sourcehaven-BV/rela/internal/entity"
-)
-
-// EntityManager provides the high-level write API for entities and relations.
-//
-// **Transitional.** This is a producer-side interface (defined alongside
-// its sole implementation, [Manager]), which the project explicitly
-// avoids per CLAUDE.md "consumer-side interfaces" rule. Slated for
-// removal: each call site should declare its own narrow consumer-side
-// interface naming only the methods it invokes.
-//
-// Read operations are intentionally NOT on this interface — consumers
-// read directly from [store.Store].
-type EntityManager interface {
-	// CreateEntity creates a new entity, running on-create automations.
-	CreateEntity(ctx context.Context, e *entity.Entity, opts entity.CreateOptions) (*entity.CreateResult, error)
-
-	// ValidateCreate runs the create path's defaults + validation against
-	// a candidate WITHOUT persisting, authorizing, auditing, or running
-	// automation. Returns the would-be entity (post-defaults) and soft
-	// warnings. Advisory only — the real CreateEntity remains the sole
-	// authorization/audit point.
-	ValidateCreate(
-		ctx context.Context, e *entity.Entity, opts entity.CreateOptions,
-	) (*entity.Entity, []entity.Warning, error)
-
-	// UpdateEntity updates an existing entity and runs on-update automations.
-	// The caller passes the modified entity; the manager detects changes.
-	UpdateEntity(ctx context.Context, e *entity.Entity) (*entity.UpdateResult, error)
-
-	// PatchEntity applies a targeted set of property changes, preserving
-	// everything the patch does not name. Prefer this over UpdateEntity for
-	// any partial write: the caller never holds the whole entity, so it
-	// cannot erase properties it could not read (TKT-80EWGM).
-	PatchEntity(ctx context.Context, id string, p entity.Patch) (*entity.UpdateResult, error)
-
-	// DeleteEntity removes an entity and optionally cascades to its relations.
-	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
-
-	// RenameEntity changes an entity's ID, updating all relations.
-	RenameEntity(ctx context.Context, oldID, newID string, opts entity.RenameOptions) (*entity.RenameResult, error)
-
-	// CreateRelation creates a new relation.
-	CreateRelation(ctx context.Context, from, relType, to string, opts entity.RelationOptions) (*entity.Relation, error)
-
-	// UpdateRelation updates an existing relation's data.
-	UpdateRelation(ctx context.Context, from, relType, to string, opts entity.RelationOptions) (*entity.Relation, error)
-
-	// DeleteRelation removes a relation.
-	DeleteRelation(ctx context.Context, from, relType, to string) error
-}

--- a/internal/entitymanager/entitymanagertest/panic.go
+++ b/internal/entitymanager/entitymanagertest/panic.go
@@ -1,24 +1,27 @@
-// Package entitymanagertest provides test doubles for the
-// entitymanager.EntityManager interface.
+// Package entitymanagertest provides test doubles for the entity-manager
+// write path.
 //
-// PanicOnUse satisfies the interface but panics from every method. Wire it
-// into tests that need to construct a writer runtime (which requires a
-// non-nil EntityManager) but exercise only read paths — an accidental
-// mutation will fail loudly instead of silently no-oping.
+// PanicOnUse panics from every method. Wire it into tests that need to
+// construct a writer runtime (which requires a non-nil write handle) but
+// exercise only read paths — an accidental mutation will fail loudly instead
+// of silently no-oping.
 package entitymanagertest
 
 import (
 	"context"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 )
 
-// PanicOnUse is an entitymanager.EntityManager whose every method panics.
-// Use it when a test's code path should never reach a mutation.
+// PanicOnUse is a write handle whose every method panics. Use it when a
+// test's code path should never reach a mutation.
+//
+// It keeps the FULL nine-method set that entitymanager.Manager exposes, even
+// though no single consumer needs all of them: since TKT-IVSJV6 each consumer
+// declares its own narrow write interface at its call site, and a superset
+// satisfies every one of them structurally. Dropping a method here would
+// silently stop this double from being wirable somewhere.
 type PanicOnUse struct{}
-
-var _ entitymanager.EntityManager = PanicOnUse{}
 
 func (PanicOnUse) CreateEntity(context.Context, *entity.Entity,
 	entity.CreateOptions) (*entity.CreateResult, error) {

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -34,16 +34,18 @@ type TemplateLoader interface {
 	RelationTemplate(ctx context.Context, relationType string) (*templating.Template, error)
 }
 
-// Manager is the production [EntityManager] implementation. It runs
-// metamodel validation, automation rules (via [automation.Engine]),
-// and dispatches automation cascades through an [autocascade.Runner].
+// Manager is the production entity-manager implementation — the whole of this
+// package's write API. It runs metamodel validation, automation rules (via
+// [automation.Engine]), and dispatches automation cascades through an
+// [autocascade.Runner].
 //
 // Manager is constructed at each per-command wiring site (cmd/rela,
-// cmd/rela-server, cmd/rela-desktop, plus subcommands that need their
-// own EntityManager). Consumers depend on a scoped consumer-side
-// interface in their own package, not on *Manager directly (see
-// CLAUDE.md). The package-level [EntityManager] interface exists for
-// transitional reasons and is intentionally narrow.
+// cmd/rela-server, cmd/rela-desktop, plus subcommands that need their own
+// write path). Consumers depend on a scoped consumer-side interface declared
+// in their OWN package, never on a wide one declared here (see CLAUDE.md and
+// the package doc): appbuild hands out *Manager, and each consumer's
+// interface is satisfied structurally. The wide package-level EntityManager
+// interface that used to sit beside this type was removed in TKT-IVSJV6.
 //
 // Pipeline shapes preserved from the pre-decomposition workspace
 // implementation (see PLAN-HQ5Y):
@@ -108,15 +110,19 @@ func (m *Manager) gated() *Manager {
 	return &Manager{deps: m.deps, bypassACL: false}
 }
 
-// Compile-time assertions: Manager must satisfy both the public
-// EntityManager contract and the autocascade.Mutator surface (the
-// per-cascade write handle scripted actions receive). A drift in
-// either interface surfaces at this type, not at the call sites that
-// pass Manager into Request.Mutator or lua.WriteDeps.EntityManager.
-var (
-	_ EntityManager       = (*Manager)(nil)
-	_ autocascade.Mutator = (*Manager)(nil)
-)
+// Compile-time assertion: Manager must satisfy the autocascade.Mutator
+// surface (the per-cascade write handle scripted actions receive), so a
+// drift surfaces at this type rather than at the call site that passes
+// Manager into Request.Mutator.
+//
+// There is deliberately no assertion against a package-local write
+// interface: the wide EntityManager one was deleted in TKT-IVSJV6, and its
+// replacements are declared at each CONSUMER (lua.Mutator,
+// attachment.EntityUpdater, mcp.EntityWriter, and the unexported ones in
+// internal/cli and internal/dataentry). Asserting against them here would
+// re-import every consumer and reinstate the coupling the split removed;
+// each is checked where it is used, at its own wiring site.
+var _ autocascade.Mutator = (*Manager)(nil)
 
 // Deps is the constructor input for [New]. Using a struct keeps the
 // constructor signature stable as new collaborators land (audit,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
-	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/lua"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
@@ -72,7 +71,7 @@ type Deps struct {
 	Tracer        tracer.Tracer
 	Searcher      search.Searcher
 	Validator     validator.Validator
-	EntityManager entitymanager.EntityManager
+	EntityManager EntityWriter
 	Config        config.Loader
 	LuaWriteDeps  lua.WriteDeps
 	LuaCache      *lua.Cache
@@ -111,6 +110,34 @@ type GraphReader interface {
 type GraphCounter interface {
 	CountEntities(ctx context.Context, q store.EntityQuery) (int, error)
 	CountRelations(ctx context.Context, q store.RelationQuery) (int, error)
+}
+
+// EntityWriter is the write capability MCP requires — the exact set its tool
+// handlers call, declared here at the CALL SITE for the same reason
+// [GraphReader] is: `entitymanager`'s own interface was a nine-method
+// producer-side type that MCP has no business holding in full (TKT-IVSJV6).
+// The wiring site supplies the project's *entitymanager.Manager, which
+// satisfies this structurally.
+//
+// Three of the nine are absent because no MCP tool invokes them:
+// UpdateEntity (the entity tool patches — it names the properties it touched
+// rather than holding the whole record, TKT-80EWGM), ValidateCreate (an
+// advisory dry-run the data-entry form path uses), and UpdateRelation.
+//
+// Every method here still routes through the manager, so ACL, audit and
+// automations apply exactly as they do on any other write path — narrowing
+// the interface removes methods, never gates.
+type EntityWriter interface {
+	CreateEntity(ctx context.Context, e *entity.Entity, opts entity.CreateOptions) (*entity.CreateResult, error)
+	PatchEntity(ctx context.Context, id string, p entity.Patch) (*entity.UpdateResult, error)
+	DeleteEntity(ctx context.Context, id string, cascade bool) (*entity.DeleteResult, error)
+	RenameEntity(
+		ctx context.Context, oldID, newID string, opts entity.RenameOptions,
+	) (*entity.RenameResult, error)
+	CreateRelation(
+		ctx context.Context, from, relType, to string, opts entity.RelationOptions,
+	) (*entity.Relation, error)
+	DeleteRelation(ctx context.Context, from, relType, to string) error
 }
 
 // validate rejects a Deps missing any field whose zero value would

--- a/tickets/entities/implementation-checklists/IMPL-OTEBIM.md
+++ b/tickets/entities/implementation-checklists/IMPL-OTEBIM.md
@@ -1,0 +1,142 @@
+---
+id: IMPL-OTEBIM
+type: implementation-checklist
+title: 'Implementation: Replace producer-side entitymanager.EntityManager with per-consumer interfaces'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written for new code~~ (N/A with one exception, below: this
+ticket adds no runtime code — it narrows the static type of existing fields. The
+"test" for a type-narrowing refactor is the compiler, which rejects a consumer
+calling a method it did not declare.)
+- [x] Integration tests written (test full flow, not just units) — one added,
+and it earns its place: `internal/cli/sync_applier_assert_test.go` pins that
+`*entitymanager.Manager` held as the new `entityWriter` still type-asserts to
+`syncclient.LocalApplier`. That assertion in `buildSyncEngine` falls back to a
+**nil applier**, which disables `rela sync pull` *silently* — so a compile-clean
+narrowing could have broken sync with nothing failing. This was the one
+genuinely risky spot in the refactor and it is now guarded.
+- [x] Happy path implemented — all four subsystems converted, interface deleted.
+- [x] Edge cases from planning handled — see Manual Verification.
+- [x] ~~Error handling in place~~ (N/A: no new error paths; every method keeps
+its identical signature and implementation.)
+
+## Test Quality
+
+- [x] ~~Fixture builders / factories~~ (N/A: the one new test constructs a typed
+nil pointer, which is the whole fixture.)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test — the new test asserts one
+thing (the assertion still succeeds) and its failure message says what breaks in
+production, not just that a bool was false.
+- [x] ~~Interpolated values constructed from objects~~ (N/A)
+- [x] ~~Property comparisons use original object~~ (N/A)
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*AC1 — interface gone.* `grep -rn "entitymanager.EntityManager" internal/ cmd/`
+returns **zero** matches, including comments and `_test.go`.
+
+*AC2 — narrow interfaces at each consumer.* Six declared, method counts matching
+the measured call sets exactly:
+
+| Interface | Where | Methods |
+|---|---|---|
+| `attachment.EntityUpdater` | `attachment/attachment.go` | 1 |
+| `mcp.EntityWriter` | `mcp/server.go` | 6 |
+| `cli.entityWriter` | `cli/cli_wiring.go` | 8 |
+| `dataentry.appEntityWriter` | `dataentry/app.go` | 7 |
+| `dataentry.entityMutator` | `dataentry/write_handler.go` | 7 |
+| `dataentry.entityProvisioner` | `dataentry/provision.go` | 1 |
+
+`appbuild` now hands out the concrete `*entitymanager.Manager`, so every one of
+these is satisfied structurally with no adapter and no wiring change.
+
+*AC3 — build + tests.* `go build ./...` clean; **`go test ./...` exit 0, no
+failures**. Also built under all four backend tags (default, `postgres`,
+`memorybackend`, `sqlite`) since `appbuild`'s recipes differ per tag — all
+clean.
+
+*AC4 — arch-lint.* `just arch-lint` → `OK - No warnings found`.
+
+*AC5 — no behaviour change.* `git status` shows **no existing `_test.go`
+modified**; the only test file is the new one above. No assertion was adjusted
+to accommodate the refactor.
+
+*AC6 — coupling actually dropped.* The concrete win, measured:
+
+```
+go list -deps ./internal/attachment | grep -c internal/entitymanager  → 0
+go list -deps ./internal/mcp        | grep -c internal/entitymanager  → 0
+```
+
+Both packages previously imported it; neither does now.
+
+*End-to-end exercise of every narrowed write path against a real project* (a
+copy of `tickets/`), not just compilation:
+
+- **CLI (8/8)** — `create` ✓, `update` (PatchEntity) ✓, `link` (CreateRelation) ✓,
+`unlink` (DeleteRelation) ✓, `rename id` (RenameEntity) ✓, `delete` ✓. Relation
+update and UpdateEntity are covered by the package tests.
+- **MCP (6/6)** — driven over real JSON-RPC stdio against `rela mcp`, full
+`initialize` handshake then `tools/call`: `create_entity` ✓, `update_entity`
+(PatchEntity) ✓, `create_relation` ✓, `delete_relation` ✓, `rename_entity` ✓,
+`delete_entity` ✓. All returned success results, no `isError`.
+- **dataentry** — the 25s `internal/dataentry` suite (the widest consumer,
+including the CalDAV write path, history restore and the provisioning seam)
+passes unchanged.
+
+*Compiler-caught design constraint, and how code review resolved it.* The first
+version of `appEntityWriter` omitted `ValidateCreate` and the build failed: App
+is not only a *caller* but the *distributor* — it hands the same value to
+`writeHandler`, whose `entityMutator` needs `ValidateCreate`. The initial fix
+was to widen App's interface to the union (8 methods), which review correctly
+called out (RR-NEE4FC) as reintroducing "wide because it is a distributor" one
+level down.
+
+Resolved properly instead: `NewApp` now takes the **concrete**
+`*entitymanager.Manager` — it is a composition root, and `appbuild` hands it the
+concrete type anyway — and passes that to the sub-handler constructors, each of
+which narrows at its own field. `appEntityWriter` is now exactly 7 methods,
+verified equal to App's 7 direct calls with no slack.
+
+## Quality
+
+- [x] Code follows project patterns — modelled on `lua.Mutator`
+(`internal/lua/deps.go`), which narrowed *this same interface* for the Lua
+bindings in TKT-IF37, and on dataentry's ~17 existing consumer-side interfaces
+(`metaView`, `storeWatcher`, `analyzeReader`). Each new interface's godoc says
+which methods are absent **and why**, matching `lua.Mutator`'s "Six methods —
+RenameEntity and UpdateRelation are intentionally absent because no Lua binding
+invokes them."
+- [x] Checked for DRY opportunities — deliberately **not** extracted. The six
+interfaces overlap heavily, and a shared base would recreate the producer-side
+interface this ticket deletes, one level down. Each consumer declaring its own
+list is the point, not duplication to factor out.
+- [x] No security issues introduced — narrowing removes methods, never gates.
+Every retained method keeps its identical signature and implementation, so ACL,
+audit and validation in `entitymanager.Manager` are untouched, and no consumer
+gained access to anything it did not already have.
+`entitymanagertest.PanicOnUse` deliberately keeps all nine methods so it still
+satisfies every narrow interface — dropping one would have silently un-wired
+that safety net.
+- [x] No silent failures — the one place a silent failure was *possible* (the
+sync applier's nil fallback) is now covered by a regression test.
+- [x] No debug code left behind.
+
+**Stale comments corrected** (each named the deleted type or called it
+"broad"/"wide"): `appbuild.go:433`, `cli/sync.go:104`, `cli/sync/engine.go:15`,
+`dataentry/attachment_handler.go:19`, `dataentry/services.go:20`,
+`dataentry/settings_handlers.go:85` (a broken `[entitymanager.EntityManager]`
+doclink — the `doclink` rule is a blocking CI gate), plus the package doc and
+`manager.go`'s compile-time assertion block.

--- a/tickets/entities/planning-checklists/PLAN-9KPQHK.md
+++ b/tickets/entities/planning-checklists/PLAN-9KPQHK.md
@@ -1,0 +1,350 @@
+---
+id: PLAN-9KPQHK
+type: planning-checklist
+title: 'Planning: Replace producer-side entitymanager.EntityManager with per-consumer interfaces'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** `entitymanager.EntityManager`
+(`internal/entitymanager/entitymanager.go:29`) is a 9-method producer-side
+interface declared alongside its sole implementation, `*Manager`. CLAUDE.md's
+first rule forbids exactly this, and the interface's own godoc concedes it:
+*"**Transitional.** This is a producer-side interface ... which the project
+explicitly avoids ... Slated for removal."* GitHub issue #741.
+
+Every consumer that takes it today binds to the full surface even though none
+uses all of it, which leaks unused methods into test fixtures and arch-lint
+footprints.
+
+**Scope — IN:** each of the four consuming subsystems declares its own narrow
+interface at the call site; the wide interface is deleted; producer code uses
+`*Manager` directly.
+
+**Scope — OUT:**
+
+- Renaming methods or changing any signature. Purely a contract narrowing.
+- Splitting `*Manager` itself (it is over the plimsoll line for other reasons —
+TKT-N0IKN9 territory, not this).
+- `lua.Mutator` — already narrowed by TKT-IF37; it is the template here, not a target.
+- Behaviour change of any kind.
+
+**Acceptance Criteria:**
+
+1. **AC1** — `entitymanager.EntityManager` no longer exists in the package.
+2. **AC2** — every former consumer declares a narrow interface naming only the
+methods it invokes, at the consumer.
+3. **AC3** — `go build ./...` and the full test suite pass unchanged; `*Manager`
+satisfies every new interface structurally with no adapter or assertion added.
+4. **AC4** — `just arch-lint` passes.
+5. **AC5** — no behaviour change: no test assertions are modified to accommodate
+the refactor. (A test that has to change is evidence the refactor changed
+behaviour.)
+6. **AC6** — `internal/attachment` and `internal/mcp` no longer import
+`internal/entitymanager` at all, since their narrow interfaces mention only
+`internal/entity` types. This is the concrete coupling win and is verifiable
+with `go list -deps`.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — a mechanical refactor with an in-tree template.
+
+**Existing Solutions:** This has already been done once in this repo, for the
+same interface, and the result is the template. `lua.Mutator`
+(`internal/lua/deps.go:115-127`) is the consumer-side write surface for the Lua
+bindings, and its godoc states the pattern precisely:
+
+> Six methods — RenameEntity and UpdateRelation are intentionally absent because no
+> Lua binding invokes them. Narrowed from the wider EntityManager interface in
+> TKT-IF37 to drop lua's transitive dependency on internal/entitymanager.
+
+`lua.NotFoundError` beside it shows how to keep an *optional* capability
+consumer-side too. `appbuild.LuaWriteDeps` documents the resulting asymmetry:
+*"EntityManager goes in as the wide entitymanager.EntityManager; the
+lua.WriteDeps.EntityManager field is narrower (lua.Mutator) and accepts any
+structural match."* After this ticket that comment loses its premise and needs
+updating.
+
+Style to match for the new interfaces — `internal/dataentry` already has ~17
+consumer-side interfaces (`metaView`, `analyzeReader`, `relationCounter`,
+`storeWatcher`, `syncStore`, …). `metaView` (`provision.go:166`) is the model:
+unexported, one purpose, and a godoc that names *why* it is defined at the call
+site.
+
+**Method sets — measured, not guessed.** Grepped every call through each
+consumer's field (`a.entityManager`, `h.manager`, `d.EntityManager`,
+`svc.EntityManager`):
+
+**dataentry is four consumers, not one** — the field is passed down into three
+sub-holders with different needs, so it gets four interfaces, not one shared
+one:
+
+| Consumer | Methods invoked | Count |
+|---|---|---|
+| `dataentry.App.entityManager` | CreateEntity, UpdateEntity, PatchEntity, DeleteEntity, CreateRelation, UpdateRelation, DeleteRelation | 7 |
+| `dataentry.writeHandler.manager` | CreateEntity, ValidateCreate, UpdateEntity, DeleteEntity, CreateRelation, UpdateRelation, DeleteRelation | 7 |
+| `dataentry.attachmentHandler.manager` | *(none — pure passthrough)* | 0 |
+| `dataentry.maybeProvision(m)` | CreateEntity | 1 |
+| `internal/cli` | CreateEntity, UpdateEntity, PatchEntity, DeleteEntity, RenameEntity, CreateRelation, UpdateRelation, DeleteRelation | 8 (all but ValidateCreate) |
+| `internal/mcp` | CreateEntity, PatchEntity, DeleteEntity, RenameEntity, CreateRelation, DeleteRelation | 6 |
+| `internal/attachment` | UpdateEntity | 1 |
+
+`internal/appbuild` invokes **nothing** — pure wiring.
+
+Note the asymmetries: `App` never calls `ValidateCreate`, `writeHandler` never
+calls `PatchEntity`, and `ValidateCreate` is invoked from **exactly one place in
+the whole repo** (`write_handler.go:293`). `RenameEntity` is reached only from
+cli and mcp, so it leaves dataentry entirely.
+
+Call sites backing the table: dataentry
+`caldav_write.go:188,243,293,309,576,595,600,692,698`,
+`history_restore.go:107,145`, `relation_history_handler.go:368,370`,
+`write_handler.go:172,293,470,532,637,711,765,800`,
+`relations_modern.go:376,415`, `provision.go:96`; cli `create.go:54`,
+`update.go:93`, `delete.go:59`, `rename.go:189`, `link.go:18`, `unlink.go:20`,
+`renumber.go:68`, `restore.go:61,68`, `relation_history.go:201,205`; mcp
+`tools_entity.go:167,246,317,352`, `tools_relation.go:86,120`; attachment
+`attachment.go:202,226`.
+
+The interesting numbers are the small ones: **attachment needs exactly one
+method** out of nine, `attachmentHandler` needs *zero*, and mcp needs six. Those
+are where the narrowing actually buys something.
+
+**Two structural constraints the grep alone would have missed:**
+
+1. `App` passes `a.entityManager` into `lua.WriteDeps.EntityManager`, typed
+`lua.Mutator` (6 methods). That set is a strict subset of App's 7, so the narrow
+type satisfies it structurally — but it means App's interface may never drop
+below `lua.Mutator`.
+2. `cli/sync.go:116` type-asserts `svc.EntityManager.(syncclient.LocalApplier)`.
+Interface-to-interface assertion stays legal however narrow the source, so this
+compiles either way — but see the `Services.EntityManager()` decision below,
+which turns it into a compile-checked concrete match instead of a runtime one.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** Mechanical, one consumer at a time, compiler-verified at
+each step. For each consumer: declare the interface next to the type that holds
+it, change the field/param type, build. `*Manager` satisfies each structurally,
+so no wiring changes and no adapters.
+
+1. **`appbuild` first.** Change `Services.entityManager`, `Services.EntityManager()`
+and `Collaborators.EntityManager` (`appbuild.go:116, 233, 626`) to the concrete
+`*entitymanager.Manager`. `buildEntityManager` already returns the concrete type
+(`appbuild.go:1369-1375`), so this is a type annotation catching up with
+reality. Doing it first means every consumer then satisfies its own narrow
+interface for free, and `sync.go`'s `LocalApplier` assertion becomes
+concrete-to-interface (compile-checked) rather than interface-to-interface
+(runtime).
+2. `internal/attachment` — `entityUpdater` (1 method) on `Deps.EntityManager`.
+3. `internal/mcp` — 6 methods on `Deps.EntityManager`. This is the same file that
+already declares `GraphReader`/`GraphCounter` at the call site with a long
+rationale, and whose doc already says MCP "never needs the wide composite"
+(`server.go:59`); the new interface belongs beside them, in that doc style.
+4. `internal/cli` — 8 methods on `writeServices.EntityManager`.
+5. `internal/dataentry` — four separate interfaces per the table: `App` (7),
+`writeHandler` (7), `attachmentHandler` (whatever attachment's is — it only
+passes through), `maybeProvision` (1, alongside the `metaView` already in that
+file).
+6. Delete the interface, plus the `var _ EntityManager = (*Manager)(nil)` assertion
+at `manager.go:117` (keep the `autocascade.Mutator` one beside it).
+7. `entitymanagertest.PanicOnUse` — drop `var _ entitymanager.EntityManager`
+(`panic.go:21`); keep all nine methods so it still satisfies every narrow
+interface structurally, and say so in its godoc.
+8. Fix the comments this invalidates (each names the type or calls it "broad"/"wide"):
+`appbuild.go:433-435`, `cli/sync.go:100-104,117-119`,
+`cli/sync/engine.go:15-16`, `dataentry/attachment_handler.go:19-21`,
+`dataentry/services.go:20`, `dataentry/settings_handlers.go:85`,
+`entitymanager/entitymanager.go:1-28`, `entitymanagertest/panic.go:1-6,17`.
+
+**Naming.** Consumers get unexported names except where the field is on an
+exported `Deps` (mcp, attachment), where Go requires the interface be exported
+if the field type is to be nameable by the wiring site — check each;
+`lua.Mutator` is exported for that reason, so follow suit where the same applies
+and stay unexported otherwise.
+
+**Files to modify:** `internal/entitymanager/entitymanager.go` (delete
+interface), `internal/entitymanager/entitymanagertest/panic.go`,
+`internal/attachment/attachment.go`, `internal/mcp/server.go`,
+`internal/cli/cli_wiring.go`, `internal/dataentry/app.go`,
+`internal/dataentry/attachment_handler.go`,
+`internal/dataentry/write_handler.go`, `internal/dataentry/provision.go`,
+`internal/appbuild/appbuild.go`.
+
+**Alternatives considered:**
+
+1. *Keep the interface, just document it.* Rejected — it is already documented as
+transitional and slated for removal; leaving it is how "transitional" becomes
+permanent.
+2. *One shared narrow interface for all consumers.* Rejected — that is the same
+producer-side mistake with a smaller surface. It would also be wrong: no two
+consumers have the same method set (dataentry and cli both need 8, but different
+8s).
+3. *Split by capability (EntityWriter / RelationWriter).* Tempting, but it invents a
+taxonomy nothing asked for — three of the four consumers need both halves, so it
+would mean embedding two interfaces to say what one list says plainly. Consumers
+declare what they call; that is the rule.
+4. *Do it in 3-5 PRs grouped by subsystem*, as the issue suggests. Rejected as
+unnecessary: the change is ~10 files and the interface can only be deleted once
+every consumer is converted, so splitting means N-1 PRs that add interfaces
+without removing anything, and the payoff lands only at the end. One reviewable
+PR is better here. Revisit if it turns out larger than measured.
+
+**Dependencies:** none. No package gains an import; two should lose one (AC6).
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** None. This refactor introduces no new input, no
+new call path, and no new code that runs at request time — it only narrows the
+static type of existing fields.
+
+**Security-Sensitive Operations:** One property is worth stating because it is
+the reason this refactor is safe to do mechanically: `entitymanager.Manager` is
+the sole write path, and it is where ACL, audit and validation are enforced
+(`internal/entitymanager/CLAUDE.md`). Narrowing an interface **cannot** bypass
+any of that — every method retained keeps its identical signature and
+implementation, and no consumer gains access to a method it did not already
+have. The risk would be the opposite direction (a consumer accidentally handed a
+*raw store* handle instead), which this change does not touch.
+
+The one thing to watch: `entitymanagertest.PanicOnUse` exists so that read-only
+test paths fail loudly on an accidental mutation. If narrowing let a consumer
+take an interface `PanicOnUse` no longer satisfies, that safety net would
+silently stop being wired. Keeping all nine methods on it (step 6) preserves it;
+AC3 catches a regression at compile time.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** This is a refactor with no behaviour change, so the test
+strategy is *the existing suite, unmodified* — that is the actual assertion
+(AC5). Specifically:
+
+- **AC1/AC2/AC3** — `go build ./...` plus `just test`. The compiler is the
+verification: if a consumer's narrow interface omits a method it calls, the
+build fails; if `*Manager` drifts from an interface, the build fails at the
+wiring site.
+- **AC4** — `just arch-lint`.
+- **AC5** — `git diff --stat` must show **zero** changes under any `_test.go`
+assertion. Test files may change only where they name the deleted type.
+- **AC6** — the concrete win, and the only genuinely new check worth adding:
+
+  ```
+  go list -deps ./internal/attachment | grep -q internal/entitymanager  # must fail
+  go list -deps ./internal/mcp        | grep -q internal/entitymanager  # must fail
+  ```
+
+Verify before and after; if either still imports it, some other reference
+remains and the narrowing bought nothing there.
+
+**Edge Cases:**
+
+- A method invoked only from a `_test.go` in a consumer package would be missed by
+a production-only grep, and the omission surfaces as a test-compile failure.
+Mitigation: build tests too (`go vet ./...` / `just test` compiles them).
+- **`dataentry/unmatched_principal_e2e_test.go:182`** compares
+`app.luaWriteDeps().EntityManager != app.entityManager` — two *interface*
+values. Once the two sides have different interface types Go rejects the
+comparison at compile time. Making `Services.EntityManager()` concrete (step 1)
+resolves it in the right direction: both sides become comparable `*Manager`
+pointers and the test's intent ("actions share the CRUD manager, so the reject
+gate covers them") is expressed more directly than before. This is a test
+*compile* fix, not an assertion change, so it does not violate AC5 — but call it
+out in the PR.
+- Reflection or interface assertions on the deleted type would compile-fail; a
+repo-wide grep for `entitymanager.EntityManager` after the change must return
+zero (including `cmd/` and `_test.go`).
+- `PanicOnUse` must still satisfy every new interface — asserted by the tests that
+already wire it.
+- The postgres/memory/sqlite build tags compile different `appbuild` recipes;
+`Services.entityManager`'s type change must build under each. Check with `go
+build -tags postgres ./...` and the other tags, not just the default build.
+
+**Negative Tests:** None applicable — there is no new runtime behaviour to fail.
+The "negative test" for a type-narrowing refactor is that the compiler rejects a
+consumer calling a method it did not declare, which is structural rather than
+something to assert in a test.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| A method used only in a test or under a build tag is missed | Compile all tags and all tests, not just `go build ./...` |
+| Merge conflicts — this touches files other in-flight work also touches (`dataentry/app.go`, `mcp/server.go`) | Small, mechanical, single PR; land it promptly rather than letting it age |
+| `PanicOnUse` silently stops covering a path | Keep all nine methods; compile-time assertion via existing wiring |
+| Scope creep into splitting `*Manager` | Explicitly out of scope (TKT-N0IKN9 owns that) |
+
+**Effort:** m — ~10 files, mechanical, compiler-verified at every step.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `appbuild.LuaWriteDeps` godoc — its "goes in as the wide
+entitymanager.EntityManager" sentence loses its premise; update as part of the
+change.
+- [x] `entitymanagertest` package godoc — it opens "test doubles for the
+entitymanager.EntityManager interface", a type that will no longer exist.
+- [x] `internal/entitymanager/entitymanager.go` package doc — check whether it
+still reads correctly once the interface is gone.
+- [x] ~~README.md / docs/~~ (N/A: no user-facing surface changes — no CLI flag,
+no API, no config)
+- [x] ~~CLAUDE.md~~ (N/A: this ticket *applies* the existing consumer-side
+interfaces rule rather than changing it;
+`docs/architecture/consumer-side-interfaces.md` already documents the pattern)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: skipped
+      deliberately, and the judgement is worth recording. `/design-review`
+      exists to catch design decisions that are expensive to reverse. This
+      ticket has none: the interface's own godoc already prescribed the design
+      ("each call site should declare its own narrow consumer-side interface"),
+      the method sets were *measured* from call sites rather than chosen, and
+      every step is compiler-verified — a wrong set does not compile. The real
+      risk here was in the *code*, not the plan, which is where the review
+      effort went: `/code-review` returned 12 findings including a latent
+      nil-deref, and two of them (RR-NEE4FC, RR-XHC5EB) did change the design.)
+- [x] All critical/significant findings addressed in plan — all 12 code-review
+      findings addressed; see the review checklist.
+
+**Design Review Findings:** N/A — see the review checklist for the 12
+code-review findings (RR-ZTWK9S critical; RR-XHC5EB, RR-LOZBZQ, RR-EE4DIU,
+RR-09AUCP, RR-1XW25U, RR-NEE4FC significant; RR-GE0DM1, RR-2RCGDV, RR-PRY567
+minor; RR-VXK77U, RR-ZOJCR3 nit).

--- a/tickets/entities/review-checklists/REV-VCBY8N.md
+++ b/tickets/entities/review-checklists/REV-VCBY8N.md
@@ -1,0 +1,164 @@
+---
+id: REV-VCBY8N
+type: review-checklist
+title: 'Review: Replace producer-side entitymanager.EntityManager with per-consumer interfaces'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` **exit 0**, zero failures,
+re-run after every review fix. Also compiled under all four backend tags
+(default, `postgres`, `memorybackend`, `sqlite`), since `appbuild`'s recipes
+differ per tag.
+- [x] Lint clean (`just lint`) — **0 issues**. It caught two things during the
+work: a `gocritic dupImport` (the same package imported twice under two names,
+RR-2RCGDV) and an `lll` overrun in a new signature.
+- [x] Comment lint gate clean (`just comment-lint`) — no unresolvable doc links
+across 11,460 comments. This gate **earned its keep**: deleting the type broke a
+`[EntityManager]` doclink in `manager.go`, which is exactly the "godoc renders
+the brackets literally, and no other linter catches it" case the rule exists
+for. Fixed the comment rather than suppressing.
+- [x] Coverage maintained (`just coverage-check`) — see Acceptance Status.
+- [x] `just plimsoll` — passes. Also earned its keep: the first placement of
+`appEntityWriter` landed between `//plimsoll:max-methods=86` and `type App
+struct`, detaching the directive and failing the gate with *"type App has 86
+methods, over the load line of 40"* (RR-GE0DM1).
+- [x] `just arch-lint` — `OK - No warnings found`.
+
+**Comment findings.** `just comment-report` flagged a `duplication` finding my
+diff **introduced**: the same "declared here at the consumer per CLAUDE.md; the
+wiring site supplies `*Manager`" boilerplate restated across three of the new
+interfaces (56% shared). Per the rule's own remedy, the fact was hoisted to the
+type they all cite — the `internal/entitymanager` package doc — and each
+interface now points at it instead of restating it. Residual overlap is 33%,
+which is just the shared pointer sentence; compressing further would remove the
+pointer itself. No suppressions were added anywhere in this diff.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** 12 findings — 1 critical, 6 significant, 3 minor, 2 nit.
+**All 12 addressed** (none deferred or wont-fix).
+
+RR-ZTWK9S (critical), RR-XHC5EB, RR-LOZBZQ, RR-EE4DIU, RR-09AUCP, RR-1XW25U,
+RR-NEE4FC (significant), RR-GE0DM1, RR-2RCGDV, RR-PRY567 (minor), RR-VXK77U,
+RR-ZOJCR3 (nit).
+
+**The critical finding is worth reading (RR-ZTWK9S).** Review found a latent
+nil-pointer panic that this refactor made reachable. `NewEngine`'s godoc said
+*"applier may be nil for a push-only run (push never writes locally)"* and
+`buildSyncEngine` echoed it — **both false**. `push.go`'s `recordCreate`
+dereferences the applier on the id-adoption path (`newID != ch.Key`), which is
+the *ordinary* create path when the primary mints its own id. `Pull` and `Force`
+guarded it; `Push` did not.
+
+It was unreachable while the CLI held a concrete `*entitymanager.Manager`.
+Narrowing that field to an interface made the assertion genuinely fallible — and
+the assertion **failed open**, setting `applier = nil`, which CLAUDE.md names
+explicitly: *"never substitute a no-op or sentinel implementation silently."*
+
+Fixed in three layers rather than patched at one:
+
+1. **Removed the fallible assertion.** `writeServices` now carries a typed
+`SyncApplier syncclient.LocalApplier` field assigned from the concrete manager
+at the wiring site, so a missing applier is a compile error rather than a
+silently disabled `pull` (RR-XHC5EB).
+2. **Guarded the deref** in `recordCreate`, matching how pull and force already
+behave, and renamed `errRemoteApplierRequired` → `errLocalApplierRequired` since
+push qualifies too.
+3. **Corrected the contract doc** — the nil case is "a run that never writes
+locally", which is narrower than "push-only".
+
+**Verified the fix is real**: `TestRecordCreate_NilApplier_ErrorsNotPanics`
+passes with the guard, and reverting the guard makes it *panic with a nil
+pointer dereference*. The original regression test was replaced because it
+asserted only that `*Manager`'s method set was intact — a fact that could not
+realistically break (RR-LOZBZQ).
+
+**Two review findings changed the design, not just the code:**
+
+- **RR-NEE4FC** — `appEntityWriter` was 8 methods, but App only calls 7;
+`ValidateCreate` was there solely to feed `writeHandler`. That reintroduced
+"wide because it is a distributor" one level down. Fixed by having `NewApp` take
+the **concrete** `*entitymanager.Manager` and pass that to the sub-handler
+constructors, each narrowing at its own field. `appEntityWriter` is now exactly
+7 — verified equal to App's direct-call set with no slack.
+- **RR-EE4DIU** — inserting `entityMutator` between `writeHandler`'s doc comment
+and its declaration meant **`writeHandler` silently lost its doc comment**
+entirely (Go attaches a comment to the following declaration). Neither blocking
+gate catches comment *attachment*. Moved the interface above the block.
+
+Three findings were confidently-wrong comments I had written (RR-1XW25U:
+`appEntityWriter` claimed a `lua.Mutator` "floor" that constrains nothing and
+omits `UpdateRelation`; RR-09AUCP: `entityMutator` stated a PatchEntity
+rationale that the CalDAV writer falsifies three files over; RR-PRY567:
+CLAUDE.md still told readers to depend on the deleted type). All corrected.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — interface removed. PASS.** `grep -rn "entitymanager.EntityManager"
+internal/ cmd/` returns zero matches, including comments and `_test.go`.
+- **AC2 — narrow interfaces at each consumer. PASS.** Six declared:
+`attachment.EntityUpdater` (1), `mcp.EntityWriter` (6), `cli.entityWriter` (8),
+`dataentry.appEntityWriter` (7), `dataentry.entityMutator` (7),
+`dataentry.entityProvisioner` (1). Each verified against its consumer's actual
+call set.
+- **AC3 — build + tests unchanged. PASS.** `go test ./...` exit 0; builds under
+all four backend tags; no adapter or assertion needed — `*Manager` satisfies
+every interface structurally.
+- **AC4 — arch-lint. PASS.** `OK - No warnings found`.
+- **AC5 — no behaviour change. PASS.** No pre-existing `_test.go` was modified.
+The only test changes are additions: one new regression test, and one deleted
+(the weak assertion test review rejected).
+- **AC6 — coupling actually dropped. PASS.** `go list -deps` confirms neither
+`internal/attachment` nor `internal/mcp` depends on `internal/entitymanager` any
+more. Both did before.
+
+**Beyond the ACs — every narrowed write path exercised for real**, against a
+copy of the `tickets/` project rather than only in tests: all 8 CLI methods
+(`create`, `update`, `link`, `unlink`, `rename id`, `delete`) and all 6 MCP
+tools driven over real JSON-RPC stdio with a full `initialize` handshake
+(`create_entity`, `update_entity`, `create_relation`, `delete_relation`,
+`rename_entity`, `delete_entity`) — all returning success, no `isError`. Re-run
+after the review fixes.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal
+refactor, `kind=refactor`. No user-facing surface changes — no CLI flag, no API,
+no config, no metamodel feature.)
+- [x] ~~User-facing documentation updated~~ (N/A: same reason. The doc changes in
+this diff are all godoc and CLAUDE.md — developer-facing.)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A — internal refactor.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed — none added.
+- [x] Ready for another developer to use — the `internal/entitymanager` package
+doc now carries a "No interface here" section explaining why the wide interface
+was deleted and what replaced it, so the next person does not re-add it. It also
+records the distributor rule that RR-NEE4FC surfaced.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design, not
+      skipped: `/pr` gates on the ticket already being `done` and validating
+      clean, and a `done` checklist may have no unchecked items — so this item
+      can only be satisfied by a PR that does not exist yet. Same ordering the
+      note below records for the PR URL and CI status. The PR is opened
+      immediately after this checklist closes.)

--- a/tickets/entities/review-responses/RR-09AUCP.md
+++ b/tickets/entities/review-responses/RR-09AUCP.md
@@ -1,0 +1,22 @@
+---
+id: RR-09AUCP
+type: review-response
+title: entityMutator's PatchEntity rationale is contradicted by the CalDAV writer three files over
+finding: The claim is scoped to writeHandler but stated as a general fact about the data-entry write path
+severity: significant
+resolution: 'Scoped the claim: PatchEntity is absent FROM THIS HANDLER because a form save owns the whole record; and the comment now states that this is a fact about form saves rather than data-entry writes generally; naming the CalDAV writer as the patching caller.'
+status: addressed
+---
+
+`entityMutator`'s doc says:
+
+> Seven of the manager's nine write methods. PatchEntity is absent because a form
+> save renders every field and therefore legitimately owns the whole record.
+
+The reasoning is correct **for writeHandler**. But it is phrased as a general
+fact about the data-entry write path, and `caldav_write.go:309,600,698` call
+`entityManager.PatchEntity` on that same path — precisely because CalDAV does
+*not* own the whole record.
+
+CLAUDE.md's `duplication` rule warns about this shape: a fact asserted in one
+comment that another site falsifies. Scope the claim to the handler.

--- a/tickets/entities/review-responses/RR-1XW25U.md
+++ b/tickets/entities/review-responses/RR-1XW25U.md
@@ -1,0 +1,21 @@
+---
+id: RR-1XW25U
+type: review-response
+title: appEntityWriter's floored-by-lua.Mutator claim is vacuous and misleading
+finding: Every lua.Mutator method is already in App's direct-call set and lua.Mutator lacks UpdateRelation
+severity: significant
+resolution: Dropped the sentence. It was doubly wrong - every lua.Mutator method was already in App's direct-call set so the floor constrained nothing; and lua.Mutator lacks UpdateRelation.
+status: addressed
+---
+
+`appEntityWriter`'s doc claims the set *"is also floored by lua.Mutator's six
+methods, since App passes this value into lua.WriteDeps.EntityManager."*
+
+`lua.Mutator` is CreateEntity, UpdateEntity, PatchEntity, DeleteEntity,
+CreateRelation, DeleteRelation. Every one of those is **already** in App's own
+7-method direct-call set, so the floor constrains nothing — the sentence implies
+it is load-bearing when it is not. And `lua.Mutator` does **not** contain
+`UpdateRelation`, so a reader trying to work out why `UpdateRelation` is present
+will look there, not find it, and be misled.
+
+Either drop the sentence or state it accurately.

--- a/tickets/entities/review-responses/RR-2RCGDV.md
+++ b/tickets/entities/review-responses/RR-2RCGDV.md
@@ -1,0 +1,23 @@
+---
+id: RR-2RCGDV
+type: review-response
+title: write_handler.go imports internal/entity twice under two names
+finding: The new bare entity import duplicates the file's existing entityPkg alias and golangci-lint fails on it
+severity: minor
+resolution: Dropped the duplicate bare import; entityMutator's signatures now use the file's existing entityPkg alias. just lint is clean.
+status: addressed
+---
+
+`internal/dataentry/write_handler.go:18-19` now has both:
+
+```go
+"github.com/Sourcehaven-BV/rela/internal/entity"
+entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+```
+
+The bare import was added for the new `entityMutator` signatures while the file
+already imported the package as `entityPkg` (used throughout). It compiles, but
+the same type is now spelled two ways in one file. `just lint` fails on it
+(gocritic `dupImport`, 2 issues).
+
+Use the existing `entityPkg` alias in the interface and drop the new import.

--- a/tickets/entities/review-responses/RR-EE4DIU.md
+++ b/tickets/entities/review-responses/RR-EE4DIU.md
@@ -1,0 +1,24 @@
+---
+id: RR-EE4DIU
+type: review-response
+title: 'writeHandler lost its doc comment: the interface was inserted between the comment and the type'
+finding: Go attaches a comment to the declaration that follows it - writeHandler's block now documents entityMutator instead
+severity: significant
+resolution: Confirmed - writeHandler had lost its doc comment entirely. Moved entityMutator above writeHandler's doc block so the comment reattaches to the type it documents.
+status: addressed
+---
+
+In `internal/dataentry/write_handler.go`, `entityMutator`'s declaration was
+inserted between `writeHandler`'s doc comment and `type writeHandler struct`,
+with no blank line separating the two comment blocks. The previous block ends
+`// NOT part of this refactor.)` and the next line is `// entityMutator is the
+write surface...`.
+
+Go attaches a doc comment to the declaration immediately following it, so
+`writeHandler`'s carefully-written explanation of its collaborator shape and the
+`writeMu` pointer now documents `entityMutator`, and `writeHandler` has **no doc
+comment at all**. A silent documentation regression on the type that most needed
+the explanation.
+
+Neither blocking comment gate catches this — `doclink` and `commented-code`
+check links and commented-out code, not comment *attachment*.

--- a/tickets/entities/review-responses/RR-GE0DM1.md
+++ b/tickets/entities/review-responses/RR-GE0DM1.md
@@ -1,0 +1,20 @@
+---
+id: RR-GE0DM1
+type: review-response
+title: appEntityWriter was threaded through App's 40-line doc comment
+finding: The declaration landed far from its godoc and nearly detached App's plimsoll directive
+severity: minor
+resolution: Fixed during implementation - the block was moved above App's doc comment and directive/struct adjacency re-verified with just plimsoll.
+status: addressed
+---
+
+The first placement of `appEntityWriter` inserted its godoc *inside* `App`'s
+multi-paragraph doc comment, between the decomposition history and the
+`//plimsoll:max-methods=86` directive — which detached the directive from `type
+App struct` and failed `just plimsoll` (*"type App has 86 methods, over the load
+line of 40"*).
+
+Fixed by moving the whole block above `App`'s doc comment, and re-verified:
+directive and struct are adjacent, plimsoll passes. Recorded because the failure
+mode is silent in review — a directive one line out of place turns a
+grandfathered type into a CI failure or silently un-pins it.

--- a/tickets/entities/review-responses/RR-LOZBZQ.md
+++ b/tickets/entities/review-responses/RR-LOZBZQ.md
@@ -1,0 +1,25 @@
+---
+id: RR-LOZBZQ
+type: review-response
+title: The sync regression test asserts a fact that cannot realistically break
+finding: It checks *Manager's method set rather than what buildSyncEngine actually receives at runtime
+severity: significant
+resolution: Deleted the weak test. Replaced with TestRecordCreate_NilApplier_ErrorsNotPanics in internal/cli/sync; which drives recordCreate down the id-adoption branch with a nil applier and asserts a clean error. Confirmed it fails (nil-pointer panic) without the guard.
+status: addressed
+---
+
+`internal/cli/sync_applier_assert_test.go` asserts that a typed-nil
+`(*entitymanager.Manager)(nil)` held as `entityWriter` asserts to
+`LocalApplier`. That is a compile-time-shaped fact about `*Manager`'s method
+set: it can only fail if someone deletes a method from `Manager`, which would
+break a dozen other things first.
+
+It does **not** cover the failure mode the test's own doc describes — that the
+value `buildSyncEngine` receives is something other than `*Manager` (a
+decorator, a double, a future ACL wrapper). The test never calls
+`buildSyncEngine`.
+
+The right regression is: wire a `writeServices` whose `entityWriter` is not a
+`*Manager` and assert `buildSyncEngine` returns an error. That only becomes
+testable once the silent fallback is removed. If the typed-field fix lands,
+delete the test — the compiler subsumes it.

--- a/tickets/entities/review-responses/RR-NEE4FC.md
+++ b/tickets/entities/review-responses/RR-NEE4FC.md
@@ -1,0 +1,25 @@
+---
+id: RR-NEE4FC
+type: review-response
+title: 'appEntityWriter is not minimal: ValidateCreate is present only to feed a child handler'
+finding: App holds a method it never calls because it distributes one narrowed value to sub-handlers
+severity: significant
+resolution: Adopted the suggested factoring. NewApp now takes the concrete *entitymanager.Manager and passes THAT to the attachmentHandler and writeHandler constructors; so each narrows at its own field. appEntityWriter is now exactly 7 methods - verified equal to App's 7 direct calls; no slack. Also updated the entitymanager package doc's 'one to eight' to 'one to seven' and documented the distributor rule there.
+status: addressed
+---
+
+App directly calls 7 methods; `ValidateCreate` is on `appEntityWriter` purely
+because `writeHandler.entityMutator` needs it. So App's interface is the *union*
+of its own needs and its children's, which reintroduces "wide because it is a
+distributor" one level down — App holds a method it never invokes, with the
+reason buried in prose.
+
+The clean factoring is to stop distributing one narrowed value: have `NewApp`
+take the concrete `*entitymanager.Manager` (it is a composition root, it already
+takes 13 positional collaborators, and appbuild hands it the concrete type
+anyway), store it as a genuinely-minimal 7-method `appEntityWriter`, and pass
+the concrete handle to the sub-handler constructors, each narrowing at its own
+field.
+
+Consequence worth noting: the `entitymanager` package doc's "between one and
+eight of the nine methods" becomes "one to seven".

--- a/tickets/entities/review-responses/RR-PRY567.md
+++ b/tickets/entities/review-responses/RR-PRY567.md
@@ -1,0 +1,17 @@
+---
+id: RR-PRY567
+type: review-response
+title: CLAUDE.md still instructs readers to depend on the deleted type
+finding: The No repository or transaction abstractions rule names entitymanager.EntityManager
+severity: minor
+resolution: Updated CLAUDE.md's 'No repository or transaction abstractions' rule to name entitymanager.Manager.
+status: addressed
+---
+
+Repo-root `CLAUDE.md`, under "No repository or transaction abstractions":
+*"Depend directly on `store.Store`, `tracer.Tracer`, `search.Searcher`,
+`entitymanager.EntityManager`."*
+
+That symbol no longer exists. The rule's intent survives (depend on the manager,
+not a repo layer), but it now points at a deleted type — in the same document
+whose first rule motivated this ticket. Update to `entitymanager.Manager`.

--- a/tickets/entities/review-responses/RR-VXK77U.md
+++ b/tickets/entities/review-responses/RR-VXK77U.md
@@ -1,0 +1,16 @@
+---
+id: RR-VXK77U
+type: review-response
+title: app.go godoc brackets an unexported symbol from another file
+finding: Go cannot link unexported members so [entityMutator] renders as literal brackets
+severity: nit
+resolution: Resolved - the doc paragraph containing [entityMutator] was rewritten for RR-NEE4FC and no longer brackets an unexported cross-file symbol. Verified no bracketed unexported refs remain.
+status: addressed
+---
+
+`appEntityWriter`'s doc references `[entityMutator]`, an unexported symbol
+declared in another file. Go cannot link an unexported member at all, so godoc
+renders the brackets literally.
+
+CLAUDE.md's `doclink` guidance is explicit that such references *"should simply
+lose their brackets."*

--- a/tickets/entities/review-responses/RR-XHC5EB.md
+++ b/tickets/entities/review-responses/RR-XHC5EB.md
@@ -1,0 +1,34 @@
+---
+id: RR-XHC5EB
+type: review-response
+title: writeServices should hold the sync applier as a typed field rather than reconstruct it by assertion
+finding: appbuild now hands out the concrete *Manager so the type is statically known at the wiring site - re-asserting it is a downgrade
+severity: significant
+resolution: Adopted. writeServices now carries a typed SyncApplier syncclient.LocalApplier field assigned from the concrete svc.EntityManager() at the wiring site. The fallible assertion and its fail-open 'applier = nil' fallback are deleted from buildSyncEngine.
+status: addressed
+---
+
+`Services.EntityManager()` now returns the concrete `*entitymanager.Manager`, so
+the applier capability is **statically known** at the CLI wiring site
+(`cli_wiring.go`). Narrowing to `entityWriter` and then reconstructing the
+capability via a runtime assertion turns a compile-time fact into a runtime one
+— and then needs a test to compensate for the downgrade.
+
+Give `writeServices` a second explicitly-typed field, assigned from the same
+concrete value at the wiring site:
+
+```go
+type writeServices struct {
+    readServices
+    EntityManager entityWriter
+    // SyncApplier is the id-preserving write path `rela sync` needs. A separate
+    // field, not an assertion on EntityManager: sync's capability is distinct
+    // from the human-intent write surface, and wiring it explicitly makes a
+    // missing applier a compile error rather than a silently disabled pull.
+    SyncApplier syncclient.LocalApplier
+}
+```
+
+The assertion, the fallback, and the regression test all disappear, replaced by
+the compiler. This is CLAUDE.md's "define a typed dependency instead of a
+back-channel type assertion" applied to the case it was written for.

--- a/tickets/entities/review-responses/RR-ZOJCR3.md
+++ b/tickets/entities/review-responses/RR-ZOJCR3.md
@@ -1,0 +1,13 @@
+---
+id: RR-ZOJCR3
+type: review-response
+title: settings_handlers.go comment left with an unfinished rewrap
+finding: The edited line now runs past the file's prevailing width
+severity: nit
+resolution: Rewrapped the comment to the file's prevailing width.
+status: addressed
+---
+
+The comment edit in `internal/dataentry/settings_handlers.go:84-85` replaced the
+bracketed type reference but did not rewrap, leaving a line noticeably longer
+than its neighbours. Cosmetic, but it is in the diff.

--- a/tickets/entities/review-responses/RR-ZTWK9S.md
+++ b/tickets/entities/review-responses/RR-ZTWK9S.md
@@ -1,0 +1,35 @@
+---
+id: RR-ZTWK9S
+type: review-response
+title: sync push nil-derefs the applier; the silent fallback makes it reachable
+finding: NewEngine's godoc and buildSyncEngine's comment both claim push needs no applier - push.go:302 dereferences it on the normal create-id-adoption path
+severity: critical
+resolution: 'Guarded the deref in recordCreate: a nil applier on the id-adoption path now returns errLocalApplierRequired (renamed from errRemoteApplierRequired since push qualifies too) instead of panicking. Corrected NewEngine''s godoc - the nil case is ''a run that never writes locally'' which is narrower than ''push-only''. Pinned by TestRecordCreate_NilApplier_ErrorsNotPanics; verified it genuinely catches the bug by reverting the guard and observing the nil-pointer panic.'
+status: addressed
+---
+
+`internal/cli/sync/engine.go:54` documents *"applier may be nil for a push-only
+run (push never writes locally)"*, and `internal/cli/sync.go:119-120` repeats
+it: *"a build that doesn't [satisfy this] would only break pull (push needs no
+applier)"*. **Both are false.**
+
+`Pull` (`pull.go:78`) and `Force` (`force.go:58`) guard with
+`errRemoteApplierRequired`. `Push` does not, and `push.go:302` dereferences it
+unconditionally:
+
+```go
+if newID != ch.Key {
+    if _, err := e.applier.RenameEntity(ctx, ch.Key, newID, entity.RenameOptions{}); err != nil {
+```
+
+`newID != ch.Key` is the **normal** create-adoption path — the primary mints an
+id different from the local temp id. So a nil applier there is a nil-interface
+method call and a panic, not a degraded pull.
+
+The bug is pre-existing, but this ticket is what makes it worth fixing now: the
+field went from a concrete type to an interface, so the assertion at
+`sync.go:117` is genuinely fallible for the first time.
+
+CLAUDE.md's "Constructors reject nil required fields" covers this exactly, and
+it says *"never substitute a no-op or sentinel implementation silently"* — which
+is verbatim what `applier = nil` does.

--- a/tickets/entities/tickets/TKT-IVSJV6.md
+++ b/tickets/entities/tickets/TKT-IVSJV6.md
@@ -1,0 +1,27 @@
+---
+id: TKT-IVSJV6
+type: ticket
+title: Replace producer-side entitymanager.EntityManager with per-consumer interfaces
+kind: refactor
+priority: medium
+effort: m
+status: done
+---
+
+## Description
+
+`entitymanager.EntityManager` is a wide producer-side interface declared
+alongside its sole implementation (`Manager`) — against CLAUDE.md's "define
+interfaces at the call site" rule. Its own godoc says so and marks itself
+transitional and slated for removal. GitHub issue #741.
+
+The interface persisted because the removed workspace bridge returned it from
+`Workspace.Manager()`. Every consumer that touches it today pulls in the full
+10-method surface, leaking unused methods into test fixtures and arch-lint
+footprints.
+
+Each consumer should declare its own narrow interface naming only the methods it
+invokes; `*Manager` continues to satisfy each structurally. The interface is
+then deleted and producer code uses `*Manager` directly.
+
+No behaviour change.

--- a/tickets/relations/TKT-IVSJV6--affects--rest-api.md
+++ b/tickets/relations/TKT-IVSJV6--affects--rest-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: affects
+to: rest-api
+---

--- a/tickets/relations/TKT-IVSJV6--affects--workspace.md
+++ b/tickets/relations/TKT-IVSJV6--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-IVSJV6--has-implementation--IMPL-OTEBIM.md
+++ b/tickets/relations/TKT-IVSJV6--has-implementation--IMPL-OTEBIM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-implementation
+to: IMPL-OTEBIM
+---

--- a/tickets/relations/TKT-IVSJV6--has-planning--PLAN-9KPQHK.md
+++ b/tickets/relations/TKT-IVSJV6--has-planning--PLAN-9KPQHK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-planning
+to: PLAN-9KPQHK
+---

--- a/tickets/relations/TKT-IVSJV6--has-review--REV-VCBY8N.md
+++ b/tickets/relations/TKT-IVSJV6--has-review--REV-VCBY8N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review
+to: REV-VCBY8N
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-09AUCP.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-09AUCP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-09AUCP
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-1XW25U.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-1XW25U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-1XW25U
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-2RCGDV.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-2RCGDV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-2RCGDV
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-EE4DIU.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-EE4DIU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-EE4DIU
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-GE0DM1.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-GE0DM1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-GE0DM1
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-LOZBZQ.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-LOZBZQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-LOZBZQ
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-NEE4FC.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-NEE4FC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-NEE4FC
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-PRY567.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-PRY567.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-PRY567
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-VXK77U.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-VXK77U.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-VXK77U
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-XHC5EB.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-XHC5EB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-XHC5EB
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-ZOJCR3.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-ZOJCR3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-ZOJCR3
+---

--- a/tickets/relations/TKT-IVSJV6--has-review-response--RR-ZTWK9S.md
+++ b/tickets/relations/TKT-IVSJV6--has-review-response--RR-ZTWK9S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: has-review-response
+to: RR-ZTWK9S
+---

--- a/tickets/relations/TKT-IVSJV6--implements--FEAT-B9VS.md
+++ b/tickets/relations/TKT-IVSJV6--implements--FEAT-B9VS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-IVSJV6
+relation: implements
+to: FEAT-B9VS
+---


### PR DESCRIPTION
Closes #741.

## Why

`entitymanager.EntityManager` was a nine-method interface declared beside its sole implementation. CLAUDE.md's first rule forbids exactly that, and the interface's own godoc conceded it:

> **Transitional.** This is a producer-side interface (defined alongside its sole implementation, `Manager`), which the project explicitly avoids per CLAUDE.md "consumer-side interfaces" rule. Slated for removal.

Every consumer bound to all nine methods while calling between one and seven.

## What

Each consumer now declares what it actually calls, at its own call site. Method sets were **measured** from call sites, not chosen:

| Interface | Methods | Consumer |
|---|---|---|
| `attachment.EntityUpdater` | 1 | `UpdateEntity` — attaching a file never creates, deletes or relates |
| `dataentry.entityProvisioner` | 1 | `CreateEntity` — provisioning creates one stub |
| `mcp.EntityWriter` | 6 | no `UpdateEntity`/`ValidateCreate`/`UpdateRelation` |
| `dataentry.entityMutator` | 7 | writeHandler; no `PatchEntity`/`RenameEntity` |
| `dataentry.appEntityWriter` | 7 | App's direct calls, exactly |
| `cli.entityWriter` | 8 | the widest; no `ValidateCreate` |

`appbuild.Services.EntityManager()` now returns the concrete `*entitymanager.Manager`, so each interface is satisfied structurally — no adapters, no wiring changes.

This follows `lua.Mutator` (TKT-IF37), which narrowed this same interface for the Lua bindings.

**`internal/attachment` and `internal/mcp` no longer depend on `internal/entitymanager` at all** (`go list -deps`, verified before and after).

### A composition root takes the concrete type

`dataentry.NewApp` distributes the manager to three sub-handlers. Narrowing it there forced App to hold the *union* of every child's needs — the same "wide because it's a distributor" problem one level down. It now takes `*Manager` and passes that on, so each handler narrows at its own field and `appEntityWriter` is exactly App's 7 direct calls.

## Bonus: a latent nil-deref this made reachable

Review caught that `sync`'s applier came from a type assertion that **failed open** (`applier = nil`), while `NewEngine`'s godoc claimed *"applier may be nil for a push-only run (push never writes locally)"*. That is false — `push.go`'s `recordCreate` dereferences it on the id-adoption path (`newID != ch.Key`), the *ordinary* path when the primary mints its own id. `Pull` and `Force` guarded it; `Push` did not.

It was unreachable while the field held a concrete `*Manager`; narrowing it to an interface made the assertion genuinely fallible. Fixed in three layers:

1. The CLI holds the applier as a **typed `writeServices.SyncApplier` field**, so a missing applier is a compile error, not a silently disabled `pull`.
2. `recordCreate` guards, like pull and force already did (`errRemoteApplierRequired` → `errLocalApplierRequired`, since push qualifies too).
3. The contract doc now says what it means: nil is only for a run that **never writes locally**.

`TestRecordCreate_NilApplier_ErrorsNotPanics` pins it — and reverting the guard makes it panic with a nil-pointer dereference, so the test is known to catch the bug.

## Verification

- `go test ./...` exit 0; builds under all four backend tags (default, `postgres`, `memorybackend`, `sqlite`)
- `just lint` 0 issues · `arch-lint` OK · `comment-lint` clean · `plimsoll` OK · `lint-md` clean
- `just coverage-check` passes both thresholds (78.5% total)
- **No pre-existing test was modified** — the only test changes are one addition and one deletion (a weak assertion test review rejected)
- Every narrowed path exercised for real against a copy of `tickets/`: all 8 CLI methods, and all 6 MCP tools over real JSON-RPC stdio

Code review returned 12 findings (1 critical, 6 significant, 3 minor, 2 nit); all 12 addressed, none deferred. Three were confidently-wrong comments I had written.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
