### PR TITLE
fix(dataentry): a staged file satisfies a required file property (BUG-L1DHC5)

### DIFF
--- a/e2e/pages/form.page.ts
+++ b/e2e/pages/form.page.ts
@@ -810,6 +810,34 @@ export class FormPage extends BasePage {
     return (await err.count()) > 0 ? err.innerText() : "";
   }
 
+  /** The inline validation error rendered under a field, or '' when none.
+   *  FieldShell renders `.field-error` for every field type, file included. */
+  async fieldErrorText(property: string): Promise<string> {
+    const err = this.page.locator(`#field-${property}`).locator("xpath=..").locator(".field-error");
+    return (await err.count()) > 0 ? err.first().innerText() : "";
+  }
+
+  /** Click Create and assert NO create request is issued — the client-side
+   *  required gate should stop it. Waits a beat so a POST that was going to
+   *  fire has time to. */
+  async submitExpectingNoCreate(plural: string) {
+    let posted = false;
+    const listener = (r: { url: () => string; method: () => string }) => {
+      // `?dry_run=true` POSTs the same path on every keystroke to re-derive
+      // create-mode affordances — it persists nothing, so it must not count
+      // as a create here.
+      const url = r.url();
+      if (url.includes(`/api/v1/${plural}`) && !url.includes("dry_run") && r.method() === "POST") {
+        posted = true;
+      }
+    };
+    this.page.on("request", listener);
+    await this.submitButton.first().click();
+    await this.page.waitForTimeout(500);
+    this.page.off("request", listener);
+    expect(posted, "a blocked submit must not POST").toBe(false);
+  }
+
   /** Text of the error toast, waited for. Used by the create-with-attachments
    *  failure path, where the entity IS created but an upload was rejected —
    *  the message is the only thing telling the user which files to re-attach. */

--- a/e2e/tests/attachments-create.spec.ts
+++ b/e2e/tests/attachments-create.spec.ts
@@ -131,6 +131,29 @@ test.describe('Attachments on entity create', () => {
     expect(entity.properties.screenshot ?? '').toBe('');
   });
 
+  // BUG-L1DHC5: staged files live outside `formData`, which is where the
+  // required check looks — so before the fix a required file property could
+  // never be satisfied and Create did nothing at all.
+  test.describe('a required file property', () => {
+    test('blocks Create until a file is staged, then goes through', async ({ appPage, api }) => {
+      const formPage = new FormPage(appPage);
+      await formPage.navigateToCreateForm('bug_signoff');
+      await formPage.fillField('title', 'Needs sign-off');
+
+      // No file yet: submitting must not create anything, and must say why.
+      await formPage.submitExpectingNoCreate('signoffs');
+      await expect(appPage).toHaveURL(/\/form\/bug_signoff/);
+      expect(await formPage.fieldErrorText('document')).toContain('required');
+
+      // Staging one satisfies it — the whole point of the fix.
+      await formPage.attachFile('document', 'signed.txt', 'approved');
+      const created = await formPage.submitAndExpectCreateWithUploads('signoffs', 1);
+
+      const entity = await api.getEntity('signoffs', created.id);
+      expect((entity._attachments?.document ?? []).map((f) => f.filename)).toEqual(['signed.txt']);
+    });
+  });
+
   test('creating without touching a file property is unchanged', async ({ appPage, api }) => {
     // The common case by far: it must not gain a request or change behaviour.
     const listPage = new ListPage(appPage);

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -882,6 +882,21 @@ entities:
         type: file
         max: 3
 
+  # BUG-L1DHC5: a dedicated type whose file property is REQUIRED. Separate from
+  # 'bug' on purpose — a required property on a shared type makes every other
+  # test's entity emit a required_property_unset warning.
+  signoff:
+    label: Sign-off
+    id_type: sequential
+    id_prefix: SIGN
+    properties:
+      title:
+        type: string
+        required: true
+      document:
+        type: file
+        required: true
+
   task:
     label: Task
     id_type: sequential
@@ -1097,6 +1112,16 @@ forms:
       # TKT-7K3BJF: exercised by attachments-create.spec.ts.
       - property: screenshot
       - property: evidence
+
+  # BUG-L1DHC5: a form whose file property is REQUIRED. Kept SEPARATE from the
+  # 'bug' form on purpose — adding a required field there would block every
+  # other bug-creation test in the suite.
+  bug_signoff:
+    entity_type: signoff
+    title: "Sign-off"
+    fields:
+      - property: title
+      - property: document
 
   task:
     entity_type: task

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -165,7 +165,8 @@ test.describe('Settings', () => {
 
       await settingsPage.navigateToSettings();
 
-      await settingsPage.expectAppInfo('Entity Types', '7'); // feature, bug, task, tag, decision, module, specification
+      // feature, bug, signoff, task, tag, decision, module, specification
+      await settingsPage.expectAppInfo('Entity Types', '8');
     });
 
     test('shows relation type count', async ({ appPage }) => {
@@ -181,10 +182,10 @@ test.describe('Settings', () => {
 
       await settingsPage.navigateToSettings();
 
-      // feature, bug, task, task_wizard, task_flat_conditional,
+      // feature, bug, bug_signoff, task, task_wizard, task_flat_conditional,
       // task_clear_when_hidden, task_mixed_policies, tag, decision,
       // module, specification
-      await settingsPage.expectAppInfo('Forms', '11');
+      await settingsPage.expectAppInfo('Forms', '12');
     });
 
     test('shows lists count', async ({ appPage }) => {

--- a/frontend/src/components/forms/DynamicForm.attachments.test.ts
+++ b/frontend/src/components/forms/DynamicForm.attachments.test.ts
@@ -42,6 +42,8 @@ vi.mock('@/api', async () => {
         screenshot: '',
         evidence: [],
         needs_evidence: false,
+        // `report.evidence` shares this key; harmless for the bug form.
+
         ...((body as { properties?: Record<string, unknown> })?.properties ?? {}),
       },
       _fields: {},
@@ -119,6 +121,31 @@ const CREATED: Entity = {
   warnings: [],
 }
 
+// A type whose file property is REQUIRED, for the BUG-L1DHC5 regression: the
+// required check reads formData, and staged files deliberately live outside it.
+const REPORT_TYPE = {
+  name: 'report',
+  label: 'Report',
+  id_type: 'sequential',
+  properties: {
+    title: { type: 'string' },
+    evidence: { type: 'file', required: true },
+  },
+}
+
+const REPORT_FORM = {
+  id: 'report-form',
+  entity: 'report',
+  fields: [{ property: 'title' }, { property: 'evidence' }],
+}
+
+const REPORT_CREATED: Entity = {
+  id: 'REP-1',
+  type: 'report',
+  properties: { title: 'r' },
+  warnings: [],
+}
+
 const mounted: VueWrapper[] = []
 
 afterEach(() => {
@@ -136,11 +163,15 @@ async function mountCreate(form: { id: string } = FORM) {
   const schema = useSchemaStore()
   schema.forms.set(FORM.id, FORM as never)
   schema.forms.set(WIZARD_FORM.id, WIZARD_FORM as never)
+  schema.forms.set(REPORT_FORM.id, REPORT_FORM as never)
+  schema.entityTypes.set('report', REPORT_TYPE as never)
   schema.entityTypes.set('bug', ENTITY_TYPE as never)
   schema.loaded = true
 
   const entities = useEntitiesStore()
-  const create = vi.spyOn(entities, 'create').mockResolvedValue(CREATED)
+  const create = vi
+    .spyOn(entities, 'create')
+    .mockResolvedValue(form.id === REPORT_FORM.id ? REPORT_CREATED : CREATED)
 
   const wrapper = mount(DynamicForm, {
     props: { formId: form.id },
@@ -413,6 +444,46 @@ describe('DynamicForm — attachments on create', () => {
 
     expect(create).toHaveBeenCalledTimes(1)
     expect(mockUpload).not.toHaveBeenCalled()
+  })
+
+  describe('a required file property (BUG-L1DHC5)', () => {
+    it('blocks submit until a file is staged', async () => {
+      const { wrapper, create } = await mountCreate(REPORT_FORM)
+      await wrapper.find('#field-title').setValue('A report')
+
+      await submit(wrapper)
+
+      // The gate is the point: no entity, and the field is flagged.
+      expect(create).not.toHaveBeenCalled()
+      expect(wrapper.find('#field-evidence').exists()).toBe(true)
+      expect(wrapper.text()).toContain('This field is required')
+    })
+
+    it('a staged file satisfies the requirement and the create proceeds', async () => {
+      // The regression: staged files live outside formData, so before the fix
+      // this stayed blocked forever with no way for the user to satisfy it.
+      const { wrapper, create } = await mountCreate(REPORT_FORM)
+      await wrapper.find('#field-title').setValue('A report')
+      await stage(wrapper, 'evidence', textFile('proof.txt'))
+
+      await submit(wrapper)
+
+      expect(create).toHaveBeenCalledTimes(1)
+      expect(mockUpload).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears the standing error as soon as a file is staged', async () => {
+      const { wrapper } = await mountCreate(REPORT_FORM)
+      await wrapper.find('#field-title').setValue('A report')
+      await submit(wrapper)
+      expect(wrapper.text()).toContain('This field is required')
+
+      await stage(wrapper, 'evidence', textFile('proof.txt'))
+
+      // Mirrors updateField: the flag goes as the user addresses it, rather
+      // than lingering until the next submit.
+      expect(wrapper.text()).not.toContain('This field is required')
+    })
   })
 
   it('leaves the no-attachment create path untouched', async () => {

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -152,6 +152,15 @@ function updateStagedFiles(property: string, files: File[]) {
     delete next[property]
     stagedFiles.value = next
   }
+  // Clear a standing validation error once a file is staged, mirroring what
+  // updateField does as the user edits an ordinary field (BUG-L1DHC5) — else a
+  // "This field is required" flag would persist after the user has addressed
+  // it. A full re-check still runs on submit.
+  if (files.length && errors.value[property]) {
+    const next = { ...errors.value }
+    delete next[property]
+    errors.value = next
+  }
   checkDirty()
 }
 
@@ -828,9 +837,16 @@ function validate(scopeFields?: FormFieldOrRelation[], requiredProps?: Set<strin
 
     const value = formData.value[propName]
 
-    // Required check (metamodel `required` OR a matching `required_when`)
+    // Required check (metamodel `required` OR a matching `required_when`).
+    //
+    // A staged file counts as a value (BUG-L1DHC5). Staged files deliberately
+    // live outside `formData` — a File there would be POSTed as the property's
+    // value, and the server stamps that property itself once the bytes land —
+    // so without this term a `required` file property can never be satisfied
+    // and Create is blocked forever with no visible error.
     const isRequired = propDef.required || (requiredProps?.has(propName) ?? false)
-    if (isRequired && (value === undefined || value === null || value === '')) {
+    const hasStagedFile = (stagedFiles.value[propName]?.length ?? 0) > 0
+    if (isRequired && !hasStagedFile && (value === undefined || value === null || value === '')) {
       next[propName] = 'This field is required'
       scopeValid = false
       continue

--- a/tickets/entities/automated-measures/AM-required-file-satisfied-by-staged-file.md
+++ b/tickets/entities/automated-measures/AM-required-file-satisfied-by-staged-file.md
@@ -1,0 +1,46 @@
+---
+id: AM-required-file-satisfied-by-staged-file
+type: automated-measure
+title: 'Regression tests: a staged file satisfies a required file property'
+description: 'Unit and e2e tests asserting that a staged (not-yet-uploaded) file satisfies a `required: true` file property in the create form: submit is blocked with the field flagged while none is staged, the standing error clears the moment one is, and the create then proceeds with the attachment landing. Guards the divergence between the two readers of ''does this property have a value?'' — formData and stagedFiles.'
+kind: test
+location: frontend/src/components/forms/DynamicForm.attachments.test.ts, e2e/tests/attachments-create.spec.ts
+status: active
+---
+
+## Measure
+
+Four tests that fail against the pre-fix code, covering the divergence between
+the two places that answer "does this property have a value?".
+
+**Unit** — `frontend/src/components/forms/DynamicForm.attachments.test.ts`,
+against a type declaring `document: {type: file, required: true}`:
+
+- submit with no file → no create, and the field is flagged
+- a staged file satisfies the requirement → create and upload both proceed
+- the standing error clears the moment a file is staged
+
+**E2E** — `e2e/tests/attachments-create.spec.ts`, against a real server:
+
+- a blocked Create issues no POST (excluding the `?dry_run=true` affordance
+probe) and shows the required error; staging a file then lets the create
+through, and the attachment reads back from the API
+
+The unit reproduction was `created: 0, uploaded: 0` before the fix and `1`/`1`
+after, so these are genuine regression tests rather than tests written to pass.
+
+## Fixture note
+
+The required file property lives on its own `signoff` entity type in
+`e2e/tests/fixtures.ts`, deliberately **not** on the shared `bug` type. A
+required property on a shared type makes every other test's entity emit a
+`required_property_unset` warning — the first attempt did exactly that and broke
+an unrelated assertion.
+
+## What it does not cover
+
+The systemic cause in why5 — that "has a value" is derived ad hoc from
+`formData` at each call site rather than through one accessor. These tests pin
+the two readers that exist today; a third value source added later would not be
+caught. A single `hasValueFor(property)` accessor is the structural fix, noted
+on BUG-L1DHC5 and not built here.

--- a/tickets/entities/bugs/BUG-L1DHC5.md
+++ b/tickets/entities/bugs/BUG-L1DHC5.md
@@ -1,0 +1,97 @@
+---
+id: BUG-L1DHC5
+type: bug
+title: 'A required file property makes the create form unsubmittable: Save silently does nothing'
+description: 'On a create form with a `file` property declared required: true, picking a file and pressing Create does nothing — no entity, no upload, no visible error. validate() reads formData, but staged files deliberately live outside formData (TKT-7K3BJF), so the required check can never be satisfied. Regression from #1479.'
+priority: high
+effort: s
+why1: Pressing Create does nothing because handleSubmit's `if (!validate(...)) return` gate (DynamicForm.vue:1032) rejects the form.
+why2: validate() (DynamicForm.vue:833) decides required-ness by reading `formData.value[propName]`, and a staged file is not there.
+why3: Staged files are deliberately held in a separate `stagedFiles` ref, because a File in formData would be POSTed as the property's value — the server stamps that property itself once the bytes land.
+why4: TKT-7K3BJF introduced that separate staging store but did not update the one other place that answers 'does this property have a value?', so the two views of 'is this field filled' diverged.
+why5: The systemic cause is that 'has a value' is derived ad hoc from formData at each call site rather than through a single accessor, so adding a second value source silently breaks every reader that was not updated by hand. No in-tree schema declares a required file property, so no test exercised the combination and both reviews missed it.
+prevention: 'Fix routes the staged-file check through the same required rule rather than adding a parallel one, and adds a regression test asserting a staged file satisfies `required`. Longer-term: a single `hasValueFor(property)` accessor would make a new value source impossible to miss — noted on the ticket, not built here.'
+status: done
+---
+
+## Symptom
+
+On a create form with a `file` property declared `required: true`, the user
+picks a file, presses **Create**, and **nothing happens**. No entity is created,
+no upload is attempted, and no error is shown against the file field.
+
+Reproduced with a component test (`created: 0, uploaded: 0`) against a schema
+declaring `evidence: {type: file, required: true}`.
+
+## Cause
+
+`validate()` (`frontend/src/components/forms/DynamicForm.vue:833`) decides
+required-ness by reading `formData`:
+
+```js
+const isRequired = propDef.required || (requiredProps?.has(propName) ?? false)
+if (isRequired && (value === undefined || value === null || value === '')) {
+```
+
+But staged files deliberately live **outside** `formData` (TKT-7K3BJF): a `File`
+in `formData` would be POSTed as the property's value, and the server stamps
+that property itself once the bytes land. So staging a file cannot satisfy the
+check, and `handleSubmit`'s gate at line 1032 blocks the submit forever.
+
+The error IS written into `errors[propName]` and `FieldShell` renders it
+(`.field-error`, `FieldShell.vue:46`) for every field type including file — so
+the user does see "This field is required". The defect is that the message is
+unactionable: picking a file, which is the only thing it asks for, does not
+clear it or unblock the button.
+
+## Regression
+
+Introduced by TKT-7K3BJF (#1479, merged as `ae132dad`). On `develop` only — no
+release has been cut, so no user can have hit this. Before that change the file
+field was inert in create mode ("Attachment editing unavailable") and the entity
+could still be created — the server returned a soft `required_property_unset`
+warning and `analyze properties` kept flagging it. Now the field accepts a file
+and the form silently refuses to submit, which is the worse of the two.
+
+Neither the design review nor the code review caught it because no in-tree
+schema declares a required `file` property, so nothing exercised the
+combination.
+
+## Fix
+
+Count a staged file as satisfying `required`, in the place that already owns the
+rule:
+
+```js
+const hasStaged = (stagedFiles.value[propName]?.length ?? 0) > 0
+if (isRequired && !hasStaged && (value === undefined || value === null || value === '')) {
+```
+
+This yields the intended behaviour — Save blocked until a file is selected, then
+the normal create-then-attach flow — using the same mechanism every other
+required field uses.
+
+## Why a client-side gate is the right shape here
+
+`required` is a **soft** server-side rule by design
+(`metamodel/validation.go:132` classifies `ValidationErrorRequired` as soft;
+`entitymanager/validation.go:44` maps it to the `required_property_unset`
+warning), because FS-backed content can be edited outside rela, so the server
+cannot treat it as a hard guarantee. `analyze properties` is the backstop.
+
+The data-entry form does control its own input, so gating there is a UX
+affordance layered on that soft rule — which is the convention the SPA already
+follows for every other property type (`validate()` plus the e2e test "form
+blocks POST when required fields are missing"). On the postgres backend, where
+out-of-band edits are unlikely, the gate approximates a real invariant closely.
+It is deliberately not a security boundary.
+
+## Known residue (accepted)
+
+If the create succeeds and the subsequent upload fails, the entity exists with
+the required property unset. That is unavoidable under create-then-attach, and
+it degrades to exactly the server's pre-existing soft-warning state, which
+`analyze properties` reports. Stated here so it is a decision rather than a
+discovery.
+
+Supersedes the premise of TKT-87VSDE.

--- a/tickets/entities/review-checklists/REV-3Q2DKJ.md
+++ b/tickets/entities/review-checklists/REV-3Q2DKJ.md
@@ -1,0 +1,78 @@
+---
+id: REV-3Q2DKJ
+type: review-checklist
+title: 'Review: A required file property makes the create form unsubmittable: Save silently does nothing'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] Frontend unit tests — 2055/2055 across 126 files
+- [x] E2E — 272 passed / 8 pre-existing skips / 0 failures
+- [x] `npm run typecheck` and e2e `npx tsc --noEmit` — clean
+- [x] `npm run lint` — 0 errors; `npx eslint` on changed e2e files — clean
+- [x] `just arch-lint` — OK
+- [x] `just docs-check` — in sync (no doc change needed; behaviour now matches
+      what `docs/data-entry.md` already implied)
+
+## Code Review
+
+- [x] Self-review of the diff
+- [x] No new findings requiring `review-response` entities
+
+The fix is three lines of behaviour in one function plus an error-clearing
+mirror of the existing `updateField` pattern. Reviewed for: the gate not leaking
+into edit mode (it reads `stagedFiles`, which only create mode populates); no
+interaction with the wizard prune (that filters uploads, this filters
+validation); and no change to the server contract.
+
+Two mistakes of mine were caught during verification and fixed:
+
+- The first fixture put `required: true` on the **shared** `bug` type, which
+  made every other test's bug emit a `required_property_unset` warning and broke
+  the oversize-upload assertion. Moved to a dedicated `signoff` type.
+- `submitExpectingNoCreate` counted the create-mode **dry-run** POST (same path,
+  `?dry_run=true`) as a create, so it failed against correct code. Excluded.
+
+Also corrected a claim in the bug's own writeup: I had said the file widget
+renders no error slot. It does — `FieldShell.vue:46` renders `.field-error` for
+every field type. The defect was that the message was unactionable, not absent.
+
+## Verification
+
+Manual run against a real `rela-server` with `evidence: {type: file, required: true}`:
+
+```
+1. creates after submit with no file (want 0): 0
+2. still on the form (want true): true
+3. visible error: ["This field is required"]
+4. error after staging (want []): []
+5. creates after staging (want 1): 1
+6. attached: ["req-evidence.txt"]
+7. property stamped: "attachments/REP-001/evidence/req-evidence.txt"
+```
+
+Regression tests added:
+
+- Unit (`DynamicForm.attachments.test.ts`): submit blocked with the field
+  flagged; a staged file satisfies the requirement and create proceeds; the
+  standing error clears on staging.
+- E2E (`attachments-create.spec.ts`): blocked Create issues no POST and shows
+  the required error, then staging a file lets the create through and the
+  attachment is readable back from the server.
+
+Each fails against the pre-fix code — the unit reproduction was
+`created: 0, uploaded: 0` before, `1` and `1` after.
+
+## Acceptance
+
+| Criterion | Result |
+|-----------|--------|
+| Create blocked while a required file is unstaged | **PASS** (manual 1-2, unit, e2e) |
+| The reason is visible to the user | **PASS** (manual 3) |
+| Staging a file clears the error | **PASS** (manual 4, unit) |
+| Staging a file unblocks Create, and the file attaches | **PASS** (manual 5-7, unit, e2e) |
+| No regression to non-required file properties | **PASS** (existing 7 attachment e2e + full suite green) |
+| No change to server behaviour | **PASS** (no Go changes; `required` stays soft) |

--- a/tickets/entities/tickets/TKT-87VSDE.md
+++ b/tickets/entities/tickets/TKT-87VSDE.md
@@ -5,87 +5,55 @@ title: 'Required file properties: decide when a required attachment is due, and 
 kind: enhancement
 priority: low
 effort: m
-status: backlog
+status: wont-fix
 ---
 
-## Description
+## Closed: the premise was wrong
 
-A `file` property declared `required: true` has no coherent meaning on the
-create path today, and the create-time attachment work (TKT-7K3BJF) makes the
-gap reachable rather than theoretical.
+This ticket asked "when is a required attachment *due*?", presenting three
+candidate semantics as an open decision. Investigation showed the decision was
+already made and implemented — the ticket was written from a misreading of
+`internal/metamodel/validation.go`.
 
-**This is latent, not a live bug.** No in-tree schema currently declares a
-required `file` property, which is why TKT-7K3BJF was allowed to ship without
-solving it.
+**`required` is a soft rule, server-side, for every property type.**
+`ValidationErrorRequired` is classified soft (`validation.go:132`, `IsSoft()`)
+and mapped to the `required_property_unset` warning
+(`entitymanager/validation.go:44`). Verified end to end against a scratch
+project declaring `evidence: {type: file, required: true}`:
 
-## The problem
+```
+$ rela create report -P title="Test report"
+WARNING: required_property_unset at /properties/evidence: This field is required
+✓ Created report REP-001          ← exit 0
 
-`required` is validated generically in `Metamodel.ValidateProperties`
-(`internal/metamodel/validation.go:147`) — a property is present-and-non-empty,
-or it is an error. There is no file-type special case.
+$ rela analyze properties
+✗ Found 1 property errors:
+  REP-001 (report): This field is required
+```
 
-But an attachment cannot exist at create time. The bytes can only be written
-after the entity row exists (`AttachFile` returns `store.ErrNotFound` otherwise
-— `fsstore/attachment.go:47`, `pgstore/attachment.go:43`,
-`memstore/memstore.go:762`, pinned by `storetest/attachment.go:54`), and the
-property is only stamped afterwards by `attachment.Service.WriteAttachment`
-(`internal/attachment/attachment.go:200`).
+So the entity is created with a warning and `analyze properties` keeps flagging
+it until a file lands. That is the "due eventually" option this ticket proposed
+building — it already exists, and it is not file-specific.
 
-So the create POST *necessarily* carries the property empty. `required: true`
-therefore means the create either:
+The rationale is sound and worth recording: FS-backed content can be edited
+outside rela, so the server cannot treat `required` as a hard guarantee. The
+data-entry form, which *does* control its own input, layers a client-side gate
+on top (`DynamicForm.vue` `validate()`, pinned by the e2e test "form blocks POST
+when required fields are missing"). Soft server rule + client affordance, with
+`analyze properties` as the backstop. On a networked backend like postgres the
+gate approximates a real invariant closely, but it remains an affordance, not a
+security boundary.
 
-- hard-fails, making the property impossible to ever satisfy through the web
-form; or
-- passes with a soft warning (DEC-HWZHA), making `required` decorative on this
-one property type.
+The two other options this ticket floated were both worse:
 
-Neither is a decision anyone made deliberately — it is a consequence of the
-write ordering.
+- *Hard-fail at create* would make a required file property permanently
+unsatisfiable, since the file can only arrive after the entity exists.
+- *Refuse the declaration at schema load* would delete a working feature.
 
-## The actual question
+## What was actually broken
 
-**When is a required attachment due?** The candidate answers are genuinely
-different products, and this ticket should pick one before any code:
+One real defect, and it was narrower than anything described here: staged files
+live outside `formData`, which is where the client-side gate looks, so a
+required `file` property blocked Create with no way to satisfy it.
 
-1. **Due at create.** Enforced client-side: the create form blocks Save until a
-file is staged. Honest to the user, but the server still cannot enforce it, so
-it is a UI convention an API/MCP client bypasses. Cheapest.
-2. **Due eventually.** `required` on a file property means "this entity is
-incomplete until a file lands" — a soft warning that persists on the entity and
-surfaces in validation/analyze output until satisfied. Consistent with
-DEC-HWZHA's existing "temporarily invalid state" stance, and enforceable
-server-side because it is checked on read/analyze rather than on write.
-3. **Refuse the declaration.** Reject `required: true` on a `file` property as a
-schema **load error**, on the grounds that it cannot be honoured. Smallest
-surface, and arguably the most honest — but it forecloses a real use case (an
-evidence field that genuinely must be filled).
-
-Option 2 looks closest to how rela already treats partially-valid entities, but
-this needs a decision, not an assumption — likely a `decision` entity.
-
-## Scope
-
-- Pick and document the semantics (probably a linked `decision`).
-- Implement whichever gate that implies. For (1) that is a client-side gate in
-the staged `FileWidget` TKT-7K3BJF builds — that widget is the host site. For
-(2) it is validation/analyze surfacing. For (3) it is a loader check plus a
-clear error.
-- Cover the API/MCP path too, or explicitly state that it is out of scope and
-why (a UI-only gate is bypassable by design).
-
-## Out of scope
-
-- Create-time attachment UX generally — TKT-7K3BJF.
-- Atomic create-with-attachments (multipart create), which would make option (1)
-server-enforceable but is deferred there for independent reasons.
-
-## Acceptance
-
-- The chosen semantics are written down with their rationale, and the two
-rejected options recorded so this is not re-litigated.
-- A schema declaring `required: true` on a `file` property behaves per that
-decision, with a test pinning it.
-- The behaviour is the same whether the entity is created via the web form, the
-API, or MCP — or the difference is deliberate and documented.
-
-Blocked by / follows: TKT-7K3BJF. Parent: FEAT-870YCY.
+Tracked and fixed as **BUG-L1DHC5**.

--- a/tickets/relations/BUG-L1DHC5--adds-measure--AM-required-file-satisfied-by-staged-file.md
+++ b/tickets/relations/BUG-L1DHC5--adds-measure--AM-required-file-satisfied-by-staged-file.md
@@ -1,0 +1,5 @@
+---
+from: BUG-L1DHC5
+relation: adds-measure
+to: AM-required-file-satisfied-by-staged-file
+---

--- a/tickets/relations/BUG-L1DHC5--affects--data-entry-ui.md
+++ b/tickets/relations/BUG-L1DHC5--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: BUG-L1DHC5
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/BUG-L1DHC5--fixes--FEAT-870YCY.md
+++ b/tickets/relations/BUG-L1DHC5--fixes--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: BUG-L1DHC5
+relation: fixes
+to: FEAT-870YCY
+---

--- a/tickets/relations/BUG-L1DHC5--has-review--REV-3Q2DKJ.md
+++ b/tickets/relations/BUG-L1DHC5--has-review--REV-3Q2DKJ.md
@@ -1,0 +1,5 @@
+---
+from: BUG-L1DHC5
+relation: has-review
+to: REV-3Q2DKJ
+---

--- a/tickets/relations/BUG-L1DHC5--implements--FEAT-870YCY.md
+++ b/tickets/relations/BUG-L1DHC5--implements--FEAT-870YCY.md
@@ -1,0 +1,5 @@
+---
+from: BUG-L1DHC5
+relation: implements
+to: FEAT-870YCY
+---


### PR DESCRIPTION
A create form with a `file` property declared `required: true` was **unsubmittable**: pick a file, press Create, nothing happens.

Follow-up to #1479 (`develop` only — no release cut, so nobody can have hit it).

## Cause

`validate()` (`DynamicForm.vue:833`) decides required-ness by reading `formData`. But staged files deliberately live **outside** `formData` — a `File` there would be POSTed as the property's value, and the server stamps that property itself once the bytes land. So staging could never satisfy the check, and `handleSubmit`'s gate blocked the submit forever.

The "This field is required" message *did* render (`FieldShell` renders `.field-error` for every field type). It was simply unactionable: doing the one thing it asked for changed nothing.

Reproduced with a component test — `created: 0, uploaded: 0` before, `1`/`1` after.

## Fix

Count a staged file as a value, in the place that already owns the rule:

```js
const hasStagedFile = (stagedFiles.value[propName]?.length ?? 0) > 0
if (isRequired && !hasStagedFile && (value === undefined || value === null || value === '')) {
```

Plus clearing the standing error on staging, mirroring what `updateField` already does as the user edits an ordinary field.

## Why a client-side gate is the right shape

`required` is **soft** server-side by design — `ValidationErrorRequired` is classified soft (`metamodel/validation.go:132`) and becomes a `required_property_unset` warning (`entitymanager/validation.go:44`) — because FS-backed content can be edited outside rela, so the server cannot treat it as a hard guarantee. `analyze properties` is the backstop.

The data-entry form *does* control its own input, so gating there is a UX affordance layered on that soft rule. That is the convention the SPA already follows for every other property type (`validate()`, pinned by the e2e test "form blocks POST when required fields are missing"). On a networked backend like postgres, where out-of-band edits are unlikely, it approximates a real invariant closely — but it remains an affordance, not a security boundary.

This also closes TKT-87VSDE, whose premise ("decide when a required attachment is due") was written from a misreading: the decision was already made and implemented.

## Accepted residue

If the create succeeds and the upload then fails, the entity exists with the required property unset. Unavoidable under create-then-attach, and it degrades to exactly the server's pre-existing soft-warning state, which `analyze properties` reports.

## Tests

- **Unit** — submit blocked with the field flagged; a staged file satisfies the requirement; the error clears on staging.
- **E2E** — a blocked Create issues no POST (excluding the `?dry_run=true` affordance probe) and shows the error; staging then lets it through and the attachment reads back from the API.

All four fail against the pre-fix code.

The e2e fixture puts the required file on its own `signoff` type, **not** the shared `bug` type — a required property on a shared type makes every other test's entity emit a warning, which the first attempt did and which broke an unrelated assertion.

## Verification

Frontend 2055/2055 (126 files); e2e 272 passed / 8 pre-existing skips / 0 failures; typecheck, lint, `arch-lint`, `docs-check` all clean. Manual run against a real server:

```
1. creates after submit with no file (want 0): 0
2. still on the form (want true): true
3. visible error: ["This field is required"]
4. error after staging (want []): []
5. creates after staging (want 1): 1
6. attached: ["req-evidence.txt"]
7. property stamped: "attachments/REP-001/evidence/req-evidence.txt"
```

https://claude.ai/code/session_01MZ49QM1jaftgozhDmyWLoV