### PR TITLE
fix(search): fail closed when the searcher cannot redact hidden fields

### DIFF
--- a/examples/idp-sync.lua
+++ b/examples/idp-sync.lua
@@ -33,6 +33,32 @@ if uid == "" or org == "" then
   return { message_type = "error", message = "idp-sync: missing user_id/org_id param" }
 end
 
+-- Validate the identifiers before interpolating them into a request path and an
+-- entity query below.
+--
+-- They arrive from a cryptographically verified webhook JWT, so this is
+-- defence in depth rather than the primary control — but it is the cheap half
+-- of it. A compromised or misconfigured IdP that emits a `sub` containing `/`,
+-- `?`, `#` or a newline would otherwise reshape the outbound operator-API path
+-- or the entity filter (rela#1083). An allowlist, not a blocklist: enumerate
+-- what an identifier may contain rather than guessing what it may not.
+--
+-- The set covers the usual shapes: UUIDs, ULIDs, emails, and slugs. Some IdPs
+-- issue subjects it rejects — Auth0's `auth0|abc123` is the common one — so
+-- widen the pattern if yours does. Widen it deliberately, character by
+-- character, and never to `.*`: the point is that a `/` or a newline in a
+-- subject cannot reshape the request path built below.
+local function valid_id(v)
+  return v:match("^[%w._@%-]+$") ~= nil
+end
+
+if not valid_id(uid) or not valid_id(org) then
+  return {
+    message_type = "error",
+    message = "idp-sync: user_id/org_id contains characters outside the allowed set",
+  }
+end
+
 -- Build the Pratique operator-API request path and its HMAC signature. The
 -- canonical string + header names are Pratique's wire format (see its
 -- docs/04-architecture.md §operator API):

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -393,16 +393,38 @@ func addCheckboxIndices(s string) string {
 // The field filter is engaged only when the resolver can actually hide a
 // property (a policy-backed resolver); under the Nop resolver redaction is a
 // provable no-op, so the plain entity-level path runs — and a searcher that
-// isn't a FieldVisibleSearcher is fine there. When redaction IS in play but the
-// searcher can't do it, SearchVisibleFields fails closed (it does not silently
-// skip) — see search.Visible.SearchVisibleFields.
+// isn't a FieldVisibleSearcher is fine there.
+//
+// When redaction IS in play but the searcher cannot do it, this FAILS CLOSED:
+// it yields search.ErrScope rather than falling back to the un-redacted
+// SearchVisible. A searcher that reaches here without implementing
+// FieldVisibleSearcher is a wiring bug — a decorator (cache, metrics, tracing)
+// wrapped around the searcher without forwarding the method — and the failure
+// it would otherwise produce is silent: search stops redacting while the policy
+// still hides, with no error and no log.
+//
+// This mirrors search.Visible.SearchVisibleFields one layer down, whose godoc
+// settles the principle: "silently skipping redaction is exactly the oracle
+// this closes" (RR-8W40EW). The two decision points are the same shape; the
+// outer one was the one still failing open (TKT-NCLA67).
 func searchVisibleHits(
 	ctx context.Context, vs search.VisibleSearcher, aff affordanceService,
 	q search.Query, scope map[string]search.TypeScope,
 ) iter.Seq2[search.Hit, error] {
-	fvs, ok := vs.(search.FieldVisibleSearcher)
-	if !ok || !aff.hidesAnyField() {
+	// Nothing to redact: the plain entity-level path is correct, and a searcher
+	// that isn't a FieldVisibleSearcher is fine here.
+	if !aff.hidesAnyField() {
 		return vs.SearchVisible(ctx, q, scope)
+	}
+	fvs, ok := vs.(search.FieldVisibleSearcher)
+	if !ok {
+		// Redaction is in play but this searcher cannot do it. Refuse rather
+		// than serve un-redacted hits.
+		return func(yield func(search.Hit, error) bool) {
+			yield(search.Hit{}, fmt.Errorf(
+				"%w: policy hides fields but the wired searcher (%T) cannot redact them",
+				search.ErrScope, vs))
+		}
 	}
 	return fvs.SearchVisibleFields(ctx, q, scope, hiddenSearchFields(aff))
 }

--- a/internal/dataentry/search_fail_closed_test.go
+++ b/internal/dataentry/search_fail_closed_test.go
@@ -1,0 +1,117 @@
+package dataentry
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/search"
+)
+
+// entityOnlySearcher is a VisibleSearcher that does NOT implement
+// search.FieldVisibleSearcher — the shape a future decorator (cache, metrics,
+// tracing) produces when it wraps the searcher without forwarding
+// SearchVisibleFields.
+type entityOnlySearcher struct{ served bool }
+
+func (s *entityOnlySearcher) SearchVisible(
+	_ context.Context, _ search.Query, _ map[string]search.TypeScope,
+) iter.Seq2[search.Hit, error] {
+	return func(yield func(search.Hit, error) bool) {
+		// Serving even one hit here means un-redacted results reached the
+		// caller — the oracle this path must refuse to open.
+		s.served = true
+		yield(search.Hit{ID: "TKT-001"}, nil)
+	}
+}
+
+// hidingResolver reports that it can hide fields, so hidesAnyField() is true
+// and redaction is genuinely in play.
+type hidingResolver struct{}
+
+func (hidingResolver) FieldVerdicts(context.Context, *entityPkg.Entity) FieldVerdicts {
+	return FieldVerdicts{}
+}
+func (hidingResolver) RelationVerdicts(context.Context, *entityPkg.Entity) RelationVerdicts {
+	return RelationVerdicts{}
+}
+
+// TestSearchVisibleHits_FailsClosedWithoutFieldSearcher pins TKT-NCLA67
+// (gh#1093): when the ACL policy hides fields but the wired searcher cannot
+// redact them, search must REFUSE rather than fall back to un-redacted results.
+//
+// The failure this prevents is silent by construction: a decorator wraps the
+// searcher, the type assertion misses, and search stops redacting while the
+// policy still hides — no error, no log, no test failure. The only signal would
+// be a user seeing a value they should not.
+//
+// search.Visible.SearchVisibleFields already fails closed one layer down for
+// the same reason ("silently skipping redaction is exactly the oracle this
+// closes", RR-8W40EW). This is that principle applied to the outer seam.
+func TestSearchVisibleHits_FailsClosedWithoutFieldSearcher(t *testing.T) {
+	t.Parallel()
+
+	vs := &entityOnlySearcher{}
+	aff := affordanceService{
+		acl:      func() acl.ACL { return acl.NopACL{} },
+		resolver: func() FieldVerdictResolver { return hidingResolver{} },
+	}
+
+	var gotErr error
+	var hits int
+	for _, err := range searchVisibleHits(
+		context.Background(), vs, aff, search.Query{Text: "anything"}, nil,
+	) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		hits++
+	}
+
+	if gotErr == nil {
+		t.Fatalf("want an error when the searcher cannot redact; got %d hit(s) and no error", hits)
+	}
+	// ErrScope specifically: the caller (queryservice) maps it to
+	// errACLListQuery, so it surfaces as an authorization failure rather than
+	// a generic search error.
+	if !errors.Is(gotErr, search.ErrScope) {
+		t.Errorf("want search.ErrScope so the caller reports an ACL failure, got %v", gotErr)
+	}
+	if vs.served {
+		t.Error("un-redacted hits were served before the refusal — the fallback must not run at all")
+	}
+}
+
+// TestSearchVisibleHits_NoRedactionNeededStillWorks pins the other half: when
+// the policy hides nothing, an entity-level-only searcher is CORRECT and must
+// keep working.
+//
+// Without this, "fail closed whenever the searcher isn't a FieldVisibleSearcher"
+// would also pass — and would break every deployment running the Nop resolver,
+// where redaction is a provable no-op.
+func TestSearchVisibleHits_NoRedactionNeededStillWorks(t *testing.T) {
+	t.Parallel()
+
+	vs := &entityOnlySearcher{}
+	aff := affordanceService{
+		acl:      func() acl.ACL { return acl.NopACL{} },
+		resolver: func() FieldVerdictResolver { return NopFieldVerdictResolver{} },
+	}
+
+	var hits int
+	for _, err := range searchVisibleHits(
+		context.Background(), vs, aff, search.Query{Text: "anything"}, nil,
+	) {
+		if err != nil {
+			t.Fatalf("no redaction is in play, so this must not error: %v", err)
+		}
+		hits++
+	}
+	if hits != 1 {
+		t.Errorf("want the entity-level search to serve its hit, got %d", hits)
+	}
+}

--- a/tickets/entities/docs-checklists/DOCS-UJ53MS.md
+++ b/tickets/entities/docs-checklists/DOCS-UJ53MS.md
@@ -1,0 +1,47 @@
+---
+id: DOCS-UJ53MS
+type: docs-checklist
+title: 'Documentation: idp-sync claim validation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — for an example script the comment IS
+the deliverable, so it carries three things the five lines of Lua cannot:
+
+  1. **What it defends against** — a compromised or misconfigured IdP emitting a
+subject containing `/`, `?`, `#` or a newline, which would reshape the outbound
+request path or the entity filter.
+  2. **What it is not** — defence in depth, not the primary control. The JWT is
+already cryptographically verified (ES256, confused-deputy guard via a separate
+audience). Without this sentence someone could read the regex as *the*
+protection and relax the verification.
+  3. **How to change it safely** — widen character by character, never to `.*`,
+and specifically that Auth0's `auth0|abc123` is rejected by the default set.
+Naming the realistic failure is what stops the first person who hits it from
+reaching for `.*`.
+
+- [x] ~~Function/type docs if public API~~ (N/A: a local Lua helper.)
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A)
+- [x] ~~CLAUDE.md updated~~ (N/A: no rela behaviour changes. The
+allowlist-over-blocklist principle this follows is already in the project's
+design-review guidance, with its own worked example.)
+- [x] ~~Help text accurate~~ (N/A: no CLI change)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no CHANGELOG.)
+- [x] User-facing documentation updated — the script's own comment. That is the
+correct and only place: `examples/` is documentation that happens to execute,
+and a note in `docs/` telling readers the example validates its input would be
+read by fewer people than the example itself.
+
+The script's existing header already documents its params and secrets, so the
+new comment sits where a reader adapting the file will encounter it — at the
+guard, not in a preamble they skim.

--- a/tickets/entities/docs-checklists/DOCS-UY46VA.md
+++ b/tickets/entities/docs-checklists/DOCS-UY46VA.md
@@ -1,0 +1,54 @@
+---
+id: DOCS-UY46VA
+type: docs-checklist
+title: 'Documentation: search fail-closed guard'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — and here the comment was the *bug's
+accomplice*, which is the point worth recording.
+
+`searchVisibleHits`'s godoc already **claimed** this guarantee:
+
+> When redaction IS in play but the searcher can't do it, SearchVisibleFields
+> fails closed (it does not silently skip)
+
+True of `SearchVisibleFields` — and irrelevant, because the code returned before
+ever calling it. Anyone auditing this seam would have read that sentence,
+matched it against the intent, and moved on. A comment describing a method you
+don't reach is worse than no comment: it launders the gap.
+
+The godoc now describes what **this function** does, names the failure it
+prevents (a decorator wrapping the searcher without forwarding the method), and
+cites RR-8W40EW so the next reader sees the settled principle rather than
+re-deriving it.
+
+- [x] ~~Function/type docs if public API~~ (N/A: unexported free function.)
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A)
+- [x] ~~CLAUDE.md updated~~ (N/A: applies the existing fail-closed rule rather
+than establishing one. The rule already exists in
+`search.Visible.SearchVisibleFields`'s godoc; this ticket carried it to the seam
+that missed it.)
+- [x] ~~Help text accurate~~ (N/A: no CLI change)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no CHANGELOG; releases come from commit
+history.)
+- [x] ~~API docs updated~~ (N/A, and worth stating why rather than waving
+through: `docs/acl-security.md` documents the **policy model** — what `visible:`
+means, how verdicts resolve, what the read gate promises. This change adds no
+policy surface and no operator-visible configuration; it closes an internal
+wiring hole so the documented promise actually holds. Documenting "the code now
+does what this page already said" would be noise.)
+
+If the guard ever becomes operator-visible — e.g. surfacing as a distinct API
+error code rather than the existing `errACLListQuery` — that *would* belong in
+the guide.

--- a/tickets/entities/implementation-checklists/IMPL-JJW87Q.md
+++ b/tickets/entities/implementation-checklists/IMPL-JJW87Q.md
@@ -1,0 +1,88 @@
+---
+id: IMPL-JJW87Q
+type: implementation-checklist
+title: 'Implementation: Make searchVisibleHits fail closed when the searcher cannot redact fields'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — two in
+`internal/dataentry/search_fail_closed_test.go`.
+- [x] Integration tests written — they drive `searchVisibleHits` with a searcher
+of the exact shape that causes the bug (a `VisibleSearcher` that is not a
+`FieldVisibleSearcher`), rather than asserting on an internal flag.
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — both orders of (policy hides?, searcher
+can redact?) are covered.
+- [x] Error handling in place — yields `search.ErrScope`, the sentinel the caller
+already maps to `errACLListQuery`.
+
+## Test Quality
+
+- [x] Using fixture builders or factories — two small purpose-built doubles; the
+package's app fixtures would drag in a whole App for a two-collaborator free
+function.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter — each double implements exactly the
+method set that makes the type assertion hit or miss.
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*Mutation-verified.* Restoring the fall-through:
+
+```
+--- FAIL: TestSearchVisibleHits_FailsClosedWithoutFieldSearcher
+    want an error when the searcher cannot redact; got 1 hit(s) and no error
+```
+
+The message states the failure in the terms that matter — a hit was served —
+rather than "expected error, got nil".
+
+*The test asserts more than "an error came back".* `entityOnlySearcher` records
+whether it served at all, and the test fails if it did. An implementation that
+yielded an error *after* the fallback had already produced hits would satisfy a
+naive error assertion while still opening the oracle; here the fallback must not
+run at all.
+
+*The negative case is load-bearing.*
+`TestSearchVisibleHits_NoRedactionNeededStillWorks` uses the same non-redacting
+searcher with the Nop resolver and asserts the hit **is** served. Without it,
+"fail closed whenever the searcher isn't a FieldVisibleSearcher" would also pass
+— and would break the default deployment, where the Nop resolver makes redaction
+a provable no-op.
+
+**Gates:** `go test ./...` exit 0; `just lint` 0 issues; arch-lint,
+comment-lint, plimsoll, lint-md clean.
+
+## Quality
+
+- [x] Code follows project patterns — same sentinel (`search.ErrScope`), same
+fail-closed shape and same rationale as `search.Visible.SearchVisibleFields` one
+layer down.
+- [x] Checked for DRY opportunities — the two conditions were **split** rather
+than combined. They looked like one check (`!ok || !hides`) and are two
+different facts: one is a wiring bug, the other is a legitimate no-op.
+Collapsing them is what allowed the bug.
+- [x] No security issues introduced — the change can only refuse where it
+previously served. The error names the searcher's Go type, not policy content or
+entity data: a wiring diagnostic, not a description of what was hidden.
+- [x] No silent failures — that is the entire ticket.
+- [x] No debug code left behind.
+
+**A confidently-wrong comment was corrected.** The godoc already *claimed* this
+guarantee — *"When redaction IS in play but the searcher can't do it,
+SearchVisibleFields fails closed"* — while the code returned before ever
+reaching `SearchVisibleFields`. The doc described the intended behaviour of a
+method that was never called. It now describes what this function does, and
+cites RR-8W40EW for why.

--- a/tickets/entities/implementation-checklists/IMPL-V8XQ3S.md
+++ b/tickets/entities/implementation-checklists/IMPL-V8XQ3S.md
@@ -1,0 +1,84 @@
+---
+id: IMPL-V8XQ3S
+type: implementation-checklist
+title: 'Implementation: idp-sync example: validate webhook claims before interpolating them'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] ~~Unit tests written~~ (N/A: an example Lua script; the repo has no test
+harness for `examples/`. The pattern itself WAS verified — see evidence.)
+- [x] ~~Integration tests written~~ (N/A: same)
+- [x] Happy path implemented — an allowlist regex on both identifiers, before
+either interpolation site.
+- [x] Edge cases from planning handled — see the verification table.
+- [x] Error handling in place — returns the script's existing structured error
+shape (`message_type = "error"`), matching the two validation failures already
+above it, rather than erroring in a new way.
+
+## Test Quality
+
+- [x] ~~Fixture builders~~ (N/A)
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+The pattern is the whole change, so it was executed against a real `lua`
+interpreter rather than eyeballed — a Lua character class is easy to get subtly
+wrong, and a too-narrow one silently rejects legitimate users:
+
+| input | accepted | note |
+|---|---|---|
+| `user@example.com` | ✅ | email subjects |
+| `a-b_c.d` | ✅ | slugs |
+| `01H8XGJ` | ✅ | ULIDs / UUIDs |
+| `ABC-123` | ✅ | |
+| `../etc/passwd` | ❌ | path traversal |
+| `a/b` | ❌ | path segment injection |
+| `a?b`, `a#b` | ❌ | query / fragment injection |
+| `a b` | ❌ | space |
+| `a\nb` | ❌ | newline |
+| `` (empty) | ❌ | already caught above, belt-and-braces |
+| `auth0\|abc123` | ❌ | **see below** |
+
+All twelve behaved as intended.
+
+**The Auth0 case is called out in the comment rather than accommodated.**
+`auth0|abc123` is a common real subject format and this pattern rejects it. That
+is a deliberate default: `|` is harmless in a path, but widening the set to
+"characters that happen to be safe today" is how an allowlist decays into a
+blocklist. The comment names the case, says to widen the pattern if your IdP
+issues such subjects, and says to do it character by character — never `.*`.
+
+## Quality
+
+- [x] Code follows project patterns — reuses the script's existing structured
+error return; no new failure mechanism.
+- [x] Checked for DRY opportunities — one `valid_id` helper covering both
+identifiers, rather than two inline matches.
+- [x] No security issues introduced — this **adds** a control. Allowlist, not
+blocklist, per the project's own design-review guidance.
+- [x] No silent failures — an invalid identifier returns a named error rather
+than being silently dropped or sanitized into something else.
+- [x] No debug code left behind.
+
+**Scope note.** This is defence in depth, not the primary control: the webhook
+JWT is already cryptographically verified (ES256, with a confused-deputy guard
+via a separate audience), which is why the issue rates it Low. The comment says
+so, so nobody reads the check as *the* protection and relaxes the JWT
+verification.
+
+The reason it is still worth doing: this is an **example**, and examples get
+copied. Whoever adapts it inherits whatever it models.

--- a/tickets/entities/planning-checklists/PLAN-3ULDLM.md
+++ b/tickets/entities/planning-checklists/PLAN-3ULDLM.md
@@ -1,0 +1,162 @@
+---
+id: PLAN-3ULDLM
+type: planning-checklist
+title: 'Planning: idp-sync example: validate webhook claims before interpolating them'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** `examples/idp-sync.lua` interpolates `org_id` and `user_id` from
+the webhook JWT straight into an outbound request path and an entity query, with
+no validation. GitHub issue #1083 (IB-review rela#1069), severity Low.
+
+**Scope — IN:** allowlist validation of both identifiers before either
+interpolation, with a comment explaining the reasoning and how to widen it.
+
+**Scope — OUT:**
+
+- Anything in rela core. This is an example script; the JWT verification it
+depends on is core and is not in question.
+- A general Lua string-escaping helper. Tempting, but this is one script with two
+interpolation sites, and a shared helper would need a policy on what "safe"
+means for paths versus filters versus bodies.
+
+**Acceptance Criteria:**
+
+1. Identifiers containing `/`, `?`, `#`, whitespace or newlines are rejected
+before reaching either interpolation site.
+2. Ordinary identifier shapes (UUID, ULID, email, slug) are accepted.
+3. The rejection uses the script's existing structured error return, not a new
+failure mechanism.
+
+## Research
+
+- [x] For larger features: run `/research`
+- [x] Searched for existing libraries
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — a five-line guard in an example.
+
+**Existing Solutions:** the script already has two guard clauses in the same
+shape (missing secrets, missing params), each returning `{ message_type =
+"error", message = ... }`. The new check follows them so the script has one
+failure idiom rather than two.
+
+The project's design-review guidance is explicit that an allowlist beats a
+blocklist here — its own worked example is *"Use allowlist (alphanumeric +
+hyphen + underscore) instead of blocklist"*.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:** a `valid_id` helper matching `^[%w._@%-]+$`, applied to
+both identifiers immediately after the existing empty-check.
+
+**Files to modify:** `examples/idp-sync.lua`.
+
+**Alternatives considered:**
+
+1. *Percent-encode instead of reject.* Rejected — encoding turns a malformed
+identifier into a *different* valid one and the sync silently targets the wrong
+record. Rejecting is louder and correct.
+2. *Only document the risk, per the issue's second suggestion.* Rejected — the
+issue offers "validate or document", and validation is five lines. A comment
+telling the reader to add validation is worse than the validation.
+3. *Blocklist the dangerous characters.* Rejected — see the project's own
+guidance; the next unexpected character is the one you did not list.
+
+**Dependencies:** none — plain Lua patterns, no library.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** `org_id` / `user_id` from the verified webhook
+JWT. Validation is an **allowlist** on the whole string, anchored at both ends.
+
+**Security-Sensitive Operations:** two interpolation sites — an outbound
+operator-API request path, and an entity filter string. Both are now unreachable
+with an identifier outside the set.
+
+*What this is and is not.* Defence in depth, not the primary control: the JWT is
+cryptographically verified (ES256, confused-deputy guard via a separate
+audience), which is why the finding is Low. The comment says so, so nobody reads
+the regex as the protection and relaxes the verification. What it defends
+against is a compromised or misconfigured IdP emitting an unexpected subject —
+the case where the primary control is intact but its output is not what was
+assumed.
+
+**Error handling:** the message names the failing condition without echoing the
+offending value, so a hostile identifier cannot be reflected into an operator's
+logs or UI.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:** the repo has no test harness for `examples/`, so the pattern
+was executed against a real `lua` interpreter over a twelve-case table rather
+than reasoned about. A Lua character class is easy to get subtly wrong, and a
+too-narrow one silently rejects legitimate users — a failure mode that would
+only surface in someone else's production.
+
+**Edge Cases:** path traversal (`../etc/passwd`), path separator, query and
+fragment characters, space, newline, empty, and the realistic `auth0|abc123` —
+which the default set rejects, deliberately, with the comment naming it.
+
+**Negative Tests:** the six rejection cases in that table.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+| Risk | Mitigation |
+|---|---|
+| Pattern too narrow → legitimate subjects rejected in someone's deployment | Verified against real identifier shapes; the comment names Auth0's format and says how to widen |
+| Someone widens it to `.*` to make an error go away | The comment says to widen character by character and never to `.*`, and says what the point is |
+| Read as *the* control, leading to relaxed JWT verification | The comment states it is defence in depth and names the primary control |
+
+**Effort:** xs
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] The comment in the script itself IS the documentation — this is example
+code, where the surrounding prose is the deliverable as much as the code.
+- [x] ~~docs/ guides~~ (N/A: no rela behaviour changes; the example's own header
+already documents its params and secrets.)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: five lines in
+an example, with the allowlist-over-blocklist decision already made by the
+project's own guidance. The one judgement call — reject rather than encode — is
+recorded under Alternatives.)
+- [x] All critical/significant findings addressed in plan — none raised.
+
+**Design Review Findings:** N/A.

--- a/tickets/entities/planning-checklists/PLAN-UBRFEY.md
+++ b/tickets/entities/planning-checklists/PLAN-UBRFEY.md
@@ -1,0 +1,168 @@
+---
+id: PLAN-UBRFEY
+type: planning-checklist
+title: 'Planning: Make searchVisibleHits fail closed when the searcher cannot redact fields'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** `searchVisibleHits` degrades silently when the wired
+`visibleSearcher` does not satisfy `search.FieldVisibleSearcher` — it falls back
+to `SearchVisible`, which does no field redaction, **even when the active policy
+hides fields**. No error, no log. GitHub issue #1093 (IB-review rela#1089).
+
+**Scope — IN:** make the `!ok` branch fail closed, plus a regression test for
+that specific path.
+
+**Scope — OUT:**
+
+- The `!aff.hidesAnyField()` branch. That is a **different** case and must keep
+falling through: if the policy hides nothing, redaction is a provable no-op and
+plain `SearchVisible` is correct. Conflating the two would break every
+deployment on the Nop resolver.
+- Anything about the timing exposure of redaction (that is #1094 / TKT-VR5U3Q).
+
+**Acceptance Criteria:**
+
+1. Policy hides fields + searcher cannot redact → the iterator yields
+`search.ErrScope` and serves **no hits**.
+2. Policy hides nothing + searcher cannot redact → unchanged; hits are served.
+3. The error is `ErrScope` specifically, so the caller maps it to
+`errACLListQuery` rather than a generic search failure.
+
+## Research
+
+- [x] For larger features: run `/research`
+- [x] Searched for existing libraries
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the correct shape already exists one layer down.
+
+**Existing Solutions:** `search.Visible.SearchVisibleFields` settled this exact
+question (RR-8W40EW). Its godoc:
+
+> If a hidden func is supplied but this Visible has no provenance source, the
+> method FAILS CLOSED — it yields ErrScope rather than silently returning
+> un-redacted hits. A missing provenance source is a wiring bug ... and silently
+> skipping redaction is exactly the oracle this closes.
+
+So this ticket is not a design decision; it is carrying a settled principle to
+the seam that was missed. Using the same sentinel (`ErrScope`) matters: the
+caller in `queryservice.go` already special-cases it into `errACLListQuery`.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:** reorder the two conditions so the cheap "nothing to
+redact" case returns first, then refuse when redaction is in play but the
+searcher cannot do it. The error names the concrete searcher type (`%T`) so the
+wiring bug is diagnosable from the message.
+
+**Files to modify:** `internal/dataentry/helpers.go`, plus a test.
+
+**Alternatives considered:**
+
+1. *Log a warning and continue.* Rejected — this is the fail-open the issue is
+about. A warning in a server log is not a control.
+2. *Panic at wiring time.* Tempting (it is a wiring bug), but the assertion
+happens per-request, not at construction, so there is no wiring-time seam to
+panic from without restructuring how the searcher is held.
+3. *Make `FieldVisibleSearcher` mandatory on the interface.* Rejected as bigger
+than the issue: every `VisibleSearcher` implementation would have to grow the
+method, including ones for which redaction is meaningless.
+
+**Dependencies:** none new.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** none new — this changes a failure mode, not an
+input path.
+
+**Security-Sensitive Operations:** the whole ticket. The property being restored
+is that a **wiring** mistake cannot silently become a **disclosure**. The
+direction of the change is strictly safe: it can only refuse where it previously
+served.
+
+One detail worth stating: the error text names the searcher's Go type, not any
+policy content or entity data. It is a wiring diagnostic for an operator reading
+a server error, not a description of what was hidden.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+
+- **AC1** — a `VisibleSearcher` that deliberately does NOT implement
+`FieldVisibleSearcher` (the shape a cache/metrics/tracing decorator produces),
+with a resolver that reports it can hide. Assert `ErrScope`, and assert the
+fallback **never ran** — the double records whether it served, because "an error
+was returned" is not the same as "no un-redacted hit escaped".
+- **AC2** — the same searcher with the Nop resolver: hits are served, no error.
+Without this, "fail closed whenever the searcher isn't a FieldVisibleSearcher"
+would also pass and would break the default deployment.
+- **AC3** — `errors.Is(err, search.ErrScope)`.
+
+**Edge Cases:** the two conditions are now independent, which is the point — the
+test table covers both orders of (hides?, can-redact?).
+
+**Negative Tests:** AC2 is the negative test.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+| Risk | Mitigation |
+|---|---|
+| Over-refusing breaks the Nop-resolver default | AC2 pins it; the "nothing to redact" check runs first |
+| An error was returned but a hit already escaped | The test double records whether it served at all |
+| The change is reverted later as "defensive" | The godoc now cites RR-8W40EW and names the oracle |
+
+**Effort:** s
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `searchVisibleHits`'s godoc — it previously **claimed** this guarantee
+("When redaction IS in play but the searcher can't do it, SearchVisibleFields
+fails closed") while the code returned before ever reaching that method.
+Corrected to describe what the function itself does.
+- [x] ~~docs/acl-security.md~~ (N/A: the guide describes the policy model; this
+is an internal wiring guard with no operator-visible configuration.)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the design is
+quoted verbatim from `search.Visible.SearchVisibleFields`, which settled it one
+layer down. The only judgement call — keeping `hidesAnyField` as a legitimate
+fall-through — is recorded under Scope.)
+- [x] All critical/significant findings addressed in plan — none raised.
+
+**Design Review Findings:** N/A.

--- a/tickets/entities/review-checklists/REV-6LC57O.md
+++ b/tickets/entities/review-checklists/REV-6LC57O.md
@@ -1,0 +1,67 @@
+---
+id: REV-6LC57O
+type: review-checklist
+title: 'Review: Make searchVisibleHits fail closed when the searcher cannot redact fields'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` exit 0.
+- [x] Lint clean (`just lint`) — 0 issues.
+- [x] Comment lint gate clean (`just comment-lint`) — clean.
+- [x] Coverage maintained (`just coverage-check`) — adds tests, removes none.
+- [x] `just arch-lint`, `just plimsoll`, `just lint-md` — clean.
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ — self-reviewed. The change is a
+three-line reorder plus a refusal branch, quoted from a settled precedent one
+layer down, and the property that needed proving (the fallback does not run at
+all) was established by mutation.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — none raised.
+- [x] Self-reviewed the diff for unrelated changes — two files, both intended.
+
+**Review Responses:** none.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — fails closed. PASS.** Mutation-verified: restoring the fall-through
+yields `got 1 hit(s) and no error`. The test also asserts the fallback never
+ran, so an implementation that errored *after* serving would still fail.
+- **AC2 — the no-redaction case still works. PASS.** Same non-redacting searcher
+with the Nop resolver serves its hit. This is what stops the fix from breaking
+the default deployment.
+- **AC3 — `ErrScope` specifically. PASS.** The caller in `queryservice.go` maps
+it to `errACLListQuery`, so the refusal surfaces as an authorization failure
+rather than a generic search error.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal wiring
+guard, no operator-visible configuration or behaviour. The one doc change is a
+godoc correction, covered in the implementation checklist.)
+- [x] ~~User-facing documentation updated~~ (N/A: same reason)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — the godoc now says what the function
+does rather than what a method it never called does, and cites RR-8W40EW so the
+next person sees the principle rather than re-deriving it.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design.)

--- a/tickets/entities/review-checklists/REV-GJ4ZN3.md
+++ b/tickets/entities/review-checklists/REV-GJ4ZN3.md
@@ -1,0 +1,78 @@
+---
+id: REV-GJ4ZN3
+type: review-checklist
+title: 'Review: idp-sync example: validate webhook claims before interpolating them'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` exit 0 (unaffected: no Go
+code changed).
+- [x] Lint clean (`just lint`) — 0 issues.
+- [x] Comment lint gate clean (`just comment-lint`) — clean.
+- [x] Coverage maintained (`just coverage-check`) — no Go code changed.
+- [x] `just arch-lint`, `just plimsoll`, `just lint-md` — clean.
+
+Note the repo has **no linter or test harness for `examples/`**, so none of the
+above actually exercises this change. That is why the pattern was executed
+against a real `lua` interpreter — see the implementation checklist. Worth
+knowing when reviewing: the gates being green says nothing about this diff.
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ — self-reviewed. Five lines of Lua in an
+example script; the only thing worth checking is whether the pattern is right,
+and that was established by running it over a twelve-case table rather than by
+reading it.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — none raised.
+- [x] Self-reviewed the diff for unrelated changes — one file.
+
+**Review Responses:** none.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — dangerous characters rejected. PASS.** `../etc/passwd`, `a/b`, `a?b`,
+`a#b`, `a b`, `a\nb` all rejected.
+- **AC2 — ordinary identifiers accepted. PASS.** Emails, slugs, ULIDs, uppercase
+ids all accepted.
+- **AC3 — existing error shape. PASS.** Returns
+`{ message_type = "error", message = ... }`, matching the two guard clauses
+already above it.
+
+**One deliberate rejection is worth flagging to a reviewer:** `auth0|abc123`, a
+common real subject format, does **not** pass. That is intentional — `|` is
+harmless in a path, but adding characters because they happen to be safe today
+is how an allowlist decays into a blocklist. The comment names the case and says
+to widen the pattern character by character if your IdP needs it.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: `kind=docs`, and
+the change *is* documentation — the comment in the example is the deliverable as
+much as the five lines of code.)
+- [x] User-facing documentation updated — the comment states why the check
+exists, that it is defence in depth rather than the primary control (so nobody
+relaxes the JWT verification), and how to widen it safely.
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A — the example's own comment.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — which for an example is the whole
+point: the next person copies this file, and now copies the guard with it.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design.)

--- a/tickets/entities/tickets/TKT-KX0DPZ.md
+++ b/tickets/entities/tickets/TKT-KX0DPZ.md
@@ -1,0 +1,36 @@
+---
+id: TKT-KX0DPZ
+type: ticket
+title: 'idp-sync example: validate webhook claims before interpolating them'
+kind: docs
+priority: low
+effort: xs
+status: done
+---
+
+## Description
+
+`examples/idp-sync.lua` interpolates `org_id` and `user_id` — taken from the
+verified webhook JWT — straight into an outbound request path and an entity
+query with no validation:
+
+```lua
+local path = "/api/v1/orgs/" .. org .. "/members/" .. uid
+local found = rela.list_entities("person", "sub=" .. uid)
+```
+
+GitHub issue #1083 (IB-review rela#1069). Severity: low — the JWT is
+cryptographically verified (ES256, with a confused-deputy guard via a separate
+audience), and this is an **example** script, so the blast radius is whoever
+adapts it.
+
+But that is exactly why it matters: an example is copied. A compromised or
+misconfigured IdP emitting a `sub` containing `/`, `?`, `#` or a newline would
+reshape the request path or the filter, and anyone who reused the script
+inherits that.
+
+## Fix
+
+An allowlist regex on both identifiers before interpolation, with a comment
+explaining why it is there and how to widen it safely — including that some IdPs
+(Auth0's `auth0|abc123`) issue subjects the default set rejects.

--- a/tickets/entities/tickets/TKT-NCLA67.md
+++ b/tickets/entities/tickets/TKT-NCLA67.md
@@ -1,0 +1,49 @@
+---
+id: TKT-NCLA67
+type: ticket
+title: Make searchVisibleHits fail closed when the searcher cannot redact fields
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+`searchVisibleHits` (`internal/dataentry/helpers.go`) degrades silently when the
+wired `visibleSearcher` does not satisfy `search.FieldVisibleSearcher`:
+
+```go
+fvs, ok := vs.(search.FieldVisibleSearcher)
+if !ok || !aff.hidesAnyField() {
+    return vs.SearchVisible(ctx, q, scope)   // no field redaction, no error
+}
+```
+
+A future decorator — a cache, a metrics wrapper, a tracing shim — that wraps the
+searcher without forwarding `SearchVisibleFields` makes the type assertion miss,
+and search silently stops redacting fields **even when the active ACL policy
+hides them**. No error, no log.
+
+GitHub issue #1093 (IB-review rela#1089, finding 1). Severity: low, because the
+`visible:` affordances are not yet in production.
+
+## The precedent this misses
+
+The same failure mode was identified and made fail-closed **one layer down**, in
+`search.Visible.SearchVisibleFields` (RR-8W40EW). Its godoc is explicit:
+
+> If a hidden func is supplied but this Visible has no provenance source ... the
+> method FAILS CLOSED — it yields ErrScope rather than silently returning
+> un-redacted hits. A missing provenance source is a wiring bug ... and silently
+> skipping redaction is exactly the oracle this closes.
+
+So the principle is already settled in this codebase; it simply was not carried
+to the outer seam. The two decision points are the same shape and should behave
+the same way.
+
+## Note on the second condition
+
+`!aff.hidesAnyField()` is a **different** case and must keep falling through: if
+the policy hides nothing, there is nothing to redact and plain `SearchVisible`
+is correct. Only the `!ok` half is a wiring bug.

--- a/tickets/entities/tickets/TKT-VR5U3Q.md
+++ b/tickets/entities/tickets/TKT-VR5U3Q.md
@@ -1,0 +1,49 @@
+---
+id: TKT-VR5U3Q
+type: ticket
+title: Decide and document the timing exposure of property-level field redaction
+kind: docs
+priority: medium
+effort: s
+status: backlog
+---
+
+## Description
+
+Entity-level ACL visibility is pushed entirely into SQL, and the ACL-security
+guide says why: *"hidden rows never leave the database ... there is no
+hidden-row work to measure through timing."*
+
+Property-level `visible:` redaction does **not** follow that rule. For pgstore
+the per-field match runs in Go over the already-scanned entity, explicitly not
+pushed into SQL — documented in `visiblesearch.go` as *"a tracked performance
+follow-up, not a correctness gap"*. The generic bleve/linear path has the same
+shape. So per-candidate work varies with whether an entity has hidden fields for
+the requester: the same category of observable difference the entity-level
+design deliberately avoided, framed only as performance.
+
+GitHub issue #1094 (IB-review rela#1089, finding 2). Severity: low **because
+`visible:` is not yet in production** — a reduction that expires when it ships.
+
+## Why this is a decision, not a fix
+
+The obvious move (SQL pushdown) is already tracked as a perf item and would
+narrow the pg window without closing it — result-set size and count stay
+observable wherever the matching happens — and does nothing for the default
+build. Constant-time redaction means doing the hidden-field work for every
+candidate on every search.
+
+Whether a per-property timing oracle crosses the line depends on what `visible:`
+is meant to defend against. Rela already treats entity *existence* as the secret
+worth protecting hardest while stating that property *names* are not secret at
+all, so the answer is not obvious from the existing threat model.
+
+Options, costs and a recommendation are in
+`.ignored/issue-round/DISCUSS-1094-timing-sidechannel.md`.
+
+## Minimum outcome
+
+Whatever is decided, the guide's entity-level *"no hidden-row work to measure
+through timing"* claim needs a qualifying sentence. As written a reader
+reasonably concludes the whole ACL is timing-safe, which is the actively
+misleading part rather than merely the incomplete one.

--- a/tickets/relations/TKT-KX0DPZ--affects--lua-scripting.md
+++ b/tickets/relations/TKT-KX0DPZ--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KX0DPZ
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-KX0DPZ--has-docs--DOCS-UJ53MS.md
+++ b/tickets/relations/TKT-KX0DPZ--has-docs--DOCS-UJ53MS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KX0DPZ
+relation: has-docs
+to: DOCS-UJ53MS
+---

--- a/tickets/relations/TKT-KX0DPZ--has-implementation--IMPL-V8XQ3S.md
+++ b/tickets/relations/TKT-KX0DPZ--has-implementation--IMPL-V8XQ3S.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KX0DPZ
+relation: has-implementation
+to: IMPL-V8XQ3S
+---

--- a/tickets/relations/TKT-KX0DPZ--has-planning--PLAN-3ULDLM.md
+++ b/tickets/relations/TKT-KX0DPZ--has-planning--PLAN-3ULDLM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KX0DPZ
+relation: has-planning
+to: PLAN-3ULDLM
+---

--- a/tickets/relations/TKT-KX0DPZ--has-review--REV-GJ4ZN3.md
+++ b/tickets/relations/TKT-KX0DPZ--has-review--REV-GJ4ZN3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KX0DPZ
+relation: has-review
+to: REV-GJ4ZN3
+---

--- a/tickets/relations/TKT-KX0DPZ--implements--FEAT-YIOF.md
+++ b/tickets/relations/TKT-KX0DPZ--implements--FEAT-YIOF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-KX0DPZ
+relation: implements
+to: FEAT-YIOF
+---

--- a/tickets/relations/TKT-NCLA67--affects--authorization.md
+++ b/tickets/relations/TKT-NCLA67--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NCLA67
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-NCLA67--has-docs--DOCS-UY46VA.md
+++ b/tickets/relations/TKT-NCLA67--has-docs--DOCS-UY46VA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NCLA67
+relation: has-docs
+to: DOCS-UY46VA
+---

--- a/tickets/relations/TKT-NCLA67--has-implementation--IMPL-JJW87Q.md
+++ b/tickets/relations/TKT-NCLA67--has-implementation--IMPL-JJW87Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NCLA67
+relation: has-implementation
+to: IMPL-JJW87Q
+---

--- a/tickets/relations/TKT-NCLA67--has-planning--PLAN-UBRFEY.md
+++ b/tickets/relations/TKT-NCLA67--has-planning--PLAN-UBRFEY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NCLA67
+relation: has-planning
+to: PLAN-UBRFEY
+---

--- a/tickets/relations/TKT-NCLA67--has-review--REV-6LC57O.md
+++ b/tickets/relations/TKT-NCLA67--has-review--REV-6LC57O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NCLA67
+relation: has-review
+to: REV-6LC57O
+---

--- a/tickets/relations/TKT-NCLA67--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-NCLA67--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NCLA67
+relation: implements
+to: FEAT-PPH1EU
+---

--- a/tickets/relations/TKT-VR5U3Q--affects--authorization.md
+++ b/tickets/relations/TKT-VR5U3Q--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VR5U3Q
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-VR5U3Q--implements--FEAT-PPH1EU.md
+++ b/tickets/relations/TKT-VR5U3Q--implements--FEAT-PPH1EU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VR5U3Q
+relation: implements
+to: FEAT-PPH1EU
+---


### PR DESCRIPTION
Closes #1093, #1083.

## `searchVisibleHits` failed open — TKT-NCLA67, closes #1093

```go
fvs, ok := vs.(search.FieldVisibleSearcher)
if !ok || !aff.hidesAnyField() {
    return vs.SearchVisible(ctx, q, scope)   // no field redaction, no error
}
```

A future decorator — cache, metrics, tracing — wrapping the searcher without forwarding `SearchVisibleFields` makes the assertion miss, and search **silently stops redacting fields while the policy still hides them**. No error, no log. The only signal is a user seeing a value they shouldn't.

**The principle was already settled one layer down.** `search.Visible.SearchVisibleFields` fails closed for exactly this, and its godoc says why:

> A missing provenance source is a wiring bug ... and silently skipping redaction is exactly the oracle this closes.

This carries that to the seam that missed it.

**The two conditions are now split rather than combined.** They looked like one check and are two different facts: a searcher that cannot redact is a *wiring bug*; a policy that hides nothing is a *legitimate no-op* that must keep falling through. Collapsing them is what allowed the bug — and keeping them separate is what stops the fix from breaking every deployment on the Nop resolver, which is the second test.

**The godoc was part of the problem.** It already claimed this guarantee:

> When redaction IS in play but the searcher can't do it, SearchVisibleFields fails closed

True of `SearchVisibleFields` — and irrelevant, because the code returned before ever calling it. Anyone auditing the seam would have read that, matched it against the intent, and moved on. It now describes what *this function* does.

## `examples/idp-sync.lua` validates its claims — TKT-KX0DPZ, closes #1083

`org_id` / `user_id` went from the verified webhook JWT straight into an outbound request path and an entity filter. Defence in depth rather than the primary control — the JWT is cryptographically verified, which is why the finding is Low — but **examples get copied**, and whoever adapts it inherits what it models.

An allowlist, not a blocklist, per the project's own design-review guidance. The comment states what it defends against, that it is *not* the primary control (so nobody relaxes the JWT verification), and how to widen it safely.

## Verification

The fail-closed change is mutation-verified — restoring the fall-through gives:

```
want an error when the searcher cannot redact; got 1 hit(s) and no error
```

The test asserts more than "an error came back": the searcher double records whether it served *at all*, so an implementation that errored **after** producing hits would still fail. Returning an error having already opened the oracle is not fixing it.

The Lua pattern was executed against a real `lua` interpreter over twelve cases rather than eyeballed — a character class is easy to get subtly wrong, and a too-narrow one silently rejects legitimate users in someone else's production. `auth0|abc123` is rejected by the default set, deliberately, and the comment names it.

- `go test ./...` exit 0 · `just lint` 0 issues · arch-lint, comment-lint, plimsoll, lint-md clean

Note there is **no linter or test harness for `examples/`**, so the green gates say nothing about that half of the diff — hence the interpreter run.

---

Also filed from this batch: **#1094** (timing side-channel in property-level redaction) is real and unaddressed, but asks for a risk-acceptance decision rather than a code change — the guide currently implies the whole ACL is timing-safe when only the entity-level half is. Written up in `.ignored/issue-round/DISCUSS-1094-timing-sidechannel.md` with four options; tracked as TKT-VR5U3Q.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
