### PR TITLE
test(acl): pin empty FromType against a type-scoped policy (TKT-ZJXO19)

### DIFF
--- a/internal/entitymanager/acl_empty_fromtype_test.go
+++ b/internal/entitymanager/acl_empty_fromtype_test.go
@@ -1,0 +1,219 @@
+package entitymanager_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// TestCreateRelation_EmptyFromType_AgainstTypeScopedPolicy pins TKT-ZJXO19
+// (gh#1129): a relation write whose SOURCE ENTITY DOES NOT EXIST must never be
+// authorized more permissively than the same write with the real source type.
+//
+// # Why this needs its own test
+//
+// CreateRelation computes a best-effort — possibly empty — FromType before the
+// ACL check, so authorization does not depend on peer existence (BUG-K6FEVB).
+// The existing regression tests cover that only against ReadOnlyACL (denies
+// everything) and NopACL (allows everything). Neither is type-scoped, so
+// neither can show what an EMPTY FromType does against a realistic acl.yaml
+// with specific per-type grants — which is the only configuration where the
+// question has an answer.
+//
+// The reasoning that this is safe holds: grantsVerb matches `t == "*" ||
+// t == target`, so an empty target can only hit a wildcard grant (already
+// permissive without the change) or a literal empty-string grant (not a real
+// configuration). But that was PROSE. Nothing failed if a future change to
+// grantsVerb, or to how FromType is derived, made "" match something it should
+// not — and the ACL has been in production since 2026-07-07.
+//
+// The table pairs each policy with both source states so the comparison is
+// direct: for every policy, absent-source must be no more permissive than
+// present-source.
+//
+// # What this does and does not catch
+//
+// Honest scope, established by mutation rather than assumed. Substituting "*"
+// for an empty FromType inside authorizeRelationWrite — the concrete bypass
+// shape the issue imagines — is caught only by the `create: [""]` row, because
+// with a realistic `create: [decision]` grant an empty type fails to match
+// either way. Catching the wildcard substitution on a realistic grant would
+// need a client-baseline ceiling (the one mechanism that denies a type a role
+// holds `*` on), which is a different subsystem and belongs with the ceiling's
+// own tests.
+//
+// What this test DOES pin is the property the issue asked for: across every
+// realistic grant shape, an unresolvable source is never authorized where the
+// resolved one is refused — and the one configuration where that is untrue is
+// named, not silently absent.
+func TestCreateRelation_EmptyFromType_AgainstTypeScopedPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// create is the role's `create:` grant list. The relation gate keys on
+		// the SOURCE ENTITY's type (see acl.authorizeRelationWrite), not the
+		// relation type — so these are entity types, which is exactly why an
+		// unresolvable source is the interesting case.
+		create []string
+		// wantWithSource: allowed when the source entity EXISTS, so FromType
+		// resolves to "decision".
+		wantWithSource bool
+		// wantWithoutSource: allowed when the source is ABSENT, so FromType is
+		// "". Must never be true where wantWithSource is false — except in the
+		// one case flagged below.
+		wantWithoutSource bool
+		// exemptFromInvariant marks the single configuration where an absent
+		// source IS more permissive than a present one. It exists only for a
+		// grant nobody can write by accident; see that case's comment.
+		exemptFromInvariant bool
+	}{
+		{
+			// The realistic grant. Present source matches "decision" and is
+			// allowed; absent source yields "" which matches nothing, so it
+			// fails CLOSED — more restrictive, never more permissive.
+			name:              "grant on the source entity type",
+			create:            []string{"decision"},
+			wantWithSource:    true,
+			wantWithoutSource: false,
+		},
+		{
+			name:              "no grant",
+			create:            []string{},
+			wantWithSource:    false,
+			wantWithoutSource: false,
+		},
+		{
+			// A grant on a different entity type must not leak: "" must not
+			// make an unrelated grant match.
+			name:              "grant on a different entity type",
+			create:            []string{"requirement"},
+			wantWithSource:    false,
+			wantWithoutSource: false,
+		},
+
+		{
+			// The ONE case where an empty type matches, and the point of
+			// including it: a wildcard grant was already permissive before
+			// this code path existed, so allowing it here adds nothing. This
+			// is the whole of grantsVerb's `t == "*"` branch.
+			name:              "wildcard grant",
+			create:            []string{"*"},
+			wantWithSource:    true,
+			wantWithoutSource: true,
+		},
+		{
+			// The other theoretical match from the prose: a literal
+			// empty-string grant. Not a realistic acl.yaml — you cannot write
+			// `create: [""]` by accident — but it is the second half of the
+			// claim, so it is pinned rather than assumed. If this ever became
+			// reachable from a real config, THIS is the case that would need
+			// re-examining.
+			name:                "literal empty-string grant (not a real config)",
+			create:              []string{""},
+			wantWithSource:      false,
+			wantWithoutSource:   true,
+			exemptFromInvariant: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotWith := createRelationAllowed(t, tc.create, true)
+			gotWithout := createRelationAllowed(t, tc.create, false)
+
+			if gotWith != tc.wantWithSource {
+				t.Errorf("source present: allowed=%v, want %v", gotWith, tc.wantWithSource)
+			}
+			if gotWithout != tc.wantWithoutSource {
+				t.Errorf("source absent (empty FromType): allowed=%v, want %v",
+					gotWithout, tc.wantWithoutSource)
+			}
+			// The invariant that actually matters, asserted independently of
+			// the expectations above: an absent source may never be allowed
+			// where a present source is denied.
+			//
+			// The `create: [""]` case is the sole exemption, and finding it is
+			// half the value of this test. The issue's prose named it as a
+			// theoretical match ("a literal empty-string grant — no realistic
+			// acl.yaml configuration"); running it confirms the behavior is
+			// real rather than hypothetical. It stays exempt rather than
+			// "fixed" because no operator can write that grant by accident:
+			// `create: [""]` is a deliberate, visible act in the policy file.
+			// If empty-string grants ever became reachable another way — a
+			// generator, a migration, a template — this exemption is where to
+			// start.
+			if gotWithout && !gotWith && !tc.exemptFromInvariant {
+				t.Errorf("BYPASS: an absent source entity was authorized where the real " +
+					"source type was denied — an empty FromType must only ever be more restrictive")
+			}
+			if tc.exemptFromInvariant && (!gotWithout || gotWith) {
+				t.Error("the empty-string-grant exemption no longer applies; if the ACL " +
+					"stopped honoring `create: [\"\"]`, delete the exemption and this case")
+			}
+		})
+	}
+}
+
+// createRelationAllowed reports whether CreateRelation passes the ACL gate for
+// a role holding the given `create:` grants, with the source entity either
+// seeded or absent.
+//
+// It distinguishes an ACL denial from the not-found error that follows it: when
+// the source is absent the write cannot succeed regardless, so "allowed" means
+// "got past authorization", which is the thing under test. ErrEntityNotFound
+// is reached only after the gate.
+func createRelationAllowed(t *testing.T, createGrants []string, seedSource bool) bool {
+	t.Helper()
+
+	st := memstore.New()
+	bg := context.Background()
+	// The target always exists, so a failure is never about the peer.
+	if err := st.CreateEntity(bg, entity.New("REQ-001", "requirement")); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if seedSource {
+		if err := st.CreateEntity(bg, entity.New("DEC-001", "decision")); err != nil {
+			t.Fatalf("seed source: %v", err)
+		}
+	}
+
+	d, err := acl.NewDeclarative(&acl.Policy{
+		Roles:       map[string]acl.RoleDef{"writer": {Create: createGrants}},
+		Assignments: map[string]string{"alice": "writer"},
+	}, acl.NewStoreGraph(st), st)
+	if err != nil {
+		t.Fatalf("acl.NewDeclarative: %v", err)
+	}
+
+	mgr, err := entitymanager.New(entitymanager.Deps{
+		Store:       st,
+		Meta:        parseMeta(t),
+		Templater:   nopTemplater{},
+		Audit:       audit.Nop{},
+		ACL:         d,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+	})
+	if err != nil {
+		t.Fatalf("entitymanager.New: %v", err)
+	}
+
+	ctx := principal.With(bg, principal.Principal{User: "alice", Tool: principal.ToolDataEntry})
+	_, wErr := mgr.CreateRelation(ctx, "DEC-001", "addresses", "REQ-001", entity.RelationOptions{})
+
+	// A ForbiddenError means the gate refused. Anything else — including the
+	// not-found error for an absent source — means it got through.
+	var fe *acl.ForbiddenError
+	return !errors.As(wErr, &fe)
+}

--- a/tickets/entities/implementation-checklists/IMPL-NC60BV.md
+++ b/tickets/entities/implementation-checklists/IMPL-NC60BV.md
@@ -1,0 +1,98 @@
+---
+id: IMPL-NC60BV
+type: implementation-checklist
+title: 'Implementation: Regression test for empty FromType against a type-scoped policy'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — this ticket IS a test; there is no
+production change.
+- [x] Integration tests written — the table drives the real
+`Manager.CreateRelation` against a real `acl.Declarative`, not `grantsVerb` in
+isolation. That matters: half the concern is how `FromType` is *derived*, which
+a policy-level test would skip entirely.
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — five grant shapes, each with and
+without the source entity.
+- [x] ~~Error handling in place~~ (N/A: test-only)
+
+## Test Quality
+
+- [x] Using fixture builders or factories — the package's `parseMeta`,
+`nopTemplater` and the `acl.NewDeclarative` pattern from
+`cascade_authz_test.go`.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter — one role, one assignment, one grant
+list per row.
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*The first version of this test was wrong, and finding out why is most of the
+value.* I granted `create: [addresses]` — the **relation** type — and every row
+failed. Reading `authorizeRelationWrite` rather than adjusting the expectations
+showed the gate keys on the **source entity's** type:
+
+> A relation create checks the source type's `create` grant (consistent with
+> entity create).
+
+Had I "fixed" the expectations instead, the test would have passed while
+asserting a model of the ACL that does not exist.
+
+*A real finding, kept rather than smoothed over.* With `create: [""]` — a
+literal empty-string grant — an **absent** source is authorized while a
+**present** one is denied. That is the one configuration where the invariant
+genuinely does not hold. The issue's prose named it as theoretical ("no
+realistic acl.yaml configuration"); running it confirms the behaviour is real.
+
+It is documented and exempted rather than fixed, and the exemption is asserted
+in **both directions**: the test also fails if the exemption stops applying. So
+it cannot decay into a permanent excuse — if the ACL ever rejects empty-string
+grants, this test says to delete the exemption.
+
+*Mutation testing established the honest scope, and it is narrower than I first
+claimed.* Substituting `"*"` for an empty `FromType` inside
+`authorizeRelationWrite` — the concrete bypass shape — reddens **only** the
+`create: [""]` row. With a realistic `create: [decision]` grant, an empty type
+fails to match either way, so those rows cannot see it.
+
+I initially added a "discriminating case" (`update: ["*"]`, no `create` grant)
+believing it would catch the substitution. It did not — `grantsVerb` reads the
+verb's own list, so a wildcard on `update` is invisible to an `OpCreate` check.
+**I removed it rather than keep a case whose comment claimed a property it did
+not have.** Reaching that substitution on a realistic grant needs a
+client-baseline ceiling, which is a different subsystem; the test's doc says so.
+
+**Gates:** `go test ./...` exit 0; `just lint` 0 issues (it caught a De Morgan
+simplification); arch-lint, comment-lint, plimsoll clean.
+
+## Quality
+
+- [x] Code follows project patterns — table-driven with `t.Run` subtests and
+`t.Parallel()`, per CLAUDE.md.
+- [x] Checked for DRY opportunities — one helper runs both source states, so
+each row declares only what differs. `UpdateRelation`/`DeleteRelation` were
+deliberately NOT added: they share `authorizeRelationWrite` and the same
+derivation, so a per-verb copy would triple the table to re-exercise one
+function.
+- [x] No security issues introduced — a test.
+- [x] No silent failures — the directional invariant is asserted *separately*
+from the per-row expectations, so a row whose `want` values are wrong still
+cannot hide a bypass.
+- [x] No debug code left behind.
+
+**Why the assertion is directional.** It checks "absent is never more permissive
+than present", not specific verdicts. A test pinning exact verdicts would pass
+while the policy model changed underneath it; the direction is the property the
+issue actually cares about and the one that survives a `grantsVerb` refactor.

--- a/tickets/entities/planning-checklists/PLAN-M43BQF.md
+++ b/tickets/entities/planning-checklists/PLAN-M43BQF.md
@@ -1,0 +1,193 @@
+---
+id: PLAN-M43BQF
+type: planning-checklist
+title: 'Planning: Regression test for empty FromType against a type-scoped policy'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** `CreateRelation` computes a best-effort — possibly empty —
+`FromType` before the ACL check, so authorization does not depend on peer
+existence (BUG-K6FEVB). The existing tests cover that only against
+`acl.ReadOnlyACL` (denies all) and `acl.NopACL` (allows all). Neither is
+type-scoped, so neither can show what an empty `FromType` does against a
+realistic `acl.yaml`. GitHub issue #1129 (IB-review rela#1115), CONTROL-5-15.
+
+The safety argument exists and looks right — but as **prose**. Nothing fails if
+a future change to `grantsVerb`, or to how `FromType` is derived, makes `""`
+match something it should not. The ACL has been in production since 2026-07-07.
+
+**Scope — IN:** a table test over realistic grant shapes, asserting an
+unresolvable source is never authorized where the resolved one is refused.
+
+**Scope — OUT:**
+
+- Any production change. The behaviour is believed correct; this pins it.
+- `UpdateRelation` / `DeleteRelation`. They share `authorizeRelationWrite` and
+the same `FromType` derivation, so a per-verb copy would triple the table to
+re-exercise one function. If they ever diverge, that is when to split.
+- Client-baseline ceilings — see the Test Plan for why the one bypass shape they
+would cover is out of reach here.
+
+**Acceptance Criteria:**
+
+1. For every realistic grant shape, absent-source is never *more* permissive
+than present-source.
+2. The realistic grant (`create: [decision]`) is allowed with the source and
+**denied without** — the fail-closed claim, stated positively.
+3. Any configuration where the invariant does not hold is **named in the test**,
+not silently absent from the table.
+
+## Research
+
+- [x] For larger features: run `/research`
+- [x] Searched for existing libraries
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — one table test.
+
+**Existing Solutions:** `internal/entitymanager/acl_bypass_test.go` and
+`internal/dataentry/acl_relation_write_bypass_test.go` are the tests the issue
+says are insufficient — and it is right about why: both use all-or-nothing ACLs.
+`acl_test.go`'s `newManagerWithACL` and `cascade_authz_test.go`'s
+`acl.NewDeclarative` pattern give the type-scoped setup they lack.
+
+**The load-bearing find — the issue's mental model of the gate is slightly off,
+and so was mine.** `authorizeRelationWrite` keys the type-level gate on the
+**source entity's type**, not the relation type:
+
+> Type-level gate: principal needs the matching verb grant on the source
+> entity's type. A relation create checks the source type's `create` grant
+> (consistent with entity create).
+
+My first table granted `create: [addresses]` (the relation type) and every row
+failed. Reading the gate rather than adjusting the expectations is what produced
+a table that tests the real model.
+
+The same function already documents the exact property under test:
+
+> Four of the five RelationSubject call sites leave it empty when the source
+> entity is missing or unreadable, and today that fails closed because no role
+> lists "". Honoring a relation grant on an empty FromType would silently turn
+> "source unresolvable ⇒ deny" into "⇒ allow".
+
+So this ticket converts a comment into a gate.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:** a table over grant shapes; each row runs
+`CreateRelation` twice — source seeded and source absent — against a real
+`acl.Declarative`. A helper distinguishes an ACL denial (`*acl.ForbiddenError`)
+from the not-found error that follows it, so "allowed" means "got past the
+gate", which is the thing under test.
+
+**Files to modify:** `internal/entitymanager/acl_empty_fromtype_test.go` (new).
+
+**Alternatives considered:**
+
+1. *Assert on `acl.Request` directly.* Rejected — it would test `grantsVerb` in
+isolation and miss the derivation of `FromType`, which is half the concern.
+2. *Extend an existing bypass test.* Rejected — those are about the elevated
+handle; this is about type scoping, and merging them makes both harder to read.
+3. *Fix the empty-string-grant case.* Rejected — see AC3 and the Risk table.
+
+**Dependencies:** none new.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** none — a test.
+
+**Security-Sensitive Operations:** the subject is an authorization decision, so
+the framing matters: the test asserts a **direction** (never more permissive),
+not a specific verdict. A test asserting exact verdicts would pass while the
+policy model changed underneath it; a directional invariant is what survives a
+refactor of `grantsVerb`.
+
+The `create: [""]` finding is real behaviour, not a vulnerability: it requires
+an operator to write an empty-string grant deliberately in `acl.yaml`. It is
+documented in the test rather than fixed, because the fix (rejecting empty
+strings at policy load) is a separate change with its own migration question for
+existing policies.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:** five rows — grant on the source type, no grant, grant on a
+different type, wildcard, and the literal empty-string grant — each run with and
+without the source entity.
+
+**Edge Cases:** the wildcard row is included precisely because it is the one
+realistic shape where an empty type *does* match, and to record that it was
+already that permissive before this code path existed.
+
+**Negative Tests:** the invariant assertion is the negative test, and it fires
+independently of the per-row expectations — so a row whose expectations are
+wrong still cannot hide a bypass.
+
+**Scope of what mutation testing can reach here (established, not assumed):**
+substituting `"*"` for an empty `FromType` inside `authorizeRelationWrite` is
+caught only by the `create: [""]` row, because with `create: [decision]` an
+empty type fails to match either way. Catching that substitution on a realistic
+grant needs a client-baseline ceiling — the one mechanism that denies a type a
+role holds `*` on — which is a different subsystem. That limit is written into
+the test's doc rather than left for a reader to discover.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+| Risk | Mitigation |
+|---|---|
+| The test encodes my model of the gate rather than the gate | It did, at first — every row failed. Fixed by reading `authorizeRelationWrite`, not by adjusting expectations |
+| A row's expectations are wrong, hiding a bypass | The directional invariant is asserted separately from the per-row wants |
+| The empty-string exemption silently becomes wrong | Asserted in BOTH directions: the test fails if the exemption stops applying, so it cannot rot into a permanent excuse |
+| A reader over-trusts the coverage | The doc states which bypass shape it cannot reach, and why |
+
+**Effort:** s
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] ~~All user-facing docs~~ (N/A: `kind=test`, no behaviour or surface change)
+- [x] The test's own doc comment carries the finding — that `create: [""]` is a
+real (if unwritable-by-accident) exemption — since that is the one piece of new
+knowledge this ticket produced.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: adding a test
+for stated, unchanged behaviour. The judgement calls — directional invariant
+over exact verdicts; document the empty-string case rather than fix it — are
+recorded under Alternatives and Security.)
+- [x] All critical/significant findings addressed in plan — none raised.
+
+**Design Review Findings:** N/A.

--- a/tickets/entities/review-checklists/REV-BLT0PT.md
+++ b/tickets/entities/review-checklists/REV-BLT0PT.md
@@ -1,0 +1,85 @@
+---
+id: REV-BLT0PT
+type: review-checklist
+title: 'Review: Regression test for empty FromType against a type-scoped policy'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` exit 0.
+- [x] Lint clean (`just lint`) — 0 issues (caught a De Morgan simplification).
+- [x] Comment lint gate clean (`just comment-lint`) — clean.
+- [x] Coverage maintained (`just coverage-check`) — adds a test, removes none.
+- [x] `just arch-lint`, `just plimsoll` — clean.
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ — self-reviewed. One new test file, no
+production change. The property worth checking — does the table actually test
+the ACL as it exists — was established by the test failing first against my
+wrong model, and by mutation for the coverage claim.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — none raised.
+- [x] Self-reviewed the diff for unrelated changes — one file.
+
+**Review Responses:** none.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — never more permissive. PASS**, with one named exemption (below). The
+invariant is asserted separately from each row's expectations, so a row with
+wrong `want` values still cannot conceal a bypass.
+- **AC2 — the realistic grant fails closed. PASS.** `create: [decision]` is
+allowed with the source present and **denied** with it absent — the claim stated
+positively rather than inferred from an absence of failures.
+- **AC3 — exemptions named, not hidden. PASS.** `create: [""]` authorizes an
+absent source while denying a present one. Real behaviour, requiring an operator
+to write an empty-string grant deliberately. Asserted in **both directions** so
+it fails if the exemption stops applying — it cannot rot into a permanent
+excuse.
+
+**Two things this ticket got wrong first, both recorded rather than smoothed
+over:**
+
+1. The initial table granted the **relation** type and every row failed. The gate
+keys on the **source entity's** type. Fixed by reading `authorizeRelationWrite`,
+not by adjusting expectations to match a green run — which would have shipped a
+test asserting an ACL model that does not exist.
+2. A "discriminating case" I added believing it would catch the wildcard
+substitution did not, because `grantsVerb` reads the verb's own list. Removed
+rather than kept with a comment claiming a property it lacked.
+
+The test's doc now states which bypass shape it **cannot** reach (the wildcard
+substitution on a realistic grant needs a client-baseline ceiling, a different
+subsystem) so a reader does not over-trust the coverage.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: `kind=test`, no
+behaviour or surface change. The one piece of new knowledge — the `create: [""]`
+exemption — lives in the test's own doc comment, which is where someone auditing
+this control will look.)
+- [x] ~~User-facing documentation updated~~ (N/A: same reason)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** N/A — test-only.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — the test converts an existing prose
+guarantee in `authorizeRelationWrite` into a gate, and names both its exemption
+and its blind spot.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design.)

--- a/tickets/entities/tickets/TKT-ZJXO19.md
+++ b/tickets/entities/tickets/TKT-ZJXO19.md
@@ -1,0 +1,40 @@
+---
+id: TKT-ZJXO19
+type: ticket
+title: Regression test for empty FromType against a type-scoped policy
+kind: test
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+`CreateRelation` computes a best-effort — possibly empty — `FromType` **before**
+the ACL check, so authorization does not depend on whether the source entity
+exists yet (BUG-K6FEVB). The existing regression tests exercise that only
+against `acl.ReadOnlyACL` (denies everything) and `acl.NopACL` (allows
+everything). Neither is type-scoped, so neither can show what an empty
+`FromType` does against a realistic `acl.yaml`-shaped policy with specific
+per-type grants.
+
+GitHub issue #1129 (IB-review rela#1115). Basis: CONTROL-5-15; the rela ACL has
+been in production since 2026-07-07.
+
+## The claim under test
+
+Code inspection of `grantsVerb` says an empty `FromType` can only match a
+wildcard grant (`t == "*"`, already permissive without the change) or a literal
+empty-string grant (not a realistic configuration) — so it can only ever be
+*more* restrictive than the real type, never more permissive.
+
+That reasoning looks right. But it is currently **prose only**: nothing fails if
+a future change to `grantsVerb`, or to how `FromType` is derived, makes an empty
+type match something it should not.
+
+## Scope
+
+A test that calls the relation write paths with a **non-existent source entity**
+against a policy with specific (non-wildcard) type grants, and asserts the
+outcome is never *more* permissive than the same call with the correct
+`FromType`.

--- a/tickets/relations/TKT-ZJXO19--affects--authorization.md
+++ b/tickets/relations/TKT-ZJXO19--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZJXO19
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-ZJXO19--has-implementation--IMPL-NC60BV.md
+++ b/tickets/relations/TKT-ZJXO19--has-implementation--IMPL-NC60BV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZJXO19
+relation: has-implementation
+to: IMPL-NC60BV
+---

--- a/tickets/relations/TKT-ZJXO19--has-planning--PLAN-M43BQF.md
+++ b/tickets/relations/TKT-ZJXO19--has-planning--PLAN-M43BQF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZJXO19
+relation: has-planning
+to: PLAN-M43BQF
+---

--- a/tickets/relations/TKT-ZJXO19--has-review--REV-BLT0PT.md
+++ b/tickets/relations/TKT-ZJXO19--has-review--REV-BLT0PT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZJXO19
+relation: has-review
+to: REV-BLT0PT
+---

--- a/tickets/relations/TKT-ZJXO19--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-ZJXO19--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZJXO19
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Closes #1129.

## Why

`CreateRelation` computes a best-effort — possibly empty — `FromType` **before** the ACL check, so authorization doesn't depend on whether the source entity exists yet (BUG-K6FEVB).

The existing regression tests cover that only against `acl.ReadOnlyACL` (denies everything) and `acl.NopACL` (allows everything). Neither is type-scoped, so neither can show what an empty `FromType` does against a realistic `acl.yaml` — which is the only configuration where the question has an answer.

The safety argument exists and holds, but as **prose**. Nothing failed if a change to `grantsVerb`, or to how `FromType` is derived, made `""` match something it shouldn't — and the ACL has been in production since 2026-07-07.

## What

Five grant shapes, each run with and without the source entity. The invariant — *absent-source is never more permissive than present-source* — is asserted **separately** from each row's expectations, so a row whose `want` values are wrong still can't conceal a bypass.

The assertion is directional rather than exact-verdict on purpose: a test pinning specific verdicts would pass while the policy model changed underneath it.

## Two findings worth reading

**The gate keys on the source entity's type, not the relation type.** My first table granted `create: [addresses]` and every row failed. Reading `authorizeRelationWrite` rather than adjusting the expectations is what produced a table that tests the real model — the other way round would have shipped a green test asserting an ACL that doesn't exist.

**`create: [""]` is a real exemption, not a theoretical one.** It authorizes an *absent* source while denying a *present* one. The issue called it "no realistic acl.yaml configuration" — true, you can't write it by accident — so it's documented and **asserted in both directions** rather than fixed: the test also fails if the exemption stops applying, so it can't decay into a permanent excuse.

## Honest scope

Mutation testing established what this does **not** catch, and it's narrower than I first claimed. Substituting `"*"` for an empty `FromType` inside `authorizeRelationWrite` reddens **only** the `create: [""]` row — with a realistic `create: [decision]` grant an empty type fails to match either way.

I initially added a "discriminating case" believing it would catch that. It didn't (`grantsVerb` reads the verb's own list, so a wildcard on `update` is invisible to an `OpCreate` check), so **I removed it** rather than keep a case whose comment claimed a property it lacked. Reaching that substitution on a realistic grant needs a client-baseline ceiling — a different subsystem, and where that test belongs. The test's doc says so.

`UpdateRelation`/`DeleteRelation` deliberately aren't included: they share `authorizeRelationWrite` and the same derivation, so a per-verb copy would triple the table to re-exercise one function.

- `go test ./...` exit 0 · `just lint` 0 issues · arch-lint, comment-lint, plimsoll clean

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
