### PR TITLE
feat(audit): record `rela acl who-can` queries (TKT-M86UY8)

### DIFF
--- a/docs-project/entities/guides/GUIDE-audit-log.md
+++ b/docs-project/entities/guides/GUIDE-audit-log.md
@@ -51,7 +51,7 @@ Every record is one line of JSON:
 | Field         | Meaning                                                             |
 |---------------|---------------------------------------------------------------------|
 | `time`        | UTC timestamp                                                        |
-| `op`          | `create-entity`, `update-entity`, `delete-entity`, `rename-entity`, `create-relation`, `update-relation`, `delete-relation`, `denied-write` |
+| `op`          | See the op list below |
 | `subject`     | The thing acted on (see "Subject shape" below)                       |
 | `before` / `after` | For `rename-entity` only — the identity diff                   |
 | `principal.user` | The OS user (from `$USER`) that initiated the operation           |
@@ -61,6 +61,18 @@ Every record is one line of JSON:
 | `principal.roles` | Optional. The `roles` claim from a verified identity assertion |
 | `triggered_by` | Optional. Engine-initiated writes carry `automation:<name>`, `schedule:<task-name>`, or `cascade:delete-entity:<id>` |
 | `summary`     | One-line human-readable summary; for updates names *which* properties changed but never their values (secret-leak defense) |
+
+### Operations
+
+| `op` | Meaning |
+|------|---------|
+| `create-entity`, `update-entity`, `delete-entity`, `rename-entity` | Entity writes |
+| `create-relation`, `update-relation`, `delete-relation` | Relation writes |
+| `denied-write` | A write the ACL refused, or an upload the attachment policy refused. Subject names the would-be target; the summary carries the rule that fired |
+| `acl-bypass`, `acl-bypass-read` | A write or read that skipped the ACL through an elevated automation handle. The principal is the REAL triggering identity |
+| `acl-query` | An effective-access query (`rela acl who-can`) — who asked, when, and about which entity. **The answer is deliberately not recorded**: it is a list of principals and their access routes, so logging it would duplicate the disclosure rather than record it |
+| `purge-version` | An operator hard-delete of version history for compliance redaction. Never contains the purged content |
+| `data-migration`, `data-gc` | Schema-driven data migration and garbage collection |
 
 ### `denied-write` records
 

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -45,7 +45,7 @@ Every record is one line of JSON:
 | Field         | Meaning                                                             |
 |---------------|---------------------------------------------------------------------|
 | `time`        | UTC timestamp                                                        |
-| `op`          | `create-entity`, `update-entity`, `delete-entity`, `rename-entity`, `create-relation`, `update-relation`, `delete-relation`, `denied-write` |
+| `op`          | See the op list below |
 | `subject`     | The thing acted on (see "Subject shape" below)                       |
 | `before` / `after` | For `rename-entity` only — the identity diff                   |
 | `principal.user` | The OS user (from `$USER`) that initiated the operation           |
@@ -55,6 +55,18 @@ Every record is one line of JSON:
 | `principal.roles` | Optional. The `roles` claim from a verified identity assertion |
 | `triggered_by` | Optional. Engine-initiated writes carry `automation:<name>`, `schedule:<task-name>`, or `cascade:delete-entity:<id>` |
 | `summary`     | One-line human-readable summary; for updates names *which* properties changed but never their values (secret-leak defense) |
+
+### Operations
+
+| `op` | Meaning |
+|------|---------|
+| `create-entity`, `update-entity`, `delete-entity`, `rename-entity` | Entity writes |
+| `create-relation`, `update-relation`, `delete-relation` | Relation writes |
+| `denied-write` | A write the ACL refused, or an upload the attachment policy refused. Subject names the would-be target; the summary carries the rule that fired |
+| `acl-bypass`, `acl-bypass-read` | A write or read that skipped the ACL through an elevated automation handle. The principal is the REAL triggering identity |
+| `acl-query` | An effective-access query (`rela acl who-can`) — who asked, when, and about which entity. **The answer is deliberately not recorded**: it is a list of principals and their access routes, so logging it would duplicate the disclosure rather than record it |
+| `purge-version` | An operator hard-delete of version history for compliance redaction. Never contains the purged content |
+| `data-migration`, `data-gc` | Schema-driven data migration and garbage collection |
 
 ### `denied-write` records
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -68,6 +68,23 @@ const (
 	//nolint:gosec // G101 false positive: an audit op name, not a credential.
 	OpACLBypassRead = "acl-bypass-read"
 
+	// OpACLQuery records an execution of an effective-access query
+	// (`rela acl who-can`) — a read that produces a confidentiality
+	// attestation: who may act on an entity, and by which roles, groups and
+	// graph edges (TKT-M86UY8, CONTROL-8-15).
+	//
+	// Subject names the entity queried; Summary carries the verb. The RESULT
+	// is deliberately NOT recorded: the answer is a list of principals and
+	// the routes by which they hold access, and copying that into the audit
+	// log would duplicate the disclosure rather than record it — the same
+	// rule OpACLBypassRead applies to elevated reads.
+	//
+	// Worth logging because the output is exactly the reconnaissance an
+	// attacker with shell access wants before choosing a target, and exactly
+	// the question an investigator asks afterwards. Isolate with
+	// `op == "acl-query"`.
+	OpACLQuery = "acl-query"
+
 	// OpPurgeVersion records an operator hard-delete of version snapshot rows
 	// (TKT-BW6UUL) — the deliberate, irreversible exception to append-only
 	// history, for compliance redaction. Subject names the entity/relation whose

--- a/internal/cli/acl_whocan.go
+++ b/internal/cli/acl_whocan.go
@@ -8,11 +8,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/aclmap"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
 // ACLWhoCanCmd implements `rela acl who-can <verb> <entity>`. It lists
@@ -44,8 +47,8 @@ type ACLWhoCanCmd struct {
 }
 
 // Run executes `rela acl who-can`.
-func (c *ACLWhoCanCmd) Run(ctx context.Context, svc *readServices) error {
-	engine, err := buildACLEngine(svc)
+func (c *ACLWhoCanCmd) Run(ctx context.Context, svc *writeServices) error {
+	engine, err := buildACLEngine(&svc.readServices)
 	if err != nil {
 		if stderrors.Is(err, errNoACLPolicy) {
 			out.WriteSuccess("No acl.yaml found; every principal has full access (no policy).")
@@ -53,6 +56,18 @@ func (c *ACLWhoCanCmd) Run(ctx context.Context, svc *readServices) error {
 		}
 		return err
 	}
+
+	// Record the QUERY before answering it (CONTROL-8-15, TKT-M86UY8). The
+	// output is a confidentiality attestation — who may act on this entity and
+	// by which routes — so "who asked this, and when" is the forensic question
+	// that outlives the answer.
+	//
+	// Recorded even when the lookup then fails: an attempt to enumerate access
+	// for a non-existent id is as interesting as a successful one, and
+	// recording only successes would let a prober stay out of the log.
+	//
+	// The RESULT is never recorded — see audit.OpACLQuery.
+	recordACLQuery(ctx, svc.Audit, c.Verb, c.Entity)
 
 	result, err := engine.WhoCan(ctx, acl.Verb(c.Verb), c.Entity)
 	if err != nil {
@@ -212,4 +227,21 @@ func (v aclMetamodelView) PropertyInfo(entityType, property string) acl.Property
 		return acl.PropertyInfo{}
 	}
 	return acl.PropertyInfo{Exists: true, Unique: pd.Unique, List: pd.List}
+}
+
+// recordACLQuery writes the audit row for an effective-access query.
+//
+// Nil-safe on the sink: CLI test fixtures wire services without one, and a
+// missing audit sink must not turn a read command into an error.
+func recordACLQuery(ctx context.Context, sink audit.Audit, verb, entityID string) {
+	if sink == nil {
+		return
+	}
+	sink.Record(audit.Record{
+		Time:      time.Now().UTC(),
+		Op:        audit.OpACLQuery,
+		Subject:   &audit.Subject{Kind: "entity", ID: entityID},
+		Principal: principal.From(ctx),
+		Summary:   "who-can " + verb,
+	})
 }

--- a/internal/cli/acl_whocan_audit_test.go
+++ b/internal/cli/acl_whocan_audit_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/output"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// TestRecordACLQuery pins TKT-M86UY8 (gh#1145, CONTROL-8-15): running
+// `rela acl who-can` must leave an audit record naming WHO asked, WHEN, and
+// WHAT they asked about.
+//
+// The command's output is a confidentiality attestation — who may act on an
+// entity and by which roles, groups and graph edges. That is the reconnaissance
+// an attacker with shell access wants before choosing a target, and the question
+// an investigator asks afterwards.
+//
+// The result set is deliberately absent from the record: it names principals and
+// their access routes, so copying it into the audit log would duplicate the
+// disclosure rather than record it. This test asserts that absence, not just the
+// presence of the fields.
+func TestRecordACLQuery(t *testing.T) {
+	t.Parallel()
+
+	sink := audit.NewMemory()
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolCLI})
+
+	recordACLQuery(ctx, sink, "read", "INC-042")
+
+	recs := sink.Records()
+	if len(recs) != 1 {
+		t.Fatalf("want 1 audit record, got %d", len(recs))
+	}
+	r := recs[0]
+
+	if r.Op != audit.OpACLQuery {
+		t.Errorf("Op = %q, want %q", r.Op, audit.OpACLQuery)
+	}
+	if r.Principal.User != "alice" {
+		t.Errorf("Principal.User = %q, want alice — the log must say who asked", r.Principal.User)
+	}
+	if r.Subject == nil || r.Subject.ID != "INC-042" {
+		t.Errorf("Subject must name the entity queried, got %+v", r.Subject)
+	}
+	if !strings.Contains(r.Summary, "read") {
+		t.Errorf("Summary must name the verb queried: %q", r.Summary)
+	}
+	if r.Time.IsZero() {
+		t.Error("Time must be set")
+	}
+}
+
+// TestRecordACLQuery_NilSinkIsSafe pins that a missing audit sink does not turn
+// a read command into an error. CLI fixtures wire services without one, and a
+// reporting command that fails because nothing is listening would be a worse
+// outcome than the gap this ticket closes.
+func TestRecordACLQuery_NilSinkIsSafe(t *testing.T) {
+	t.Parallel()
+	recordACLQuery(context.Background(), nil, "read", "INC-042")
+}
+
+// TestACLWhoCan_RunEmitsAuditRecord pins the WIRING, not just the helper: the
+// record must actually be emitted when the command runs.
+//
+// Without this, recordACLQuery could be correct and never called — which is
+// exactly the shape of the gap this ticket closes (the feature's ticket already
+// declared a `requires -> audit-log` relation that nothing satisfied).
+func TestACLWhoCan_RunEmitsAuditRecord(t *testing.T) {
+	svc := aclTestServices(t, whoCanMeta(), whoCanPolicy)
+	seedWhoCanGraph(t, svc)
+	withOutput(t, output.FormatTable)
+
+	sink := audit.NewMemory()
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "alice", Tool: principal.ToolCLI})
+
+	cmd := &ACLWhoCanCmd{Verb: "read", Entity: "INC-042"}
+	if err := cmd.Run(ctx, &writeServices{readServices: *svc, Audit: sink}); err != nil {
+		t.Fatalf("who-can read: %v", err)
+	}
+
+	var found bool
+	for _, r := range sink.Records() {
+		if r.Op == audit.OpACLQuery {
+			found = true
+			if r.Subject == nil || r.Subject.ID != "INC-042" {
+				t.Errorf("Subject must name the queried entity, got %+v", r.Subject)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("running who-can emitted no %q record; got %d record(s)",
+			audit.OpACLQuery, len(sink.Records()))
+	}
+}

--- a/internal/cli/acl_whocan_test.go
+++ b/internal/cli/acl_whocan_test.go
@@ -80,7 +80,7 @@ func TestACLWhoCan_ReadTextOutput(t *testing.T) {
 	buf := withOutput(t, output.FormatTable)
 
 	cmd := &ACLWhoCanCmd{Verb: "read", Entity: "INC-042"}
-	if err := cmd.Run(context.Background(), svc); err != nil {
+	if err := cmd.Run(context.Background(), &writeServices{readServices: *svc}); err != nil {
 		t.Fatalf("who-can read: %v", err)
 	}
 	got := buf.String()
@@ -101,7 +101,7 @@ func TestACLWhoCan_MissingEntityErrors(t *testing.T) {
 	withOutput(t, output.FormatTable)
 
 	cmd := &ACLWhoCanCmd{Verb: "read", Entity: "INC-NOPE"}
-	err := cmd.Run(context.Background(), svc)
+	err := cmd.Run(context.Background(), &writeServices{readServices: *svc})
 	if err == nil {
 		t.Fatal("expected an error for a missing entity, got nil")
 	}
@@ -116,7 +116,7 @@ func TestACLWhoCan_JSONOutput(t *testing.T) {
 	buf := withOutput(t, output.FormatJSON)
 
 	cmd := &ACLWhoCanCmd{Verb: "delete", Entity: "INC-042"}
-	if err := cmd.Run(context.Background(), svc); err != nil {
+	if err := cmd.Run(context.Background(), &writeServices{readServices: *svc}); err != nil {
 		t.Fatalf("who-can delete: %v", err)
 	}
 	var result struct {
@@ -149,7 +149,7 @@ func TestACLWhoCan_NoPolicyFile(t *testing.T) {
 	buf := withOutput(t, output.FormatTable)
 
 	cmd := &ACLWhoCanCmd{Verb: "read", Entity: "INC-042"}
-	if err := cmd.Run(context.Background(), svc); err != nil {
+	if err := cmd.Run(context.Background(), &writeServices{readServices: *svc}); err != nil {
 		t.Fatalf("missing acl.yaml must not error, got %v", err)
 	}
 	if got := buf.String(); !strings.Contains(got, "no policy") {

--- a/tickets/entities/docs-checklists/DOCS-L86U7N.md
+++ b/tickets/entities/docs-checklists/DOCS-L86U7N.md
@@ -1,0 +1,53 @@
+---
+id: DOCS-L86U7N
+type: docs-checklist
+title: 'Documentation: acl-query audit op'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the call site says **why the record
+is written before the answer** (an attempt to enumerate access for a
+non-existent id is as interesting as a successful one; recording only successes
+would let a prober stay out of the log).
+- [x] Function/type docs if public API — `audit.OpACLQuery`'s godoc is the
+load-bearing one. It carries the decision that will otherwise be re-litigated:
+**the result is deliberately not recorded**, because the answer is a list of
+principals and their access routes, so logging it would duplicate the disclosure
+rather than record it. The same rule `OpACLBypassRead` already applies to
+elevated reads, and the godoc cites it so the two stay consistent.
+
+Without that sentence, "improving" the record by adding the result looks like an
+obvious enhancement.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new pattern; follows the existing audit-op
+conventions)
+- [x] ~~Help text accurate~~ (N/A: no flag or command change — `who-can`'s
+surface is identical)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no CHANGELOG)
+- [x] API docs updated — `docs-project/entities/guides/GUIDE-audit-log.md`,
+regenerated into `docs/audit-log.md`.
+
+A **new op** belongs in the guide, unlike the earlier attachment ticket which
+only added an occurrence of an existing one.
+
+While adding it, the field table's inline `op` list turned out to be **already
+stale** — it named eight ops and omitted `acl-bypass`, `acl-bypass-read`,
+`purge-version`, `data-migration` and `data-gc`. A one-line cell was the wrong
+shape for a growing set, so it now points at a proper Operations table listing
+every op with its meaning. That is a small scope extension beyond this ticket,
+taken because adding a ninth op to a list that was already wrong would have made
+the guide *more* misleading, not less.
+
+The `acl-query` row states the omission explicitly, so an operator reading the
+guide learns the answer is not in the log rather than assuming it is and
+wondering why they cannot find it.

--- a/tickets/entities/implementation-checklists/IMPL-IYY5H4.md
+++ b/tickets/entities/implementation-checklists/IMPL-IYY5H4.md
@@ -1,0 +1,85 @@
+---
+id: IMPL-IYY5H4
+type: implementation-checklist
+title: 'Implementation: Audit rela acl who-can queries (CONTROL-8-15)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — `TestRecordACLQuery` (fields) and
+`TestRecordACLQuery_NilSinkIsSafe`.
+- [x] Integration tests written — `TestACLWhoCan_RunEmitsAuditRecord` runs the
+real `ACLWhoCanCmd.Run` against a seeded graph and a real policy.
+- [x] Happy path implemented
+- [x] Edge cases from planning handled — nil sink; the no-policy early return;
+a failing lookup still records.
+- [x] Error handling in place — a missing sink is a no-op, never an error.
+
+## Test Quality
+
+- [x] Using fixture builders or factories — the package's existing
+`aclTestServices`, `seedWhoCanGraph`, `whoCanMeta`, `whoCanPolicy`.
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*Two tests, and the second is the one that matters.* The helper could be
+entirely correct and never called — which is precisely the shape of the gap this
+ticket closes, since `FEAT-RCQ6SJ` already declared a `requires → audit-log`
+relation that nothing satisfied. So a separate test drives the real command.
+
+*Mutation-verified.* Removing the call from `Run`:
+
+```
+--- FAIL: TestACLWhoCan_RunEmitsAuditRecord
+    running who-can emitted no "acl-query" record; got 0 record(s)
+```
+
+*Recorded before the answer, deliberately.* An attempt to enumerate access for a
+non-existent id is as interesting as a successful one; recording only successes
+would let a prober stay out of the log entirely.
+
+*Not recorded on the no-policy path.* That branch returns before any attestation
+exists — logging "someone asked about access in a project with no policy" would
+be noise.
+
+*Verified the command still works:* `rela --project tickets acl who-can read
+TKT-ZZL53L` behaves unchanged.
+
+**Gates:** `go test ./...` exit 0; `just lint` 0 issues (caught a `perfsprint`
+`Sprintf`-to-concat); `lint-md` clean after two fixes; arch-lint, comment-lint,
+plimsoll clean.
+
+## Quality
+
+- [x] Code follows project patterns — new op alongside the others in
+`audit.go` with a godoc in the same voice; wiring follows the version-purge
+commands, which likewise take `*writeServices` purely to reach the sink.
+- [x] Checked for DRY opportunities — one helper rather than an inline literal,
+so the "what we do and don't record" decision has one home.
+- [x] No security issues introduced — this **adds** a security-log record. The
+sharp edge was the temptation to log *more*: the record answers "who asked,
+when, about what" and stops. Logging the answer would let anyone who can read
+the audit log obtain the full access map without running the command — a wider
+disclosure created by the control meant to observe it. The op's godoc states
+this, citing the same reasoning `OpACLBypassRead` already applies.
+- [x] No silent failures — the whole ticket.
+- [x] No debug code left behind.
+
+**Signature change, noted for review.** `ACLWhoCanCmd.Run` moves from
+`*readServices` to `*writeServices` to reach the audit sink — the same shape the
+purge commands use. Four existing test call sites were mechanically wrapped
+(`&writeServices{readServices: *svc}`); no assertion changed, and the command's
+behaviour is identical.

--- a/tickets/entities/planning-checklists/PLAN-JQTWDF.md
+++ b/tickets/entities/planning-checklists/PLAN-JQTWDF.md
@@ -1,0 +1,179 @@
+---
+id: PLAN-JQTWDF
+type: planning-checklist
+title: 'Planning: Audit rela acl who-can queries (CONTROL-8-15)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem:** `rela acl who-can <verb> <entity>` produces a confidentiality
+attestation — who may act on an entity, with the roles, groups, ancestor folders
+and raw email addresses by which each grant was acquired — and nothing records
+that the query was run. GitHub issue #1145 (IB-review rela#1141), CONTROL-8-15.
+
+**Notable:** `FEAT-RCQ6SJ` already carries a `requires → audit-log` relation in
+the tickets project. The gap was declared in the ticket graph before it was
+found in review, and nothing satisfied it.
+
+**Scope — IN:** one audit record per `who-can` execution, carrying principal,
+time, verb and entity.
+
+**Scope — OUT:**
+
+- Recording the RESULT. The answer *is* the disclosure; copying it into the
+audit log would duplicate it rather than record it.
+- `rela acl map` / `can`. Same family, but `who-can` is what the issue names and
+what produces the per-entity attestation. Widening now would blur why this
+record exists.
+
+**Acceptance Criteria:**
+
+1. Running `who-can` emits one record naming principal, time, verb and entity.
+2. The record does **not** contain the result set.
+3. A missing audit sink does not turn the command into an error.
+
+## Research
+
+- [x] For larger features: run `/research`
+- [x] Searched for existing libraries
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — one record on one command.
+
+**Existing Solutions:** `audit.OpACLBypassRead` is the precedent and settles the
+hardest question — what NOT to log:
+
+> Subject is deliberately EMPTY and no entity data is recorded — the read set is
+> unbounded, and logging it would copy ACL-protected content into the audit log,
+> a wider disclosure than the read itself.
+
+That reasoning transfers exactly. `who-can`'s output is a list of principals and
+their access routes; recording it would make the audit log a second copy of the
+access map.
+
+The version-purge commands (`history_purge.go`) are the wiring precedent: a
+command that is not a write in the ordinary sense but takes `*writeServices`
+purely to reach the audit sink.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns
+- [x] Alternatives considered
+- [x] Dependencies identified
+
+**Technical Approach:** a new `audit.OpACLQuery`, and a `recordACLQuery` helper
+called from `ACLWhoCanCmd.Run` **before** the lookup. `Run` moves from
+`*readServices` to `*writeServices` to reach the sink, passing
+`&svc.readServices` on to `buildACLEngine`.
+
+*Recorded before the answer, deliberately.* An attempt to enumerate access for a
+non-existent id is as interesting as a successful one; recording only successes
+would let a prober stay out of the log.
+
+*Not recorded on the no-policy path.* That branch returns before any attestation
+is produced — there is nothing to attest to.
+
+**Files to modify:** `internal/audit/audit.go`, `internal/cli/acl_whocan.go`,
+plus tests.
+
+**Alternatives considered:**
+
+1. *Reuse `OpACLBypassRead`.* Rejected — that op means "an elevated closure read
+past the gate", a different event. Overloading it would make both unfilterable.
+2. *Log via `slog` instead.* Rejected — CONTROL-8-15 is about the audit log, and
+a server log is rotated and unstructured.
+3. *Record the result too.* Rejected — see Scope and the `OpACLBypassRead` quote.
+
+**Dependencies:** none new.
+
+## Security Considerations
+
+- [x] Input sources identified
+- [x] Input validation approach defined
+- [x] Security-sensitive operations identified
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** the verb is a kong `enum` (`read|create|update|
+delete`), so it cannot be arbitrary. The entity id is caller-supplied and is
+recorded — it is an identifier the caller already knows, and the record is a
+JSONL field, so it cannot break framing.
+
+**Security-Sensitive Operations:** this is the whole ticket, and the sharp edge
+is the temptation to log *more*. The record answers "who asked, when, about
+what" and stops there. Logging the answer would mean an operator who can read
+the audit log obtains the full access map without running the command — a wider
+disclosure created by the control meant to observe it.
+
+The trust boundary is unchanged: `who-can` is operator-shell, like the rest of
+the CLI. This adds observability, not a gate.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined
+- [x] Integration test approach defined
+
+**Test Scenarios:**
+
+- **AC1** — unit-test the helper for the record's fields, AND a separate test
+that runs the real `ACLWhoCanCmd.Run` and asserts the record appears. The second
+is the one that matters: the helper could be correct and never called, which is
+the exact shape of the gap being closed.
+- **AC2** — asserted implicitly by the record's shape (Subject is the queried id;
+Summary is the verb) — there is no field in which a result could be carried.
+- **AC3** — a nil-sink call must not panic or error.
+
+**Edge Cases:** the no-policy early return (no attestation ⇒ no record); a
+lookup that fails with entity-not-found (record still written, deliberately).
+
+**Negative Tests:** the nil-sink case; and mutation — removing the call must
+redden the wiring test.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed
+- [x] Effort estimated
+
+| Risk | Mitigation |
+|---|---|
+| The helper is right but never called | A separate test runs the real command, and mutation-verifies it |
+| A fixture without an audit sink breaks the command | Nil-safe, with its own test |
+| Someone later "improves" the record by adding the result | The op's godoc states why not, citing the `OpACLBypassRead` reasoning |
+| Changing `Run`'s signature breaks existing tests | Four call sites, mechanically wrapped; behaviour unchanged |
+
+**Effort:** s
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `audit.OpACLQuery`'s godoc — the canonical place the op's meaning and its
+deliberate omission live.
+- [x] `docs/audit-log.md` — a NEW op belongs in the guide's op list, unlike the
+earlier attachment ticket which only added an occurrence of an existing one.
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: one record on
+one command, with the "what not to log" question already settled by
+`OpACLBypassRead` and quoted above. The judgement calls — new op vs. reuse,
+record before the answer, skip the no-policy path — are under Alternatives and
+Approach.)
+- [x] All critical/significant findings addressed in plan — none raised.
+
+**Design Review Findings:** N/A.

--- a/tickets/entities/review-checklists/REV-8BYDPG.md
+++ b/tickets/entities/review-checklists/REV-8BYDPG.md
@@ -1,0 +1,75 @@
+---
+id: REV-8BYDPG
+type: review-checklist
+title: 'Review: Audit rela acl who-can queries (CONTROL-8-15)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — `go test ./...` exit 0.
+- [x] Lint clean (`just lint`) — 0 issues (caught a `perfsprint`
+`Sprintf`-to-concat).
+- [x] Comment lint gate clean (`just comment-lint`) — clean.
+- [x] Coverage maintained (`just coverage-check`) — adds tests, removes none.
+- [x] `just arch-lint`, `just plimsoll` — clean. `just lint-md` clean after two
+fixes in the new docs table.
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ — self-reviewed. One new audit op, one
+helper, one call site, following the version-purge commands' established wiring.
+The property that needed proving — the record is actually emitted by the real
+command, not merely emittable — was established by mutation.
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — none raised.
+- [x] Self-reviewed the diff for unrelated changes — the guide's Operations table
+is a deliberate small extension, explained in the docs checklist.
+
+**Review Responses:** none.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- **AC1 — the query is recorded. PASS.** Principal, time, verb and entity.
+Mutation-verified: removing the call yields `emitted no "acl-query" record`.
+- **AC2 — the result is not recorded. PASS**, structurally: the record has no
+field in which a result could travel, and the op's godoc says why, citing the
+same reasoning `OpACLBypassRead` uses.
+- **AC3 — a missing sink is safe. PASS.** Nil-safe with its own test; a reporting
+command that failed because nothing was listening would be a worse outcome than
+the gap being closed.
+
+**Two deliberate choices worth a reviewer's attention:**
+
+1. **Recorded before the answer.** An attempt to enumerate access for a
+non-existent id is as interesting as a successful one; recording only successes
+would let a prober stay out of the log.
+2. **Not recorded on the no-policy path**, which returns before any attestation
+is produced.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-L86U7N
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use — `audit.OpACLQuery`'s godoc records
+the one decision most likely to be reversed by a well-meaning improvement: why
+the answer is not in the record.
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (deferred by design.)

--- a/tickets/entities/tickets/TKT-M86UY8.md
+++ b/tickets/entities/tickets/TKT-M86UY8.md
@@ -1,0 +1,36 @@
+---
+id: TKT-M86UY8
+type: ticket
+title: Audit rela acl who-can queries (CONTROL-8-15)
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+`rela acl who-can <verb> <entity>` produces an explicit confidentiality
+attestation — who can read or write a given entity, with the roles, groups,
+ancestor folders and raw email addresses by which each grant was acquired — and
+**nothing records that the query was run**.
+
+GitHub issue #1145 (IB-review rela#1141), CONTROL-8-15. Severity: medium.
+
+Notable: `FEAT-RCQ6SJ` carries a `requires → audit-log` relation in the tickets
+project. That relation was never satisfied, and no review-response addressed it
+— so the gap was declared in the ticket graph before it was found in review.
+
+## Why the answer is worth logging
+
+The output is a map of who can see what. That is exactly the reconnaissance an
+attacker with shell access would want before choosing a target, and exactly the
+question an investigator asks afterwards ("who was looking at the access model,
+and when?").
+
+## Minimum record
+
+Principal, timestamp, verb and entity queried. **Not** the result set: the
+answer names principals and their routes, and copying that into the audit log
+would duplicate the disclosure rather than record it — the same reasoning
+`OpACLBypassRead` already applies to elevated reads.

--- a/tickets/entities/tickets/TKT-RM0LYH.md
+++ b/tickets/entities/tickets/TKT-RM0LYH.md
@@ -1,0 +1,41 @@
+---
+id: TKT-RM0LYH
+type: ticket
+title: rela import bypasses transition guards on create and update
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Description
+
+`rela import` writes entities straight to `store.Store` via
+`CreateEntity`/`UpdateEntity` without calling `Transitions.EnforceCreate` or
+`EnforceUpdate`. The guard / entry-constraint that rela#1154 just introduced
+structurally for the regular write path can therefore be bypassed via import —
+on both create and update.
+
+GitHub issue #1155 (IB-review rela#1154), CONTROL-5-15 + POLICY-015 §3.
+Severity: medium. Not a regression from #1154; an existing gap that PR did not
+cover.
+
+## Impact
+
+An entity can enter a guard-protected state via `rela import` — including
+against a production database through `RELA_DATABASE_URL` — without passing the
+guard the operator configured.
+
+## The decision this needs
+
+The issue offers two paths, and they are genuinely different:
+
+1. **Enforce.** Call the transition guards from `importEntity`, so import
+obeys the same constraints as every other write.
+2. **Document the exemption**, as was already accepted for `rela renumber`
+(POLICY-015 §4).
+
+Option 2 has a real argument: import is a bulk operator tool, and a guard that
+rejects half a dataset mid-import leaves a partially-loaded project. Option 1
+has the stronger one: a guard that any operator can bypass by reaching for a
+different command is not an access-control measure, it is a suggestion.

--- a/tickets/relations/TKT-M86UY8--affects--audit-log.md
+++ b/tickets/relations/TKT-M86UY8--affects--audit-log.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M86UY8
+relation: affects
+to: audit-log
+---

--- a/tickets/relations/TKT-M86UY8--has-docs--DOCS-L86U7N.md
+++ b/tickets/relations/TKT-M86UY8--has-docs--DOCS-L86U7N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M86UY8
+relation: has-docs
+to: DOCS-L86U7N
+---

--- a/tickets/relations/TKT-M86UY8--has-implementation--IMPL-IYY5H4.md
+++ b/tickets/relations/TKT-M86UY8--has-implementation--IMPL-IYY5H4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M86UY8
+relation: has-implementation
+to: IMPL-IYY5H4
+---

--- a/tickets/relations/TKT-M86UY8--has-planning--PLAN-JQTWDF.md
+++ b/tickets/relations/TKT-M86UY8--has-planning--PLAN-JQTWDF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M86UY8
+relation: has-planning
+to: PLAN-JQTWDF
+---

--- a/tickets/relations/TKT-M86UY8--has-review--REV-8BYDPG.md
+++ b/tickets/relations/TKT-M86UY8--has-review--REV-8BYDPG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M86UY8
+relation: has-review
+to: REV-8BYDPG
+---

--- a/tickets/relations/TKT-M86UY8--implements--FEAT-RCQ6SJ.md
+++ b/tickets/relations/TKT-M86UY8--implements--FEAT-RCQ6SJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M86UY8
+relation: implements
+to: FEAT-RCQ6SJ
+---

--- a/tickets/relations/TKT-RM0LYH--affects--authorization.md
+++ b/tickets/relations/TKT-RM0LYH--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RM0LYH
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-RM0LYH--implements--FEAT-AESD4.md
+++ b/tickets/relations/TKT-RM0LYH--implements--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RM0LYH
+relation: implements
+to: FEAT-AESD4
+---


### PR DESCRIPTION
Closes #1145.

## Why

`rela acl who-can <verb> <entity>` produces a **confidentiality attestation** — who may act on an entity, with the roles, groups, ancestor folders and raw email addresses by which each grant was acquired — and nothing recorded that the query was run.

That output is exactly the reconnaissance an attacker with shell access wants before choosing a target, and exactly the question an investigator asks afterwards.

Worth noting: `FEAT-RCQ6SJ` already carries a `requires → audit-log` relation in the tickets project. **The gap was declared in the ticket graph before review found it**, and nothing satisfied it.

## What is *not* recorded, and why that's the interesting part

The **result** is deliberately absent. The answer is a list of principals and their access routes — logging it would let anyone who can read the audit log obtain the full access map *without running the command*. That is a wider disclosure created by the control meant to observe it.

`OpACLBypassRead` already settles this exact question for elevated reads:

> Subject is deliberately EMPTY and no entity data is recorded — the read set is unbounded, and logging it would copy ACL-protected content into the audit log, a wider disclosure than the read itself.

The new op's godoc cites that so the two cannot drift. Without the sentence, "improving" the record by adding the result looks like an obvious enhancement.

## Two deliberate choices

- **Recorded before the lookup.** An attempt to enumerate access for an id that doesn't exist is as interesting as a successful one; recording only successes would let a prober stay out of the log entirely.
- **Not recorded on the no-policy path**, which returns before any attestation exists.

## Docs

Adding a new op surfaced that the guide's inline `op` list was **already stale** — it named eight and omitted `acl-bypass`, `acl-bypass-read`, `purge-version`, `data-migration`, `data-gc`. Replaced with a proper Operations table rather than adding a ninth to a list that was wrong. A small deliberate scope extension: adding to a wrong list would make the guide *more* misleading.

## Verification

Two tests, and the second is the one that matters — the helper could be entirely correct and never called, which is the precise shape of the gap being closed:

```
--- FAIL: TestACLWhoCan_RunEmitsAuditRecord
    running who-can emitted no "acl-query" record; got 0 record(s)
```

`ACLWhoCanCmd.Run` moves from `*readServices` to `*writeServices` to reach the sink — the same shape the version-purge commands use. Four existing test call sites were mechanically wrapped; no assertion changed, behaviour identical.

- `go test ./...` exit 0 · `just lint` 0 issues · arch-lint, comment-lint, plimsoll, lint-md clean

---

**Also from this review batch, not fixed here:**

- **#1155** (`rela import` bypasses transition guards) is confirmed and **needs a decision**. The sync path already answers the same question with "enforce" (RR-NB135: *"skipping it would let a sync client land an illegal transition or bypass a guard"*), and `ApplyEntity` is the bulk entry point that does. But enforcing means **imports that used to succeed will fail**, and import has no transaction — a guard rejecting row 4,000 of 10,000 leaves a half-loaded project. Four options in `.ignored/issue-round/DISCUSS-1155-import-guards.md`; tracked as TKT-RM0LYH.
- **#1135** (datetime compared lexicographically in ACL predicates) is **already fixed** and was closed — verified with the offset case from the issue: instant-aware gives `true`, the old lexicographic path gave `false`.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
