### PR TITLE
feat(audit): attribute cascade writes to the originating automation (TKT-JJRVX9)

### DIFF
--- a/docs-project/entities/guides/GUIDE-audit-log.md
+++ b/docs-project/entities/guides/GUIDE-audit-log.md
@@ -179,14 +179,26 @@ the operator who started the server is the right grain for forensics.
 When a write is caused by an automation cascade or scheduler task,
 `triggered_by` distinguishes it from direct user actions:
 
-- `automation:<name>` — a scripted automation action.
-- `automation` — a non-scripted automation action (relation create,
-  cascaded entity create). Generic label by design — the engine
-  doesn't currently thread the originating automation name through
-  these paths.
+- `automation:<name>` — an automation action, named after the
+  automation that produced it. Scripted (`lua:`) and non-scripted
+  (relation create, cascaded entity create, and the delete half of an
+  `if_exists: replace`) actions alike.
+- `automation` — the fallback for an automation declared without a
+  `name:`. Note `name:` is an optional field on an `automations:` list
+  entry and nothing rejects an automation that omits it, so this label
+  means "the schema did not say which rule this was" — not that
+  something went wrong.
 - `schedule:<task-name>` — a scheduler-driven Lua task.
 - `cascade:delete-entity:<id>` — a relation deleted as a side effect
   of `delete-entity` with `cascade=true`.
+
+**One label per record: the outermost cause wins.** A write can have
+more than one true cause — a scheduled task whose write trips an
+automation, for instance — but `triggered_by` is a single string, not a
+stack. The enclosing label is kept, so every row a scheduled task
+produced (including the ones an automation cascaded underneath it)
+answers `triggered_by == "schedule:<task>"`. Querying "what did last
+night's run do?" therefore returns the complete set.
 
 ## Known gaps
 
@@ -206,15 +218,6 @@ If the gap is unacceptable for your operational model, consider:
   `O_SYNC` via a fork — not built in).
 - Forwarding records to an external append-only sink in a future
   phase.
-
-### Per-automation attribution for cascaded relations / entities
-
-When an `on: created` automation fires `create_relation` or
-`create_entity` actions, the resulting records carry `triggered_by:
-"automation"` (generic) rather than `automation:<originating-name>`.
-The automation engine's Result type doesn't carry the per-action
-originating-name today. Scripted actions (`lua: |` blocks) do carry
-the specific name as `automation:<name>`.
 
 ### Retention
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -173,14 +173,26 @@ the operator who started the server is the right grain for forensics.
 When a write is caused by an automation cascade or scheduler task,
 `triggered_by` distinguishes it from direct user actions:
 
-- `automation:<name>` — a scripted automation action.
-- `automation` — a non-scripted automation action (relation create,
-  cascaded entity create). Generic label by design — the engine
-  doesn't currently thread the originating automation name through
-  these paths.
+- `automation:<name>` — an automation action, named after the
+  automation that produced it. Scripted (`lua:`) and non-scripted
+  (relation create, cascaded entity create, and the delete half of an
+  `if_exists: replace`) actions alike.
+- `automation` — the fallback for an automation declared without a
+  `name:`. Note `name:` is an optional field on an `automations:` list
+  entry and nothing rejects an automation that omits it, so this label
+  means "the schema did not say which rule this was" — not that
+  something went wrong.
 - `schedule:<task-name>` — a scheduler-driven Lua task.
 - `cascade:delete-entity:<id>` — a relation deleted as a side effect
   of `delete-entity` with `cascade=true`.
+
+**One label per record: the outermost cause wins.** A write can have
+more than one true cause — a scheduled task whose write trips an
+automation, for instance — but `triggered_by` is a single string, not a
+stack. The enclosing label is kept, so every row a scheduled task
+produced (including the ones an automation cascaded underneath it)
+answers `triggered_by == "schedule:<task>"`. Querying "what did last
+night's run do?" therefore returns the complete set.
 
 ## Known gaps
 
@@ -200,15 +212,6 @@ If the gap is unacceptable for your operational model, consider:
   `O_SYNC` via a fork — not built in).
 - Forwarding records to an external append-only sink in a future
   phase.
-
-### Per-automation attribution for cascaded relations / entities
-
-When an `on: created` automation fires `create_relation` or
-`create_entity` actions, the resulting records carry `triggered_by:
-"automation"` (generic) rather than `automation:<originating-name>`.
-The automation engine's Result type doesn't carry the per-action
-originating-name today. Scripted actions (`lua: |` blocks) do carry
-the specific name as `automation:<name>`.
 
 ### Retention
 

--- a/internal/autocascade/runner.go
+++ b/internal/autocascade/runner.go
@@ -127,14 +127,31 @@ func (r *Runner) processEntityCreations(
 	var newItems []queueItem
 
 	for _, toCreate := range toCreateList {
-		if skip := r.handleIfExists(ctx, host, trigger, toCreate, outcome); skip {
+		// Tag the write ctx with the originating automation so EVERY write
+		// this entry causes is attributed to it (TKT-JJRVX9): the if_exists
+		// replace-delete, the entity create, and the trigger relation.
+		//
+		// Derived per entry, not per cascade run — one run creates entities
+		// for several automations — and derived BEFORE handleIfExists, whose
+		// replace path deletes the entity being superseded. Deriving it after
+		// would leave that delete on the generic `automation` label while the
+		// matching create carried the specific one: two labels on adjacent
+		// rows of one operation, so a filter on the automation's name would
+		// return the create and miss the delete.
+		//
+		// The cascaded relation-deletes underneath that delete keep
+		// `cascade:delete-entity:<id>`, which cascadeHost.DeleteEntity stamps
+		// on a ctx it derives itself.
+		writeCtx := triggeredByCtx(ctx, toCreate.AutomationName)
+
+		if skip := r.handleIfExists(writeCtx, host, trigger, toCreate, outcome); skip {
 			continue
 		}
 
 		// Create entity. Runner takes responsibility for the
 		// follow-up cascade evaluation on the result; Host.CreateEntity
 		// must not fire automations itself (see Host doc).
-		created, createErr := host.CreateEntity(ctx, toCreate.Type, CreateEntityOptions{
+		created, createErr := host.CreateEntity(writeCtx, toCreate.Type, CreateEntityOptions{
 			TemplateVariant: toCreate.Template,
 			Properties:      toCreate.Properties,
 		})
@@ -148,7 +165,7 @@ func (r *Runner) processEntityCreations(
 
 		// Create relation from trigger if specified.
 		if toCreate.RelationFromTrigger != "" {
-			r.createTriggerRelation(ctx, host, trigger, created, toCreate.RelationFromTrigger, outcome)
+			r.createTriggerRelation(writeCtx, host, trigger, created, toCreate.RelationFromTrigger, outcome)
 		}
 
 		// Run automation on newly created entity.
@@ -206,14 +223,25 @@ func (r *Runner) runCreatedEntityAutomation(
 // validation; the To is looked up to ensure the target exists, and
 // the (from-type, type, to-type) tuple is validated against the
 // metamodel before persisting.
+//
+// The write ctx is tagged per entry with the originating automation's name
+// (TKT-JJRVX9), the same way executeScriptActions tags scripted actions. It
+// must be PER ENTRY, not hoisted out of the loop: one cascade run applies
+// relations from several automations, so a single wrap would attribute all of
+// them to whichever name happened to be last.
 func (r *Runner) applyRelationCreations(
 	ctx context.Context,
 	host Host,
 	triggerEntity *entity.Entity,
-	relations []*entity.Relation,
+	relations []automation.RelationToCreate,
 	outcome *Outcome,
 ) {
-	for _, rel := range relations {
+	for _, toCreate := range relations {
+		// Same shape as processEntityCreations: derive once at the top of the
+		// loop BODY. Per entry, never hoisted above the loop — see the doc.
+		writeCtx := triggeredByCtx(ctx, toCreate.AutomationName)
+
+		rel := toCreate.Relation
 		rel.From = triggerEntity.ID
 
 		targetEntity, err := host.GetEntity(ctx, rel.To)
@@ -228,13 +256,53 @@ func (r *Runner) applyRelationCreations(
 			continue
 		}
 
-		if err := host.WriteRelation(ctx, rel); err != nil {
+		if err := host.WriteRelation(writeCtx, rel); err != nil {
 			outcome.Errors = append(outcome.Errors,
 				fmt.Sprintf("failed to create automation relation: %v", err))
 			continue
 		}
 		outcome.RelationsCreated = append(outcome.RelationsCreated, rel)
 	}
+}
+
+// triggeredByCtx tags ctx with `automation:<name>` so the audit record for the
+// resulting write names the automation that caused it rather than the generic
+// `automation` label (TKT-JJRVX9).
+//
+// It declines to tag in two cases, and both are load-bearing.
+//
+// EMPTY NAME → ctx unchanged, rather than a dangling `automation:`. The
+// fallback in entitymanager's recordCascade then supplies the generic
+// `automation` label, which is the right answer for a producer with no name to
+// give. An automation name is an ordinary optional field on a YAML list entry
+// and no loader validation requires it, so "" is reachable, not theoretical.
+//
+// CTX ALREADY LABELED → ctx unchanged. **The outermost cause wins.**
+// `audit.WithTriggeredBy` is an unconditional `context.WithValue`, so tagging
+// here would OVERWRITE an enclosing label — and the enclosing one is the more
+// useful attribution. The case that matters: a scheduler task
+// (`schedule:<task>`) whose write trips an on:created automation. "What did
+// last night's task write?" is the single most obvious audit query for a
+// scheduler, and answering it requires the cascaded rows to keep the schedule
+// label. Naming the inner automation instead would silently shrink that query's
+// result set — a forensic regression nothing errors on.
+//
+// This mirrors recordCascade, which has always stamped its generic label only
+// when the ctx label was empty; that `if` is the same policy, and this helper
+// now enforces it one layer earlier. `triggered_by` is a single string, not a
+// stack, so "both causes" is not representable — see the Known-labels list in
+// the audit-log guide.
+//
+// ALL THREE cascade write paths route through here — relation creations, entity
+// creations, and scripted actions. The scripted path used to stamp the label
+// inline and unconditionally, which is where both the dangling `automation:`
+// and the scheduler-label clobbering came from; keep new paths on this helper
+// rather than re-deriving the string.
+func triggeredByCtx(ctx context.Context, name string) context.Context {
+	if name == "" || audit.TriggeredByFrom(ctx) != "" {
+		return ctx
+	}
+	return audit.WithTriggeredBy(ctx, "automation:"+name)
 }
 
 // executeScriptActions dispatches each automation-emitted script
@@ -267,7 +335,7 @@ func (r *Runner) executeScriptActions(
 			continue
 		}
 
-		actionCtx := audit.WithTriggeredBy(ctx, "automation:"+action.AutomationName)
+		actionCtx := triggeredByCtx(ctx, action.AutomationName)
 		err := scripts.Run(actionCtx, ScriptAction{
 			Code:      action.Code,
 			FilePath:  action.FilePath,

--- a/internal/autocascade/runner_test.go
+++ b/internal/autocascade/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/autocascade"
 	"github.com/Sourcehaven-BV/rela/internal/automation"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -365,8 +366,8 @@ relations:
 	req := autocascade.Request{
 		Trigger: trigger,
 		Result: &automation.Result{
-			RelationsToCreate: []*entity.Relation{
-				entity.NewRelation("", "references", "DEC-001"),
+			RelationsToCreate: []automation.RelationToCreate{
+				{Relation: entity.NewRelation("", "references", "DEC-001")},
 			},
 		},
 	}
@@ -438,8 +439,8 @@ relations:
 			LuaToExecute: []automation.LuaToExecute{
 				{Code: "print('hi')", AutomationName: "test-lua"},
 			},
-			RelationsToCreate: []*entity.Relation{
-				entity.NewRelation("", "references", "DEC-001"),
+			RelationsToCreate: []automation.RelationToCreate{
+				{Relation: entity.NewRelation("", "references", "DEC-001")},
 			},
 			EntitiesToCreate: []automation.EntityToCreate{
 				{Type: "checklist"},
@@ -547,4 +548,100 @@ type failingScriptRunner struct {
 
 func (f *failingScriptRunner) Run(_ context.Context, _ autocascade.ScriptAction, _ autocascade.Mutator) error {
 	return f.err
+}
+
+// ctxCapturingScriptRunner records the ctx each scripted action runs under, so
+// a test can assert the audit `triggered_by` label the cascade stamped.
+type ctxCapturingScriptRunner struct {
+	labels []string
+}
+
+func (c *ctxCapturingScriptRunner) Run(
+	ctx context.Context, _ autocascade.ScriptAction, _ autocascade.Mutator,
+) error {
+	c.labels = append(c.labels, audit.TriggeredByFrom(ctx))
+	return nil
+}
+
+// TestRunnerScriptActionTriggeredByLabel pins the label a scripted action runs
+// under (TKT-JJRVX9).
+//
+// The empty-name case is the point. This path used to stamp
+// `audit.WithTriggeredBy(ctx, "automation:"+name)` unguarded, which wrote a
+// literal dangling `"automation:"` for a nameless automation — an automation
+// name is an ordinary optional field on a YAML list entry with no loader
+// validation behind it, so "" is reachable. It now routes through
+// triggeredByCtx like the relation and entity paths, leaving the ctx untagged
+// so the audit layer supplies the generic `automation` label instead.
+func TestRunnerScriptActionTriggeredByLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		automation    string
+		wantLabel     string
+		wantLabelDesc string
+	}{
+		{
+			name:          "named automation is attributed",
+			automation:    "notify-owner",
+			wantLabel:     "automation:notify-owner",
+			wantLabelDesc: "the automation's own name",
+		},
+		{
+			name:          "nameless automation leaves ctx untagged",
+			automation:    "",
+			wantLabel:     "",
+			wantLabelDesc: "no label, so the audit layer falls back to generic \"automation\"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scripts := &ctxCapturingScriptRunner{}
+			r := newRunner(t, nil)
+			// The Result carries only a scripted action, so the host is never
+			// asked to write anything — a bare metamodel is enough.
+			meta, err := metamodel.Parse([]byte(`version: "1.0"
+entities:
+  requirement:
+    label: Requirement
+    plural: requirements
+    id_prefix: "REQ-"
+    id_type: short
+    properties:
+      title:
+        type: string
+`))
+			if err != nil {
+				t.Fatalf("metamodel.Parse: %v", err)
+			}
+			host := &stubHost{t: t, meta: meta, store: memstore.New()}
+
+			outcome, err := r.Process(context.Background(), host, autocascade.Request{
+				Trigger: entity.New("REQ-001", "requirement"),
+				Scripts: scripts,
+				Result: &automation.Result{
+					LuaToExecute: []automation.LuaToExecute{
+						{Code: "print('hi')", AutomationName: tc.automation},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Process: %v", err)
+			}
+			if len(outcome.Errors) != 0 {
+				t.Fatalf("unexpected errors: %v", outcome.Errors)
+			}
+
+			if len(scripts.labels) != 1 {
+				t.Fatalf("want 1 script invocation, got %d", len(scripts.labels))
+			}
+			if scripts.labels[0] != tc.wantLabel {
+				t.Errorf("triggered_by: want %q (%s), got %q",
+					tc.wantLabel, tc.wantLabelDesc, scripts.labels[0])
+			}
+		})
+	}
 }

--- a/internal/automation/engine.go
+++ b/internal/automation/engine.go
@@ -228,7 +228,7 @@ func (e *Engine) SetTemplateVars(vars TemplateVars) {
 func (e *Engine) Process(ctx context.Context, event Event) *Result {
 	result := &Result{
 		PropertiesSet:     make(map[string]string),
-		RelationsToCreate: make([]*entity.Relation, 0),
+		RelationsToCreate: make([]RelationToCreate, 0),
 		EntitiesToCreate:  make([]EntityToCreate, 0),
 		LuaToExecute:      make([]LuaToExecute, 0),
 		Warnings:          make([]string, 0),
@@ -394,7 +394,8 @@ func (e *Engine) executeAction(action Action, event Event, result *Result, autom
 		targetID := e.interpolate(action.CreateRelation.To, event)
 		if targetID != "" && event.Entity != nil {
 			rel := entity.NewRelation(event.Entity.ID, action.CreateRelation.Relation, targetID)
-			result.RelationsToCreate = append(result.RelationsToCreate, rel)
+			result.RelationsToCreate = append(result.RelationsToCreate,
+				RelationToCreate{Relation: rel, AutomationName: automationName})
 		}
 	}
 
@@ -432,6 +433,7 @@ func (e *Engine) executeAction(action Action, event Event, result *Result, autom
 			Properties:          props,
 			RelationFromTrigger: action.CreateEntity.Relation,
 			IfExists:            ifExists,
+			AutomationName:      automationName,
 		})
 	}
 

--- a/internal/automation/engine_test.go
+++ b/internal/automation/engine_test.go
@@ -210,7 +210,7 @@ func TestEngine_CreateRelation(t *testing.T) {
 	if len(result.RelationsToCreate) != 1 {
 		t.Fatalf("expected 1 relation to create, got %d", len(result.RelationsToCreate))
 	}
-	rel := result.RelationsToCreate[0]
+	rel := result.RelationsToCreate[0].Relation
 	if rel.From != entity.ID || rel.Type != "belongs-to" || rel.To != "sprint-current" {
 		t.Errorf("unexpected relation: %+v", rel)
 	}
@@ -1135,5 +1135,49 @@ func TestEngine_LuaFileExtensionPassthrough(t *testing.T) {
 	}
 	if result.LuaToExecute[0].FilePath != "script.txt" {
 		t.Errorf("expected path to be passed through, got: %s", result.LuaToExecute[0].FilePath)
+	}
+}
+
+// TestProcess_TagsResultsWithAutomationName pins the engine half of TKT-JJRVX9:
+// every create_relation / create_entity entry a Result carries names the
+// automation that produced it.
+//
+// Localized on purpose. Without it, a regression here surfaces only three
+// packages away as a wrong `triggered_by` string in an audit assertion, which
+// is a much longer path from symptom to cause.
+//
+// Two automations, one Result: Process aggregates every matching automation
+// into a single Result, so this also pins that the entries do not all take
+// whichever name was processed last.
+func TestProcess_TagsResultsWithAutomationName(t *testing.T) {
+	t.Parallel()
+	engine := NewEngine([]Automation{
+		newAutomation("alpha").
+			OnCreate("ticket").
+			CreateRelation("belongs-to", "sprint-current").
+			Build(),
+		newAutomation("beta").
+			OnCreate("ticket").
+			CreateEntity("checklist", nil).
+			Build(),
+	})
+
+	result := engine.Process(context.Background(), Event{
+		Type:   EventEntityCreated,
+		Entity: buildEntity(testutil.Entity("ticket")),
+	})
+
+	if len(result.RelationsToCreate) != 1 {
+		t.Fatalf("want 1 relation to create, got %d", len(result.RelationsToCreate))
+	}
+	if got := result.RelationsToCreate[0].AutomationName; got != "alpha" {
+		t.Errorf("relation AutomationName: want %q, got %q", "alpha", got)
+	}
+
+	if len(result.EntitiesToCreate) != 1 {
+		t.Fatalf("want 1 entity to create, got %d", len(result.EntitiesToCreate))
+	}
+	if got := result.EntitiesToCreate[0].AutomationName; got != "beta" {
+		t.Errorf("entity AutomationName: want %q, got %q", "beta", got)
 	}
 }

--- a/internal/automation/types.go
+++ b/internal/automation/types.go
@@ -128,12 +128,35 @@ const (
 )
 
 // EntityToCreate specifies an entity to be created by automation.
+//
+// AutomationName carries the name of the automation that produced this action,
+// so the cascade can attribute the resulting audit record to it
+// (`automation:<name>`) instead of the generic `automation` label — same
+// rationale as [LuaToExecute.AutomationName], applied to the non-scripted path
+// (TKT-JJRVX9).
 type EntityToCreate struct {
 	Type                string         // Entity type to create
 	Template            string         // Optional: template variant name
 	Properties          map[string]any // Properties for the new entity
 	RelationFromTrigger string         // Optional: relation type from triggering entity
 	IfExists            string         // Behavior when relation exists: skip (default), error, replace
+	AutomationName      string         // Name of the originating automation
+}
+
+// RelationToCreate pairs a relation an automation wants created with the name of
+// the automation that asked for it.
+//
+// The name travels in a struct rather than a parallel []string indexed
+// alongside RelationsToCreate: a parallel slice can drift in length or order
+// with no compile-time signal, and this value crosses a package boundary into
+// autocascade, where a misattributed audit record would be silently wrong
+// (TKT-JJRVX9).
+type RelationToCreate struct {
+	Relation *entity.Relation
+	// AutomationName is the originating automation. Empty when the producer
+	// did not supply one, in which case the cascade keeps the generic
+	// `automation` audit label rather than emitting a dangling `automation:`.
+	AutomationName string
 }
 
 // LuaToExecute specifies Lua code to be executed by the workspace layer.
@@ -168,8 +191,9 @@ type Result struct {
 	// PropertiesSet contains properties that were automatically set.
 	PropertiesSet map[string]string
 
-	// RelationsToCreate contains relations that should be created.
-	RelationsToCreate []*entity.Relation
+	// RelationsToCreate contains relations that should be created, each
+	// tagged with the automation that produced it.
+	RelationsToCreate []RelationToCreate
 
 	// EntitiesToCreate contains entities that should be created.
 	EntitiesToCreate []EntityToCreate

--- a/internal/entitymanager/audit_test.go
+++ b/internal/entitymanager/audit_test.go
@@ -454,8 +454,14 @@ func TestAudit_AC5_TriggeredByOnAutomationCascade(t *testing.T) {
 	records := mem.Records()
 	// Expect:
 	//   - 1 create-entity record for the requirement (no triggered_by).
-	//   - 1 create-entity record for the cascaded checklist (triggered_by=automation).
-	//   - 1 create-relation record for has-checklist (triggered_by=automation).
+	//   - 1 create-entity record for the cascaded checklist.
+	//   - 1 create-relation record for has-checklist.
+	//
+	// Both cascaded records name the ORIGINATING automation
+	// (`automation:create-checklist-for-req`), not the generic `automation`
+	// label. Tightened from "non-empty" by TKT-JJRVX9 — the generic label
+	// could not tell an operator which of several on:created rules fired.
+	const wantLabel = "automation:create-checklist-for-req"
 	var direct, cascadedEntity, cascadedRelation int
 	for _, r := range records {
 		switch {
@@ -463,8 +469,14 @@ func TestAudit_AC5_TriggeredByOnAutomationCascade(t *testing.T) {
 			direct++
 		case r.Op == audit.OpCreateEntity && r.TriggeredBy != "":
 			cascadedEntity++
+			if r.TriggeredBy != wantLabel {
+				t.Errorf("cascaded create-entity: want TriggeredBy=%q, got %q", wantLabel, r.TriggeredBy)
+			}
 		case r.Op == audit.OpCreateRelation && r.TriggeredBy != "":
 			cascadedRelation++
+			if r.TriggeredBy != wantLabel {
+				t.Errorf("cascaded create-relation: want TriggeredBy=%q, got %q", wantLabel, r.TriggeredBy)
+			}
 		}
 		// All records must inherit the user's Principal.
 		if r.Principal.User != "alice" {
@@ -480,6 +492,74 @@ func TestAudit_AC5_TriggeredByOnAutomationCascade(t *testing.T) {
 	}
 	if cascadedRelation == 0 {
 		t.Errorf("want >=1 cascaded create-relation records with TriggeredBy, got 0")
+	}
+}
+
+// TestAudit_IfExistsReplaceAttributesDeleteToTheAutomation pins that BOTH
+// halves of an `if_exists: replace` carry the same automation label
+// (TKT-JJRVX9).
+//
+// Replace is one operation with two writes: delete the superseded entity, then
+// create its replacement. Before this ticket the create carried the specific
+// label and the delete carried the generic `automation`, because the runner
+// derived its tagged ctx AFTER calling handleIfExists. Two labels on adjacent
+// rows of one operation meant an operator filtering on the automation's name
+// got the create and silently missed the delete — the exact question this
+// ticket exists to make answerable.
+//
+// The cascaded relation-deletes underneath keep `cascade:delete-entity:<id>`;
+// that is asserted by TestAudit_IfExistsReplaceUsesCascadeLabel below, and the
+// two together describe the full label set for a replace.
+func TestAudit_IfExistsReplaceAttributesDeleteToTheAutomation(t *testing.T) {
+	t.Parallel()
+	mem := audit.NewMemory()
+
+	const autoName = "replace-checklist-on-active"
+	autos := []automation.Automation{{
+		Name: autoName,
+		On: automation.Trigger{
+			Entity:   []string{"requirement"},
+			Property: "status",
+			Becomes:  "accepted",
+		},
+		Do: []automation.Action{{
+			CreateEntity: &automation.CreateEntityAction{
+				Type:     "checklist",
+				Relation: "has-checklist",
+				IfExists: automation.IfExistsReplace,
+			},
+		}},
+	}}
+	mgr := newManagerWithAudit(t, mem, autos)
+	ctx := ctxWithPrincipal("alice", principal.ToolCLI)
+
+	res, err := mgr.CreateEntity(ctx, entity.New("", "requirement"), entity.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	// Trip the automation, drop out of the triggering state, then trip it
+	// again — the second run is the one that finds an existing checklist and
+	// takes the replace path.
+	req := res.Entity
+	for _, status := range []string{"accepted", "draft", "accepted"} {
+		req.SetString("status", status)
+		if _, uerr := mgr.UpdateEntity(ctx, req); uerr != nil {
+			t.Fatalf("UpdateEntity(status=%s): %v", status, uerr)
+		}
+	}
+
+	var sawDelete bool
+	for _, r := range mem.Records() {
+		if r.Op != audit.OpDeleteEntity || r.Subject == nil || r.Subject.Type != "checklist" {
+			continue
+		}
+		sawDelete = true
+		if r.TriggeredBy != "automation:"+autoName {
+			t.Errorf("replace-delete: want TriggeredBy=%q, got %q", "automation:"+autoName, r.TriggeredBy)
+		}
+	}
+	if !sawDelete {
+		t.Fatal("no delete-entity record for the superseded checklist; the replace path did not run")
 	}
 }
 
@@ -647,3 +727,297 @@ func TestAudit_AC11_NopRecordsNothing(t *testing.T) {
 
 // --- AC12: nil Audit is rejected at construction (already covered by
 // TestNew_RejectsNilAudit in manager_test.go) ---
+
+// TestAudit_PerAutomationAttribution is the discriminating test for
+// TKT-JJRVX9: TWO automations on the same trigger, with different names, each
+// producing a cascade write. Each resulting audit record must name ITS OWN
+// automation.
+//
+// Two is the minimum that catches the bug this ticket is really about. With a
+// single automation, an implementation that hoists the `triggered_by` ctx wrap
+// out of the per-entry loop — attributing every write to whichever name it saw
+// last — passes anyway. With two, it cannot.
+func TestAudit_PerAutomationAttribution(t *testing.T) {
+	t.Parallel()
+	mem := audit.NewMemory()
+
+	// Both fire on requirement-created, and BOTH emit a create_relation. That
+	// matters: Engine.Process aggregates every matching automation into ONE
+	// Result, so the two relations arrive in a single RelationsToCreate slice.
+	// A per-entry ctx tag attributes each correctly; a tag hoisted out of the
+	// loop gives both whichever name came last. `spawn-checklist` also creates
+	// an entity, covering the create_entity path in the same run.
+	autos := []automation.Automation{
+		{
+			Name: "spawn-checklist",
+			On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+			Do: []automation.Action{
+				{
+					CreateEntity: &automation.CreateEntityAction{
+						Type:     "checklist",
+						Relation: "has-checklist",
+					},
+				},
+				{
+					CreateRelation: &automation.CreateRelationAction{
+						Relation: "informed-by",
+						To:       "DEC-001",
+					},
+				},
+			},
+		},
+		{
+			Name: "link-decision",
+			On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+			Do: []automation.Action{{
+				CreateRelation: &automation.CreateRelationAction{
+					Relation: "supersedes",
+					To:       "DEC-001",
+				},
+			}},
+		},
+	}
+	mgr := newManagerWithAudit(t, mem, autos)
+	ctx := ctxWithPrincipal("alice", principal.ToolCLI)
+
+	// The relation target must exist before the trigger fires.
+	if _, err := mgr.CreateEntity(ctx, entity.New("DEC-001", "decision"), entity.CreateOptions{}); err != nil {
+		t.Fatalf("seed decision: %v", err)
+	}
+	if _, err := mgr.CreateEntity(ctx, entity.New("", "requirement"), entity.CreateOptions{}); err != nil {
+		t.Fatalf("CreateEntity requirement: %v", err)
+	}
+
+	// Collect the cascade-attributed records by relation type / entity type.
+	var sawChecklistEntity, sawHasChecklist, sawInformedBy, sawSupersedes bool
+	for _, r := range mem.Records() {
+		if r.TriggeredBy == "" || r.Subject == nil {
+			continue // direct writes
+		}
+		switch {
+		case r.Op == audit.OpCreateEntity && r.Subject.Type == "checklist":
+			sawChecklistEntity = true
+			if r.TriggeredBy != "automation:spawn-checklist" {
+				t.Errorf("checklist entity: want automation:spawn-checklist, got %q", r.TriggeredBy)
+			}
+		case r.Op == audit.OpCreateRelation && r.Subject.RelationType == "has-checklist":
+			sawHasChecklist = true
+			// The trigger relation belongs to the automation that created the
+			// entity, not to whichever automation ran last.
+			if r.TriggeredBy != "automation:spawn-checklist" {
+				t.Errorf("has-checklist relation: want automation:spawn-checklist, got %q", r.TriggeredBy)
+			}
+		case r.Op == audit.OpCreateRelation && r.Subject.RelationType == "informed-by":
+			sawInformedBy = true
+			if r.TriggeredBy != "automation:spawn-checklist" {
+				t.Errorf("informed-by relation: want automation:spawn-checklist, got %q", r.TriggeredBy)
+			}
+		case r.Op == audit.OpCreateRelation && r.Subject.RelationType == "supersedes":
+			sawSupersedes = true
+			if r.TriggeredBy != "automation:link-decision" {
+				t.Errorf("supersedes relation: want automation:link-decision, got %q", r.TriggeredBy)
+			}
+		}
+	}
+
+	if !sawChecklistEntity {
+		t.Error("no cascade-attributed create-entity record for the checklist")
+	}
+	if !sawHasChecklist {
+		t.Error("no cascade-attributed create-relation record for has-checklist")
+	}
+	if !sawInformedBy {
+		t.Error("no cascade-attributed create-relation record for informed-by")
+	}
+	if !sawSupersedes {
+		t.Error("no cascade-attributed create-relation record for supersedes")
+	}
+}
+
+// TestAudit_UnnamedAutomationKeepsGenericLabel pins the fallback (TKT-JJRVX9):
+// a cascade entry carrying no automation name must record the generic
+// "automation" label, NOT a dangling "automation:".
+//
+// This is reachable from a user-authored schema, not hypothetical: `name:` is
+// an ordinary optional field on an `automations:` list entry, and no loader
+// validation rejects an automation that omits it. So the test drives the FULL
+// production path — Manager.CreateEntity through the engine, runner and audit
+// sink — with a nameless automation, rather than poking the runner directly.
+func TestAudit_UnnamedAutomationKeepsGenericLabel(t *testing.T) {
+	t.Parallel()
+	mem := audit.NewMemory()
+
+	// An automation with an EMPTY name: the engine plumbs "" through, and the
+	// cascade must fall back rather than emit "automation:".
+	autos := []automation.Automation{{
+		Name: "",
+		On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+		Do: []automation.Action{{
+			CreateEntity: &automation.CreateEntityAction{
+				Type:     "checklist",
+				Relation: "has-checklist",
+			},
+		}},
+	}}
+	mgr := newManagerWithAudit(t, mem, autos)
+	ctx := ctxWithPrincipal("alice", principal.ToolCLI)
+
+	if _, err := mgr.CreateEntity(ctx, entity.New("", "requirement"), entity.CreateOptions{}); err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	var cascaded int
+	for _, r := range mem.Records() {
+		if r.TriggeredBy == "" {
+			continue
+		}
+		cascaded++
+		if r.TriggeredBy != "automation" {
+			t.Errorf("unnamed automation: want generic %q, got %q", "automation", r.TriggeredBy)
+		}
+	}
+	// Assert the exact count, not just non-zero: a future change that stopped
+	// one of the two cascade writes firing would otherwise quietly reduce this
+	// test's coverage instead of failing.
+	if cascaded != 2 {
+		t.Errorf("want 2 cascade-attributed records (checklist entity + has-checklist relation), got %d", cascaded)
+	}
+}
+
+// TestAudit_NestedCascadeAttribution covers the multi-level case for
+// TKT-JJRVX9: automation "outer" creates a checklist, which itself triggers
+// automation "inner". Each write must name the automation that actually
+// produced it, not the one that started the chain.
+//
+// This works because the cascade runner queues one item per created entity,
+// each carrying its OWN automation Result — so the name travels with the work
+// rather than being derived from the originating trigger. Pinned here because
+// a future change that hoisted attribution to the cascade's entry point would
+// silently collapse every level onto the outermost automation.
+func TestAudit_NestedCascadeAttribution(t *testing.T) {
+	t.Parallel()
+	mem := audit.NewMemory()
+
+	autos := []automation.Automation{
+		{
+			Name: "outer",
+			On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+			Do: []automation.Action{{
+				CreateEntity: &automation.CreateEntityAction{
+					Type:     "checklist",
+					Relation: "has-checklist",
+				},
+			}},
+		},
+		{
+			Name: "inner",
+			On:   automation.Trigger{Entity: []string{"checklist"}, Created: true},
+			Do: []automation.Action{{
+				CreateRelation: &automation.CreateRelationAction{
+					Relation: "covers",
+					To:       "DEC-001",
+				},
+			}},
+		},
+	}
+	mgr := newManagerWithAudit(t, mem, autos)
+	ctx := ctxWithPrincipal("alice", principal.ToolCLI)
+
+	if _, err := mgr.CreateEntity(ctx, entity.New("DEC-001", "decision"), entity.CreateOptions{}); err != nil {
+		t.Fatalf("seed decision: %v", err)
+	}
+	if _, err := mgr.CreateEntity(ctx, entity.New("", "requirement"), entity.CreateOptions{}); err != nil {
+		t.Fatalf("CreateEntity requirement: %v", err)
+	}
+
+	var sawOuterEntity, sawInnerRelation bool
+	for _, r := range mem.Records() {
+		if r.TriggeredBy == "" || r.Subject == nil {
+			continue
+		}
+		switch {
+		case r.Op == audit.OpCreateEntity && r.Subject.Type == "checklist":
+			sawOuterEntity = true
+			if r.TriggeredBy != "automation:outer" {
+				t.Errorf("checklist entity: want automation:outer, got %q", r.TriggeredBy)
+			}
+		case r.Op == audit.OpCreateRelation && r.Subject.RelationType == "covers":
+			sawInnerRelation = true
+			// The decisive assertion: this write came from the SECOND-level
+			// automation, so it must not inherit "outer".
+			if r.TriggeredBy != "automation:inner" {
+				t.Errorf("covers relation: want automation:inner, got %q", r.TriggeredBy)
+			}
+		}
+	}
+
+	if !sawOuterEntity {
+		t.Error("no cascade-attributed create-entity record for the checklist")
+	}
+	if !sawInnerRelation {
+		t.Error("no cascade-attributed create-relation record for covers (second-level automation did not fire)")
+	}
+}
+
+// TestAudit_OuterLabelSurvivesCascade pins the composition policy for
+// `triggered_by`: when a write has two true causes, the OUTERMOST one wins.
+//
+// The case that matters is a scheduler task whose write trips an on:created
+// automation. "What did last night's task write?" is the most obvious audit
+// query for a scheduler, and answering it requires the cascaded rows to keep
+// `schedule:<task>` rather than being relabelled with the inner automation.
+//
+// This is a REGRESSION TEST in the literal sense: the first version of
+// TKT-JJRVX9 tagged the cascade ctx unconditionally, and
+// `audit.WithTriggeredBy` is an unconditional context.WithValue — so the
+// cascaded rows silently changed from `schedule:nightly` to
+// `automation:<name>`, shrinking that query's result set with nothing to
+// error on. The guard lives in autocascade's triggeredByCtx.
+//
+// Note this could NOT be caught by TestAudit_IfExistsReplaceUsesCascadeLabel:
+// that one asserts a label cascadeHost.DeleteEntity stamps internally,
+// downstream of the runner's wrap, so it never exercises an enclosing label.
+func TestAudit_OuterLabelSurvivesCascade(t *testing.T) {
+	t.Parallel()
+	mem := audit.NewMemory()
+
+	autos := []automation.Automation{{
+		Name: "spawn-checklist",
+		On:   automation.Trigger{Entity: []string{"requirement"}, Created: true},
+		Do: []automation.Action{{
+			CreateEntity: &automation.CreateEntityAction{
+				Type:     "checklist",
+				Relation: "has-checklist",
+			},
+		}},
+	}}
+	mgr := newManagerWithAudit(t, mem, autos)
+
+	// Exactly what scheduler.go does before running a task.
+	const outer = "schedule:nightly"
+	ctx := audit.WithTriggeredBy(ctxWithPrincipal("alice", principal.ToolScheduler), outer)
+
+	if _, err := mgr.CreateEntity(ctx, entity.New("", "requirement"), entity.CreateOptions{}); err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	records := mem.Records()
+	if len(records) == 0 {
+		t.Fatal("no audit records emitted")
+	}
+	// EVERY record in this run — the direct write and both cascaded ones —
+	// must carry the schedule label, so a `triggered_by == "schedule:nightly"`
+	// query returns the complete set of what the task did.
+	var cascaded int
+	for _, r := range records {
+		if r.TriggeredBy != outer {
+			t.Errorf("op=%s: want TriggeredBy=%q, got %q", r.Op, outer, r.TriggeredBy)
+		}
+		if r.Subject != nil && (r.Subject.Type == "checklist" || r.Subject.RelationType == "has-checklist") {
+			cascaded++
+		}
+	}
+	if cascaded != 2 {
+		t.Errorf("want 2 cascaded records (checklist entity + has-checklist relation), got %d", cascaded)
+	}
+}

--- a/internal/entitymanager/cascadehost.go
+++ b/internal/entitymanager/cascadehost.go
@@ -29,9 +29,12 @@ import (
 // Audit: cascadeHost emits audit records directly (bypassing
 // Manager's recordEntityAudit / recordRelationAudit) because it
 // bypasses Manager itself — going through createCore / direct store
-// writes to avoid double-cascading. Records carry triggered_by="automation"
-// (or the cascade-delete label when invoked from IfExistsReplace) to
-// distinguish them from direct writes.
+// writes to avoid double-cascading. Records carry a triggered_by label
+// distinguishing them from direct writes: normally
+// `automation:<name>`, stamped on the ctx by the autocascade runner
+// (TKT-JJRVX9); `cascade:delete-entity:<id>` for the relation deletes
+// under an IfExistsReplace; and a bare `automation` only when the
+// automation was declared without a name.
 type cascadeHost struct {
 	deps Deps
 }
@@ -245,12 +248,18 @@ func relationSubject(r *entity.Relation) *audit.Subject {
 	}
 }
 
-// recordCascade emits one audit record from the cascade path. If ctx
-// doesn't already carry a triggered_by, "automation" is stamped as
-// the generic label (per runner.go applyRelationCreations rationale —
-// automation.Result doesn't carry per-action names through the
-// engine). Callers that already wrapped ctx with a specific label
-// (e.g. cascade:delete-entity:<id>) keep that label.
+// recordCascade emits one audit record from the cascade path.
+//
+// The ctx label wins when there is one: the autocascade runner stamps
+// `automation:<name>` per entry, and a caller may have stamped something more
+// specific still (`cascade:delete-entity:<id>`). "automation" is only the
+// fallback for a cascade whose originating automation had no name — since
+// TKT-JJRVX9 it is no longer the normal case, and this `if` is now what makes
+// the runner's per-entry label survive rather than what supplies attribution.
+//
+// The same `if` is mirrored one layer up in autocascade's triggeredByCtx,
+// which likewise declines to overwrite an existing label — that is what keeps
+// a scheduler's `schedule:<task>` on rows an automation cascaded underneath it.
 //
 // One emitter for both entity and relation subjects — the Subject
 // pointer carries the shape; the rest of the Record envelope is

--- a/internal/entitymanager/manager_test.go
+++ b/internal/entitymanager/manager_test.go
@@ -65,6 +65,18 @@ relations:
     label: HasChecklist
     from: [requirement]
     to: [checklist]
+  informed-by:
+    label: InformedBy
+    from: [requirement]
+    to: [decision]
+  supersedes:
+    label: Supersedes
+    from: [requirement]
+    to: [decision]
+  covers:
+    label: Covers
+    from: [checklist]
+    to: [decision]
 types:
   status:
     values: [draft, proposed, accepted]

--- a/tickets/entities/docs-checklists/DOCS-QTGT8N.md
+++ b/tickets/entities/docs-checklists/DOCS-QTGT8N.md
@@ -1,0 +1,70 @@
+---
+id: DOCS-QTGT8N
+type: docs-checklist
+title: 'Documentation: per-automation audit attribution'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — `triggeredByCtx`'s godoc is the main
+one, and it earns its length: it states *both* guards (empty name, and
+already-labelled ctx) and **why each is load-bearing**, because both were
+re-derived incorrectly during this ticket. The empty-name guard exists because a
+dangling `automation:` is worse than the generic label it replaces; the
+already-labelled guard exists because tagging would overwrite an enclosing
+`schedule:<task>` and silently shrink the answer to "what did last night's run
+do?".
+- [x] Function/type docs if public API — `automation.RelationToCreate` is new
+and exported; its doc says why the name travels in a struct rather than a
+parallel `[]string` (a parallel slice can drift in length or order with no
+compile-time signal, and this value crosses a package boundary where the
+consequence is a silently misattributed audit record).
+`EntityToCreate.AutomationName` cross-references `LuaToExecute.AutomationName`,
+the field it mirrors.
+
+**Corrected, not just added.** Three comments asserted the pre-fix behaviour as
+fact and would have misled the next reader:
+
+- `cascadehost.go`'s `recordCascade` doc cited *"automation.Result doesn't carry
+per-action names through the engine"* — the exact limitation this ticket
+removes, pointing at the function whose new doc says the opposite.
+- The `cascadeHost` type doc claimed records carry `triggered_by="automation"`.
+- `TestAudit_UnnamedAutomationKeepsGenericLabel`'s comment described a test that
+drives the runner directly and asserted the engine always supplies a name —
+neither true.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new pattern. The composition policy this
+ticket settled is documented where operators read it — the audit-log guide —
+rather than in the contributor rules, because it describes the *log's*
+semantics, not a coding convention.)
+- [x] ~~Help text accurate~~ (N/A: no CLI change — no new flag or command)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: this repo has no CHANGELOG; releases are
+cut from commit history — see `docs/releasing.md`)
+- [x] API docs updated — `docs-project/entities/guides/GUIDE-audit-log.md`
+(source of truth) → `docs/audit-log.md` (generated via
+`./scripts/generate-docs.sh`; never edited directly). Three changes:
+
+  1. **Removed the known-gap section.** "Per-automation attribution for cascaded
+relations / entities" documented exactly the limitation this ticket removes.
+  2. **Corrected the `triggered_by` label list.** It described
+`automation:<name>` as scripted-only and `automation` as "generic label by
+design" — both now false. It also briefly claimed *"you should not normally see
+it, since every automation declared in `schema.yaml` has a `name:`"*, which
+review correctly rejected: `name:` is an ordinary optional field on an
+`automations:` list entry and **no loader validation requires it**. Documenting
+an unenforced invariant as a guarantee would send the next operator on a
+false-positive hunt, so the text now says what the label actually means.
+  3. **Added the composition policy.** "One label per record: the outermost
+cause wins" — with the scheduler example, because that is the query the policy
+protects.
+
+Regeneration touched only `docs/audit-log.md`, confirming no unrelated drift.

--- a/tickets/entities/implementation-checklists/IMPL-HLR62T.md
+++ b/tickets/entities/implementation-checklists/IMPL-HLR62T.md
@@ -1,0 +1,173 @@
+---
+id: IMPL-HLR62T
+type: implementation-checklist
+title: 'Implementation: Plumb AutomationName through automation.Result for per-action audit attribution'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — `TestProcess_TagsResultsWithAutomationName`
+in `internal/automation`, pinning the engine half locally so a regression there
+surfaces at the seam rather than three packages away as a wrong string in an
+audit assertion.
+- [x] Integration tests written (test full flow, not just units) — two new tests
+in `internal/entitymanager/audit_test.go` driving a real `Manager.CreateEntity`
+through the automation engine, the cascade runner and the audit sink.
+- [x] Happy path implemented — name plumbed at the engine seam, ctx tagged per
+entry in the runner.
+- [x] Edge cases from planning handled — empty name, multi-automation, both
+relation and entity paths.
+- [x] ~~Error handling in place~~ (N/A: no new error paths; this adds a string
+to an existing record and changes no control flow.)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — the engine test uses
+the package's existing `newAutomation(...).OnCreate(...).Build()` fluent builder
+and `testutil.Entity`, matching the file's convention rather than hand-rolling
+literals.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test — each automation declares
+exactly the one action its assertion covers.
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*Both new behaviours were verified by MUTATION, not just by a green test* — for
+an attribution change, a passing assertion proves little unless the assertion is
+known to fail when the attribution is wrong.
+
+**AC3 — tightened test actually catches the regression.** Reverting the two
+`AutomationName:` assignments in `engine.go` and re-running:
+
+```
+audit_test.go:473: cascaded create-entity: want TriggeredBy="automation:create-checklist-for-req", got "automation"
+audit_test.go:478: cascaded create-relation: want TriggeredBy="automation:create-checklist-for-req", got "automation"
+```
+
+Exactly the generic label the issue reports. Restored → passes.
+
+**AC1/AC2 — and the test that first passed for the wrong reason.** The
+discriminating test uses **two** differently-named automations, because with one
+an implementation that hoists the ctx tag out of the per-entry loop would pass
+anyway. The first version of this test did *not* catch that: mutating the runner
+to hoist the tag left it green.
+
+The reason was worth finding — `spawn-checklist` emitted a `create_entity` and
+`link-decision` a `create_relation`, so the two never shared a
+`RelationsToCreate` slice and there was nothing to mis-order. `Engine.Process`
+aggregates **every matching automation into one `Result`**
+(`engine.go:238-246`), so a mixed slice genuinely occurs — the test just wasn't
+producing one. Reworked so both automations emit relations, and re-ran the
+mutation:
+
+```
+audit_test.go:745: informed-by relation: want automation:spawn-checklist, got "automation:link-decision"
+```
+
+Now it discriminates. This is the bug the per-entry wrap exists to prevent, and
+without the mutation check the test would have been decorative.
+
+**AC4 — fallback preserved. My first claim here was WRONG, and code review
+caught it.**
+
+The empty-name half is fine: `TestAudit_UnnamedAutomationKeepsGenericLabel`
+drives an automation with an empty `Name:` and asserts the record says
+`automation`, not a dangling `automation:`.
+
+The **pre-wrapped-ctx** half was not. I credited
+`TestAudit_IfExistsReplaceUsesCascadeLabel`, but that test asserts a label
+`cascadeHost.DeleteEntity` stamps *internally*, downstream of the runner's wrap
+— so it never exercises an enclosing label at all. The negative test I was
+relying on tested a different code path than I believed, which is worse than
+having no test because it bought false confidence.
+
+Behind that gap was a real regression this ticket introduced (RR-ZYVERL):
+`audit.WithTriggeredBy` is an unconditional `context.WithValue`, so the new
+per-entry tag **overwrote** an enclosing label. Measured before and after on the
+production path, with a scheduler ctx pre-stamped `schedule:nightly`:
+
+```text
+BEFORE                                     AFTER (the regression)
+create-entity   requirement   schedule:nightly   schedule:nightly
+create-entity   checklist     schedule:nightly   automation:spawn-checklist
+create-relation has-checklist schedule:nightly   automation:spawn-checklist
+```
+
+"What did last night's task write?" silently returned fewer rows. Nothing
+errored; no test failed.
+
+Fixed by making `triggeredByCtx` compose rather than clobber — it declines when
+the ctx already carries a label, mirroring `recordCascade`'s own guard. The
+policy is now a written decision rather than an accident: **the outermost cause
+wins**, because `triggered_by` is a single string and the enclosing cause is the
+operator-facing one. Documented in the helper and in the audit-log guide. Pinned
+by `TestAudit_OuterLabelSurvivesCascade`, verified to fail with
+`got "automation:spawn-checklist"` when the guard is removed.
+
+**AC4b — `if_exists: replace` consistency (RR-4JUX43).** Review also found the
+replace-delete carried the generic label while its matching create carried the
+specific one — two labels on adjacent rows of one operation, so a filter on the
+automation's name returned the create and missed the delete. Caused by deriving
+the tagged ctx *after* `handleIfExists`. Hoisted above it; verified the delete
+now reads `automation:replace-checklist-on-active` while the cascaded
+relation-deletes still read `cascade:delete-entity:CL-001`. Pinned by
+`TestAudit_IfExistsReplaceAttributesDeleteToTheAutomation`.
+
+**AC5 — docs.** The known-gap section is removed from the guide entity and
+`docs/audit-log.md` regenerated via `./scripts/generate-docs.sh` (the file is
+generated — *"auto-generated from docs-project/entities/. Do not edit
+directly."*). The regeneration touched **only** `docs/audit-log.md`, confirming
+no unrelated drift. The `triggered_by` reference list was also corrected: it
+previously described `automation:<name>` as scripted-only and `automation` as
+"generic label by design", both now false.
+
+**Full-suite and gates:** `go test ./...` exit 0; builds under all four backend
+tags; `just lint` 0 issues; `comment-lint`, `arch-lint`, `plimsoll`, `lint-md`
+all clean.
+
+## Quality
+
+- [x] Code follows project patterns — this generalizes the mechanism the
+*scripted* path already uses, three lines from where the change lands:
+`LuaToExecute.AutomationName` (`types.go`) set at the same engine seam, and
+`audit.WithTriggeredBy(ctx, "automation:"+name)` in `executeScriptActions`
+(`runner.go`). The audit layer needed no change at all — `recordCascade` already
+prefers a ctx label and only falls back to the generic one.
+- [x] Checked for DRY opportunities — the ctx tag is a single `triggeredByCtx`
+helper shared by **all three** cascade write paths: relation creations, entity
+creations, and scripted actions. The scripted path was NOT in my first pass
+(review caught it, RR-KPTYPY); it had been stamping the label inline and
+unguarded since long before this ticket, which is where both the dangling
+`automation:` and the scheduler-label clobbering originated. Ordering mattered:
+routing it through the helper was only safe *after* the helper itself was fixed
+to compose — landing it first would have spread the clobbering bug to a fourth
+call site.
+- [x] No security issues introduced — this touches the audit log, so two
+properties were checked explicitly: attribution only becomes *more* specific (no
+record loses a field, and the generic fallback survives), and the name is
+operator-authored config from `schema.yaml`, which CLAUDE.md states is not
+secret. Principal attribution is untouched.
+- [x] No silent failures — the one silent-failure risk was the empty-name case
+emitting a dangling `automation:`; `triggeredByCtx` returns ctx unchanged
+instead, and that is tested.
+- [x] No debug code left behind — the temporary record-dumping test used to
+diagnose the metamodel direction issue was removed.
+
+**One design note worth carrying to review.** `RelationsToCreate` changed from
+`[]*entity.Relation` to `[]RelationToCreate` rather than gaining a parallel
+`[]string` of names. A parallel slice can drift in length or order with no
+compile-time signal, and this value crosses a package boundary into
+`autocascade` where the consequence is a silently misattributed audit record.
+The struct makes the pairing unrepresentable-if-wrong; the cost is three
+mechanical test-site updates.

--- a/tickets/entities/planning-checklists/PLAN-VKUSB7.md
+++ b/tickets/entities/planning-checklists/PLAN-VKUSB7.md
@@ -1,0 +1,280 @@
+---
+id: PLAN-VKUSB7
+type: planning-checklist
+title: 'Planning: Plumb AutomationName through automation.Result for per-action audit attribution'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** Audit records for cascade-created relations and entities carry the
+generic `triggered_by: "automation"`, so an operator filtering the log cannot
+tell *which* automation caused a given write in a project with several `on:
+created` rules. Scripted actions already carry `automation:<name>`. GitHub issue
+#764.
+
+**Root cause, precisely.** It is not the audit layer.
+`cascadeHost.recordCascade` (`internal/entitymanager/cascadehost.go:258-274`)
+already does the right thing: it uses a ctx-carried `triggered_by` when present
+and only falls back to `"automation"` when there is none. And
+`executeScriptActions` (`internal/autocascade/runner.go:270`) already wraps ctx
+per action with `audit.WithTriggeredBy(ctx,
+"automation:"+action.AutomationName)`. The mechanism exists and works — the
+*name* just never reaches the non-scripted paths, because
+`automation.Result.RelationsToCreate` is a bare `[]*entity.Relation` and
+`automation.EntityToCreate` has no name field. `LuaToExecute` has one; its two
+siblings do not.
+
+**Scope — IN:**
+
+- `automation.EntityToCreate` gains `AutomationName`; relation creations gain an
+equivalent carrier.
+- Both set at the engine seam (`executeAction`), where `automationName` is
+**already a parameter** (`engine.go:387`).
+- `autocascade.Runner` wraps ctx per entry with `automation:<name>`, exactly as
+`executeScriptActions` already does.
+- Tighten `TestAudit_AC5_TriggeredByOnAutomationCascade` from "non-empty" to the
+exact expected label.
+- Remove the known-gap section from the audit-log guide.
+
+**Scope — OUT:**
+
+- Any change to the audit record schema, `recordCascade`, or the ctx mechanism —
+all already correct.
+- Attribution for `set:` actions (they mutate the trigger entity itself, which is
+covered by the entity's own update record, not a cascade record).
+- Renaming or restructuring `automation.Result` beyond the minimum.
+- `cascade:delete-entity:<id>` labels — a different, already-specific label whose
+callers must keep it (`recordCascade`'s "callers that already wrapped ctx keep
+that label" contract).
+
+**Acceptance Criteria:**
+
+1. **AC1** — a metamodel with two `on: created` automations, both producing
+`create_relation`, yields audit records where each relation-create carries
+`triggered_by: "automation:<originating-name>"`, not the generic label.
+2. **AC2** — same for cascade-created entities (`create_entity` actions).
+3. **AC3** — `TestAudit_AC5_TriggeredByOnAutomationCascade` asserts the exact
+label `automation:create-checklist-for-req` rather than "non-empty".
+4. **AC4** — the generic `"automation"` fallback still applies when no name is
+available, and a caller that already wrapped ctx with a specific label (e.g.
+`cascade:delete-entity:<id>`) keeps it. No regression in `recordCascade`.
+5. **AC5** — the known-gap section is removed from
+`docs-project/entities/guides/GUIDE-audit-log.md` and `docs/audit-log.md`
+regenerated from it.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — small, and the in-tree pattern is exact.
+
+**Existing Solutions:** the scripted path is the reference implementation of
+this very feature, three lines away from where the fix goes:
+
+- `automation.LuaToExecute.AutomationName` (`types.go:149`) — the field to
+mirror, with a godoc explaining *why* the name travels ("so that error envelopes
+can identify which inline `lua: |` block failed").
+- `engine.go:444,455` — set at the engine seam from the in-scope
+`automationName` parameter. The two new sites are in the *same function*.
+- `runner.go:270` — `audit.WithTriggeredBy(ctx, "automation:"+action.AutomationName)`,
+the exact ctx wrap to copy.
+- `cascadehost.go:264` — the fallback that already yields to a ctx label.
+
+So this ticket generalizes a working pattern rather than designing one.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. **`EntityToCreate` gains `AutomationName string`** — it is already a struct,
+so this is one field, mirroring `LuaToExecute`.
+2. **Relations need a carrier.** `RelationsToCreate` is `[]*entity.Relation`.
+Introduce `RelationToCreate{Relation *entity.Relation; AutomationName string}`
+and change the slice's element type. Chosen over a parallel `[]string` because a
+parallel slice can silently desynchronise from the one it indexes — length drift
+is a runtime bug with no compile-time signal, and this value crosses a package
+boundary into autocascade. The struct makes the pairing
+unrepresentable-if-wrong.
+3. **Engine seam** (`executeAction`, `engine.go:387`): set the name in both
+branches. `automationName` is already a parameter — no signature change.
+4. **Runner**: `applyRelationCreations` and `processEntityCreations` wrap ctx
+per entry with `audit.WithTriggeredBy(ctx, "automation:"+name)` when the name is
+non-empty, and pass that ctx to the `host.Write*` / `host.CreateEntity` call.
+Leave ctx untouched when empty so AC4's fallback still fires.
+5. **Test + docs** per AC3/AC5.
+
+*Where the label is applied matters.* It must wrap the ctx handed to the **host
+write call**, not the outer loop ctx — `applyRelationCreations` iterates several
+relations that may come from different automations, so a per-loop wrap would
+attribute all of them to the last name seen. Per-entry, like
+`executeScriptActions` does.
+
+**Files to modify:** `internal/automation/types.go`,
+`internal/automation/engine.go`, `internal/autocascade/runner.go`,
+`internal/entitymanager/audit_test.go`,
+`docs-project/entities/guides/GUIDE-audit-log.md` (+ regenerate `docs/`).
+
+**Alternatives considered:**
+
+1. *Parallel `[]string` of names alongside the relation slice.* Rejected — see
+above; desync is a silent runtime bug.
+2. *Put the name on `entity.Relation` itself.* Rejected — `entity.Relation` is
+the domain type persisted to disk; automation provenance is not part of a
+relation's identity and must not leak into storage.
+3. *Stamp the label in `cascadeHost` by looking up which automation matched.*
+Rejected — the host has no access to that; it is precisely the information the
+Result drops, which is why plumbing it is the fix.
+4. *Leave it and document.* Rejected — it is already documented as a gap, and
+the issue is that the documentation is not the desired end state.
+
+**Dependencies:** none new.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** the automation *name* comes from `schema.yaml`,
+which is operator-authored config. CLAUDE.md is explicit that config contents —
+including automation names — are not secret, so writing one into an audit record
+discloses nothing that the repo does not already.
+
+**Security-Sensitive Operations:** this touches the **audit log**, which is a
+security control, so two properties matter:
+
+- *It only ever makes attribution more specific.* No record loses a field; the
+generic label remains for the no-name case (AC4). An audit consumer parsing
+`triggered_by` sees `automation:<name>` where it previously saw `automation` — a
+documented refinement, and the reason AC5 updates the guide.
+- *The name is a config identifier, not caller-supplied input*, so there is no
+injection surface into the record. Worth noting the label is a plain JSONL
+string field, so even a hostile name cannot break the record framing — but
+automation names come from the same file that defines the automations, i.e. from
+an actor who could simply write whatever records they liked.
+
+Principal attribution is untouched: `recordCascade` keeps taking
+`principal.From(ctx)`, and `triggered_by` is orthogonal to *who* acted.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+- **AC1 (the discriminating test)** — two `on: created` automations on the same
+entity type, with **different names**, each emitting a `create_relation` to a
+different target. Assert each resulting audit record carries its *own*
+automation's name. Two automations is the minimum that catches the per-entry
+wrap bug: with one, a wrongly-placed per-loop wrap would pass.
+- **AC2** — same shape with `create_entity` actions.
+- **AC3** — tighten the existing test to the exact label.
+- **AC4** — two negative cases: (a) an automation-driven write with no name set
+still records `"automation"`; (b) a delete cascade keeps
+`cascade:delete-entity:<id>` and is *not* overwritten.
+- **AC5** — `docs/audit-log.md` regenerated; assert the gap section is gone and
+the file still matches its generated form (the repo's docs check).
+- Unit-level: an `internal/automation` engine test asserting `Result` entries
+carry the name, so a break is localized rather than only surfacing three
+packages away in an audit assertion.
+
+**Edge Cases:**
+
+- An automation with an **empty** `Name:` — the generic fallback must fire, not
+`"automation:"` with a dangling colon. Explicitly tested.
+- A cascade several levels deep: the entity created by automation A itself
+triggers automation B. The record for B's write must say B, not A. Covered by
+the queue-driven cascade in the runner; assert it.
+- One automation emitting several relations — all carry the same name (trivially
+true, but it is what the per-entry wrap must not break).
+- `IfExistsReplace` path (`cascadehost.go:178`), which has its own attribution
+comment — verify it is unaffected.
+
+**Negative Tests:** empty name → generic label; pre-wrapped ctx → preserved
+label. Both above.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| Per-loop instead of per-entry ctx wrap misattributes to the last automation | The AC1 test uses **two** differently-named automations, which is what makes the bug detectable |
+| Changing `RelationsToCreate`'s element type breaks callers | Compiler-enforced; the consumer set is small (engine + runner + tests) |
+| An audit consumer parses `triggered_by == "automation"` exactly and breaks | This is the documented intent of the change; AC5 updates the guide. Flag in the PR |
+| Silently losing the generic fallback | AC4 tests it explicitly, both branches |
+
+**Effort:** s
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs-project/entities/guides/GUIDE-audit-log.md` — remove the
+"Per-automation attribution for cascaded relations / entities" known-gap section
+(line ~210). **Edit the entity, not `docs/`**: `docs/audit-log.md` is generated
+("This file is auto-generated from docs-project/entities/. Do not edit
+directly.") and is regenerated via `just docs`.
+- [x] `docs/audit-log.md` — regenerate; verify the gap section is gone and the
+`triggered_by` documentation describes the `automation:<name>` form.
+- [x] ~~CLI reference / metamodel docs~~ (N/A: no new flag, command, or schema
+key — automation names already exist)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: skipped, and
+      with hindsight this was the wrong call — see below.)
+- [x] All critical/significant findings addressed in plan — via `/code-review`;
+      7 of 9 addressed, 2 deferred with reasons. See the review checklist.
+
+**Design Review Findings:** N/A as a separate pass — but the skip is worth
+recording honestly rather than waving through.
+
+The reasoning at the time: the mechanism already existed on the scripted path,
+`recordCascade` already preferred a ctx label, and the change was a few lines at
+a seam where the needed value was already in scope. That reasoning was sound
+about the *plumbing*, which was indeed correct first time.
+
+What it missed is that the plan's own Negative Tests section named the exact
+failure a design review would have interrogated — *"pre-wrapped ctx → preserved
+label"* — and the plan asserted that an existing test covered it **without
+checking which code path that test exercised**. `audit.WithTriggeredBy` being an
+unconditional overwrite is a property of the API this change was built on, and
+"what happens when two causes are both true?" is a design question, not an
+implementation detail. It went unanswered until `/code-review` found the
+regression (RR-ZYVERL).
+
+The lesson is narrow and worth carrying: a change can be mechanically trivial and
+still carry a *semantic* decision. When a plan writes down a negative test, verify
+the named test actually exercises the named path before crediting it.
+
+Code-review findings: RR-ZYVERL (critical); RR-4JUX43, RR-KPTYPY, RR-KA9LD5,
+RR-3DWRZX, RR-Z1V5Z6 (significant); RR-14X83F, RR-OPBDAY (minor); RR-2FY0O8
+(significant, deferred → BUG-IK9IYL).

--- a/tickets/entities/review-checklists/REV-4X5CRK.md
+++ b/tickets/entities/review-checklists/REV-4X5CRK.md
@@ -1,0 +1,163 @@
+---
+id: REV-4X5CRK
+type: review-checklist
+title: 'Review: Plumb AutomationName through automation.Result for per-action audit attribution'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` **exit 0**, re-run after
+every review fix. Builds under all four backend tags.
+- [x] Lint clean (`just lint`) — **0 issues** (caught one `misspell`).
+- [x] Comment lint gate clean (`just comment-lint`) — no unresolvable doc links.
+- [x] Coverage maintained (`just coverage-check`) — both thresholds PASS,
+78.5% total.
+- [x] `just arch-lint`, `just plimsoll`, `just lint-md` — all clean.
+
+**Comment findings.** `just comment-report` introduced no new advisory finding
+from this diff, and no suppression was added anywhere.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** 9 findings — 1 critical, 5 significant, 2 minor, plus one
+out-of-scope bug. **7 addressed, 2 deferred with reasons.**
+
+RR-ZYVERL (critical), RR-4JUX43, RR-KPTYPY, RR-KA9LD5, RR-3DWRZX, RR-Z1V5Z6
+(significant), RR-14X83F (minor) — addressed. RR-OPBDAY (minor), RR-2FY0O8
+(significant) — deferred, see below.
+
+**The critical finding was a regression I introduced (RR-ZYVERL), and my own
+checklist claimed a test covered it that did not.**
+
+`audit.WithTriggeredBy` is an unconditional `context.WithValue`. The new
+per-entry tag therefore **overwrote** an enclosing label. Confirmed by running
+the probe against the pre-change tree — this is a before/after regression, not a
+pre-existing gap:
+
+```text
+BEFORE                                     AFTER
+create-entity   requirement   schedule:nightly   schedule:nightly
+create-entity   checklist     schedule:nightly   automation:spawn-checklist
+create-relation has-checklist schedule:nightly   automation:spawn-checklist
+```
+
+"What did last night's scheduled task write?" silently returned fewer rows. No
+error, no failing test — the forensic-regression shape that only surfaces when
+someone needs the log.
+
+It slipped through because PLAN-VKUSB7 listed a negative test for exactly this
+("pre-wrapped ctx → preserved label") and IMPL-HLR62T credited
+`TestAudit_IfExistsReplaceUsesCascadeLabel`. That test asserts a label
+`cascadeHost.DeleteEntity` stamps *internally*, downstream of the runner's wrap,
+so it never exercises an enclosing label. **The negative test I relied on tested
+a different code path than I believed** — worse than no test, because it bought
+false confidence. The implementation checklist has been corrected to say so.
+
+Fixed by making `triggeredByCtx` decline when the ctx already carries a label,
+mirroring `recordCascade`'s own guard. The composition policy is now a **written
+decision** rather than an accident: *the outermost cause wins*, because
+`triggered_by` is a single string (not a stack) and the enclosing cause is the
+operator-facing one. Recorded in the helper's godoc and in the audit-log guide.
+
+**Two more attribution holes review found, both now closed:**
+
+- **RR-4JUX43** — `if_exists: replace` emitted the generic label on its *delete*
+half while the matching create carried the specific one, because the tagged ctx
+was derived after `handleIfExists`. Two labels on adjacent rows of one
+operation, so a filter on the automation's name returned the create and missed
+the delete — the very question this ticket exists to answer. Hoisted the
+derivation; the cascaded relation-deletes still keep
+`cascade:delete-entity:<id>`.
+- **RR-KPTYPY** — the pre-existing scripted path stamped `"automation:"+name`
+inline and unguarded, so a nameless automation wrote a literal dangling
+`automation:`, and it clobbered enclosing labels the same way. Now routed
+through the shared helper. **Ordering was load-bearing**: doing this before
+fixing the helper would have spread the clobbering bug to a fourth call site.
+
+**Docs correction (RR-Z1V5Z6).** The sentence I added — "you should not normally
+see it, since every automation declared in `schema.yaml` has a `name:`" — was
+false twice over. `name:` is an ordinary optional field on an `automations:`
+list entry with **no loader validation** behind it, and the `if_exists: replace`
+hole meant the bare label appeared routinely. Both halves rewritten; documenting
+an unenforced invariant as a guarantee would have sent the next operator on a
+false-positive hunt.
+
+**Deferred, with reasons:**
+
+- **RR-2FY0O8** — automations in an `includes:` file are **silently dropped**
+(`partialMetamodel` has no `Automations` field: not merged, and not in the "not
+allowed in included files" list that errors, so it falls through the gap).
+Verified empirically: the include is read, `len(meta.Automations)` is 0, no
+warning. Genuinely out of scope — a metamodel-include bug with its own blast
+radius — so it is filed as **BUG-IK9IYL** rather than folded in here.
+- **RR-OPBDAY** — cosmetic `automation ""` / `automations.` diagnostics. The real
+remedy is making an empty name impossible at load time, which belongs with the
+validation work, not with an attribution ticket.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — per-automation relation attribution. PASS.**
+`TestAudit_PerAutomationAttribution` uses two differently-named automations both
+emitting relations into one `Result`. Mutation-verified: hoisting the ctx tag
+out of the loop fails it with a cross-attributed name.
+- **AC2 — same for entities. PASS.** Same test, plus
+`TestAudit_NestedCascadeAttribution` for the multi-level case (an entity created
+by automation A that itself triggers B — B's write names B).
+- **AC3 — tightened existing test. PASS.** Mutation-verified: reverting the
+engine assignments fails it with `got "automation"`.
+- **AC4 — fallback and enclosing labels. PASS**, after the RR-ZYVERL fix.
+`TestAudit_UnnamedAutomationKeepsGenericLabel` (empty name → generic label, not
+a dangling colon) and `TestAudit_OuterLabelSurvivesCascade` (enclosing label
+wins), the latter mutation-verified.
+- **AC5 — docs. PASS.** Gap section removed from the guide entity,
+`docs/audit-log.md` regenerated (generated file — never edited directly);
+regeneration touched only that file. `triggered_by` reference list corrected,
+and the one-label-per-record policy documented.
+
+**Every behavioural claim in this ticket was verified by mutation**, not just by
+a green test — for an attribution change a passing assertion proves little
+unless the assertion is known to fail when attribution is wrong. That practice
+is what exposed the first version of `TestAudit_PerAutomationAttribution`
+passing for the wrong reason (both automations wrote to different slices, so
+nothing could be mis-ordered), and it is why the reworked test is trustworthy.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` — see below.
+- [x] User-facing documentation updated — `docs-project/entities/guides/GUIDE-audit-log.md`
+(source) → `docs/audit-log.md` (generated).
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** covered inline — the doc change is two edits to one guide
+entity (remove the stale known-gap section; correct the `triggered_by` label
+list and add the composition policy), both verified in the regenerated output.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed — none added.
+- [x] Ready for another developer to use — `triggeredByCtx`'s godoc states both
+guards and *why* each is load-bearing, so the next person does not reintroduce
+either. The audit-log guide documents the label vocabulary and the
+outermost-wins policy in one place.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design, not
+skipped: `/pr` gates on the ticket already being `done` and validating clean,
+and a `done` checklist may have no unchecked items — so this item can only be
+satisfied by a PR that does not exist yet. Same ordering the note below records
+for the PR URL and CI status.)

--- a/tickets/entities/review-responses/RR-14X83F.md
+++ b/tickets/entities/review-responses/RR-14X83F.md
@@ -1,0 +1,18 @@
+---
+id: RR-14X83F
+type: review-response
+title: The two cascade paths derived the tagged ctx in different shapes
+finding: One inlined it at the call and the other hoisted it to the top of the loop body inviting a wrong tidy-up
+severity: minor
+resolution: Both loops now assign writeCtx at the top of the loop body; so the per-entry shape is uniform and a wrong hoist is visibly wrong.
+status: addressed
+---
+
+`applyRelationCreations` derived the tagged ctx inline at the `WriteRelation`
+call while `processEntityCreations` assigned it at the top of the loop body.
+Both were per-entry (which is what matters), but the asymmetry invites a future
+reader to "tidy" the inline call by lifting it above the loop — exactly the
+mutation the attribution test exists to catch.
+
+Both now assign `writeCtx` at the top of the loop body. Uniform shape, and the
+wrong edit becomes visibly wrong.

--- a/tickets/entities/review-responses/RR-2FY0O8.md
+++ b/tickets/entities/review-responses/RR-2FY0O8.md
@@ -1,0 +1,21 @@
+---
+id: RR-2FY0O8
+type: review-response
+title: Included files silently drop their automations
+finding: 'partialMetamodel has no Automations field so automations in an include: are discarded without warning'
+severity: significant
+reason: 'Out of scope and genuinely separate: internal/metamodel/include.go''s partialMetamodel has no Automations field so automations in an included file are silently dropped. That is a metamodel-include bug with its own blast radius (silent non-execution) and needs its own ticket plus its own tests - folding it into an audit-attribution change would make both harder to review. Recorded here so it is not lost.'
+status: deferred
+---
+
+Found while verifying the name-validation claim, and outside this diff's scope,
+but it should not be lost: `internal/metamodel/include.go` does not merge
+automations at all — `partialMetamodel` has no `Automations` field, so any
+`automations:` block in an included file is **silently dropped**.
+
+No error, no warning; the automations simply never run. Given that this ticket
+is about operators being able to reason about which automation caused what, an
+automation that silently does not exist is a sharper version of the same
+problem.
+
+Needs its own ticket rather than a fix here.

--- a/tickets/entities/review-responses/RR-3DWRZX.md
+++ b/tickets/entities/review-responses/RR-3DWRZX.md
@@ -1,0 +1,20 @@
+---
+id: RR-3DWRZX
+type: review-response
+title: TestAudit_UnnamedAutomationKeepsGenericLabel's comment described a different test
+finding: It claimed to drive the runner directly and asserted the engine always supplies a name - neither is true
+severity: significant
+resolution: Comment rewritten to describe the test that actually exists (full Manager.CreateEntity path) and to drop the false claim that the engine always supplies a name. Assertion tightened from cascaded == 0 to an exact count of 2.
+status: addressed
+---
+
+The comment said *"The engine always supplies a name in production, so this
+drives the runner directly with an untagged Result."* The test does neither: it
+constructs an `automation.Automation{Name: ""}` and goes through the full
+`Manager.CreateEntity` path — which is the better test — and the parenthetical
+is false, since an empty name is reachable from a user-authored schema.
+
+Comment rewritten to describe the test that exists. Also tightened the assertion
+from `cascaded == 0` to an exact count of 2, so a future change that stopped one
+of the two cascade writes firing fails loudly rather than quietly reducing
+coverage.

--- a/tickets/entities/review-responses/RR-4JUX43.md
+++ b/tickets/entities/review-responses/RR-4JUX43.md
@@ -1,0 +1,28 @@
+---
+id: RR-4JUX43
+type: review-response
+title: if_exists replace emitted the generic label on its delete half
+finding: handleIfExists ran before the tagged ctx was derived so one operation produced two different labels on adjacent rows
+severity: significant
+resolution: 'Fixed by hoisting the writeCtx derivation above handleIfExists. Verified on the production path: the replace-delete now carries automation:replace-checklist-on-active (was bare automation) while the cascaded relation-deletes keep cascade:delete-entity:CL-001. Pinned by TestAudit_IfExistsReplaceAttributesDeleteToTheAutomation; TestAudit_IfExistsReplaceUsesCascadeLabel still passes.'
+status: addressed
+---
+
+`processEntityCreations` derived its tagged `writeCtx` *after* calling
+`handleIfExists`, whose replace path deletes the superseded entity. So one
+operation produced two labels:
+
+```
+delete-relation  has-checklist  cascade:delete-entity:CL-001   <- correct
+delete-entity    checklist      automation                     <- generic
+create-entity    checklist      automation:replace-checklist-on-active
+```
+
+An operator filtering on the automation's name got the create and silently
+missed the delete — the exact question this ticket exists to make answerable.
+
+Fixed by hoisting the `writeCtx` derivation above `handleIfExists`. The cascaded
+relation-deletes still keep `cascade:delete-entity:<id>`, which
+`cascadeHost.DeleteEntity` stamps on a ctx it derives itself, so both labels are
+now right. Pinned by `TestAudit_IfExistsReplaceAttributesDeleteToTheAutomation`;
+the pre-existing `TestAudit_IfExistsReplaceUsesCascadeLabel` still passes.

--- a/tickets/entities/review-responses/RR-KA9LD5.md
+++ b/tickets/entities/review-responses/RR-KA9LD5.md
@@ -1,0 +1,22 @@
+---
+id: RR-KA9LD5
+type: review-response
+title: Two comments in cascadehost.go stated the pre-fix behaviour as fact
+finding: One cited the very limitation this ticket removed and pointed at the function that no longer has it
+severity: significant
+resolution: Both comments rewritten. recordCascade's doc no longer cites the removed limitation and now explains that its guard is what makes the runner's per-entry label survive; the cascadeHost type doc now describes the real label set.
+status: addressed
+---
+
+`cascadehost.go`'s `recordCascade` doc read: *"the generic label (per runner.go
+applyRelationCreations rationale — automation.Result doesn't carry per-action
+names through the engine)"* — a direct citation of the limitation this ticket
+removes, pointing at the function whose new doc says the opposite.
+
+The `cascadeHost` type doc read: *"Records carry triggered_by=\"automation\" (or
+the cascade-delete label when invoked from IfExistsReplace)"* — now wrong in the
+common case.
+
+Both rewritten. `recordCascade`'s doc now also explains that its `if` is what
+makes the runner's label survive, and cross-references the mirrored guard in
+`triggeredByCtx`.

--- a/tickets/entities/review-responses/RR-KPTYPY.md
+++ b/tickets/entities/review-responses/RR-KPTYPY.md
@@ -1,0 +1,35 @@
+---
+id: RR-KPTYPY
+type: review-response
+title: 'executeScriptActions stamps a dangling automation: for a nameless automation'
+finding: The scripted path is unguarded twelve lines from the helper whose doc says a dangling colon is worse than the generic label
+severity: significant
+resolution: Fixed by routing runner.go's scripted path through triggeredByCtx - but only AFTER the helper itself was made to compose (RR-ZYVERL); landing it against the clobbering version would have spread that bug to a fourth call site. Now all three cascade write paths share one guarded helper. Pinned by TestRunnerScriptActionTriggeredByLabel (table test covering named and nameless).
+status: addressed
+---
+
+`internal/autocascade/runner.go:298` (the pre-existing scripted path) does:
+
+```go
+actionCtx := audit.WithTriggeredBy(ctx, "automation:"+action.AutomationName)
+```
+
+Unguarded. For an automation with no `name:`, that writes the literal string
+`"automation:"` into the audit log — exactly what this ticket's new
+`triggeredByCtx` helper exists to avoid, and its doc says so verbatim: *"a
+dangling colon would be worse than the generic label it replaced."*
+
+`internal/script/luascriptrunner.go:213-227` guards the same concept correctly
+(`action.FilePath == "" && action.Name != ""`), so the tree now holds three
+different answers to one question across two packages.
+
+Predates this change, but the implementation checklist claimed the tag was *"a
+single triggeredByCtx helper shared by the relation and entity paths"* — it
+should be shared with the script path too. Routing line 298 through the helper
+is a one-line fix.
+
+Second effect: the unguarded stamp also OVERWRITES a caller's existing label.
+`scheduler.go:212` sets `schedule:<task-name>`; a scheduled task whose script
+triggers a scripted automation action loses that attribution. Routing through
+`triggeredByCtx` does not fix the overwrite by itself, but the empty-name case
+is the half this ticket owns.

--- a/tickets/entities/review-responses/RR-OPBDAY.md
+++ b/tickets/entities/review-responses/RR-OPBDAY.md
@@ -1,0 +1,21 @@
+---
+id: RR-OPBDAY
+type: review-response
+title: A nameless automation produces blank-filled diagnostics across engine runner and analyze
+finding: Several operator-facing messages render automation "" or automations. when the name is empty
+severity: minor
+reason: Cosmetic diagnostics only (automation "" in three log/error strings and automations. in analyze). Not load-bearing and none is on the audit record itself. The real remedy is making an empty automation name impossible at load time - a metamodel-loader change that belongs with RR-2FY0O8's validation work rather than in an attribution ticket. Deferring so the fix lands once in the right place instead of papering over each string.
+status: deferred
+---
+
+Cosmetic fallout of the same empty-name case, all low priority but all in the
+diagnostics an operator reads *after* a nameless automation has misbehaved:
+
+- `runner.go:293` — `automation "": no ScriptRunner configured`
+- `engine.go:158`, `:99-126` — `automation "": when clause ...` /
+`automation "": condition requires ...`
+- `schema/analyze.go:171-180` — renders the display string `"automations."`
+
+None is load-bearing. Noted rather than fixed here: the real remedy is making an
+empty automation name impossible at load time (see the load-time validation
+finding), after which these strings can never be blank.

--- a/tickets/entities/review-responses/RR-Z1V5Z6.md
+++ b/tickets/entities/review-responses/RR-Z1V5Z6.md
@@ -1,0 +1,31 @@
+---
+id: RR-Z1V5Z6
+type: review-response
+title: The audit-log guide claims every automation has a name but nothing enforces it
+finding: 'automations: is a YAML list where name is an ordinary optional field and no validator checks it'
+severity: significant
+resolution: 'Docs corrected. The guide no longer claims every automation has a name; it now states that name: is an optional field nothing rejects and that the bare label means the schema did not say which rule this was. Also added a paragraph documenting the one-label-per-record policy. Load-time validation was NOT added - see RR-2FY0O8''s sibling note; that is a metamodel-loader change beyond this ticket''s scope.'
+status: addressed
+---
+
+The docs sentence added by this ticket — *"you should not normally see it, since
+every automation declared in `schema.yaml` has a `name:`"* — states an invariant
+nothing enforces.
+
+Verified: `automations:` is a YAML **list** of structs (`- name: foo`), not a
+map keyed by name. Entities, relations and types are `map[string]...` where the
+key *is* the name and cannot be empty; automations are the one declaration form
+where the name is an ordinary optional field.
+
+`metamodel/loader.go`'s `validate()` calls eight validators (entity structure,
+custom types, entity semantics, relation
+references/properties/inverses/orderable, transforms). There is **no
+`validateAutomations`** — the word "automation" appears once in the file, in the
+top-level key allowlist. Parsing uses plain `yaml.Unmarshal` with no
+`KnownFields(true)`, and `checkUnknownKeys` inspects only top-level keys, so a
+missing `name:` silently yields `""`. `rela validate` delegates to the same
+`validate()` and passes clean.
+
+So a schema with a bare `- on: {...}` / `do: [...]` loads, validates, and runs
+with `Name == ""`. Either soften the doc sentence to describe convention rather
+than guarantee, or add `validateAutomations` to make it true.

--- a/tickets/entities/review-responses/RR-ZYVERL.md
+++ b/tickets/entities/review-responses/RR-ZYVERL.md
@@ -1,0 +1,48 @@
+---
+id: RR-ZYVERL
+type: review-response
+title: triggeredByCtx clobbered an enclosing label - scheduler cascades lost schedule:<task>
+finding: audit.WithTriggeredBy is an unconditional WithValue so the new per-entry tag overwrote an outer label
+severity: critical
+resolution: 'Fixed. triggeredByCtx now declines when audit.TriggeredByFrom(ctx) != "" - mirroring recordCascade''s own guard - so an enclosing label survives. Policy chosen and documented in the helper and the audit-log guide: the outermost cause wins; triggered_by is a single string and the enclosing cause is the operator-facing one. Pinned by TestAudit_OuterLabelSurvivesCascade; verified it fails with got "automation:spawn-checklist" when the guard is removed. Confirmed the regression by running the probe against the pre-change tree.'
+status: addressed
+---
+
+**A regression this ticket introduced, verified by running the tree before and
+after the change.**
+
+`audit.WithTriggeredBy` is an unconditional `context.WithValue` — it overwrites.
+Before this ticket the cascade paths passed ctx through untouched and
+`recordCascade` stamped its generic label only when the ctx label was empty;
+that `if` was load-bearing, preserving an enclosing label. The new per-entry tag
+overwrote it before `recordCascade` ever saw it.
+
+Measured on the production path (scheduler ctx pre-stamped `schedule:nightly`,
+create trips an `on: created` automation):
+
+```
+BEFORE                                    AFTER (the regression)
+create-entity   requirement  schedule:nightly    schedule:nightly
+create-entity   checklist    schedule:nightly    automation:spawn-checklist
+create-relation has-checklist schedule:nightly   automation:spawn-checklist
+```
+
+"What did last night's task write?" is the most obvious audit query for a
+scheduler, and it silently returned fewer rows. Nothing errored; no test failed.
+
+**The negative test I claimed covered this does not.** PLAN-VKUSB7 listed
+"pre-wrapped ctx → preserved label" and IMPL-HLR62T credited
+`TestAudit_IfExistsReplaceUsesCascadeLabel`. That test asserts a label
+`cascadeHost.DeleteEntity` stamps *internally*, downstream of the runner's wrap,
+so it never exercises an enclosing label at all. False confidence, which is
+worse than no test.
+
+Fixed by making the helper compose rather than clobber — it now declines when
+`audit.TriggeredByFrom(ctx) != ""`, mirroring `recordCascade`'s own `if`. Policy
+chosen and written down: **the outermost cause wins**, because `triggered_by` is
+a single string and the enclosing cause is the operator-facing one. Pinned by
+`TestAudit_OuterLabelSurvivesCascade`, verified to fail with `got
+"automation:spawn-checklist"` when the guard is removed.
+
+This also fixes the same clobbering on the scripted path (RR-KPTYPY), which had
+it since day one.

--- a/tickets/entities/tickets/TKT-A23L87.md
+++ b/tickets/entities/tickets/TKT-A23L87.md
@@ -1,0 +1,27 @@
+---
+id: TKT-A23L87
+type: ticket
+title: Audit already-deleted relations when a cascade delete fails partway
+kind: enhancement
+priority: low
+effort: s
+status: ready
+---
+
+## Description
+
+When a cascade delete fails partway — an I/O error removing relation R2 after R1
+is already off disk — `fsstore.deleteEntity` returns `nil, err`. The manager
+returns early on that error, so the relations that **were** deleted get no audit
+record. The audit log therefore does not reflect the real system state.
+
+The fail-secure ordering from #899 (relations first, abort before touching the
+entity file) is correct and stays; this is the remaining edge case it left. The
+store's own comment acknowledges it: *"Not transactional: a relation file
+removed before a later failure stays removed."*
+
+Note fsstore's `Tx` is a write mutex with no rollback, so on that backend the
+partial deletion genuinely persists.
+
+GitHub issue #929. Severity: low. Basis: POLICY-015 §4 — audit records must
+reflect actual system state.

--- a/tickets/entities/tickets/TKT-A23L87.md
+++ b/tickets/entities/tickets/TKT-A23L87.md
@@ -5,7 +5,7 @@ title: Audit already-deleted relations when a cascade delete fails partway
 kind: enhancement
 priority: low
 effort: s
-status: ready
+status: backlog
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-JJRVX9.md
+++ b/tickets/entities/tickets/TKT-JJRVX9.md
@@ -1,0 +1,25 @@
+---
+id: TKT-JJRVX9
+type: ticket
+title: Plumb AutomationName through automation.Result for per-action audit attribution
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+Cascade-created relations and entities from non-scripted automation actions
+carry the generic `triggered_by: "automation"` in the audit log. Scripted
+actions (`lua:` blocks) already carry the specific `automation:<name>`, because
+`LuaToExecute.AutomationName` is plumbed through
+`autocascade.Runner.executeScriptActions`.
+
+The non-scripted paths drop the originating automation's name because
+`automation.Result.RelationsToCreate` (a bare `[]*entity.Relation`) and
+`automation.EntityToCreate` do not carry it. Operators filtering the audit log
+cannot reconstruct which automation caused which cascade-created relation or
+entity in a project with multiple `on: created` rules.
+
+GitHub issue #764.

--- a/tickets/entities/tickets/TKT-REUP5S.md
+++ b/tickets/entities/tickets/TKT-REUP5S.md
@@ -1,0 +1,42 @@
+---
+id: TKT-REUP5S
+type: ticket
+title: Automations in an included schema file are silently dropped
+kind: chore
+priority: high
+effort: s
+status: backlog
+---
+
+## Description
+
+`internal/metamodel/include.go`'s `partialMetamodel` has no `Automations` field,
+so an `automations:` block in a file pulled in via `includes:` is **silently
+discarded**. No error, no warning — the automations simply never run.
+
+Verified empirically: a `schema.yaml` with `includes: [inc.yaml]`, where
+`inc.yaml` declares one automation, loads successfully. The returned file list
+confirms `inc.yaml` **was** read, and `len(meta.Automations)` is **0**.
+
+`partialMetamodel` merges `Types`, `Entities`, `Relations` and `Validations`,
+and has an explicit "fields that are not allowed in included files" group
+(`Version`, `Namespace`, `Description`) that produces a load error.
+`Automations` is in neither group, so it falls through the gap: not merged, and
+not rejected.
+
+## Impact
+
+Silent non-execution is the worst failure shape for an automation. An operator
+who splits a large schema into includes — the reason `includes:` exists — loses
+every automation in the included files with no signal. Downstream, an audit log
+missing those writes is indistinguishable from an automation that legitimately
+did not fire.
+
+## Approach
+
+Either merge `Automations` like the other collections, or add it to the
+not-allowed group so it fails loudly. Merging is the evident intent; whichever
+is chosen, the silent-drop path must go. A regression test should assert an
+automation declared in an included file is present in the loaded metamodel.
+
+Found while reviewing TKT-JJRVX9 (per-automation audit attribution).

--- a/tickets/relations/TKT-A23L87--affects--audit-log.md
+++ b/tickets/relations/TKT-A23L87--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: TKT-A23L87
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/TKT-A23L87--affects--store-backends.md
+++ b/tickets/relations/TKT-A23L87--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-A23L87
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-A23L87--implements--FEAT-831A.md
+++ b/tickets/relations/TKT-A23L87--implements--FEAT-831A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-A23L87
+relation: implements
+to: FEAT-831A
+---

--- a/tickets/relations/TKT-JJRVX9--affects--audit-log.md
+++ b/tickets/relations/TKT-JJRVX9--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/TKT-JJRVX9--has-docs--DOCS-QTGT8N.md
+++ b/tickets/relations/TKT-JJRVX9--has-docs--DOCS-QTGT8N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-docs
+to: DOCS-QTGT8N
+---

--- a/tickets/relations/TKT-JJRVX9--has-implementation--IMPL-HLR62T.md
+++ b/tickets/relations/TKT-JJRVX9--has-implementation--IMPL-HLR62T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-implementation
+to: IMPL-HLR62T
+---

--- a/tickets/relations/TKT-JJRVX9--has-planning--PLAN-VKUSB7.md
+++ b/tickets/relations/TKT-JJRVX9--has-planning--PLAN-VKUSB7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-planning
+to: PLAN-VKUSB7
+---

--- a/tickets/relations/TKT-JJRVX9--has-review--REV-4X5CRK.md
+++ b/tickets/relations/TKT-JJRVX9--has-review--REV-4X5CRK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review
+to: REV-4X5CRK
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-14X83F.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-14X83F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-14X83F
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-2FY0O8.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-2FY0O8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-2FY0O8
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-3DWRZX.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-3DWRZX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-3DWRZX
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-4JUX43.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-4JUX43.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-4JUX43
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-KA9LD5.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-KA9LD5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-KA9LD5
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-KPTYPY.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-KPTYPY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-KPTYPY
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-OPBDAY.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-OPBDAY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-OPBDAY
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-Z1V5Z6.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-Z1V5Z6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-Z1V5Z6
+---

--- a/tickets/relations/TKT-JJRVX9--has-review-response--RR-ZYVERL.md
+++ b/tickets/relations/TKT-JJRVX9--has-review-response--RR-ZYVERL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: has-review-response
+to: RR-ZYVERL
+---

--- a/tickets/relations/TKT-JJRVX9--implements--FEAT-831A.md
+++ b/tickets/relations/TKT-JJRVX9--implements--FEAT-831A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JJRVX9
+relation: implements
+to: FEAT-831A
+---

--- a/tickets/relations/TKT-REUP5S--affects--metamodel-types.md
+++ b/tickets/relations/TKT-REUP5S--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-REUP5S
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-REUP5S--implements--FEAT-57oh.md
+++ b/tickets/relations/TKT-REUP5S--implements--FEAT-57oh.md
@@ -1,0 +1,5 @@
+---
+from: TKT-REUP5S
+relation: implements
+to: FEAT-57oh
+---


### PR DESCRIPTION
Closes #764.

## Why

Cascade-created relations and entities carried the generic `triggered_by: "automation"`, so an operator filtering the audit log could not tell **which** of several `on: created` rules caused a given write. Scripted (`lua:`) actions already carried `automation:<name>`.

## What

The mechanism was already right — `recordCascade` prefers a ctx-carried label and only falls back to the generic one. What was missing was the *name*: `Result.RelationsToCreate` was a bare `[]*entity.Relation` and `EntityToCreate` had no name field, while `LuaToExecute` did.

- `EntityToCreate` gains `AutomationName`; relations get a `RelationToCreate{Relation, AutomationName}` carrier.
- Both set at the engine seam, where `automationName` was **already a parameter**.
- The runner tags the write ctx **per entry** — `Engine.Process` aggregates every matching automation into one `Result`, so a tag hoisted out of the loop would attribute all of them to whichever name came last.
- The audit layer is unchanged.

A struct rather than a parallel `[]string`: a parallel slice can drift in length or order with no compile-time signal, and this value crosses a package boundary where the consequence is a silently misattributed record.

## The decision this settles

`triggeredByCtx` declines in two cases, both load-bearing:

- **Empty name** → no tag, so the audit layer supplies the generic label. A dangling `automation:` would be worse than what it replaced, and `name:` is an ordinary optional field with no loader validation behind it, so `""` is reachable.
- **Ctx already labelled** → **the outermost cause wins.** A scheduled task's writes keep `schedule:<task>` even when an automation cascades underneath them, so "what did last night's run do?" still returns the complete set. `triggered_by` is a single string, not a stack; the policy is now documented in the helper and in the audit-log guide instead of being an accident of ordering.

## Two pre-existing holes this exposed, also fixed

- **The scripted path** stamped `"automation:"+name` inline and unguarded — a literal dangling `automation:` for a nameless automation, and the same label clobbering, since day one. Now routed through the shared helper. *Ordering mattered:* doing this before fixing the helper would have spread the clobbering to a fourth call site.
- **`if_exists: replace`** labelled its delete half generically while the matching create was specific, because the tagged ctx was derived after `handleIfExists`. One operation, two labels on adjacent rows — a filter on the automation's name returned the create and missed the delete.

## Verification

Every behavioural claim was **mutation-tested**, not just green-tested — for an attribution change a passing assertion proves little unless it is known to fail when attribution is wrong:

| Mutation | Result |
|---|---|
| Revert the engine assignments | tightened test fails with `got "automation"` |
| Hoist the ctx tag out of the per-entry loop | fails with a cross-attributed name |
| Remove the already-labelled guard | fails with `got "automation:spawn-checklist"` where `schedule:nightly` was expected |

That practice caught the first version of `TestAudit_PerAutomationAttribution` passing for the wrong reason: both automations wrote to *different* slices, so nothing could be mis-ordered. Reworked so both emit relations into one `Result`.

Also covered: nested cascade (an entity created by automation A that itself triggers B — B's write names B), and the empty-name fallback.

- `go test ./...` exit 0; builds under all four backend tags
- `just lint` 0 issues · arch-lint · comment-lint · plimsoll · lint-md — all clean
- `just coverage-check` both thresholds PASS (78.5%)
- `docs/audit-log.md` regenerated from its source entity (never edited directly); regeneration touched only that file

Code review returned 9 findings (1 critical, 5 significant, 2 minor, 1 out-of-scope). **The critical one was a regression this PR introduced** — the details are in the commit message and the review checklist. 7 addressed; 2 deferred with reasons, one of them filed as its own ticket (automations in an `includes:` file are silently dropped — verified, no error, no warning).

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
