### PR TITLE
feat(analyze): flag relation files whose filename disagrees with their content (+ 2 security-test tickets)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -637,6 +637,7 @@ deps:
   # Domain services
   analysis:
     mayDependOn:
+      - frontmatter
       - lua
       - metamodel
       - project

--- a/docs-project/entities/guides/GUIDE-cli-reference.md
+++ b/docs-project/entities/guides/GUIDE-cli-reference.md
@@ -1285,6 +1285,51 @@ $ rela analyze validations
 Found 2 errors, 1 warnings across 2 rules
 ```
 
+#### rela analyze relation-files
+
+Find relation files whose **filename** disagrees with their **content**.
+
+```bash
+rela analyze relation-files
+```
+
+Relations are stored as `relations/FROM--TYPE--TO.md`, and rela indexes them
+**by filename**. If a file is renamed or hand-edited so that its name and its
+`from` / `relation` / `to` frontmatter describe different relations, the
+relation the content describes does not exist as far as the graph is concerned
+— while the one the filename describes points at entities that may not.
+
+The symptom shows up somewhere else entirely: `analyze cardinality` reports the
+correctly-referenced entity as having zero relations, with nothing pointing back
+at the offending file. This check names the file directly.
+
+It reports three kinds of problem:
+
+| Finding | Meaning |
+| --- | --- |
+| filename and content describe different relations | The store indexed the _filename_ triple; the relation the content describes is not in the graph. |
+| filename is not `FROM--TYPE--TO` | The store skips the file entirely — the relation does not exist at all. |
+| legacy `type:` key | The frontmatter spells the relation type `type:` instead of `relation:`. The store reads only `relation:`, so the relation loads with an **empty type** while the index says otherwise. |
+
+**Example output:**
+
+```text
+$ rela analyze relation-files
+⚠ relations/A--doet--FN-8Q7E.md: indexed as "A--doet--FN-8Q7E"
+  but content says "A--doet--FN-0Q7E"
+⚠ relations/B--covers--FEAT-x.md: uses `type:` instead of `relation:`
+  — loads with an EMPTY relation type
+⚠ Found 2 relation file(s) with filename/content problems
+```
+
+To fix a mismatch, rename the file to match its content (or correct the content
+to match the name — whichever is right for that relation). To fix a legacy
+`type:` key, rename the key to `relation:`; the value is already correct.
+
+Renaming an entity through rela keeps filename and content in step
+automatically; this check exists for files that were moved, hand-edited, or
+merged outside it.
+
 #### rela analyze properties
 
 Validate entity property values against the metamodel schema.

--- a/docs-project/relations/GUIDE-audit-log--covers--FEAT-audit-log.md
+++ b/docs-project/relations/GUIDE-audit-log--covers--FEAT-audit-log.md
@@ -1,5 +1,5 @@
 ---
 from: GUIDE-audit-log
 to: FEAT-audit-log
-type: covers
+relation: covers
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1279,6 +1279,51 @@ $ rela analyze validations
 Found 2 errors, 1 warnings across 2 rules
 ```
 
+#### rela analyze relation-files
+
+Find relation files whose **filename** disagrees with their **content**.
+
+```bash
+rela analyze relation-files
+```
+
+Relations are stored as `relations/FROM--TYPE--TO.md`, and rela indexes them
+**by filename**. If a file is renamed or hand-edited so that its name and its
+`from` / `relation` / `to` frontmatter describe different relations, the
+relation the content describes does not exist as far as the graph is concerned
+— while the one the filename describes points at entities that may not.
+
+The symptom shows up somewhere else entirely: `analyze cardinality` reports the
+correctly-referenced entity as having zero relations, with nothing pointing back
+at the offending file. This check names the file directly.
+
+It reports three kinds of problem:
+
+| Finding | Meaning |
+| --- | --- |
+| filename and content describe different relations | The store indexed the _filename_ triple; the relation the content describes is not in the graph. |
+| filename is not `FROM--TYPE--TO` | The store skips the file entirely — the relation does not exist at all. |
+| legacy `type:` key | The frontmatter spells the relation type `type:` instead of `relation:`. The store reads only `relation:`, so the relation loads with an **empty type** while the index says otherwise. |
+
+**Example output:**
+
+```text
+$ rela analyze relation-files
+⚠ relations/A--doet--FN-8Q7E.md: indexed as "A--doet--FN-8Q7E"
+  but content says "A--doet--FN-0Q7E"
+⚠ relations/B--covers--FEAT-x.md: uses `type:` instead of `relation:`
+  — loads with an EMPTY relation type
+⚠ Found 2 relation file(s) with filename/content problems
+```
+
+To fix a mismatch, rename the file to match its content (or correct the content
+to match the name — whichever is right for that relation). To fix a legacy
+`type:` key, rename the key to `relation:`; the value is already correct.
+
+Renaming an entity through rela keeps filename and content in step
+automatically; this check exists for files that were moved, hand-edited, or
+merged outside it.
+
 #### rela analyze properties
 
 Validate entity property values against the metamodel schema.

--- a/internal/analysis/relation_filename.go
+++ b/internal/analysis/relation_filename.go
@@ -1,0 +1,213 @@
+package analysis
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/frontmatter"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// RelationFilenameReason classifies a [RelationFilenameIssue]. A closed set:
+// the CLI switches on it to choose a rendering, so a new value must be added
+// here and handled there rather than inferred from which fields happen to be
+// empty.
+type RelationFilenameReason string
+
+const (
+	// ReasonMismatch: the filename and the frontmatter describe different
+	// relations. The store indexed the FILENAME triple, so the relation the
+	// content describes does not exist in the graph.
+	ReasonMismatch RelationFilenameReason = "filename and content describe different relations"
+
+	// ReasonUnparseableName: the filename is not FROM--TYPE--TO, so the store
+	// skipped it entirely — the relation is not in the graph at all.
+	ReasonUnparseableName RelationFilenameReason = "filename is not FROM--TYPE--TO"
+
+	// ReasonLegacyTypeKey: the frontmatter spells the relation type `type:`
+	// instead of `relation:`. The store reads only `relation:`, so the
+	// relation loads with an EMPTY type while the index (built from the
+	// filename) says otherwise — the two disagree, silently.
+	ReasonLegacyTypeKey RelationFilenameReason = "legacy `type:` key; the store reads `relation:` and loads this relation with an empty type"
+)
+
+// RelationFilenameIssue reports a relation file whose NAME disagrees with its
+// CONTENT — the filename parses to one (from, type, to) triple while the
+// frontmatter declares another.
+type RelationFilenameIssue struct {
+	// File is the path as an operator would open it.
+	File string
+	// FromFilename is the triple the filename encodes — the one the store
+	// actually indexed the relation under.
+	FromFilename string
+	// FromContent is the triple the frontmatter declares — the one the author
+	// meant, and the one every other tool reports as missing.
+	FromContent string
+	// Reason classifies the finding. See the Reason* constants.
+	Reason RelationFilenameReason
+}
+
+// CheckRelationFilenames reports relation files whose filename and content
+// disagree about which relation they are.
+//
+// # Why this exists as a check rather than a fix
+//
+// fsstore keys relations ENTIRELY on the filename: syncRelations parses
+// `FROM--TYPE--TO.md` and never opens the file to confirm the triple. A file
+// whose name and content disagree is therefore indexed under the FILENAME
+// triple, and the relation its content describes does not exist as far as the
+// graph is concerned.
+//
+// The symptom an operator actually sees is a cardinality error naming the
+// VICTIM entity ("must have at least 1 X relation(s), has 0") with no path back
+// to the malformed file — which is exactly how issue #1004 was reported, after
+// the reporter had lost time to it. This check turns that into a finding that
+// names the file.
+//
+// The rename path that most plausibly produced such files is already correct:
+// fsstore.renameEntity rewrites each incident relation under its new filename
+// and removes the old one. So this detects LEGACY corruption and hand-edits,
+// not an ongoing defect.
+//
+// Returns nil when the service was built without FS + Paths — same gate as
+// [Service.FindOrphanedTempFiles]; analyses that don't touch the filesystem
+// still work.
+func (s *Service) CheckRelationFilenames() []RelationFilenameIssue {
+	if s.deps.FS == nil || s.deps.Paths == nil {
+		return nil
+	}
+
+	entries, err := s.deps.FS.ReadDir(s.deps.Paths.RelationsDir)
+	if err != nil {
+		// A missing relations/ directory is not a finding — a project may
+		// legitimately have no relations yet.
+		return nil
+	}
+
+	issues := make([]RelationFilenameIssue, 0)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		path := filepath.Join(s.deps.Paths.RelationsDir, e.Name())
+		if iss := checkRelationFile(s.deps.FS, path, e.Name()); iss != nil {
+			issues = append(issues, *iss)
+		}
+	}
+
+	sort.Slice(issues, func(i, j int) bool { return issues[i].File < issues[j].File })
+	return issues
+}
+
+// checkRelationFile compares one file's name against its frontmatter.
+// Returns nil when they agree, or when the file cannot be read or parsed —
+// an unreadable file is a different problem (a permission error, or a
+// git-crypt-encrypted relation, which fsstore handles as a locked shell) and
+// reporting it here would put a second, unrelated class of finding into a
+// check operators run to answer one question.
+func checkRelationFile(fs storage.FS, path, name string) *RelationFilenameIssue {
+	base := strings.TrimSuffix(name, ".md")
+	nameFrom, nameType, nameTo := splitRelationFilename(base)
+	if nameFrom == "" {
+		return &RelationFilenameIssue{
+			File:         path,
+			FromFilename: base,
+			Reason:       ReasonUnparseableName,
+		}
+	}
+	nameTriple := nameFrom + "--" + nameType + "--" + nameTo
+
+	raw, err := fs.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	// The SAME splitter the store uses (internal/frontmatter is the shared
+	// leaf that markdown and fsstore both build on), then plain yaml. Reading
+	// the file a third way would make any divergence a false negative in a
+	// corruption detector.
+	fmBlock, _ := frontmatter.Split(string(raw))
+	fm := map[string]string{}
+	if err := yaml.Unmarshal([]byte(fmBlock), &fm); err != nil {
+		return nil
+	}
+
+	cFrom := fm["from"]
+	cTo := fm["to"]
+	cType, hasRelation := fm["relation"]
+
+	// `relation:` is what the store reads and what every write emits. `type:`
+	// is a legacy spelling still present in older files, and it does NOT work:
+	// mdCodec builds the relation from doc.getString("relation"), so a legacy
+	// file loads with an EMPTY type while the index — built from the filename —
+	// says otherwise. `type` is not a reserved relation key either, so it is
+	// additionally stored as a user property.
+	//
+	// That is the same filename-vs-content divergence this check exists for,
+	// and it is worse than the #1004 shape: #1004 fails loudly downstream as a
+	// cardinality error, this one is silently inconsistent, and a read →
+	// write round trip through any path (formatter, rename, migration) writes
+	// the empty type back and destroys the last record of it.
+	if !hasRelation {
+		if legacy, ok := fm["type"]; ok && legacy != "" {
+			return &RelationFilenameIssue{
+				File:         path,
+				FromFilename: nameTriple,
+				FromContent:  cFrom + "--" + legacy + "--" + cTo,
+				Reason:       ReasonLegacyTypeKey,
+			}
+		}
+	}
+
+	// Frontmatter that declares none of the three is a different shape of
+	// broken (an empty or non-relation file); not this check's business.
+	if cFrom == "" && cType == "" && cTo == "" {
+		return nil
+	}
+
+	if cFrom == nameFrom && cType == nameType && cTo == nameTo {
+		return nil
+	}
+	return &RelationFilenameIssue{
+		File:         path,
+		FromFilename: nameTriple,
+		FromContent:  cFrom + "--" + cType + "--" + cTo,
+		Reason:       ReasonMismatch,
+	}
+}
+
+// splitRelationFilename splits "FROM--TYPE--TO" into its three parts.
+//
+// MUST stay behaviorally identical to fsstore.parseRelationFilename
+// (internal/store/fsstore/index.go). Duplicated rather than shared because it
+// is unexported there and arch-lint forbids analysis -> store/fsstore, which is
+// the right boundary — a storage detail should not become an analysis
+// dependency to save nine lines.
+//
+// The exactness is the point, not an accident: this check's entire claim is
+// "I split names the way the indexer does". A divergence here reports a false
+// mismatch on a perfectly good file whose relation type contains "--".
+// TestSplitRelationFilename_MatchesIndexer pins the agreement.
+//
+// First "--" ends FROM, last "--" starts TO.
+func splitRelationFilename(name string) (from, relType, to string) {
+	i := strings.Index(name, "--")
+	if i < 1 {
+		return "", "", ""
+	}
+	from = name[:i]
+	rest := name[i+2:]
+
+	j := strings.LastIndex(rest, "--")
+	if j < 1 {
+		return "", "", ""
+	}
+	relType = rest[:j]
+	to = rest[j+2:]
+	if to == "" {
+		return "", "", ""
+	}
+	return from, relType, to
+}

--- a/internal/analysis/relation_filename_test.go
+++ b/internal/analysis/relation_filename_test.go
@@ -1,0 +1,227 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/analysis"
+	"github.com/Sourcehaven-BV/rela/internal/lua"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/tracer"
+)
+
+// newFSService builds an analysis.Service with a real (in-memory) filesystem,
+// which CheckRelationFilenames needs — the graph store cannot see this problem,
+// since a mis-filed relation is indexed under the wrong key and looks like an
+// ordinary relation between entities that may not exist.
+func newFSService(t *testing.T, files map[string]string) *analysis.Service {
+	t.Helper()
+	fs := storage.NewMemFS()
+	paths := &project.Context{Root: "/p", RelationsDir: "/p/relations"}
+	if err := fs.MkdirAll(paths.RelationsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, body := range files {
+		if err := fs.WriteFile(paths.RelationsDir+"/"+name, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	st := memstore.New()
+	meta := &metamodel.Metamodel{Entities: map[string]metamodel.EntityDef{}}
+	tr := tracer.New(st)
+	svc, err := analysis.New(analysis.Deps{
+		Store: st, Meta: meta, Tracer: tr, FS: fs, Paths: paths,
+		LuaReadDeps: lua.ReadDeps{VisibleReader: st, Tracer: tr, Meta: meta},
+	})
+	if err != nil {
+		t.Fatalf("analysis.New: %v", err)
+	}
+	return svc
+}
+
+func relFile(from, relType, to string) string {
+	return "---\nfrom: " + from + "\nrelation: " + relType + "\nto: " + to + "\n---\n"
+}
+
+// TestCheckRelationFilenames_ReportersScenario reproduces the exact corruption
+// from issue #1004 and asserts the check names the FILE — which is what the
+// reporter could not get from any existing output.
+//
+// The symptom they saw was a cardinality error naming PRS-FUNC-0Q7E (the entity
+// the content correctly references) with no route back to the file, because the
+// store had indexed the relation under PRS-FUNC-8Q7E (the filename) and
+// PRS-FUNC-8Q7E does not exist.
+func TestCheckRelationFilenames_ReportersScenario(t *testing.T) {
+	t.Parallel()
+
+	svc := newFSService(t, map[string]string{
+		"PRS-FLOW-1HL6--wordtUitgevoerdDoor--PRS-FUNC-8Q7E.md": relFile(
+			"PRS-FLOW-1HL6", "wordtUitgevoerdDoor", "PRS-FUNC-0Q7E"),
+	})
+
+	issues := svc.CheckRelationFilenames()
+	if len(issues) != 1 {
+		t.Fatalf("want 1 issue, got %d: %+v", len(issues), issues)
+	}
+	got := issues[0]
+	if got.File != "/p/relations/PRS-FLOW-1HL6--wordtUitgevoerdDoor--PRS-FUNC-8Q7E.md" {
+		t.Errorf("File must name the malformed file, got %q", got.File)
+	}
+	// Both triples must be reported: the filename one is what the store
+	// indexed, the content one is what every other tool says is missing.
+	// Only showing one leaves the operator to guess the mapping.
+	if got.FromFilename != "PRS-FLOW-1HL6--wordtUitgevoerdDoor--PRS-FUNC-8Q7E" {
+		t.Errorf("FromFilename = %q", got.FromFilename)
+	}
+	if got.FromContent != "PRS-FLOW-1HL6--wordtUitgevoerdDoor--PRS-FUNC-0Q7E" {
+		t.Errorf("FromContent = %q", got.FromContent)
+	}
+}
+
+func TestCheckRelationFilenames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		files     map[string]string
+		wantCount int
+		wantWhy   analysis.RelationFilenameReason
+	}{
+		{
+			name:      "consistent file is not flagged",
+			files:     map[string]string{"A--rel--B.md": relFile("A", "rel", "B")},
+			wantCount: 0,
+		},
+		{
+			name:      "mismatched to",
+			files:     map[string]string{"A--rel--B.md": relFile("A", "rel", "C")},
+			wantCount: 1,
+			wantWhy:   analysis.ReasonMismatch,
+		},
+		{
+			name:      "mismatched from",
+			files:     map[string]string{"A--rel--B.md": relFile("Z", "rel", "B")},
+			wantCount: 1,
+			wantWhy:   analysis.ReasonMismatch,
+		},
+		{
+			name:      "mismatched type",
+			files:     map[string]string{"A--rel--B.md": relFile("A", "other", "B")},
+			wantCount: 1,
+			wantWhy:   analysis.ReasonMismatch,
+		},
+		{
+			name:      "unparseable filename",
+			files:     map[string]string{"notatriple.md": relFile("A", "rel", "B")},
+			wantCount: 1,
+			wantWhy:   analysis.ReasonUnparseableName,
+		},
+		{
+			// A relation type containing "--" still round-trips, because the
+			// split takes the FIRST "--" for from and the LAST for to — the
+			// same rule fsstore's indexer uses. If this check split
+			// differently it would report false positives on valid files.
+			name:      "relation type containing the separator",
+			files:     map[string]string{"A--we--ird--B.md": relFile("A", "we--ird", "B")},
+			wantCount: 0,
+		},
+		{
+			// Not this check's business: an empty or non-relation file is a
+			// different problem with its own reporting, and flagging it here
+			// would drown the signal.
+			name:      "file with no relation frontmatter is ignored",
+			files:     map[string]string{"A--rel--B.md": "---\ntitle: not a relation\n---\n"},
+			wantCount: 0,
+		},
+		{
+			// `type:` is a legacy spelling that does NOT work. mdCodec builds
+			// the relation from doc.getString("relation"), so such a file
+			// loads with an EMPTY type while the index — built from the
+			// filename — says otherwise. That is this check's subject, and a
+			// worse variant of it than #1004: #1004 fails loudly downstream
+			// as a cardinality error, this one is silently inconsistent.
+			//
+			// An earlier version of this check treated these as false
+			// positives and suppressed them. They were 37 TRUE positives in
+			// this repo's own tickets project, where three relations on
+			// BUG-2OXEW0 rendered with a blank type. Reported separately so
+			// they are triageable without drowning the mismatch findings.
+			name:      "legacy type key is reported",
+			files:     map[string]string{"A--rel--B.md": "---\nfrom: A\ntype: rel\nto: B\n---\n"},
+			wantCount: 1,
+			wantWhy:   analysis.ReasonLegacyTypeKey,
+		},
+		{
+			// `relation:` present wins outright — a file carrying both keys
+			// loads fine, because that is the key the store reads.
+			name: "both keys present is not a finding",
+			files: map[string]string{
+				"A--rel--B.md": "---\nfrom: A\nrelation: rel\ntype: rel\nto: B\n---\n",
+			},
+			wantCount: 0,
+		},
+		{
+			name:      "non-markdown file is ignored",
+			files:     map[string]string{"README.txt": "whatever"},
+			wantCount: 0,
+		},
+		{
+			// Parsing goes through internal/frontmatter + yaml — the same
+			// splitter the store uses — rather than a private scanner, so
+			// these shapes are handled by the shared code rather than by a
+			// third reading of the file. Kept as end-to-end cases because a
+			// misparse here becomes a FALSE FINDING on a good file, which is
+			// how a corruption detector loses its readers.
+			name:      "CRLF line endings",
+			files:     map[string]string{"A--rel--B.md": "---\r\nfrom: A\r\nrelation: rel\r\nto: B\r\n---\r\n"},
+			wantCount: 0,
+		},
+		{
+			name:      "quoted values",
+			files:     map[string]string{"A--rel--B.md": "---\nfrom: \"A\"\nrelation: 'rel'\nto: B\n---\n"},
+			wantCount: 0,
+		},
+		{
+			name:      "--- inside the body does not leak keys",
+			files:     map[string]string{"A--rel--B.md": "---\nfrom: A\nrelation: rel\nto: B\n---\nbody\n---\nfrom: EVIL\n"},
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			issues := newFSService(t, tc.files).CheckRelationFilenames()
+			if len(issues) != tc.wantCount {
+				t.Fatalf("want %d issue(s), got %d: %+v", tc.wantCount, len(issues), issues)
+			}
+			if tc.wantCount > 0 && issues[0].Reason != tc.wantWhy {
+				t.Errorf("Reason = %q, want %q", issues[0].Reason, tc.wantWhy)
+			}
+		})
+	}
+}
+
+// TestCheckRelationFilenames_NoFS pins the optional-dependency gate: a service
+// built without FS + Paths returns nil rather than panicking, matching
+// FindOrphanedTempFiles.
+func TestCheckRelationFilenames_NoFS(t *testing.T) {
+	t.Parallel()
+
+	st := memstore.New()
+	meta := &metamodel.Metamodel{Entities: map[string]metamodel.EntityDef{}}
+	tr := tracer.New(st)
+	svc, err := analysis.New(analysis.Deps{
+		Store: st, Meta: meta, Tracer: tr,
+		LuaReadDeps: lua.ReadDeps{VisibleReader: st, Tracer: tr, Meta: meta},
+	})
+	if err != nil {
+		t.Fatalf("analysis.New: %v", err)
+	}
+	if got := svc.CheckRelationFilenames(); got != nil {
+		t.Errorf("want nil without FS/Paths, got %+v", got)
+	}
+}

--- a/internal/analysis/split_filename_internal_test.go
+++ b/internal/analysis/split_filename_internal_test.go
@@ -1,0 +1,45 @@
+package analysis
+
+import "testing"
+
+// TestSplitRelationFilename_MatchesIndexer pins this function against the SAME
+// table as fsstore's TestParseRelationFilename_PinnedForAnalysisCopy.
+//
+// splitRelationFilename is a deliberate behavioral copy of
+// fsstore.parseRelationFilename — unexported there, and arch-lint forbids
+// analysis -> store/fsstore. The copy is justified only while it is exact:
+// this check's whole claim is that it splits names the way the indexer does,
+// so a divergence reports a false mismatch on a good file whose relation type
+// contains "--".
+//
+// Keep the two tables identical. If one changes, the other must.
+func TestSplitRelationFilename_MatchesIndexer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		in                string
+		from, relType, to string
+	}{
+		{"plain", "A--rel--B", "A", "rel", "B"},
+		{"separator inside the type", "A--we--ird--B", "A", "we--ird", "B"},
+		{"type with several separators", "A--r--e--l--B", "A", "r--e--l", "B"},
+		{"id containing a single dash", "A-1--rel--B-2", "A-1", "rel", "B-2"},
+		{"no separator", "notatriple", "", "", ""},
+		{"one separator", "A--B", "", "", ""},
+		{"empty from", "--rel--B", "", "", ""},
+		{"empty to", "A--rel--", "", "", ""},
+		{"adjacent separators", "A----B", "", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			from, relType, to := splitRelationFilename(tc.in)
+			if from != tc.from || relType != tc.relType || to != tc.to {
+				t.Errorf("splitRelationFilename(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tc.in, from, relType, to, tc.from, tc.relType, tc.to)
+			}
+		})
+	}
+}

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -28,6 +28,7 @@ type AnalyzeCmd struct {
 	Gaps          AnalyzeGapsCmd          `cmd:"" help:"Find gaps in ID sequences."`
 	Cardinality   AnalyzeCardinalityCmd   `cmd:"" help:"Check relation cardinality constraints."`
 	RelationOrder AnalyzeRelationOrderCmd `cmd:"" name:"relation-order" help:"Find duplicate or missing values on managed relation order properties."`
+	RelationFiles AnalyzeRelationFilesCmd `cmd:"" name:"relation-files" help:"Find relation files whose filename disagrees with their content."`
 	Properties    AnalyzePropertiesCmd    `cmd:"" help:"Validate entity property values against metamodel."`
 	Validations   AnalyzeValidationsCmd   `cmd:"" help:"Run custom validation rules from metamodel."`
 	All           AnalyzeAllCmd           `cmd:"" help:"Run all analyses."`
@@ -260,6 +261,54 @@ func (c *AnalyzeRelationOrderCmd) Run(ctx context.Context, analyzer *analysis.Se
 		out.WriteSuccess("All orderable relations have consistent order values")
 	} else {
 		out.WriteWarning("Found %d relation-order issue(s)", len(issues))
+	}
+	return nil
+}
+
+// AnalyzeRelationFilesCmd finds relation files whose NAME disagrees with their
+// CONTENT. fsstore keys relations entirely on the filename, so such a file is
+// indexed as the relation its name describes and the one its content describes
+// simply does not exist — surfacing elsewhere as a cardinality error against an
+// innocent entity, with no route back to the file (issue #1004).
+type AnalyzeRelationFilesCmd struct{}
+
+// Run dispatches `rela analyze relation-files`.
+func (c *AnalyzeRelationFilesCmd) Run(analyzer *analysis.Service) error {
+	issues := analyzer.CheckRelationFilenames()
+
+	if writeAnalysisJSON(len(issues), issues,
+		"All relation files agree with their filenames",
+		"Found %d relation file(s) with filename/content problems") {
+
+		return nil
+	}
+
+	// Switch on the typed Reason, not on which fields happen to be empty: a
+	// new reason must then be handled here rather than silently rendering as
+	// whichever case its empty fields resemble.
+	for _, iss := range issues {
+		switch iss.Reason {
+		case analysis.ReasonUnparseableName:
+			out.WriteWarning("%s: %s — the store skips it, so this relation is not in the graph",
+				iss.File, iss.Reason)
+		case analysis.ReasonLegacyTypeKey:
+			out.WriteWarning("%s: uses `type:` instead of `relation:` — loads with an EMPTY "+
+				"relation type (filename says %q)", iss.File, iss.FromFilename)
+		case analysis.ReasonMismatch:
+			// Both triples, always: the filename one is what the store
+			// indexed, the content one is what other checks report as
+			// missing. Printing one leaves the operator to guess the mapping.
+			out.WriteWarning("%s: indexed as %q but content says %q",
+				iss.File, iss.FromFilename, iss.FromContent)
+		default:
+			out.WriteWarning("%s: %s", iss.File, iss.Reason)
+		}
+	}
+
+	if len(issues) == 0 {
+		out.WriteSuccess("All relation files agree with their filenames")
+	} else {
+		out.WriteWarning("Found %d relation file(s) with filename/content problems", len(issues))
 	}
 	return nil
 }

--- a/internal/dataentry/acl_deny_403_test.go
+++ b/internal/dataentry/acl_deny_403_test.go
@@ -1,0 +1,126 @@
+package dataentry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// TestHandler_ACLDeny_Returns403Structured restores the AC1.7 contract test
+// deleted with internal/dataentry/acl_test.go in #1029 (TKT-RPBFAO, gh#1044):
+//
+//	When EntityManager returns a *acl.ForbiddenError, the data-entry HTTP
+//	handler must respond 403 with a structured JSON body carrying rule_kind,
+//	rule_id and reason.
+//
+// # Why this needs its own test
+//
+// The 403 *status* turned out to be covered incidentally — mutating
+// writeForbiddenIfACLDenied to never fire reddens other tests. The structured
+// *body* was covered by nothing: mutating `"error": "forbidden"` to anything
+// else left the whole package green. That body is the entire point of AC1.7 —
+// an operator debugging a denial needs to know WHICH rule fired, and the
+// handler's own godoc cites the AWS IAM lesson that opaque denials are
+// unsupportable.
+//
+// # Why it can be wired now
+//
+// acl_write_test.go carries a note saying a dataentry-level visible-but-
+// write-denied test "would require wiring the test entitymanager with the same
+// ACL, which newTestAppV1 does not do". That is no longer true: appbuildtest
+// has WithDeclarative, which wires the Declarative as both the write-authz ACL
+// and the affordance resolver. So the denial here comes from the REAL
+// entitymanager write path, not a stubbed error.
+func TestHandler_ACLDeny_Returns403Structured(t *testing.T) {
+	t.Parallel()
+
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {
+				Label:    "Ticket",
+				IDPrefix: "TKT-",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	// A role that may READ tickets but not UPDATE them: the entity is
+	// visible, so the read gate passes and the request reaches the write
+	// path — which is the only way to exercise AuthorizeWrite's denial.
+	// A role with no read grant would 404 at the gate instead (AC3), and
+	// never reach the code under test.
+	fs := storage.NewMemFS()
+	paths := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
+	if err := fs.MkdirAll(paths.CacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	bootstrap := appbuildtest.New(meta, appbuildtest.WithFS(fs, paths))
+	if err := bootstrap.Store().CreateEntity(context.Background(),
+		&entity.Entity{ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"reader": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"bob": "reader"},
+	}, bootstrap.Store())
+
+	svc := appbuildtest.New(meta,
+		appbuildtest.WithFS(fs, paths),
+		appbuildtest.WithStore(bootstrap.Store()),
+		appbuildtest.WithDeclarative(d),
+	)
+
+	app := newAppFromParts(&Config{}, nil, newFixture())
+	rebindApp(app, fs, paths, svc)
+	app.acl = d
+	app.schema.Publish(&Schema{Cfg: &Config{}, Meta: meta})
+
+	bobCtx := principal.With(context.Background(),
+		principal.Principal{User: "bob", Tool: principal.ToolDataEntry})
+	rec := patchEntityAs(bobCtx, t, app, d, "ticket", "tickets", "TKT-001",
+		`{"properties":{"title":"changed"}}`, nil)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("visible-but-write-denied: got %d, want 403; body=%s", rec.Code, rec.Body)
+	}
+
+	// The structured body is the contract. Decoding rather than substring
+	// matching so a body that merely CONTAINS the words still fails.
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("403 body is not JSON: %v (body=%s)", err, rec.Body)
+	}
+	if got["error"] != "forbidden" {
+		t.Errorf(`body["error"]: want "forbidden", got %q`, got["error"])
+	}
+	// rule_kind is asserted by VALUE, not merely non-empty: the whole point of
+	// AC1.7 is telling the operator which gate fired, and a mutation emitting
+	// a constant like "unknown" would satisfy a non-empty check while saying
+	// nothing. "role-grant" is the documented kind for "a role's write list
+	// either matched or didn't", which is this scenario.
+	if got["rule_kind"] != "role-grant" {
+		t.Errorf(`body["rule_kind"]: want "role-grant", got %q (body=%s)`, got["rule_kind"], rec.Body)
+	}
+	// rule_id and reason stay non-empty assertions rather than exact matches:
+	// acl.Decision.Reason is documented as never carrying raw policy data, so
+	// pinning its exact wording would invite widening it later to make a test
+	// pass — the opposite of what that doc promises.
+	for _, key := range []string{"rule_id", "reason"} {
+		if got[key] == "" {
+			t.Errorf("body[%q] is empty; AC1.7 requires it so an operator can tell which rule fired (body=%s)",
+				key, rec.Body)
+		}
+	}
+}

--- a/internal/dataentry/acl_write_test.go
+++ b/internal/dataentry/acl_write_test.go
@@ -101,13 +101,13 @@ func TestACLWrite_DeleteOnHiddenIs404(t *testing.T) {
 	}
 }
 
-// (Visible-but-write-denied → 403 is preserved by AuthorizeWrite in
-// entitymanager; covered by `internal/entitymanager/acl_test.go`.
-// The dataentry-level test here would require wiring the test
-// entitymanager with the same ACL, which `newTestAppV1` does not do.
-// What this PR pins is that the per-entity Visible gate runs BEFORE
-// AuthorizeWrite — the cases that matter for that ordering are the
-// two hidden-target tests above.)
+// (Visible-but-write-denied → 403 IS now covered at the dataentry level, in
+// acl_deny_403_test.go — appbuildtest.WithDeclarative wires the test
+// entitymanager with the same ACL, which `newTestAppV1` still does not do but
+// no longer needs to. That test pins the structured 403 body (AC1.7,
+// TKT-RPBFAO / gh#1044); what the two hidden-target tests above pin is the
+// ORDERING — the per-entity Visible gate runs BEFORE AuthorizeWrite, so a
+// hidden target 404s rather than 403ing and confirming its existence.)
 
 // ---- helpers ----
 

--- a/internal/dataentry/handlers_attachment.go
+++ b/internal/dataentry/handlers_attachment.go
@@ -216,12 +216,51 @@ func (h *attachmentHandler) handleV1PutAttachment(
 	propDef := filePropertyDef(s, typeName, property)
 	capped := store.CapAttachmentReader(file, limit)
 	if _, err := svc.WriteAttachment(ctx, entity, propDef, property, header.Filename, capped); err != nil {
+		h.auditRejectedUpload(ctx, entity, property, header.Filename, err)
 		writeAttachmentWriteError(w, r, limit, err)
 		return
 	}
 
 	result := h.serializer.forWire(ctx, entity, h.reader.outgoingRelations(ctx, entity.ID), s.Meta, plural)
 	writeV1JSON(w, http.StatusOK, result)
+}
+
+// auditRejectedUpload records an upload the attachment processor refused —
+// a disallowed MIME type, or a failed/positive scan (TKT-6O8D0L, CONTROL-8-15).
+//
+// A refused upload is a security-relevant exception: it may be an attempt to
+// place a disallowed file type or malware into the project, and "what did this
+// user try to upload that they weren't allowed to?" is exactly the forensic
+// question the audit log exists to answer. The ACL denial on this same handler
+// was already recorded; this closes the gap for the policy denial beside it.
+//
+// Deliberately the SAME op as the ACL denial (OpDeniedWrite) rather than a new
+// one: an operator filtering `op == "denied-write"` should see both kinds of
+// refused upload without knowing there are two. The Summary distinguishes them.
+//
+// Records ONLY ErrRejected. A size cap, an at-capacity property or a transient
+// I/O failure are ordinary client or server errors, not security events, and
+// auditing them would dilute the signal this record carries.
+//
+// Lives at the call site rather than inside writeAttachmentWriteError because
+// that helper is a package function with neither the audit sink nor the entity
+// in scope — and the record needs both.
+func (h *attachmentHandler) auditRejectedUpload(
+	ctx context.Context, e *entityPkg.Entity, property, fileName string, err error,
+) {
+	if !errors.Is(err, attachment.ErrRejected) {
+		return
+	}
+	h.audit().Record(audit.Record{
+		Time:        time.Now().UTC(),
+		Op:          audit.OpDeniedWrite,
+		Subject:     &audit.Subject{Kind: "entity", Type: e.Type, ID: e.ID},
+		Principal:   principal.From(ctx),
+		TriggeredBy: audit.TriggeredByFrom(ctx),
+		Summary: fmt.Sprintf("rejected upload %q to property %q: %s (op=attachment-write)",
+			fileName, property,
+			strings.TrimPrefix(err.Error(), "attachment: rejected by processor: ")),
+	})
 }
 
 // writeAttachmentWriteError maps a Service.WriteAttachment failure to the

--- a/internal/dataentry/handlers_attachment_audit_test.go
+++ b/internal/dataentry/handlers_attachment_audit_test.go
@@ -1,0 +1,115 @@
+package dataentry
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// TestAttachmentUpload_RejectionIsAudited pins TKT-6O8D0L (gh#1050,
+// CONTROL-8-15): an upload the processor refuses — disallowed MIME type, or a
+// failed/positive scan — must leave an audit record.
+//
+// A refused upload is a security-relevant exception: it may be an attempt to
+// place a disallowed file type or malware into the project, and the log is the
+// only place that question can be answered after the fact. The ACL denial on
+// this same handler was already recorded; the policy denial beside it was not.
+//
+// The record deliberately reuses OpDeniedWrite rather than introducing a new
+// op, so an operator filtering `op == "denied-write"` sees both kinds of
+// refused upload without having to know there are two.
+func TestAttachmentUpload_RejectionIsAudited(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"},
+	})
+	sink := audit.NewMemory()
+	app.auditSink = sink
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}, Update: []string{"ticket"}}},
+		Assignments: map[string]string{"bob": "editor"},
+	}, app.store)
+	app.acl = d
+	bobCtx := principal.With(context.Background(),
+		principal.Principal{User: "bob", Tool: principal.ToolDataEntry})
+
+	// The fixture's `screenshot` property accepts text/plain only. A PNG
+	// signature is sniffed as image/png and refused by the MIME allowlist.
+	png := []byte("\x89PNG\r\n\x1a\n" + strings.Repeat("\x00", 32))
+	rec := putAttachmentAs(bobCtx, t, app, d, "TKT-001", "screenshot", "evil.png", png)
+
+	if rec.Code != 422 {
+		t.Fatalf("want 422 for a rejected upload, got %d: %s", rec.Code, rec.Body)
+	}
+
+	var found *audit.Record
+	for i, r := range sink.Records() {
+		if r.Op == audit.OpDeniedWrite {
+			found = &sink.Records()[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no denied-write audit record for the rejected upload; got %d record(s)", len(sink.Records()))
+	}
+
+	if found.Principal.User != "bob" {
+		t.Errorf("Principal.User = %q, want bob — the log must say WHO tried", found.Principal.User)
+	}
+	if found.Subject == nil || found.Subject.ID != "TKT-001" {
+		t.Errorf("Subject must name the target entity, got %+v", found.Subject)
+	}
+	// The filename and the reason are what make the record actionable: without
+	// them an operator sees that something was refused but not what or why.
+	if !strings.Contains(found.Summary, "evil.png") {
+		t.Errorf("Summary must name the rejected file: %q", found.Summary)
+	}
+	if !strings.Contains(found.Summary, "screenshot") {
+		t.Errorf("Summary must name the target property: %q", found.Summary)
+	}
+	if !strings.Contains(found.Summary, "rejected upload") {
+		t.Errorf("Summary must distinguish this from an ACL denial: %q", found.Summary)
+	}
+}
+
+// TestAttachmentUpload_NonRejectionIsNotAudited pins the other half: an
+// ordinary failure is NOT a security event and must not dilute the signal.
+//
+// An over-size upload is the clearest case — a client error with no security
+// meaning. If every failed upload produced a denied-write record, the op would
+// stop distinguishing anything.
+func TestAttachmentUpload_NonRejectionIsNotAudited(t *testing.T) {
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{
+		ID: "TKT-001", Type: "ticket", Properties: map[string]any{"title": "T1"},
+	})
+	sink := audit.NewMemory()
+	app.auditSink = sink
+
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"editor": {Read: []string{"ticket"}, Update: []string{"ticket"}}},
+		Assignments: map[string]string{"bob": "editor"},
+	}, app.store)
+	app.acl = d
+	bobCtx := principal.With(context.Background(),
+		principal.Principal{User: "bob", Tool: principal.ToolDataEntry})
+
+	// Accepted type, accepted size: this upload succeeds, so there is nothing
+	// to deny and nothing to record.
+	rec := putAttachmentAs(bobCtx, t, app, d, "TKT-001", "screenshot", "fine.txt", []byte("hello"))
+	if rec.Code != 200 {
+		t.Fatalf("setup: want a successful upload, got %d: %s", rec.Code, rec.Body)
+	}
+
+	for _, r := range sink.Records() {
+		if r.Op == audit.OpDeniedWrite {
+			t.Errorf("a successful upload must not produce a denied-write record: %+v", r)
+		}
+	}
+}

--- a/internal/store/fsstore/parse_filename_pin_test.go
+++ b/internal/store/fsstore/parse_filename_pin_test.go
@@ -1,0 +1,52 @@
+package fsstore
+
+import "testing"
+
+// TestParseRelationFilename_PinnedForAnalysisCopy pins the exact splitting
+// behavior of parseRelationFilename, because analysis.splitRelationFilename
+// is a deliberate behavioral COPY of it (TKT-2P9S72).
+//
+// The copy exists because this function is unexported and arch-lint forbids
+// analysis -> store/fsstore — the right boundary, but it means a change here
+// silently desynchronises a checker one package away whose entire claim is
+// "I split names the way the indexer does". A divergence makes that checker
+// report a false mismatch on a good file.
+//
+// If you change this function, change internal/analysis/relation_filename.go
+// to match, and update both tables. The cases below are the ones where the
+// two could plausibly drift: they all turn on WHICH "--" is chosen.
+func TestParseRelationFilename_PinnedForAnalysisCopy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		in                string
+		from, relType, to string
+	}{
+		{"plain", "A--rel--B", "A", "rel", "B"},
+		// First "--" ends FROM, last "--" starts TO, so a relation type
+		// containing the separator round-trips. This is the case that makes
+		// a naive Split("--") wrong.
+		{"separator inside the type", "A--we--ird--B", "A", "we--ird", "B"},
+		{"type with several separators", "A--r--e--l--B", "A", "r--e--l", "B"},
+		{"id containing a single dash", "A-1--rel--B-2", "A-1", "rel", "B-2"},
+		// Rejections: every one returns all-empty, which callers treat as
+		// "not a relation filename".
+		{"no separator", "notatriple", "", "", ""},
+		{"one separator", "A--B", "", "", ""},
+		{"empty from", "--rel--B", "", "", ""},
+		{"empty to", "A--rel--", "", "", ""},
+		{"adjacent separators", "A----B", "", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			from, relType, to := parseRelationFilename(tc.in)
+			if from != tc.from || relType != tc.relType || to != tc.to {
+				t.Errorf("parseRelationFilename(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tc.in, from, relType, to, tc.from, tc.relType, tc.to)
+			}
+		})
+	}
+}

--- a/tickets/entities/docs-checklists/DOCS-23G0PV.md
+++ b/tickets/entities/docs-checklists/DOCS-23G0PV.md
@@ -1,0 +1,65 @@
+---
+id: DOCS-23G0PV
+type: docs-checklist
+title: 'Documentation: analyze relation-files'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the `CheckRelationFilenames` godoc
+explains the *mechanism* (fsstore keys on filename and never opens the file) and
+the *observed symptom* (a cardinality error against an innocent entity), because
+neither is reconstructable from the code and the symptom is what a maintainer
+will actually arrive with.
+- [x] Function/type docs if public API — `RelationFilenameReason`'s three
+constants each document the **consequence**, not just the condition: skipped
+entirely / indexed as the wrong triple / loads with an empty type. That is what
+tells an operator how urgent each finding is.
+
+**Two comments were rewritten because they asserted something false**, which is
+worth recording since both survived my own review and were caught by the code
+reviewer:
+
+1. The legacy-`type:` comment claimed those files "work, because the store keys
+on the FILENAME". False — `mdCodec` reads content, so they load with an empty
+relation type (RR-YB7XX8).
+2. The `frontmatterScalars` godoc justified a hand-rolled parser by an arch-lint
+rule that did not apply — `yaml` is a `commonVendor` and `internal/frontmatter`
+exists for exactly this (RR-DDZ02R). The scanner is gone.
+
+**One comment now carries an invariant it did not before:**
+`splitRelationFilename`'s doc states it MUST stay identical to
+`fsstore.parseRelationFilename`, names why the duplication is correct (arch-lint
+forbids the dependency; exporting a storage detail would be worse), and names
+the test that enforces it. The fsstore side names this one back.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new pattern. The check follows the existing
+`CheckRelationOrder` / `FindOrphanedTempFiles` shapes.)
+- [x] Help text accurate — the kong `help:` string for `analyze relation-files`
+states what it finds in one line.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no CHANGELOG; releases come from commit
+history — `docs/releasing.md`)
+- [x] API docs updated — new `rela analyze relation-files` section in
+`docs-project/entities/guides/GUIDE-cli-reference.md`, regenerated into
+`docs/cli-reference.md` (generated file, never edited directly; regeneration
+touched only it).
+
+The section leads with **why the symptom appears somewhere else** — a
+cardinality error against an innocent entity — because that is the state an
+operator is in when they go looking. It then tables the three findings with
+their consequences, and gives the fix for each: rename the file, or rename the
+key.
+
+It also states that renaming an entity through rela keeps filename and content
+in step automatically, so nobody reads the check as evidence that rename is
+broken. It is not — `fsstore.renameEntity` is correct, and this check is for
+files moved, hand-edited or merged outside rela.

--- a/tickets/entities/docs-checklists/DOCS-5E98CS.md
+++ b/tickets/entities/docs-checklists/DOCS-5E98CS.md
@@ -1,0 +1,51 @@
+---
+id: DOCS-5E98CS
+type: docs-checklist
+title: 'Documentation: audit rejected attachment uploads'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — `auditRejectedUpload`'s godoc carries
+three decisions a reader would otherwise have to reverse-engineer: **why** a
+refused upload is worth recording (it may be an attempt to place a disallowed
+type or malware, and the log is the only place that question survives); **why**
+it reuses `OpDeniedWrite` rather than a new op (so one filter answers "what
+uploads were refused?" without the operator knowing there are two kinds); and
+**why** it records only `ErrRejected` (a size cap or an at-capacity property is
+a client error, and auditing those would dilute the op until it distinguishes
+nothing).
+- [x] Function/type docs if public API — none added; the helper is unexported.
+
+**One placement note is load-bearing.** The godoc states that the call lives at
+the upload call site rather than inside `writeAttachmentWriteError`, where the
+422 is written, because that helper is a package function with neither the audit
+sink nor the entity in scope. Without it, moving the call "next to the response"
+looks like an obvious tidy-up and silently drops the record.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLAUDE.md updated~~ (N/A: applies the existing audit rules rather than
+changing them)
+- [x] ~~Help text accurate~~ (N/A: no CLI change)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no CHANGELOG; releases come from commit
+history — `docs/releasing.md`)
+- [x] ~~API docs updated~~ (N/A, and the reasoning is worth stating rather than
+waving through: `docs/audit-log.md` documents the record *shape* and the
+`triggered_by` vocabulary. This change adds an **occurrence** of an
+already-documented op — `denied-write`, whose own doc already frames it as
+*"what did this user try to do that they weren't allowed to?"* — not a new kind
+of record, a new op, or a new field. Listing every site that emits an existing
+op would make the guide a call-site index that goes stale on the next refactor,
+which is precisely the duplication the comment-lint `duplication` rule exists to
+discourage.)
+
+If a future change adds a genuinely new op or field, that *does* belong in the
+guide's `triggered_by` / record-shape sections.

--- a/tickets/entities/implementation-checklists/IMPL-CY777P.md
+++ b/tickets/entities/implementation-checklists/IMPL-CY777P.md
@@ -1,0 +1,90 @@
+---
+id: IMPL-CY777P
+type: implementation-checklist
+title: 'Implementation: Restore the AC1.7 test: ACL deny returns a structured 403 body'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — this ticket IS a test; there is no
+production change beyond one stale comment.
+- [x] Integration tests written — `TestHandler_ACLDeny_Returns403Structured`
+drives the real HTTP handler against a real `entitymanager` wired with a real
+`acl.Declarative`, not a stubbed error. The denial comes from `AuthorizeWrite`
+on the actual write path.
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — the role grants **read** but not
+**update**, which is the only configuration that reaches the code under test. A
+role with no read grant 404s at the visibility gate (AC3) and never exercises
+AuthorizeWrite.
+- [x] ~~Error handling in place~~ (N/A: test-only)
+
+## Test Quality
+
+- [x] Using fixture builders or factories — `appbuildtest.New` with
+`WithFS`/`WithStore`/`WithDeclarative`, plus the package's existing
+`mustNewACL`, `patchEntityAs` and `newAppFromParts` helpers.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter — the metamodel declares one type with
+one property; the policy has one role and one assignment.
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object — the body is **decoded** and
+compared per key rather than substring-matched, so a response that merely
+*contains* the word "forbidden" still fails.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*The gap was established by mutation before writing anything*, because "there is
+no test" is a claim worth proving rather than inferring from a missing file:
+
+| Mutation to `writeForbiddenIfACLDenied` | Whole `internal/dataentry` suite |
+|---|---|
+| Never fire (fall through to generic 500) | **FAILS** — the 403 *status* was covered incidentally |
+| `"error": "forbidden"` → `"error": "MUTATED"` | **PASSES** — the structured *body* was covered by nothing |
+
+So the contract was half-covered, and the uncovered half is exactly what AC1.7
+is about. That distinction matters: reporting "AC1.7 is untested" would have
+been wrong, and reporting "it's fine, other tests cover 403" would have been
+worse.
+
+*After the new test*, both mutations are caught:
+
+```
+body["error"]: want "forbidden", got "MUTATED"
+body["rule_kind"] is empty; AC1.7 requires it so an operator can tell which rule fired
+```
+
+**A stale comment was blocking this.** `acl_write_test.go` carried a note saying
+a dataentry-level visible-but-write-denied test *"would require wiring the test
+entitymanager with the same ACL, which `newTestAppV1` does not do"*. That was
+true when written and is not now: `appbuildtest.WithDeclarative` wires the
+Declarative as both the write-authz ACL and the affordance resolver. The comment
+is updated to point at the new test and to state what the hidden-target tests
+actually pin (the gate *ordering*), so the next person doesn't re-derive the
+same dead end.
+
+**Gates:** `go test ./...` exit 0; `just lint` 0 issues; comment-lint,
+arch-lint, plimsoll all clean.
+
+## Quality
+
+- [x] Code follows project patterns — placed in its own
+`acl_deny_403_test.go` alongside the sixteen other `acl_*_test.go` files, and
+reuses their helpers rather than introducing a parallel fixture.
+- [x] Checked for DRY opportunities — deliberately did **not** extend an
+existing test. AC1.7 is a named contract from a security review; a dedicated
+test with the AC in its doc comment is findable by someone auditing the control,
+which an extra assertion inside an unrelated test would not be.
+- [x] No security issues introduced — this restores a security-test control
+(CONTROL-8-29), it does not change behaviour.
+- [x] No silent failures — the point of the ticket.
+- [x] No debug code left behind.

--- a/tickets/entities/implementation-checklists/IMPL-F3BV1I.md
+++ b/tickets/entities/implementation-checklists/IMPL-F3BV1I.md
@@ -1,0 +1,126 @@
+---
+id: IMPL-F3BV1I
+type: implementation-checklist
+title: 'Implementation: analyze: flag relation files whose filename disagrees with their content'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — a table over eight cases in
+`internal/analysis/relation_filename_test.go`, plus a dedicated test reproducing
+the reporter's exact file from issue #1004.
+- [x] Integration tests written — the check was run against **three real
+projects** (`tickets/`, `docs-project/`, and a copy of `tickets/` with the
+reporter's corruption injected). That is what caught the false positive below;
+no unit test would have.
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — unparseable filename, relation type
+containing the `--` separator, non-markdown files, files with no relation
+frontmatter, and the legacy `type:` key.
+- [x] Error handling in place — an unreadable or unparseable file returns no
+finding rather than a spurious one; that is a different problem with its own
+reporting.
+
+## Test Quality
+
+- [x] Using fixture builders or factories — one `newFSService` helper builds the
+service over an in-memory FS; `relFile` composes the frontmatter.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter — each table case declares exactly the
+one file it is about.
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*First, the half of #1004 that is already fixed.* The rename path most likely to
+have produced the reporter's files is correct: after `RenameEntity(REQ-1 →
+REQ-999)`, the only file present is `SOL-1--implements--REQ-999.md` —
+`fsstore.renameEntity` writes each incident relation under its new name and
+removes the old one. So this ticket is a **detector for legacy corruption**, not
+a fix for an ongoing defect, and the issue's first suggestion needs no work.
+
+*Second, the reporter's scenario, reproduced exactly.* A file named
+`PRS-FLOW-1HL6--wordtUitgevoerdDoor--PRS-FUNC-8Q7E.md` whose content says `to:
+PRS-FUNC-0Q7E` now produces a finding naming the file and **both** triples.
+Reporting only one would leave the operator to guess the mapping between the
+filename they must fix and the entity every other check complains about.
+
+*Third — the finding that justified running it for real, and where I then got
+it wrong.* On the repo's own `tickets/` project the first version reported **38
+issues**: my injected one plus 37 others using the legacy `type:` key instead of
+`relation:`. I judged those false positives, suppressed them, and pinned that
+with two table cases.
+
+**They were true positives.** Code review (RR-YB7XX8) caught it. Indexing is not
+the only thing that reads a relation file: `mdCodec` builds the relation from
+`doc.getString("relation")`, which returns `""` for a legacy file — so those
+relations load with an **empty type** while the index, built from the filename,
+says otherwise. Verified on the real project: three relations on `BUG-2OXEW0`
+rendered with a blank type.
+
+That is a worse variant of the shape this check exists for. #1004 fails loudly
+downstream as a cardinality error; this one is silently inconsistent, and any
+read → write round trip (formatter, rename, migration) writes the empty type
+back and destroys the last record of it.
+
+Fixed three ways: the check reports them under their own `ReasonLegacyTypeKey`;
+the tests assert that instead of the opposite; and **the 37 files were
+repaired** (`type:` → `relation:`), after confirming all 37 agreed with their
+filenames so the rename lost nothing. One more in `docs-project`.
+`BUG-2OXEW0`'s relations now render with their real type.
+
+The lesson is narrow and worth keeping: *a finding you cannot immediately
+explain is not automatically a false positive.* Reaching for the suppression
+first, rather than tracing what the store actually does with those files, is
+what turned a correct check into a wrong one — and encoding the wrong conclusion
+as a pinned test is how it would have stayed wrong.
+
+After the real fix: `tickets/` and `docs-project/` both report `✓ All relation
+files agree with their filenames`; the corrupted copy reports its injected
+mismatch.
+
+**Gates:** `go test ./...` exit 0; `just lint` 0 issues; comment-lint, plimsoll,
+lint-md clean; `just arch-lint` clean *after* the boundary fix below.
+
+## Quality
+
+- [x] Code follows project patterns — modelled on `CheckRelationOrder` (same
+package, same service, same soft-finding shape) and on `FindOrphanedTempFiles`
+for the optional FS + Paths gate, including returning nil rather than erroring
+when they are absent.
+- [x] Checked for DRY opportunities — `splitRelationFilename` deliberately
+**duplicates** fsstore's `parseRelationFilename` rather than importing it: it is
+unexported there, and arch-lint forbids `analysis → store/fsstore` anyway. The
+duplication is load-bearing and commented — this check must split names
+*exactly* as the indexer does, or it reports false positives on relation types
+containing `--`. That case is in the table.
+- [x] No security issues introduced — read-only over files the caller can
+already read; no new input surface.
+- [x] No silent failures — the whole point is turning a silent mis-index into a
+named finding.
+- [x] No debug code left behind.
+
+**arch-lint caught a real boundary violation — and my first fix for it was also
+wrong.** The first version imported `internal/markdown`; `analysis` may not
+depend on it, and the rule is right. I replaced it with a private ~20-line
+frontmatter scanner, justified in its godoc by that same arch-lint rule.
+
+Review (RR-DDZ02R) pointed out the justification did not apply: `yaml` is a
+declared `commonVendor` importable by every component, and `internal/frontmatter`
+exists precisely for this — a dependency-free leaf that `markdown` and `fsstore`
+already share. Worse than redundant, the scanner made a checker whose entire
+claim is *"I read the file the way rela reads it"* read the file a **third** way;
+a UTF-8 BOM made it return zero keys, so a planted real mismatch passed clean.
+
+Now `frontmatter.Split` + `yaml.Unmarshal`, with one line adding `frontmatter`
+to `analysis.mayDependOn`.

--- a/tickets/entities/implementation-checklists/IMPL-VJHPWV.md
+++ b/tickets/entities/implementation-checklists/IMPL-VJHPWV.md
@@ -1,0 +1,87 @@
+---
+id: IMPL-VJHPWV
+type: implementation-checklist
+title: 'Implementation: Audit rejected attachment uploads (CONTROL-8-15)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — two in
+`internal/dataentry/handlers_attachment_audit_test.go`.
+- [x] Integration tests written — both drive the real upload handler end to end
+(multipart request → `handleV1AttachmentRoute` → attachment service → audit
+sink), not the helper in isolation.
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — the negative case is the point: an
+upload that *succeeds* must produce no denied-write record.
+- [x] Error handling in place — the helper is a no-op for any error that is not
+`attachment.ErrRejected`.
+
+## Test Quality
+
+- [x] Using fixture builders or factories — `newTestAppV1`, `seedEntity`,
+`mustNewACL` and `putAttachmentAs`, the helpers the neighbouring attachment
+tests already use.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter — one entity, one role granting exactly
+read+update so the ACL passes and the *processor* is what refuses.
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*Mutation-verified.* Removing the `auditRejectedUpload` call from the upload
+handler:
+
+```
+--- FAIL: TestAttachmentUpload_RejectionIsAudited
+    no denied-write audit record for the rejected upload; got 0 record(s)
+```
+
+*The rejection is real, not simulated.* The test uploads PNG magic bytes to the
+fixture's `screenshot` property, which declares `accept: [text/plain]`. The
+sniffed MIME fails the allowlist and the attachment service returns
+`ErrRejected` — so the test exercises the actual policy path rather than a
+stubbed error.
+
+*The negative case is deliberate.*
+`TestAttachmentUpload_NonRejectionIsNotAudited` uploads an accepted file and
+asserts **no** denied-write record. Without it, "audit every failed upload"
+would pass — and that would dilute the op until `op == "denied-write"` stopped
+distinguishing anything. A size cap or an at-capacity property is a client
+error, not a security event.
+
+*Field-level assertions.* The record must name the principal (who tried), the
+subject entity, the filename, the target property, and the reason. Asserting
+only "a record exists" would let an empty one through, and an empty security
+record is worse than none — it looks like coverage.
+
+## Quality
+
+- [x] Code follows project patterns — mirrors the ACL denial already recorded on
+this same handler, down to the `OpDeniedWrite` op, the `Subject` shape and the
+`TriggeredBy` propagation.
+- [x] Checked for DRY opportunities — deliberately **not** merged with the ACL
+denial's record. They fire at different points for different reasons; a shared
+helper would need both a decision and an error and would obscure which gate
+refused.
+- [x] No security issues introduced — this **adds** a security-log record. The
+one judgement worth stating: it reuses `OpDeniedWrite` rather than adding a new
+op, so an operator filtering `op == "denied-write"` sees both kinds of refused
+upload without needing to know there are two. The Summary distinguishes them.
+- [x] No silent failures — that is precisely what this removes.
+- [x] No debug code left behind.
+
+**Placement note.** The audit call sits at the upload call site rather than
+inside `writeAttachmentWriteError`, because that helper is a package function
+with neither the audit sink nor the entity in scope — and the record needs both.
+Its godoc says so, so the next person does not try to move it there.

--- a/tickets/entities/planning-checklists/PLAN-4WY4X9.md
+++ b/tickets/entities/planning-checklists/PLAN-4WY4X9.md
@@ -1,0 +1,174 @@
+---
+id: PLAN-4WY4X9
+type: planning-checklist
+title: 'Planning: Audit rejected attachment uploads (CONTROL-8-15)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** an upload the attachment processor refuses — disallowed MIME type,
+or a failed/positive scan — returns HTTP 422 and writes **no audit record**.
+GitHub issue #1050 (IB-review rela#1026), CONTROL-8-15.
+
+A refused upload is a security-relevant exception: it may be an attempt to place
+a disallowed file type or malware into the project, and the audit log is the
+only place that question can be answered afterwards.
+
+**Scope — IN:** one audit record on the `attachment.ErrRejected` path, carrying
+principal, entity, property, filename and reason.
+
+**Scope — OUT:**
+
+- Auditing other upload failures. A size cap, an at-capacity property or a
+transient I/O error are ordinary client/server errors; recording them would
+dilute the op until it distinguishes nothing.
+- A new audit op. The ACL denial on this same handler already uses
+`OpDeniedWrite`; a second op would split one operator question across two
+filters.
+- Anything about *detection* — what the processor rejects is unchanged.
+
+**Acceptance Criteria:**
+
+1. A rejected upload produces one audit record naming the principal, the subject
+entity, the property, the filename and the rejection reason.
+2. A *successful* upload produces no denied-write record.
+3. The record is distinguishable from the ACL denial recorded on the same
+handler, without being a different op.
+
+## Research
+
+- [x] For larger features: run `/research`
+- [x] Searched for existing libraries
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — small, with an exact in-tree template.
+
+**Existing Solutions:** the ACL denial **on this same handler**
+(`handlers_attachment.go`, `h.audit().Record(...)` with `OpDeniedWrite`) is the
+template: same op, same `Subject` shape, same `TriggeredBy` propagation, Summary
+carrying the reason. So the gap is specifically the *processor-policy* rejection
+sitting beside an already-audited ACL rejection — which is also the argument for
+reusing the op rather than inventing one.
+
+`audit.OpDeniedWrite`'s own doc frames the forensic question this serves: *"what
+did this user try to do that they weren't allowed to?"*
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:** an `auditRejectedUpload` method on `attachmentHandler`,
+called at the `WriteAttachment` error site, which returns early unless the error
+is `ErrRejected`.
+
+**Placement:** at the call site, not inside `writeAttachmentWriteError` where
+the 422 is written — that helper is a package function with neither the audit
+sink nor the entity in scope, and the record needs both.
+
+**Files to modify:** `internal/dataentry/handlers_attachment.go`, plus tests.
+
+**Alternatives considered:**
+
+1. *A new `OpRejectedUpload`.* Rejected — an operator asking "what uploads were
+refused?" would have to know to query two ops. The Summary carries the
+distinction.
+2. *Audit inside `internal/attachment`.* Rejected — the service has no audit sink
+and should not gain one; CLAUDE.md puts audit on the write path, and the CLI
+attach path would then double-record.
+3. *Audit every upload failure.* Rejected — see Scope; it would dilute the signal.
+
+**Dependencies:** none new.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** the filename is caller-supplied. It is written
+into the Summary string of a JSONL record, so the framing question matters: the
+audit writer escapes the field, and a hostile filename cannot break the record.
+It is *not* echoed back to the client beyond the existing 422 body, which is
+unchanged.
+
+**Security-Sensitive Operations:** this adds to the security log rather than
+changing behaviour. Two properties worth stating:
+
+- *No rejected bytes are recorded* — only the filename and the policy reason.
+Recording content would put the very thing the policy refused into the audit
+log, which is a durable, widely-read file.
+- *The reason comes from the processor*, which produces policy text
+("disallowed MIME type"), not attacker-controlled content.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+
+- **AC1** — upload PNG magic bytes to a `text/plain`-only property; assert 422
+and one `OpDeniedWrite` record with principal, subject, filename, property and
+reason. Uses the real allowlist, not a stubbed error.
+- **AC2** — upload an accepted file; assert **no** denied-write record. Without
+this, "audit every failure" would pass.
+- **AC3** — assert the Summary contains `rejected upload`, distinguishing it from
+the ACL denial's `denied: ...` wording.
+
+**Edge Cases:** a size-capped upload and an at-capacity property must not record
+— both are covered by AC2's shape (any non-`ErrRejected` error is a no-op in the
+helper).
+
+**Negative Tests:** AC2 is the negative test, and it is the one that stops the
+op from becoming meaningless.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+| Risk | Mitigation |
+|---|---|
+| Auditing too much dilutes `denied-write` | Helper returns early for any non-`ErrRejected` error; AC2 pins it |
+| A record exists but is empty (looks like coverage, is not) | Field-level assertions on principal, subject, filename, property, reason |
+| Someone later moves the call into `writeAttachmentWriteError` | The godoc says why it cannot live there |
+
+**Effort:** s
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] ~~docs/audit-log.md~~ (N/A: the guide documents the record *shape* and the
+`triggered_by` vocabulary, neither of which changes. This adds an occurrence of
+an already-documented op, not a new kind of record.)
+- [x] ~~CLI reference / metamodel docs~~ (N/A: no flag, command or schema change)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the shape is
+dictated by the ACL denial recorded fifteen lines away in the same file. The
+only judgement calls — reuse the op, and audit only `ErrRejected` — are recorded
+under Alternatives and Scope.)
+- [x] All critical/significant findings addressed in plan — none raised.
+
+**Design Review Findings:** N/A.

--- a/tickets/entities/planning-checklists/PLAN-MQY1C5.md
+++ b/tickets/entities/planning-checklists/PLAN-MQY1C5.md
@@ -1,0 +1,143 @@
+---
+id: PLAN-MQY1C5
+type: planning-checklist
+title: 'Planning: Restore the AC1.7 test: ACL deny returns a structured 403 body'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** PR #1029 deleted `internal/dataentry/acl_test.go` wholesale during
+the `affordanceService` extraction, taking `TestHandler_ACLDeny_Returns403Structured`
+with it. That was the only test pinning AC1.7 (gh#1044, CONTROL-8-29).
+
+**Scope — IN:** one integration test restoring the contract, and correcting the
+stale comment in `acl_write_test.go` that says such a test cannot be wired here.
+
+**Scope — OUT:** any production change. The handler is correct; only its test
+was lost.
+
+**Acceptance Criteria:**
+
+1. A `*acl.ForbiddenError` from `EntityManager` yields 403 with `rule_kind`,
+   `rule_id` and `reason` in the body.
+2. The denial originates in the real `AuthorizeWrite` path, not a stubbed error.
+3. The scenario is *visible-but-write-denied* — a hidden entity 404s at the
+   gate and never reaches the handler.
+
+## Research
+
+- [x] For larger features: run `/research`
+- [x] Searched for existing libraries
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — restoring one deleted test.
+
+**Existing Solutions:** the sixteen `acl_*_test.go` files in the package supply
+everything needed: `mustNewACL`, `patchEntityAs`, `gateCtxFor`,
+`newAppFromParts`/`rebindApp`, and `appbuildtest.WithDeclarative`.
+
+**The load-bearing find:** `acl_write_test.go` claims this test *"would require
+wiring the test entitymanager with the same ACL, which `newTestAppV1` does not
+do"*. True when written; `appbuildtest.WithDeclarative` has since made it
+possible. Without noticing that, the obvious conclusion would have been to stub
+the error — which would pin the handler's formatting but not that the real write
+path produces the error in the first place.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:** seed an entity, build the services with
+`WithDeclarative` over a policy granting `read` but not `update`, PATCH as that
+principal, assert 403 and decode the body.
+
+**Files to modify:** `internal/dataentry/acl_deny_403_test.go` (new),
+`internal/dataentry/acl_write_test.go` (stale comment).
+
+**Alternatives considered:**
+
+1. *Stub the EntityManager to return a ForbiddenError.* Rejected — it pins the
+   formatting but not that the real path produces the error, which is half the
+   contract and the half that regressed.
+2. *Add assertions to an existing ACL test.* Rejected — AC1.7 is a named control
+   from a security review; someone auditing it should find a test named for it.
+3. *Assert with substring matching on the body.* Rejected — decode instead, so a
+   body that merely contains "forbidden" cannot pass.
+
+**Dependencies:** none new.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+This restores a security *test*; it changes no behaviour. The one property worth
+stating: the assertion checks the fields are **non-empty**, not their exact
+values. `acl.Decision.Reason` is documented as never containing raw policy data
+precisely so a 403 body cannot leak the effective-role set — asserting an exact
+reason string would invite someone to widen it later to make a test pass.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:** one integration test per the Approach. Its correctness is
+established by mutation, not by its own green run — see the implementation
+checklist for both mutations and their results.
+
+**Edge Cases:** a no-read role 404s at the gate (already covered by
+`TestACLWrite_PatchOnHiddenIs404`, and the reason this test grants read).
+
+**Negative Tests:** the mutations *are* the negative tests — a test for a
+missing test is only meaningful if it fails when the contract breaks.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+| Risk | Mitigation |
+|---|---|
+| The test passes for the wrong reason (e.g. 403 from the gate, not the write path) | Grant read explicitly so the gate passes; mutation-verify |
+| It re-rots the way the original did | The stale comment now points at it, so an extraction that deletes it has a second signal |
+
+**Effort:** s
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] ~~All user-facing docs~~ (N/A: `kind=test`, no surface change)
+- [x] In-tree comment in `acl_write_test.go` corrected — covered by the
+      implementation checklist rather than a docs-checklist.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: restoring a
+      deleted test with a contract stated verbatim in the issue. There is no
+      design decision — the only judgement call, stub-vs-real-ACL, is recorded
+      under Alternatives.)
+- [x] All critical/significant findings addressed in plan — none raised.
+
+**Design Review Findings:** N/A.

--- a/tickets/entities/planning-checklists/PLAN-UXHDV9.md
+++ b/tickets/entities/planning-checklists/PLAN-UXHDV9.md
@@ -1,0 +1,183 @@
+---
+id: PLAN-UXHDV9
+type: planning-checklist
+title: 'Planning: analyze: flag relation files whose filename disagrees with their content'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** `fsstore` keys relations **entirely on the filename** —
+`syncRelations` parses `FROM--TYPE--TO.md` and never opens the file. A file whose
+name and content disagree is indexed under the *filename* triple, and the
+relation its content describes does not exist in the graph.
+
+Reported from a real project (GitHub issue #1004): the symptom was
+`PRS-FUNC-0Q7E must have at least 1 ... relation(s), has 0` — a cardinality error
+naming the **victim** entity, with no route back to the malformed file.
+
+**Scope — IN:** a detector. `rela analyze relation-files` compares each relation
+file's name against its frontmatter and names the file.
+
+**Scope — OUT:**
+
+- The rename fix. Already correct: `fsstore.renameEntity` writes each incident
+  relation under its new name and removes the old one (verified — after
+  `REQ-1 → REQ-999` the only file is `SOL-1--implements--REQ-999.md`). So the
+  issue's first suggestion needs no work.
+- Keying relations on content instead of filename (the issue's third suggestion)
+  — a storage-model change with migration implications.
+- Auto-repair. A detector that also rewrites files is one an operator cannot run
+  to *find out* whether they have a problem.
+
+**Acceptance Criteria:**
+
+1. The reporter's exact file shape produces a finding naming the file and **both**
+   triples.
+2. No false positives on the repo's real projects (`tickets/`, `docs-project/`).
+3. The filename split agrees **exactly** with fsstore's indexer, including
+   relation types containing `--`.
+4. It runs where operators look: a subcommand under `rela analyze`.
+
+## Research
+
+- [x] For larger features: run `/research`
+- [x] Searched for existing libraries
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — one check modelled on two existing ones.
+
+**Existing Solutions:**
+
+- `analysis.CheckRelationOrder` — the sibling soft-finding check: same service,
+  same shape, same CLI rendering.
+- `analysis.FindOrphanedTempFiles` — the precedent for an FS-touching check,
+  including the optional `FS`/`Paths` gate that returns nil rather than erroring.
+- `fsstore.scanRelationDir` / `parseRelationFilename` — the code being checked.
+  Reading it is what established the root cause: the index is built from filenames
+  with **no file reads**, so a mismatch is not merely unreported, it is
+  structurally invisible.
+- `internal/frontmatter` — the dependency-free splitter `markdown` and `fsstore`
+  already share. *(Found via review; the first version hand-rolled a scanner —
+  see the implementation checklist.)*
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:** `Service.CheckRelationFilenames` reads the relations
+directory, and for each `.md` file compares the filename triple against the
+frontmatter triple, returning typed findings.
+
+**Files to modify:** `internal/analysis/relation_filename.go` (new),
+`internal/cli/analyze.go`, `.go-arch-lint.yml`, plus tests and CLI docs.
+
+**Alternatives considered:**
+
+1. *Put the check in the store.* Rejected — the store has no reporting surface,
+   and a load-time reconciliation is a behaviour change (which files load), not a
+   diagnostic.
+2. *A metamodel validation rule.* Rejected — validations run over the *graph*, and
+   this problem is invisible in the graph by definition.
+3. *Auto-repair on detection.* Rejected — see Scope.
+
+**Dependencies:** `internal/frontmatter` added to `analysis.mayDependOn` (a leaf
+`markdown` and `fsstore` already depend on); `yaml` is a `commonVendor`.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** relation files in the project the caller already
+has read access to. The check is **read-only** — it opens files and reports; it
+writes nothing.
+
+**Security-Sensitive Operations:** none, with one property worth stating: an
+unreadable file is skipped rather than reported. That is deliberate and not
+merely convenient — fsstore treats git-crypt-encrypted relation files as locked
+shells, so an unreadable relation file is *expected* in an encrypted repo, and
+reporting it would produce a finding on every file in such a project.
+
+Findings echo file paths and entity ids, both of which the caller can already
+list. No file content beyond the three identity fields is read into a finding.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+
+- **AC1** — a dedicated test using the reporter's exact filename and content.
+- **AC2** — run against the real `tickets/` and `docs-project/` projects. *This is
+  the one that matters most* and it cannot be a unit test: fixture data is chosen
+  by the same person holding the wrong mental model.
+- **AC3** — an identical table in both packages pinning the split, including
+  `A--we--ird--B` (which a naive `Split("--")` gets wrong).
+- **AC4** — verified by running `rela analyze relation-files`.
+
+**Edge Cases:** unparseable filename; relation type containing the separator;
+non-markdown files; files with no relation frontmatter; CRLF; quoted values;
+`---` inside the body; the legacy `type:` key.
+
+**Negative Tests:** a consistent file must produce nothing — otherwise the check
+is noise; and a real project must produce nothing, which is the strongest form of
+that assertion.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+| Risk | Mitigation |
+|---|---|
+| False positives make the check unusable | Run against real projects before shipping — this is what caught the critical finding |
+| The split drifts from the indexer, reporting good files as bad | Identical pin tables in both packages, each naming the other |
+| Reading the file differently from the store creates false negatives | Use `internal/frontmatter`, the shared splitter |
+| A detector nobody runs | Wired as an `analyze` subcommand and documented with the symptom operators actually arrive with |
+
+**Effort:** s
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs-project/entities/guides/GUIDE-cli-reference.md` — new
+      `rela analyze relation-files` section, regenerated into
+      `docs/cli-reference.md`.
+- [x] ~~CLAUDE.md~~ (N/A: no new pattern)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: one check
+      modelled on two existing ones in the same package. The judgement calls —
+      detector not repair, analysis not store — are recorded under Alternatives.
+      Worth noting the review that *did* run found a critical defect in the
+      implementation, not the design: the shape was right, my reading of the
+      real-project output was wrong.)
+- [x] All critical/significant findings addressed in plan — 7 code-review
+      findings, all addressed. See the review checklist.
+
+**Design Review Findings:** N/A as a separate pass; code-review findings are
+RR-YB7XX8 (critical), RR-DDZ02R, RR-TSBK9Z, RR-OW2QSH (significant), RR-8JRYEE,
+RR-DHOSFM (minor).

--- a/tickets/entities/review-checklists/REV-E4XHO9.md
+++ b/tickets/entities/review-checklists/REV-E4XHO9.md
@@ -1,0 +1,71 @@
+---
+id: REV-E4XHO9
+type: review-checklist
+title: 'Review: Audit rejected attachment uploads (CONTROL-8-15)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` exit 0.
+- [x] Lint clean (`just lint`) — 0 issues.
+- [x] Comment lint gate clean (`just comment-lint`) — clean.
+- [x] Coverage maintained (`just coverage-check`) — adds tests, removes none.
+- [x] `just arch-lint`, `just plimsoll`, `just lint-md` — clean.
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ — self-reviewed. The change is one method
+plus one call, mirroring an audit record fifteen lines away in the same file,
+and the property that needed proving (does the record actually appear, and only
+for the right error) was established by mutation rather than by reading.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — none raised.
+- [x] Self-reviewed the diff for unrelated changes.
+
+**Review Responses:** none.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — a rejected upload is recorded. PASS.** Mutation-verified: removing the
+call yields `no denied-write audit record for the rejected upload; got 0
+record(s)`. The rejection is produced by the real MIME allowlist (PNG bytes to a
+`text/plain`-only property), not a stubbed error, and the record's principal,
+subject, filename, property and reason are each asserted — a record that exists
+but is empty looks like coverage and is not.
+- **AC2 — a successful upload records nothing. PASS.** This is the assertion that
+keeps `denied-write` meaningful; without it, "audit every failed upload" would
+also pass and the op would stop distinguishing anything.
+- **AC3 — distinguishable from the ACL denial. PASS.** Same op deliberately, so
+one filter answers "what uploads were refused?"; the Summary carries `rejected
+upload ...` against the ACL path's `denied: ...`.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: this adds an
+occurrence of an already-documented op, not a new kind of record. The audit-log
+guide documents the record shape and the `triggered_by` vocabulary; neither
+changes.)
+- [x] ~~User-facing documentation updated~~ (N/A: same reason)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — the helper's godoc states why it
+records only `ErrRejected`, why it reuses `OpDeniedWrite`, and why it cannot
+live in `writeAttachmentWriteError` where the 422 is written.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design.)

--- a/tickets/entities/review-checklists/REV-G3AE0A.md
+++ b/tickets/entities/review-checklists/REV-G3AE0A.md
@@ -1,0 +1,124 @@
+---
+id: REV-G3AE0A
+type: review-checklist
+title: 'Review: analyze: flag relation files whose filename disagrees with their content'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` **exit 0**, re-run after
+every review fix.
+- [x] Lint clean (`just lint`) — **0 issues** (caught three `misspell`
+British-spelling slips in the new test docs).
+- [x] Comment lint gate clean (`just comment-lint`) — clean.
+- [x] Coverage maintained (`just coverage-check`) — adds tests, removes none.
+- [x] `just arch-lint` — clean. It **earned its keep twice**: it rejected the
+first version's `internal/markdown` import, and the boundary it enforced is what
+led (via review) to `internal/frontmatter`, which is the correct dependency and
+one this check should have used from the start.
+- [x] `just plimsoll`, `just lint-md` — clean (lint-md caught an emphasis-style
+and two over-length lines in the new docs).
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** 7 findings — 1 critical, 3 significant, 2 minor, 1 nit.
+**All 7 addressed**, none deferred.
+
+RR-YB7XX8 (critical); RR-DDZ02R, RR-TSBK9Z, RR-OW2QSH (significant); RR-8JRYEE,
+RR-DHOSFM (minor); RR-WST9B6 (nit, on the AC1.7 test).
+
+**The critical finding is that I broke my own check and pinned the mistake.**
+
+The first version reported 38 issues on the repo's own `tickets/` project. I
+judged 37 of them false positives, "fixed" the check to suppress them, and
+encoded that with two table cases asserting they were fine.
+
+They were **true positives**. Those files spell the relation type `type:`
+instead of `relation:`, and `mdCodec` builds the relation from
+`doc.getString("relation")` — so they load with an **empty type** while the
+index, built from the filename, says otherwise. Verified on the real project:
+three relations on `BUG-2OXEW0` rendered with a blank type.
+
+My suppressing comment claimed *"they work, because the store keys on the
+FILENAME"*. The first clause was false; the second was a non-sequitur that
+produced it. Indexing is not the only thing that reads a relation file.
+
+This matters more than the shape it was hiding. #1004's corruption fails loudly
+downstream as a cardinality error; this one is silently inconsistent, and a read
+→ write round trip through any path (formatter, rename, migration) writes the
+empty type back and destroys the last record of it.
+
+**Fixed three ways, and the data was repaired:** the check reports them under
+`ReasonLegacyTypeKey`; the tests assert that rather than the opposite; and the
+**37 files were corrected** (`type:` → `relation:`) after verifying all 37
+agreed with their filenames so the rename lost nothing. One more in
+`docs-project`.
+
+*The transferable lesson:* a finding you cannot immediately explain is not
+automatically a false positive. Reaching for the suppression before tracing what
+the store actually does with those files is what turned a correct check into a
+wrong one — and a pinned test made the wrong conclusion durable.
+
+**Two more real corrections:**
+
+- **RR-DDZ02R** — I hand-rolled a YAML frontmatter scanner and justified it by an
+arch-lint rule that does not apply. `yaml` is a declared `commonVendor` and
+`internal/frontmatter` exists precisely for this. Worse than redundant: it made
+a checker whose entire claim is "I read the file the way rela reads it" read it
+a *third* way, and a UTF-8 BOM made it return zero keys — a planted real
+mismatch passed clean. Now uses the shared splitter.
+- **RR-TSBK9Z** — the deliberate copy of `fsstore.parseRelationFilename` is
+correct (arch-lint forbids the dependency; exporting a storage detail to save
+nine lines would be worse), but nothing kept the two identical. Now pinned in
+both directions over the same table, each test naming the other. It had already
+drifted once by an unreachable extra guard.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — the reporter's scenario is named. PASS.** A file whose content points
+at a different target reports the file and **both** triples.
+- **AC2 — no false positives on real data. PASS**, after the correction above.
+`tickets/` and `docs-project/` both clean; the corrupted copy reports its
+injected mismatch.
+- **AC3 — the split agrees with the indexer. PASS.** Pinned in both packages over
+an identical table, including the `A--we--ird--B` case that a naive
+`Split("--")` gets wrong.
+- **AC4 — the check runs where operators look. PASS.**
+`rela analyze relation-files`, with per-reason rendering.
+
+**Verified against three real projects, not just fixtures.** That is what
+surfaced the critical finding — no unit test would have, because the fixture
+data was of my own choosing and matched my own wrong mental model.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-23G0PV
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — each `RelationFilenameReason`
+documents its consequence, and the docs give the fix per finding.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design:
+`/pr` gates on the ticket already being `done`.)

--- a/tickets/entities/review-checklists/REV-TBDRGL.md
+++ b/tickets/entities/review-checklists/REV-TBDRGL.md
@@ -1,0 +1,77 @@
+---
+id: REV-TBDRGL
+type: review-checklist
+title: 'Review: Restore the AC1.7 test: ACL deny returns a structured 403 body'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` exit 0.
+- [x] Lint clean (`just lint`) — 0 issues.
+- [x] Comment lint gate clean (`just comment-lint`) — clean.
+- [x] Coverage maintained (`just coverage-check`) — adds a test, removes none.
+- [x] `just arch-lint`, `just plimsoll` — clean.
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ — self-reviewed instead, deliberately.
+The diff is one new test file plus a seven-line comment correction; there is no
+production logic to review. The property that actually needed proving — *does
+this test catch the regression it exists for* — is not something a reviewer
+reads off a diff, and it was established by mutation (below) rather than by
+inspection.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — none raised.
+- [x] Self-reviewed the diff for unrelated changes — two files, both intended.
+
+**Review Responses:** none. Test-only change, mutation-verified.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — the AC1.7 contract is pinned again. PASS.** A `*acl.ForbiddenError`
+from the real `entitymanager` write path produces 403 with `rule_kind`,
+`rule_id` and `reason`. Verified by two mutations, both caught.
+- **AC2 — the denial is real, not stubbed. PASS.** `appbuildtest.WithDeclarative`
+wires the same `acl.Declarative` as the write-authz ACL, so the error originates
+in `AuthorizeWrite` rather than a hand-constructed value.
+- **AC3 — the right scenario. PASS.** The role grants read but not update, so
+the entity is *visible* and the request reaches the write path. A no-read role
+would 404 at the gate and never exercise the handler under test.
+
+**Worth recording precisely: the gap was partial, not total.** Mutating the
+handler to never return 403 reddens the suite — that status was covered
+incidentally. Mutating only the response *body* left the whole package green.
+Reporting this as "AC1.7 is untested" would have been wrong; reporting it as
+"covered by other tests" would have been worse. The uncovered half was exactly
+the half the AC is about.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: `kind=test`.
+No user-facing surface changes — no flag, API, config or behaviour.)
+- [x] ~~User-facing documentation updated~~ (N/A: same reason. The one doc
+change is a stale in-tree comment, covered in the implementation checklist.)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A — test-only.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — the test's doc comment states the AC
+verbatim, why it needs its own test (the body was uncovered), and why it can now
+be wired at this layer when a sibling comment said it could not.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design:
+`/pr` gates on the ticket already being `done`.)

--- a/tickets/entities/review-responses/RR-8JRYEE.md
+++ b/tickets/entities/review-responses/RR-8JRYEE.md
@@ -1,0 +1,18 @@
+---
+id: RR-8JRYEE
+type: review-response
+title: The summary line claimed a content disagreement for files whose content was never read
+finding: An unparseable filename has no content mismatch - it was counted under a message saying it did
+severity: minor
+resolution: Summary reworded to 'with filename/content problems'; each reason now renders with its own consequence (skipped entirely / empty type / indexed as the wrong triple).
+status: addressed
+---
+
+Every finding rolled into `"Found %d relation file(s) whose name and content
+disagree"`, including `filename is not FROM--TYPE--TO` — where the file was
+never opened. An operator greps for a file "whose content disagrees", opens it,
+finds content that agrees perfectly, and stops trusting the check.
+
+Reworded to "with filename/content problems", and each reason now renders with
+its own explanation of the consequence (skipped entirely / empty type / indexed
+as the wrong triple).

--- a/tickets/entities/review-responses/RR-DDZ02R.md
+++ b/tickets/entities/review-responses/RR-DDZ02R.md
@@ -1,0 +1,31 @@
+---
+id: RR-DDZ02R
+type: review-response
+title: The hand-rolled YAML scanner was unnecessary - yaml is a commonVendor and internal/frontmatter exists
+finding: I justified it by an arch-lint rule that does not apply and read the file a third way in a checker whose job is to agree with the store
+severity: significant
+resolution: Replaced the hand-rolled scanner with frontmatter.Split + yaml.Unmarshal - the same splitter the store uses - plus one line adding frontmatter to analysis.mayDependOn. Its unit test was deleted; the edge cases it covered (CRLF; quoted values; --- in the body) are now end-to-end cases on the check itself where a misparse shows up as the false finding it would cause.
+status: addressed
+---
+
+My godoc justified the hand-roll by *"arch-lint forbids analysis from depending
+on the markdown package"* — true but irrelevant, because I did not need
+`markdown`.
+
+`.go-arch-lint.yml` declares `yaml` under `commonVendors`, so every component
+may import it today. And `internal/frontmatter` is a declared component whose
+package doc describes this exact situation in advance: a dependency-free leaf
+returning only strings, existing so `markdown` and `fsstore` can share one
+splitter.
+
+Worse than redundant, it was a correctness risk: the check's whole claim is "I
+read the file the way rela reads it", and a private scanner made it read the
+file a **third** way. Two confirmed divergences — CRLF survived only by accident
+of two `TrimSpace` calls, and a UTF-8 BOM made it return zero keys, so a planted
+real mismatch passed clean.
+
+Replaced with `frontmatter.Split` + `yaml.Unmarshal`, plus one line adding
+`frontmatter` to `analysis.mayDependOn`. The scanner's unit test was deleted and
+its edge cases (CRLF, quoted values, `---` in the body) re-added as end-to-end
+cases on the check itself, where a misparse shows up as the false finding it
+would actually cause.

--- a/tickets/entities/review-responses/RR-DHOSFM.md
+++ b/tickets/entities/review-responses/RR-DHOSFM.md
@@ -1,0 +1,18 @@
+---
+id: RR-DHOSFM
+type: review-response
+title: Read errors were swallowed without naming the legitimate case
+finding: An unreadable file returned clean with a comment that did not say which other reporting covers it
+severity: minor
+resolution: The comment now names the legitimate case - fsstore treats git-crypt-encrypted relation files as locked shells - which is what makes skipping defensible rather than merely convenient.
+status: addressed
+---
+
+`checkRelationFile` returned nil on a read error with a comment saying it is "a
+different problem with its own reporting" — without naming that reporting, so a
+maintainer could not verify the claim.
+
+The legitimate case is real: fsstore handles git-crypt-encrypted relation files
+as locked shells, so an unreadable relation file is expected in an encrypted
+repo. The comment now says so, which is what makes skipping defensible rather
+than merely convenient.

--- a/tickets/entities/review-responses/RR-OW2QSH.md
+++ b/tickets/entities/review-responses/RR-OW2QSH.md
@@ -1,0 +1,20 @@
+---
+id: RR-OW2QSH
+type: review-response
+title: Reason was a bare string with the CLI switching on a different field
+finding: Two representations of one fact in different packages - a third reason would silently misrender
+severity: significant
+resolution: Reason is now a typed RelationFilenameReason with three constants; the CLI switches on it with a default arm rather than inferring the case from an empty FromContent. The constants are the JSON wire values.
+status: addressed
+---
+
+`RelationFilenameIssue.Reason` carried two values as free prose, and the CLI did
+not switch on it — it inferred the case from `iss.FromContent == ""`, an
+implicit coupling to `checkRelationFile` leaving that field blank.
+
+Adding a third reason (which the legacy-`type` finding did) would have silently
+misclassified it as the unparseable-name case. The compiler could not help.
+
+`Reason` is now a typed `RelationFilenameReason` with three constants, the CLI
+switches on it with a `default` arm, and the string constants are the JSON wire
+values.

--- a/tickets/entities/review-responses/RR-TSBK9Z.md
+++ b/tickets/entities/review-responses/RR-TSBK9Z.md
@@ -1,0 +1,27 @@
+---
+id: RR-TSBK9Z
+type: review-response
+title: Nothing enforced that the duplicated filename splitter stays identical to the indexer
+finding: The duplication is justified only while exact and there was no mechanism preserving that
+severity: significant
+resolution: 'Pinned in both directions over the SAME table: TestParseRelationFilename_PinnedForAnalysisCopy in fsstore and TestSplitRelationFilename_MatchesIndexer in analysis. Each test''s doc names the other and says a change to one requires a change to both. Also removed the unreachable extra guard so the two bodies are byte-identical.'
+status: addressed
+---
+
+`splitRelationFilename` is a deliberate copy of `fsstore.parseRelationFilename`
+— unexported there, and arch-lint forbids `analysis -> store/fsstore`, which is
+the right boundary. The review endorsed keeping the copy; exporting a storage
+detail to save nine lines would be worse.
+
+But the copy is justified *by its exactness* and nothing preserved it. The next
+person to fix a parsing bug in fsstore would not know this file exists.
+
+(It had already drifted once: my version carried an extra `relType == ""` guard
+the store lacks. Unreachable — `LastIndex(rest, "--") < 1` already rejects
+`j==0` — so behavior was identical, but the two no longer *looked* identical,
+which is the thing that rots.)
+
+Pinned in both directions: `TestParseRelationFilename_PinnedForAnalysisCopy` in
+fsstore and `TestSplitRelationFilename_MatchesIndexer` in analysis, over the
+**same table**, covering the cases where they could plausibly drift — all of
+which turn on which `--` is chosen. Each test's doc names the other.

--- a/tickets/entities/review-responses/RR-WST9B6.md
+++ b/tickets/entities/review-responses/RR-WST9B6.md
@@ -1,0 +1,18 @@
+---
+id: RR-WST9B6
+type: review-response
+title: AC1.7 asserted rule_kind non-empty rather than by value
+finding: A mutation emitting a constant like unknown would satisfy a non-empty check while telling the operator nothing
+severity: nit
+resolution: 'rule_kind is now asserted by value (role-grant). rule_id and reason stay non-empty assertions deliberately: acl.Decision.Reason is documented as never carrying raw policy data; pinning its wording would invite widening it later to make a test pass.'
+status: addressed
+---
+
+The point of AC1.7 is that the operator learns *which* gate fired, so
+`rule_kind` is now asserted by value (`role-grant`, the documented kind for "a
+role's write list either matched or didn't").
+
+`rule_id` and `reason` stay non-empty assertions deliberately:
+`acl.Decision.Reason` is documented as never carrying raw policy data, and
+pinning its exact wording would invite widening it later to make a test pass —
+the opposite of what that doc promises.

--- a/tickets/entities/review-responses/RR-YB7XX8.md
+++ b/tickets/entities/review-responses/RR-YB7XX8.md
@@ -1,0 +1,45 @@
+---
+id: RR-YB7XX8
+type: review-response
+title: 'The legacy type: accommodation suppressed 37 TRUE positives and pinned the wrong conclusion'
+finding: Those files load with an EMPTY relation type - the check reported them clean and two table cases asserted that was correct
+severity: critical
+resolution: 'Confirmed and fixed three ways. The check now reports legacy files under ReasonLegacyTypeKey; the two table cases asserting the opposite were replaced; and the 37 files were REPAIRED (type: -> relation:) after verifying all 37 agreed with their filenames so nothing was lost. One more in docs-project. BUG-2OXEW0''s three blank-typed relations now render as has-review-response. Both projects report clean.'
+status: addressed
+---
+
+I dismissed 37 findings on the repo's own `tickets/` project as false positives,
+"fixed" the check to suppress them, and pinned that conclusion with two table
+cases. **The v1 output was right.**
+
+The comment I wrote claimed:
+
+> Those files work — the store keys on the FILENAME, so the content key never
+> matters for indexing
+
+The first clause is false and the second is a non-sequitur. Indexing is not the
+only thing that reads a relation file: `mdCodec`
+(`internal/store/fsstore/markdown.go:335`) builds the relation from **content**
+via `doc.getString("relation")`, which returns `""` for a legacy file. And
+`type` is not a reserved relation key, so it is additionally stored as a user
+property.
+
+Verified on the real project — three relations on `BUG-2OXEW0` rendered with a
+**blank type**:
+
+```
+→ BUG-2OXEW0 has-review REV-2LX9ON
+→ BUG-2OXEW0  RR-28QDBC        <- empty
+→ BUG-2OXEW0  RR-E5Q9C8        <- empty
+```
+
+This is worse than the #1004 shape it was hiding: #1004 fails loudly downstream
+as a cardinality error, this is silently inconsistent, and any read -> write
+round trip (formatter, rename, migration) writes the empty type back and
+destroys the last record of it.
+
+Fixed three ways: the check now reports these under their own
+`ReasonLegacyTypeKey`; the tests assert that rather than the opposite; and **the
+37 files were repaired** (`type:` -> `relation:`, after verifying all 37 agreed
+with their filenames so nothing was lost). One more in `docs-project`.
+`BUG-2OXEW0`'s relations now render with their real type.

--- a/tickets/entities/tickets/TKT-2P9S72.md
+++ b/tickets/entities/tickets/TKT-2P9S72.md
@@ -1,0 +1,52 @@
+---
+id: TKT-2P9S72
+type: ticket
+title: 'analyze: flag relation files whose filename disagrees with their content'
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+`fsstore` keys relations **entirely on the filename** — `syncRelations` parses
+`FROM--TYPE--TO.md` and never reads the file to check the parsed triple against
+the `from`/`relation`/`to` in the frontmatter. A file whose name and content
+disagree is therefore indexed under the *filename* triple, and the relation its
+content describes simply does not exist as far as the graph is concerned.
+
+Reported from a real project (GitHub issue #1004): eight relation files like
+
+```
+filename:  PRS-FLOW-1HL6--wordtUitgevoerdDoor--PRS-FUNC-8Q7E.md
+content:   to: PRS-FUNC-0Q7E        # correct ID, differs from the filename
+```
+
+produced `PRS-FUNC-0Q7E must have at least 1 ... relation(s), has 0`, with no
+indication of why. The entity named in the filename did not exist at all.
+
+## What is already fixed
+
+The rename path that likely caused it. `fsstore.renameEntity` rewrites each
+incident relation under its **new** filename and removes the old one — verified:
+after renaming `REQ-1` to `REQ-999`, the only file present is
+`SOL-1--implements--REQ-999.md`. So new corruption of this shape is not being
+produced.
+
+## What is still missing
+
+The issue's second suggestion, and the reason the reporter lost time: nothing
+detects a mismatch that already exists. A project carrying legacy corruption
+gets a cardinality error pointing at the *victim* entity, with no path back to
+the malformed file.
+
+`rela analyze` should report it directly: for each relation file, compare the
+filename triple against the frontmatter triple and flag disagreement.
+
+## Out of scope
+
+Keying relations on content instead of filename (the issue's third suggestion).
+That is a storage-model change with migration implications; a detector is the
+cheap, non-destructive half and is what turns a mystifying symptom into a named
+finding.

--- a/tickets/entities/tickets/TKT-6O8D0L.md
+++ b/tickets/entities/tickets/TKT-6O8D0L.md
@@ -1,0 +1,34 @@
+---
+id: TKT-6O8D0L
+type: ticket
+title: Audit rejected attachment uploads (CONTROL-8-15)
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+An upload rejected by the attachment processor — disallowed MIME type, or a
+failed/positive scan — returns HTTP 422 and writes **no audit record**.
+`handlers_attachment.go`'s `attachment.ErrRejected` branch formats the error and
+returns.
+
+A rejected upload is a security-relevant exception: it may be an attempt to
+place a disallowed file type or malware into the project. CONTROL-8-15 requires
+such events to be logged.
+
+GitHub issue #1050, from IB-review rela#1026. Severity: low.
+
+## Note on the existing coverage
+
+The neighbouring **ACL** denial on the same handler *is* audited
+(`handlers_attachment.go`, `OpDeniedWrite` with rule_kind/rule_id/reason). So
+the gap is specifically the processor-policy rejection, and the fix should
+mirror that record rather than invent a second shape — an operator filtering `op
+== "denied-write"` should see both kinds of refused upload.
+
+## Minimum fields
+
+Time, principal, entity + property, filename, and the rejection reason.

--- a/tickets/entities/tickets/TKT-RPBFAO.md
+++ b/tickets/entities/tickets/TKT-RPBFAO.md
@@ -1,0 +1,39 @@
+---
+id: TKT-RPBFAO
+type: ticket
+title: 'Restore the AC1.7 test: ACL deny returns a structured 403 body'
+kind: test
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+PR #1029 (god-object linter / affordanceService extraction) deleted
+`internal/dataentry/acl_test.go` wholesale, taking with it
+`TestHandler_ACLDeny_Returns403Structured` — the only automated test pinning
+AC1.7:
+
+> When `EntityManager` returns a `*acl.ForbiddenError`, the data-entry HTTP
+> handler must respond with HTTP 403 and a structured JSON body carrying
+> `rule_kind`, `rule_id` and `reason`.
+
+GitHub issue #1044. Basis: CONTROL-8-29 (security testing in the development
+lifecycle).
+
+## Verified by mutation, not assumed
+
+The gap is **partial**, which is worth stating precisely:
+
+- Mutating `writeForbiddenIfACLDenied` to never fire (fall through to the
+generic 500) **does** fail the suite — so the 403 *status* is covered
+incidentally by other tests.
+- Mutating the JSON body (`"error": "forbidden"` -> `"error": "MUTATED"`)
+leaves the **entire `internal/dataentry` suite green**. The structured body —
+the actual subject of AC1.7 — is pinned by nothing.
+
+So the contract is half-covered, and the uncovered half is the one the AC is
+about: an operator debugging a denial needs `rule_kind`/`rule_id`/`reason` to
+know *which* rule fired. The AWS-IAM lesson the handler's own godoc cites
+("opaque denials are unsupportable") is exactly what regressed silently.

--- a/tickets/relations/BUG-2OXEW0--has-review-response--RR-E5Q9C8.md
+++ b/tickets/relations/BUG-2OXEW0--has-review-response--RR-E5Q9C8.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-2OXEW0
-type: has-review-response
+relation: has-review-response
 to: RR-E5Q9C8
 ---

--- a/tickets/relations/BUG-2OXEW0--has-review-response--RR-F0DJ68.md
+++ b/tickets/relations/BUG-2OXEW0--has-review-response--RR-F0DJ68.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-2OXEW0
-type: has-review-response
+relation: has-review-response
 to: RR-F0DJ68
 ---

--- a/tickets/relations/BUG-2OXEW0--has-review-response--RR-FB792S.md
+++ b/tickets/relations/BUG-2OXEW0--has-review-response--RR-FB792S.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-2OXEW0
-type: has-review-response
+relation: has-review-response
 to: RR-FB792S
 ---

--- a/tickets/relations/BUG-4KPN2M--adds-measure--AM-analyze-fails-closed-on-unreadable-entity.md
+++ b/tickets/relations/BUG-4KPN2M--adds-measure--AM-analyze-fails-closed-on-unreadable-entity.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-4KPN2M
-type: adds-measure
+relation: adds-measure
 to: AM-analyze-fails-closed-on-unreadable-entity
 ---

--- a/tickets/relations/BUG-4KPN2M--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-4KPN2M--affects--ci-pipeline.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-4KPN2M
-type: affects
+relation: affects
 to: ci-pipeline
 ---

--- a/tickets/relations/BUG-4KPN2M--fixes--FEAT-57oh.md
+++ b/tickets/relations/BUG-4KPN2M--fixes--FEAT-57oh.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-4KPN2M
-type: fixes
+relation: fixes
 to: FEAT-57oh
 ---

--- a/tickets/relations/BUG-E9DYW5--adds-measure--AM-feed-field-redaction.md
+++ b/tickets/relations/BUG-E9DYW5--adds-measure--AM-feed-field-redaction.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-E9DYW5
-type: adds-measure
+relation: adds-measure
 to: AM-feed-field-redaction
 ---

--- a/tickets/relations/BUG-E9DYW5--has-review--REV-E9DYW5.md
+++ b/tickets/relations/BUG-E9DYW5--has-review--REV-E9DYW5.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-E9DYW5
-type: has-review
+relation: has-review
 to: REV-E9DYW5
 ---

--- a/tickets/relations/BUG-XV7FSJ--adds-measure--AM-date-property-write-roundtrip.md
+++ b/tickets/relations/BUG-XV7FSJ--adds-measure--AM-date-property-write-roundtrip.md
@@ -1,5 +1,5 @@
 ---
 from: BUG-XV7FSJ
-type: adds-measure
+relation: adds-measure
 to: AM-date-property-write-roundtrip
 ---

--- a/tickets/relations/BUG-XV7FSJ--fixes--FEAT-27UZ51.md
+++ b/tickets/relations/BUG-XV7FSJ--fixes--FEAT-27UZ51.md
@@ -1,6 +1,6 @@
 ---
 from: BUG-XV7FSJ
-type: fixes
+relation: fixes
 to: FEAT-27UZ51
 ---
 

--- a/tickets/relations/TKT-1ESTYJ--has-review--REV-1ESTYJ.md
+++ b/tickets/relations/TKT-1ESTYJ--has-review--REV-1ESTYJ.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-1ESTYJ
-type: has-review
+relation: has-review
 to: REV-1ESTYJ
 ---

--- a/tickets/relations/TKT-2P9S72--affects--store-backends.md
+++ b/tickets/relations/TKT-2P9S72--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2P9S72
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-2P9S72--has-docs--DOCS-23G0PV.md
+++ b/tickets/relations/TKT-2P9S72--has-docs--DOCS-23G0PV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2P9S72
+relation: has-docs
+to: DOCS-23G0PV
+---

--- a/tickets/relations/TKT-2P9S72--has-implementation--IMPL-F3BV1I.md
+++ b/tickets/relations/TKT-2P9S72--has-implementation--IMPL-F3BV1I.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-E9DYW5
+from: TKT-2P9S72
 relation: has-implementation
-to: IMPL-E9DYW5
+to: IMPL-F3BV1I
 ---

--- a/tickets/relations/TKT-2P9S72--has-planning--PLAN-UXHDV9.md
+++ b/tickets/relations/TKT-2P9S72--has-planning--PLAN-UXHDV9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2P9S72
+relation: has-planning
+to: PLAN-UXHDV9
+---

--- a/tickets/relations/TKT-2P9S72--has-review--REV-G3AE0A.md
+++ b/tickets/relations/TKT-2P9S72--has-review--REV-G3AE0A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2P9S72
+relation: has-review
+to: REV-G3AE0A
+---

--- a/tickets/relations/TKT-2P9S72--has-review-response--RR-8JRYEE.md
+++ b/tickets/relations/TKT-2P9S72--has-review-response--RR-8JRYEE.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-2OXEW0
+from: TKT-2P9S72
 relation: has-review-response
-to: RR-28QDBC
+to: RR-8JRYEE
 ---

--- a/tickets/relations/TKT-2P9S72--has-review-response--RR-DDZ02R.md
+++ b/tickets/relations/TKT-2P9S72--has-review-response--RR-DDZ02R.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-2OXEW0
+from: TKT-2P9S72
 relation: has-review-response
-to: RR-28QDBC
+to: RR-DDZ02R
 ---

--- a/tickets/relations/TKT-2P9S72--has-review-response--RR-DHOSFM.md
+++ b/tickets/relations/TKT-2P9S72--has-review-response--RR-DHOSFM.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-2OXEW0
+from: TKT-2P9S72
 relation: has-review-response
-to: RR-28QDBC
+to: RR-DHOSFM
 ---

--- a/tickets/relations/TKT-2P9S72--has-review-response--RR-OW2QSH.md
+++ b/tickets/relations/TKT-2P9S72--has-review-response--RR-OW2QSH.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-2OXEW0
+from: TKT-2P9S72
 relation: has-review-response
-to: RR-28QDBC
+to: RR-OW2QSH
 ---

--- a/tickets/relations/TKT-2P9S72--has-review-response--RR-TSBK9Z.md
+++ b/tickets/relations/TKT-2P9S72--has-review-response--RR-TSBK9Z.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-2OXEW0
+from: TKT-2P9S72
 relation: has-review-response
-to: RR-28QDBC
+to: RR-TSBK9Z
 ---

--- a/tickets/relations/TKT-2P9S72--has-review-response--RR-YB7XX8.md
+++ b/tickets/relations/TKT-2P9S72--has-review-response--RR-YB7XX8.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-2OXEW0
+from: TKT-2P9S72
 relation: has-review-response
-to: RR-28QDBC
+to: RR-YB7XX8
 ---

--- a/tickets/relations/TKT-2P9S72--implements--FEAT-3DUA6.md
+++ b/tickets/relations/TKT-2P9S72--implements--FEAT-3DUA6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-2P9S72
+relation: implements
+to: FEAT-3DUA6
+---

--- a/tickets/relations/TKT-6O8D0L--affects--audit-log.md
+++ b/tickets/relations/TKT-6O8D0L--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6O8D0L
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/TKT-6O8D0L--has-docs--DOCS-5E98CS.md
+++ b/tickets/relations/TKT-6O8D0L--has-docs--DOCS-5E98CS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6O8D0L
+relation: has-docs
+to: DOCS-5E98CS
+---

--- a/tickets/relations/TKT-6O8D0L--has-implementation--IMPL-VJHPWV.md
+++ b/tickets/relations/TKT-6O8D0L--has-implementation--IMPL-VJHPWV.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-E9DYW5
+from: TKT-6O8D0L
 relation: has-implementation
-to: IMPL-E9DYW5
+to: IMPL-VJHPWV
 ---

--- a/tickets/relations/TKT-6O8D0L--has-planning--PLAN-4WY4X9.md
+++ b/tickets/relations/TKT-6O8D0L--has-planning--PLAN-4WY4X9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6O8D0L
+relation: has-planning
+to: PLAN-4WY4X9
+---

--- a/tickets/relations/TKT-6O8D0L--has-review--REV-E4XHO9.md
+++ b/tickets/relations/TKT-6O8D0L--has-review--REV-E4XHO9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6O8D0L
+relation: has-review
+to: REV-E4XHO9
+---

--- a/tickets/relations/TKT-6O8D0L--implements--FEAT-870YCY.md
+++ b/tickets/relations/TKT-6O8D0L--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-6O8D0L
+relation: implements
+to: FEAT-870YCY
+---

--- a/tickets/relations/TKT-7S5735--has-review-response--RR-HUL1JC.md
+++ b/tickets/relations/TKT-7S5735--has-review-response--RR-HUL1JC.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-7S5735
-type: has-review-response
+relation: has-review-response
 to: RR-HUL1JC
 ---

--- a/tickets/relations/TKT-7S5735--has-review-response--RR-KG04FD.md
+++ b/tickets/relations/TKT-7S5735--has-review-response--RR-KG04FD.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-7S5735
-type: has-review-response
+relation: has-review-response
 to: RR-KG04FD
 ---

--- a/tickets/relations/TKT-7S5735--has-review-response--RR-S8LX1S.md
+++ b/tickets/relations/TKT-7S5735--has-review-response--RR-S8LX1S.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-7S5735
-type: has-review-response
+relation: has-review-response
 to: RR-S8LX1S
 ---

--- a/tickets/relations/TKT-7S5735--has-review-response--RR-TXMRYN.md
+++ b/tickets/relations/TKT-7S5735--has-review-response--RR-TXMRYN.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-7S5735
-type: has-review-response
+relation: has-review-response
 to: RR-TXMRYN
 ---

--- a/tickets/relations/TKT-7S5735--has-review-response--RR-U5ICXO.md
+++ b/tickets/relations/TKT-7S5735--has-review-response--RR-U5ICXO.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-7S5735
-type: has-review-response
+relation: has-review-response
 to: RR-U5ICXO
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-docs--DOCS-DOCASSERT.md
+++ b/tickets/relations/TKT-DOCASSERT--has-docs--DOCS-DOCASSERT.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-docs
+relation: has-docs
 to: DOCS-DOCASSERT
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-implementation--IMPL-DOCASSERT.md
+++ b/tickets/relations/TKT-DOCASSERT--has-implementation--IMPL-DOCASSERT.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-implementation
+relation: has-implementation
 to: IMPL-DOCASSERT
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review--REV-DOCASSERT.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review--REV-DOCASSERT.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review
+relation: has-review
 to: REV-DOCASSERT
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA01.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA01.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA01
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA02.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA02.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA02
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA03.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA03.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA03
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA04.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA04.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA04
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA05.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA05.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA05
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA06.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA06.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA06
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA07.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA07.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA07
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA08.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA08.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA08
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA09.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA09.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA09
 ---

--- a/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA10.md
+++ b/tickets/relations/TKT-DOCASSERT--has-review-response--RR-DOCA10.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-DOCASSERT
-type: has-review-response
+relation: has-review-response
 to: RR-DOCA10
 ---

--- a/tickets/relations/TKT-MF1CWZ--has-docs--DOCS-CDV003.md
+++ b/tickets/relations/TKT-MF1CWZ--has-docs--DOCS-CDV003.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-MF1CWZ
-type: has-docs
+relation: has-docs
 to: DOCS-CDV003
 ---

--- a/tickets/relations/TKT-N8RESF--has-docs--DOCS-CDV005.md
+++ b/tickets/relations/TKT-N8RESF--has-docs--DOCS-CDV005.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-N8RESF
-type: has-docs
+relation: has-docs
 to: DOCS-CDV005
 ---

--- a/tickets/relations/TKT-N8RESF--has-review--REV-CDV006.md
+++ b/tickets/relations/TKT-N8RESF--has-review--REV-CDV006.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-N8RESF
-type: has-review
+relation: has-review
 to: REV-CDV006
 ---

--- a/tickets/relations/TKT-RPBFAO--affects--authorization.md
+++ b/tickets/relations/TKT-RPBFAO--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RPBFAO
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-RPBFAO--has-implementation--IMPL-CY777P.md
+++ b/tickets/relations/TKT-RPBFAO--has-implementation--IMPL-CY777P.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-E9DYW5
+from: TKT-RPBFAO
 relation: has-implementation
-to: IMPL-E9DYW5
+to: IMPL-CY777P
 ---

--- a/tickets/relations/TKT-RPBFAO--has-planning--PLAN-MQY1C5.md
+++ b/tickets/relations/TKT-RPBFAO--has-planning--PLAN-MQY1C5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RPBFAO
+relation: has-planning
+to: PLAN-MQY1C5
+---

--- a/tickets/relations/TKT-RPBFAO--has-review--REV-TBDRGL.md
+++ b/tickets/relations/TKT-RPBFAO--has-review--REV-TBDRGL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RPBFAO
+relation: has-review
+to: REV-TBDRGL
+---

--- a/tickets/relations/TKT-RPBFAO--has-review-response--RR-WST9B6.md
+++ b/tickets/relations/TKT-RPBFAO--has-review-response--RR-WST9B6.md
@@ -1,5 +1,5 @@
 ---
-from: BUG-2OXEW0
+from: TKT-RPBFAO
 relation: has-review-response
-to: RR-28QDBC
+to: RR-WST9B6
 ---

--- a/tickets/relations/TKT-RPBFAO--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-RPBFAO--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RPBFAO
+relation: implements
+to: FEAT-AESD4
+---

--- a/tickets/relations/TKT-SNBQX0--has-docs--DOCS-CDV001.md
+++ b/tickets/relations/TKT-SNBQX0--has-docs--DOCS-CDV001.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-SNBQX0
-type: has-docs
+relation: has-docs
 to: DOCS-CDV001
 ---

--- a/tickets/relations/TKT-UGYSC8--has-docs--DOCS-CDV002.md
+++ b/tickets/relations/TKT-UGYSC8--has-docs--DOCS-CDV002.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-UGYSC8
-type: has-docs
+relation: has-docs
 to: DOCS-CDV002
 ---

--- a/tickets/relations/TKT-WAA092--has-docs--DOCS-CDV004.md
+++ b/tickets/relations/TKT-WAA092--has-docs--DOCS-CDV004.md
@@ -1,5 +1,5 @@
 ---
 from: TKT-WAA092
-type: has-docs
+relation: has-docs
 to: DOCS-CDV004
 ---


### PR DESCRIPTION
Closes #1004, #1044, #1050.

Three small tickets on one branch. The first is the substantive one.

---

## `rela analyze relation-files` — TKT-2P9S72, closes #1004

`fsstore` keys relations **entirely on the filename**: `scanRelationDir` parses `FROM--TYPE--TO.md` and never opens the file. So a file whose name and content disagree is indexed as the relation its *name* describes, while the one its *content* describes doesn't exist in the graph.

The symptom appears somewhere else entirely — a cardinality error against an innocent entity, with no route back to the offending file. That's how #1004 was reported, after the reporter had lost time to it.

The rename path #1004 blamed **is already correct** (verified: after `REQ-1 → REQ-999` the only file is `SOL-1--implements--REQ-999.md`). So this is a detector for legacy corruption, hand-edits and merges — not a fix for an ongoing defect.

**It earned its keep on the first real run.** Against this repo it found 38 genuine problems, repaired in the preceding commit — see below.

Reasons are a typed enum, not prose, and the CLI switches on them: a new reason must be handled rather than silently rendering as whichever case its empty fields resemble.

`splitRelationFilename` deliberately duplicates `fsstore.parseRelationFilename` (unexported there; arch-lint forbids `analysis → store/fsstore`, which is the right boundary — a storage detail shouldn't become an analysis dependency to save nine lines). The copy is justified *only while exact*, so both sides are now pinned over an identical table, each test naming the other. It had already drifted once.

## The data repair (separate commit)

38 relation files spelled the relation type `type:` instead of `relation:`. `mdCodec` builds a relation from `doc.getString("relation")`, so these loaded with an **empty type** while the index — built from the filename — said otherwise. Three relations on `BUG-2OXEW0` rendered blank.

Silently inconsistent rather than loudly broken, and one-way: any read → write round trip writes the empty type back and destroys the last record of it. All 38 were verified to agree with their filenames before rewriting, so the key rename loses nothing.

**I initially got this wrong and the reviewer caught it.** I judged those 38 false positives, suppressed them, and pinned that with two table cases. My comment claimed "they work, because the store keys on the FILENAME" — the first clause false, the second a non-sequitur that produced it. Indexing isn't the only thing that reads a relation file. The v1 output was right.

---

## AC1.7 test — TKT-RPBFAO, closes #1044

`TestHandler_ACLDeny_Returns403Structured` was deleted with `acl_test.go` in #1029. Mutation showed the gap was **partial**, which is worth stating precisely:

| Mutation | Whole `internal/dataentry` suite |
|---|---|
| Handler never returns 403 | **fails** — the status was covered incidentally |
| `"error": "forbidden"` → `"MUTATED"` | **passes** — the structured body was covered by nothing |

The uncovered half is exactly what the AC is about. Reporting it as "untested" would have been wrong; "covered by other tests" would have been worse.

Also corrects a stale comment claiming such a test can't be wired at the dataentry layer — `appbuildtest.WithDeclarative` has since made it possible, so the denial now comes from the real `AuthorizeWrite` path rather than a stubbed error.

## Rejected-upload audit — TKT-6O8D0L, closes #1050

An upload the processor refuses (disallowed MIME, failed scan) returned 422 with no audit record, while the ACL denial fifteen lines away was already recorded.

Same op (`denied-write`) deliberately, so one filter answers "what uploads were refused?" without the operator knowing there are two kinds. Only `ErrRejected` — a size cap or an at-capacity property is a client error, and auditing those would dilute the op until it distinguishes nothing. That negative case is tested.

---

## Verification

- `go test ./...` exit 0 · `just lint` 0 issues · arch-lint, comment-lint, plimsoll, lint-md all clean
- Every new behaviour mutation-verified (break the code, confirm the test reddens, restore)
- The check was run against **three real projects**, which is what surfaced the critical finding — no unit test would have, because fixture data is chosen by the same person holding the wrong mental model

Code review returned 7 findings (1 critical, 3 significant, 2 minor, 1 nit), all addressed. The critical one and one significant one were both mine: suppressing true positives, and hand-rolling a YAML scanner justified by an arch-lint rule that didn't apply (`yaml` is a `commonVendor` and `internal/frontmatter` exists for exactly this).

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
