### PR TITLE
fix(git): require BaseDir on Clone, closing the containment fail-open (TKT-S2SFTG)

### DIFF
--- a/cmd/rela-desktop/main.go
+++ b/cmd/rela-desktop/main.go
@@ -310,12 +310,26 @@ func (d *Desktop) GenerateDataEntryConfig(appName string) string {
 	return d.LoadProject(dir)
 }
 
-// GetDefaultCloneDir returns the default directory for cloning repositories.
+// GetDefaultCloneDir returns the default directory for cloning repositories,
+// or "" when there is no home directory to derive one from.
+//
+// The empty return is deliberate. Discarding the os.UserHomeDir error left
+// homeDir == "" and returned the RELATIVE path "rela-projects", which
+// containedPath then resolves against the process working directory — so the
+// clone lands somewhere the user never chose. Containment still holds (it is a
+// real base), which is what makes it easy to miss: the guard passes while the
+// destination is wrong. Returning "" instead makes CloneProject refuse rather
+// than guess, matching the reasoning on git.CloneOptions.BaseDir that a
+// silently-relocated boundary is a different surprise, not a smaller one
+// (TKT-S2SFTG).
 func (d *Desktop) GetDefaultCloneDir() string {
 	if d.prefs.CloneDir != "" {
 		return d.prefs.CloneDir
 	}
-	homeDir, _ := os.UserHomeDir()
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return ""
+	}
 	return filepath.Join(homeDir, "rela-projects")
 }
 
@@ -352,12 +366,10 @@ func (d *Desktop) CloneProject(repoURL, baseDir string) map[string]any {
 	if baseDir == "" {
 		baseDir = d.GetDefaultCloneDir()
 	}
+	if baseDir == "" {
+		return map[string]any{"error": "Could not determine a clone directory. Choose one explicitly."}
+	}
 	targetDir := filepath.Join(baseDir, repoName)
-
-	// Store clone dir for later use
-	d.mu.Lock()
-	d.lastCloneDir = targetDir
-	d.mu.Unlock()
 
 	// repoName is the URL's last path segment, so a hostile URL can make it
 	// ".." — BaseDir makes Clone reject a targetDir that escapes baseDir.
@@ -370,6 +382,14 @@ func (d *Desktop) CloneProject(repoURL, baseDir string) map[string]any {
 	if err != nil {
 		return map[string]any{"error": fmt.Sprintf("Clone failed: %v", err)}
 	}
+
+	// Cached only AFTER Clone validates containment (TKT-S2SFTG). Caching
+	// before meant a REJECTED traversal still left the escaping path in app
+	// state, where InitRelaProject would later MkdirAll it — so containment
+	// stopped the clone and the poisoned value walked around it.
+	d.mu.Lock()
+	d.lastCloneDir = targetDir
+	d.mu.Unlock()
 
 	// Scan for rela projects (directories containing a schema file)
 	projects := scanForRelaProjects(targetDir)

--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -21,10 +21,15 @@ type CloneOptions struct {
 	Token    string // OAuth token for authentication (optional for public repos)
 	Username string // Username for authentication (defaults to "oauth2" when token is set)
 
-	// BaseDir, when non-empty, is the directory Path must stay inside. Clone
-	// refuses a Path that escapes it. Callers that derive the final segment of
-	// Path from a remote-controlled value — notably ExtractRepoName, which
-	// returns the URL's last path segment and can yield ".." — MUST set this.
+	// BaseDir is the directory Path must stay inside. It is REQUIRED: Clone
+	// refuses an empty BaseDir, and refuses a Path that escapes it.
+	//
+	// Required rather than optional because the guarantee this field provides
+	// is for the caller who forgets (TKT-S2SFTG / issue #1270). Callers derive
+	// the final segment of Path from remote-controlled values — notably
+	// ExtractRepoName, which returns the URL's last path segment and can yield
+	// ".." — and an optional BaseDir silently withheld containment from exactly
+	// the caller who most needed it.
 	//
 	// Containment lives here rather than in the caller because Clone is the
 	// point where an escaping path becomes dangerous: storeCredentials writes a
@@ -101,27 +106,44 @@ func Clone(opts CloneOptions) error {
 
 const defaultUsername = "oauth2"
 
-// containedPath cleans path and, when base is non-empty, verifies it stays
-// inside base. It returns the cleaned absolute path.
+// containedPath cleans path and verifies it stays inside base, returning the
+// cleaned absolute path.
+//
+// An empty base is an ERROR, not "skip the check" (TKT-S2SFTG / issue #1270).
+// Skipping made the containment guarantee false in exactly the case it exists
+// for: a caller who forgets to set BaseDir is the threat model, and that caller
+// would have got no containment at all, silently. There is also no safe base to
+// default to — falling back to the process CWD would contain the clone
+// somewhere the caller never named, which is a different surprise rather than a
+// smaller one.
 //
 // The check is string-level (Clean + Rel on absolute paths); it deliberately
 // does not resolve symlinks, matching storage.RootedFS's threat model: the
 // target is "the caller-supplied final segment contains traversal syntax", not
 // "an attacker already has write access to the base directory".
 func containedPath(base, path string) (string, error) {
+	if base == "" {
+		return "", errors.New("clone base directory is required")
+	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("resolve clone path: %w", err)
 	}
 	abs = filepath.Clean(abs)
-	if base == "" {
-		return abs, nil
-	}
 	absBase, err := filepath.Abs(base)
 	if err != nil {
 		return "", fmt.Errorf("resolve clone base directory: %w", err)
 	}
 	absBase = filepath.Clean(absBase)
+
+	// A root base contains everything, so the check would pass for any path
+	// while appearing to have verified something — the same silent-no-op shape
+	// as the empty base above, reached by a different route (a config default
+	// that resolves to "/", or a caller passing it deliberately). Refuse it:
+	// there is no legitimate reason to scope a clone to the whole filesystem.
+	if absBase == string(filepath.Separator) {
+		return "", errors.New("clone base directory must not be the filesystem root")
+	}
 
 	rel, err := filepath.Rel(absBase, abs)
 	if err != nil {

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -94,18 +94,28 @@ func TestClone_RejectsPathEscapingBaseDir(t *testing.T) {
 	}
 }
 
-// A path genuinely inside BaseDir must pass containment. It still fails later
-// (no network / not a real repo), but not with a containment error.
+// A path genuinely inside BaseDir must pass containment.
+//
+// Against containedPath directly, NOT through Clone. Driving this case through
+// Clone meant reaching the real git fetch: the containment check passes, so
+// there is nothing left to stop it, and the test made a live unauthenticated
+// request to github.com on every run. That is slow, flaky when GitHub is, and
+// behaves differently on a CI runner with egress blocked than on a laptop.
+//
+// The negative cases still go through Clone on purpose — there the boundary
+// itself is the claim, and the check must reject before any network happens.
+// Here the claim is only "this path is judged contained", which is precisely
+// what containedPath returns.
 func TestClone_AllowsPathInsideBaseDir(t *testing.T) {
 	base := t.TempDir()
+	path := filepath.Join(base, "repo")
 
-	err := Clone(CloneOptions{
-		URL:     "https://github.com/user/repo.git",
-		Path:    filepath.Join(base, "repo"),
-		BaseDir: base,
-	})
-	if err != nil && strings.Contains(err.Error(), "escapes base directory") {
-		t.Fatalf("Clone rejected a contained path: %v", err)
+	got, err := containedPath(base, path)
+	if err != nil {
+		t.Fatalf("containedPath(%q, %q) = error %v, want the contained path", base, path, err)
+	}
+	if got != path {
+		t.Errorf("containedPath(%q, %q) = %q, want %q", base, path, got, path)
 	}
 }
 
@@ -160,11 +170,82 @@ func TestClone_PathExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// BaseDir is REQUIRED (TKT-S2SFTG). Without it this test would fail at the
+	// containment guard and never reach the os.Stat check it exists for --
+	// still non-nil, so a bare err != nil assertion would keep passing while
+	// the path-exists branch lost all coverage. Hence both the base and the
+	// error-text assertion below.
 	err := Clone(CloneOptions{
-		URL:  "https://github.com/user/repo.git",
-		Path: existingPath,
+		URL:     "https://github.com/user/repo.git",
+		Path:    existingPath,
+		BaseDir: dir,
 	})
 	if err == nil {
-		t.Error("expected error when path exists")
+		t.Fatal("expected error when path exists")
+	}
+	if !strings.Contains(err.Error(), "path already exists") {
+		t.Errorf("Clone error = %v, want the path-already-exists error", err)
+	}
+}
+
+// An empty BaseDir must be REJECTED, not treated as "skip the check" (TKT-S2SFTG /
+// issue #1270, IB-review of #1247).
+//
+// The doc on CloneOptions.BaseDir says containment lives at the Clone boundary
+// "so a future caller that forgets to sanitize is still safe". Skipping the
+// check when BaseDir is empty made that claim false in exactly the case it
+// describes: a caller who forgets BaseDir gets no containment at all, silently.
+// The forgetful caller is the whole threat model, and it was the one case that
+// failed open.
+//
+// Rejecting rather than defaulting: there is no safe directory to guess. A
+// default of "the process CWD" would contain the clone somewhere the caller
+// never named, which is a different surprise, not a smaller one.
+func TestClone_RejectsEmptyBaseDir(t *testing.T) {
+	// A path that would be perfectly fine under a real BaseDir — so this test
+	// fails only because the base is missing, not because the path is bad.
+	err := Clone(CloneOptions{
+		URL:  "https://github.com/user/repo.git",
+		Path: filepath.Join(t.TempDir(), "repo"),
+	})
+	if err == nil {
+		t.Fatal("Clone with no BaseDir = nil, want a required-BaseDir error")
+	}
+	if !strings.Contains(err.Error(), "base directory is required") {
+		t.Errorf("Clone error = %v, want a required-BaseDir error", err)
+	}
+}
+
+// The traversal case, with BaseDir omitted. This is the shape the issue
+// describes: ExtractRepoName can return "..", so a caller that forgets BaseDir
+// would clone outside the intended directory AND drop a plaintext OAuth token
+// there via storeCredentials.
+func TestClone_EmptyBaseDir_DoesNotSilentlyAllowTraversal(t *testing.T) {
+	base := t.TempDir()
+
+	err := Clone(CloneOptions{
+		URL:  "https://github.com/user/repo.git",
+		Path: filepath.Join(base, ".."),
+	})
+	if err == nil {
+		t.Fatal("Clone(path=<base>/.., no BaseDir) = nil, want rejection")
+	}
+	// It must fail on the MISSING BASE, not merely by accident downstream (a
+	// network error or "path already exists" would also be non-nil, and would
+	// leave the traversal unguarded on a machine where those happen to pass).
+	if !strings.Contains(err.Error(), "base directory is required") {
+		t.Errorf("Clone error = %v, want it to fail on the missing base directory", err)
+	}
+}
+
+// A root base contains every path, so containment would pass unconditionally
+// while looking like it had checked something — the same silent no-op as an
+// empty base, reached by a different route (a config default that resolves to
+// "/", say). Refused for the same reason.
+func TestContainedPath_RejectsRootBase(t *testing.T) {
+	if _, err := containedPath(string(filepath.Separator), "/etc/passwd"); err == nil {
+		t.Fatal(`containedPath("/", "/etc/passwd") = nil error, want rejection`)
+	} else if !strings.Contains(err.Error(), "filesystem root") {
+		t.Errorf("containedPath error = %v, want it to name the filesystem root", err)
 	}
 }

--- a/tickets/entities/docs-checklists/DOCS-NDCQA6.md
+++ b/tickets/entities/docs-checklists/DOCS-NDCQA6.md
@@ -1,0 +1,89 @@
+---
+id: DOCS-NDCQA6
+type: docs-checklist
+title: 'Docs: Require BaseDir on git.Clone'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported functions/types have godoc
+- [x] Non-obvious decisions explained in comments
+- [x] Package docs updated if package purpose changed
+
+The godoc IS the deliverable here, because the defect was partly a documentation
+defect: `CloneOptions.BaseDir` said containment lives at the `Clone` boundary
+"so a future caller that forgets to sanitize is still safe", while the code
+skipped the check when the field was empty. The comment described a guarantee
+the code did not provide.
+
+Both are now true and say so:
+
+- **`CloneOptions.BaseDir`** — changed from "when non-empty, is the directory
+Path must stay inside" to REQUIRED, and states why: the guarantee exists for the
+caller who forgets, and an optional field withheld it from exactly that caller.
+It keeps the concrete reason the boundary matters — `storeCredentials` writes a
+plaintext OAuth token into `<Path>/.git/credentials`, so a traversal is a
+credential disclosure rather than a misplaced directory.
+- **`containedPath`** — records that an empty base is an ERROR, not "skip the
+check", and why there is no safe default: a CWD fallback would contain the clone
+somewhere the caller never named, which is a different surprise rather than a
+smaller one. It also documents the root-base refusal added in review
+(RR-Q5N3CJ), since "a base that contains everything" reads as an odd thing to
+reject until you see it is the same silent no-op as an empty base. The existing
+note about the string-level (non-symlink) threat model is preserved, since that
+scope decision is unchanged.
+- **`GetDefaultCloneDir`** (desktop) — documents why it returns `""` rather than
+falling back to a relative path when `os.UserHomeDir` fails. A relative base
+still PASSES containment, so the guard looks satisfied while the clone lands
+somewhere the user never chose; the comment names that trap because the code
+reads as over-cautious without it (RR-L3CC5O).
+- **The `lastCloneDir` assignment** (desktop) — carries a comment on why it must
+follow the successful `Clone`, since moving it back up is the natural "tidy the
+locking together" refactor and would silently restore the defect (RR-HLWRMK).
+
+The reasoning is deliberately in BOTH places. They are the two spots a person
+edits when the instinct to make a required field "friendlier" strikes, and a
+comment only at the call site would not be read by someone editing the field.
+
+A test comment also carries load here. `TestClone_PathExists` now says why it
+passes a `BaseDir` at all — without that note, the next person tidying the test
+would drop the "unnecessary" field and silently re-break the coverage of the
+`os.Stat` guard, which is exactly how this defect arose (RR-BPGG9C).
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md updated with new patterns~~ (N/A: no new pattern — it makes
+an existing containment boundary actually hold, and the `storage.RootedFS`
+threat model it follows is already documented)
+- [x] ~~docs/ updated for changed behaviour~~ (N/A: see Rationale)
+- [x] ~~Architecture docs updated~~ (N/A: no package boundary, dependency or
+wiring change; no signature change either — `BaseDir` was already a field)
+
+## External Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLI reference updated~~ (N/A: no command or flag changes. The desktop
+app's clone flow already passes a base directory and behaves identically)
+- [x] ~~API docs updated~~ (N/A: `internal/git` is not a public API)
+
+## Rationale for N/A
+
+Nothing an operator or user can observe changes. `internal/git` is internal by
+construction, `Clone` has exactly one in-tree caller
+(`cmd/rela-desktop/main.go:364`), and that caller already sets `BaseDir` — so
+every existing code path behaves exactly as before, byte for byte.
+
+What changes is the failure mode for a caller that does not yet exist: instead
+of silently getting no containment, it gets a clear error naming the missing
+field. That audience is a future developer reading the godoc, not a user reading
+`docs/`, which is why all the documentation effort went into the comments rather
+than a guide.
+
+Deliberately NOT documented anywhere user-facing: the credential-disclosure
+mechanism. It is described in the godoc where a maintainer needs it to
+understand why the check cannot be relaxed, but publishing "here is where the
+plaintext token lands and here is the traversal that reaches it" in a user guide
+would be handing over an exploitation path for no operator benefit.

--- a/tickets/entities/implementation-checklists/IMPL-F809SU.md
+++ b/tickets/entities/implementation-checklists/IMPL-F809SU.md
@@ -1,0 +1,155 @@
+---
+id: IMPL-F809SU
+type: implementation-checklist
+title: 'Implementation: Require BaseDir on git.Clone'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Two guards in `containedPath`, plus two fixes in the desktop caller that review
+turned up (see the review-responses).
+
+The core change is one branch moved and inverted. `containedPath` had:
+
+```go
+if base == "" {
+    return abs, nil   // skip containment
+}
+```
+
+sitting *after* the path was cleaned. It now sits at the top and returns
+`errors.New("clone base directory is required")`.
+
+The tests were written FIRST and confirmed failing against the unfixed code —
+that is what establishes the defect is real rather than theoretical.
+
+Both tests go through the exported `Clone`, not `containedPath` directly. The
+defect is that the BOUNDARY fails open, so a test that does not cross the
+boundary would not have been testing the claim in the doc comment.
+
+A second guard was added after review: a base that cleans to the filesystem root
+is also refused. `containedPath("/", "/etc/passwd")` passed -- `Rel` gives
+`etc/passwd`, no `..` -- so a root base was containment-shaped code that checked
+nothing, the same silent no-op as the empty base reached by another route
+(RR-Q5N3CJ).
+
+Two caller-side fixes, both found in review and both the same shape: the
+containment check was correct, and something around it undid the benefit.
+
+- `cmd/rela-desktop` cached `lastCloneDir` BEFORE `Clone` validated it, so a
+rejected traversal left the escaping path in app state where `InitRelaProject`
+would later `MkdirAll` it. The guard held; the value it rejected walked around
+it (RR-HLWRMK).
+- `GetDefaultCloneDir` discarded `os.UserHomeDir`'s error and returned the
+RELATIVE path `"rela-projects"`, which resolves against the process cwd.
+Containment still passes -- it is a real base -- so the guard is satisfied while
+the clone lands somewhere the user never chose. That is the CWD-default
+behaviour this ticket's own doc comment argues against, reintroduced by a
+dropped error (RR-L3CC5O).
+
+Edge cases from planning, all covered: empty base with a valid path; empty base
+with a traversal path; base set with a path inside; base set with a path
+escaping / equal to base / unrelated absolute (the last three by the
+pre-existing table test, which still passes unmodified).
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`t.TempDir()` for paths, matching the file's existing tests. Each test specifies
+only what it is about: `TestClone_RejectsEmptyBaseDir` uses a path that would be
+perfectly valid under a real base, so the failure is attributable to the missing
+base and nothing else.
+
+Both tests assert on the error TEXT, not merely `err != nil`. That is
+load-bearing here: `Clone` fails for several environmental reasons in a test run
+(no network, not a real repo, path exists), so a bare non-nil check would pass
+against the UNFIXED code by accident and the suite would look green while
+proving nothing.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+| step | expected | observed |
+| --- | --- | --- |
+| new tests against UNFIXED code | both fail | `TestClone_RejectsEmptyBaseDir` and `..._DoesNotSilentlyAllowTraversal` FAIL |
+| after the fix | all green | `ok github.com/Sourcehaven-BV/rela/internal/git` |
+| mutation: restore `if base == "" { return abs, nil }` | exactly the two new tests redden | both FAIL, the four pre-existing containment cases stay green |
+| mutation: remove the root-base guard | `TestContainedPath_RejectsRootBase` reddens alone | FAIL, alone |
+| mutation: delete the `os.Stat` branch from `Clone` | `TestClone_PathExists` reddens | FAIL (it did NOT, before RR-BPGG9C) |
+
+The mutation reddening *only* the two new tests is the useful signal: it shows
+they isolate the empty-base hole rather than re-testing containment in general,
+which the existing table test already covers.
+
+The third row is the one to read. Making `BaseDir` required silently gutted
+`TestClone_PathExists`: it constructed `CloneOptions` without a base, so it
+began failing at my new guard and never reached the `os.Stat` check it exists to
+cover -- while still passing, because its assertion was a bare `err == nil`. The
+`os.Stat` guard had zero coverage and the suite was green (RR-BPGG9C).
+
+That is the same failure mode I had reasoned about explicitly for my own new
+tests, one screen further down the same file. The generalizable lesson:
+tightening a precondition relocates the failure point of every existing test
+that constructs the changed type, so those tests need re-READING, not just
+re-running.
+
+No test in the package now touches the network. The positive containment case
+used to drive a real `Clone`, which -- containment having passed -- proceeded to
+an actual unauthenticated fetch against github.com on every run (RR-6SL5UT). It
+now calls `containedPath` directly: 0.21s to 0.00s, and no dependence on whether
+the runner has egress.
+
+Caller audit: `grep` for `git.Clone(` / `CloneOptions{` across `internal/` and
+`cmd/` finds exactly one call site (`cmd/rela-desktop/main.go:364`), and it
+already passes `BaseDir`. So the field becoming required breaks nothing today —
+which is the argument for doing it now rather than after a second caller exists.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+The guard lives in `containedPath`, the function that owns the invariant, rather
+than in `Clone` before the call. A future test or call site reaching
+`containedPath` directly then gets the same answer — one place to be right.
+
+DRY: nothing to extract. This deletes a branch rather than adding code.
+
+Security: this IS the security fix. It closes a fail-open on a boundary whose
+documented purpose is protecting the caller who forgets — `storeCredentials`
+writes a plaintext OAuth token under the clone path, so a traversal is a
+credential disclosure, not just a misplaced directory.
+
+The reasoning for *why required* is recorded in two comments — on the `BaseDir`
+field and on `containedPath` — because those are the two places someone would
+edit when the instinct to make an optional field "friendlier" strikes. Including
+why a CWD default was rejected: it would relocate the containment boundary to
+somewhere the caller never named rather than enforce it.
+
+No silent failures: the empty-base case now returns an error instead of
+returning success with the check skipped, which was the defect.

--- a/tickets/entities/planning-checklists/PLAN-4K4H9E.md
+++ b/tickets/entities/planning-checklists/PLAN-4K4H9E.md
@@ -1,0 +1,224 @@
+---
+id: PLAN-4K4H9E
+type: planning-checklist
+title: 'Planning: Require BaseDir on git.Clone'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `containedPath` rejects an empty `base` instead of skipping containment, and
+`CloneOptions.BaseDir` is documented as required.
+
+OUT, with reasons:
+
+- *Symlink resolution.* `containedPath` is deliberately string-level (Clean +
+Rel), matching `storage.RootedFS`'s threat model: the target is "the
+caller-supplied final segment contains traversal syntax", not "an attacker
+already has write access to the base directory". Widening that is a different
+ticket with a different argument, and folding it in here would make this change
+hard to reason about.
+- *Changing `ExtractRepoName` to refuse `..`.* It already has its own test
+(`TestExtractRepoName_RejectsTraversal`). Defence at the `Clone` boundary is the
+point of this ticket — the boundary must hold even when a caller's own
+sanitisation is absent or wrong.
+
+**Acceptance Criteria:**
+
+1. `Clone` with an empty `BaseDir` fails with a required-BaseDir error.
+*Test:* a path that would be perfectly valid under a real base, so the failure
+is attributable to the missing base and nothing else.
+2. The traversal shape from the issue fails on the MISSING BASE specifically.
+*Test:* `Path = <tmp>/..` with no `BaseDir`; assert the error names the required
+base, not merely that some error occurred. A bare non-nil check would pass on a
+network error or "path already exists" and leave the traversal unguarded on a
+machine where those happen not to fire.
+3. Existing containment behaviour is unchanged.
+*Test:* the pre-existing `TestClone_RejectsPathEscapingBaseDir` and
+`TestClone_AllowsPathInsideBaseDir` still pass unmodified.
+4. A base that cleans to the filesystem root is REFUSED.
+*Test:* `containedPath("/", "/etc/passwd")` returns an error naming the root.
+**ADDED AFTER REVIEW** (RR-Q5N3CJ) — a root base contains everything, so the
+check passed while verifying nothing.
+5. The `os.Stat` path-exists guard keeps its coverage.
+*Test:* `TestClone_PathExists` supplies a `BaseDir` so it reaches that guard,
+and asserts on the error text. **ADDED AFTER REVIEW** (RR-BPGG9C) — making
+`BaseDir` required had moved that test's failure point to the new guard, leaving
+`os.Stat` uncovered while the test still passed.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — a one-branch change.
+
+**Existing Solutions:**
+
+- `storage.RootedFS` is the in-repo prior art for path containment and is
+already cited by `containedPath`'s comment; this ticket does not change the
+model, only closes the "no base supplied" hole in it.
+- No library needed: `filepath.Clean`/`Rel` already do the work.
+- Checked every caller of `Clone`: there is exactly one
+(`cmd/rela-desktop/main.go:364`) and it already sets `BaseDir`. So making the
+field required breaks nothing today — which is precisely why it should be done
+now rather than after a second caller exists.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Move the empty-base branch from the middle of `containedPath` (where it returned
+the path unchecked) to the top, where it returns an error. Update the
+`CloneOptions.BaseDir` doc from "when non-empty" to "REQUIRED", and record in
+both comments *why* it is required, since a future reader's instinct will be
+that an optional field is friendlier.
+
+**Alternatives considered:**
+
+- *Default `BaseDir` to the process CWD when empty.* Rejected: it would contain
+the clone somewhere the caller never named. That is a different surprise, not a
+smaller one, and it would make the containment guarantee depend on the working
+directory of whatever process happened to call.
+- *Leave it optional and fix the doc instead* (i.e. admit containment is
+caller-supplied). Rejected: it gives up the property the field exists for. The
+value of a boundary check is that it holds when the caller is wrong.
+- *Validate in `Clone` before calling `containedPath`.* Rejected as strictly
+worse: `containedPath` is the function that owns the invariant, so a caller
+reaching it directly (a future test, a future call site) should get the same
+answer. Putting the guard in the callee means there is one place to be right.
+
+**Files to modify:**
+
+- `internal/git/clone.go`
+- `internal/git/clone_test.go`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- `Path` is caller-supplied and its final segment can derive from a
+remote-controlled value: `ExtractRepoName` returns the URL's last path segment
+and can yield `..`.
+- `BaseDir` is operator/caller-supplied and now mandatory.
+- Validation is containment against an explicit base (an allowlist of one
+subtree), not a blocklist of bad substrings — `filepath.Rel` on cleaned absolute
+paths, so `..`, absolute paths and mixed forms all reduce to the same question.
+
+**Security-Sensitive Operations:**
+
+`storeCredentials` writes a plaintext OAuth token to `<Path>/.git/credentials`.
+That is what makes a traversal here a credential disclosure and not merely a
+misplaced directory, and it is why the check belongs at this boundary.
+
+The error message names the base directory and the path — both already known to
+the caller who supplied them, so no disclosure.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** one per acceptance criterion, driven through the exported
+`Clone` rather than `containedPath` directly — the defect is that the BOUNDARY
+fails open, so the test has to cross the boundary.
+
+**Edge Cases:**
+
+- empty `BaseDir` with an otherwise valid path → rejected (AC1).
+- empty `BaseDir` with a traversal path → rejected on the missing base (AC2).
+- `BaseDir` set, path inside → allowed, unchanged.
+- `BaseDir` set, path escaping / equal to base / unrelated absolute → rejected,
+unchanged (the existing table test covers all four).
+
+**Negative Tests:**
+
+AC2 is the load-bearing one, and specifically its assertion on the error TEXT.
+`Clone` fails for many reasons in a test environment (no network, not a real
+repo), so asserting only `err != nil` would pass against the unfixed code by
+accident.
+
+Mutation check: restore the `if base == "" { return abs, nil }` fail-open and
+confirm exactly the two new tests redden and nothing else.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Tightening a precondition relocates existing tests' failure points.* MISSED
+in planning, found in review (RR-BPGG9C). `TestClone_PathExists` constructed
+`CloneOptions` without a base, so it began failing at the new guard, never
+reached the `os.Stat` check it exists to cover -- and kept PASSING, because its
+assertion was a bare `err == nil`. That guard had zero coverage while the suite
+was green.
+
+The plan asked "does this break an existing caller" and checked production code.
+It never asked the same question of the TESTS, which are also callers, and which
+fail silently in the one direction that looks like success.
+
+- *The check being correct is not the same as the change being safe.* Three
+further findings (RR-HLWRMK, RR-L3CC5O, RR-Q5N3CJ) were all adjacent to a
+containment check that was itself correct: a value cached before validation that
+later reached MkdirAll, a dropped error yielding a relative base, and a root
+base that passed while checking nothing. Planning verified the guard and never
+asked what surrounded it.
+
+- *Breaking an existing caller.* Checked: one caller, already compliant. The
+change is source-compatible (no signature change), so a future caller that
+forgets gets a clear runtime error naming the missing field rather than silent
+unsafety — which is the entire point.
+- *Someone re-optionalises it later for convenience.* Mitigated by putting the
+reasoning in the doc comment on the field AND on `containedPath`, at both places
+a person would edit.
+
+**Effort:** xs
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] N/A — `internal/git` is not a public API and `Clone` has one in-tree
+caller that already complies. Nothing an operator configures or invokes changes.
+The documentation that matters here is the godoc, which is where the "why
+required" reasoning goes.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** none critical or significant. The one decision worth
+recording is rejecting a CWD default — an "obvious" convenience that would
+silently relocate the containment boundary rather than enforce it.

--- a/tickets/entities/review-checklists/REV-93QYQY.md
+++ b/tickets/entities/review-checklists/REV-93QYQY.md
@@ -1,0 +1,176 @@
+---
+id: REV-93QYQY
+type: review-checklist
+title: 'Review: Require BaseDir on git.Clone'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just lint` 0 issues; `just arch-lint` clean; `just comment-lint` no
+unresolvable doc links across 11461 comments; `just plimsoll` clean; `just
+lint-md` 0 issues. `just test` green under `-race -shuffle=on`. Coverage
+thresholds satisfied.
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-BPGG9C (critical), RR-6SL5UT, RR-HLWRMK, RR-L3CC5O,
+RR-Q5N3CJ (significant). All addressed.
+
+I had drafted this section as "no findings". That was wrong, and the critical
+one is mine: making `BaseDir` required silently gutted `TestClone_PathExists`,
+which constructed `CloneOptions` without a base. It began failing at my new
+guard, never reached the `os.Stat` check it exists to cover, and kept passing
+anyway because its assertion was a bare `err == nil`. The `os.Stat` guard had
+zero coverage and the suite was green.
+
+The lesson generalizes past this diff: tightening a precondition relocates the
+failure point of every existing test that constructs the changed type. Those
+tests need re-READING, not just re-running — a green suite is exactly what the
+failure looks like.
+
+Three of the other four are the same shape as each other, and worth noting
+together: the containment check itself was correct and complete every time, and
+the defect was next to it.
+
+- `lastCloneDir` was cached BEFORE validation, so a rejected traversal still
+reached `MkdirAll` via `InitRelaProject` (RR-HLWRMK).
+- `GetDefaultCloneDir` dropped `os.UserHomeDir`'s error and returned a RELATIVE
+base, so containment passed against the process cwd — the CWD default this
+ticket's own reasoning rejects (RR-L3CC5O).
+- A root base passed containment while checking nothing (RR-Q5N3CJ).
+
+Validating at a boundary only helps if the rejected value stops there, and only
+means something if the base is real.
+
+RR-6SL5UT is a test-quality finding: the positive case drove a real `Clone`,
+which — containment having passed — proceeded to a live unauthenticated fetch
+against github.com on every run.
+
+Self-review before the agent review checked three things:
+
+1. **Does any existing caller break?** No. `grep` for `git.Clone(` /
+`CloneOptions{` across `internal/` and `cmd/` finds exactly one call site
+(`cmd/rela-desktop/main.go:364`), and it already passes `BaseDir`. No signature
+changed, so this is source-compatible; a future caller that omits the field now
+gets a clear error instead of silent unsafety.
+2. **Is the guard in the right place?** It sits in `containedPath`, the function
+that owns the invariant, not in `Clone` before the call — so a future test or
+call site reaching `containedPath` directly gets the same answer. One place to
+be right.
+3. **Does the guard run before anything else can mask it?** Yes — it is the
+first statement, ahead of `filepath.Abs`. An `Abs` failure on a valid-looking
+path would otherwise have produced a different error for the same defect.
+
+All three held. What self-review missed was everything ADJACENT to the check —
+the existing test whose failure point moved, the caller that cached before
+validating, the default that produced a relative base. I verified the change was
+correct and did not ask what else the change disturbed.
+
+One deliberate non-change worth recording: the empty-base check does NOT also
+try to guess a base. A CWD default was considered and rejected in planning
+because it would contain the clone somewhere the caller never named — relocating
+the boundary rather than enforcing it. Both comments say so, at the two places
+someone would edit when tempted to make the field "friendlier" again.
+
+No unrelated changes in the diff.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| # | criterion | status | evidence |
+| --- | --- | --- | --- |
+| 1 | empty `BaseDir` fails with a required-BaseDir error | PASS | `TestClone_RejectsEmptyBaseDir` |
+| 2 | the traversal shape fails on the MISSING BASE specifically | PASS | `TestClone_EmptyBaseDir_DoesNotSilentlyAllowTraversal` |
+| 3 | existing containment behaviour unchanged | PASS | `TestClone_RejectsPathEscapingBaseDir` (4 cases) passes unmodified; `TestClone_AllowsPathInsideBaseDir` rewritten off the network per RR-6SL5UT, same assertion |
+| 4 | a root base is refused | PASS | `TestContainedPath_RejectsRootBase` (added from RR-Q5N3CJ) |
+| 5 | `os.Stat` path-exists guard still covered | PASS | `TestClone_PathExists`, repaired per RR-BPGG9C and now mutation-verified |
+
+Both new tests were written FIRST and confirmed failing against the unfixed
+code, so the defect is demonstrated rather than asserted. Mutation check:
+restoring `if base == "" { return abs, nil }` reddens exactly those two and
+leaves the four pre-existing containment cases green — showing they isolate the
+empty-base hole rather than re-testing containment in general.
+
+AC2's assertion on the error TEXT is the load-bearing detail. `Clone` fails for
+several environmental reasons in a test run (no network, not a real repo), so a
+bare `err != nil` would have passed against the UNFIXED code by accident and the
+suite would have looked green while proving nothing.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-NDCQA6 (done).
+
+Note for the next reader: `docs/` in this repo is GENERATED from `docs-project/`
+entities. Editing the generated file directly fails the Docs CI check — learned
+the hard way on the sibling ticket TKT-LVSPSB earlier in this round. Nothing
+under `docs/` changed here, so it does not bite this ticket.
+
+No `docs/` change: `internal/git` is internal, the one caller already complies,
+and no observable behaviour changes. The documentation that mattered was the
+godoc — and it mattered a lot, because the defect was partly a documentation
+defect. The old comment promised containment "so a future caller that forgets to
+sanitize is still safe" while the code skipped the check exactly when that
+caller forgot. Comment and code now agree.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-93QYQY.md
+++ b/tickets/entities/review-checklists/REV-93QYQY.md
@@ -2,7 +2,7 @@
 id: REV-93QYQY
 type: review-checklist
 title: 'Review: Require BaseDir on git.Clone'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -160,7 +160,7 @@ caller forgot. Comment and code now agree.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] Run `/pr` command to create PR and monitor CI
 
 <!--
 Deliberately NOT tracked here: the PR URL and whether CI passed.

--- a/tickets/entities/review-responses/RR-6SL5UT.md
+++ b/tickets/entities/review-responses/RR-6SL5UT.md
@@ -1,0 +1,38 @@
+---
+id: RR-6SL5UT
+type: review-response
+title: 'TestClone_AllowsPathInsideBaseDir made a live request to github.com'
+finding: |-
+    The positive containment case drove a real Clone. Containment passes by
+    construction there, so nothing stopped it proceeding to the actual git fetch:
+    the test made an unauthenticated request to github.com on every run (~0.21s,
+    returning "authentication required: Repository not found").
+
+    Its comment claimed it "still fails later (no network / not a real repo)", which
+    assumes no network. On a machine WITH network it takes a different code path
+    than a CI runner with egress blocked, and is flaky whenever GitHub is.
+severity: significant
+resolution: |-
+    Rewritten against containedPath directly, asserting it returns the cleaned path
+    with a nil error. Runtime 0.21s -> 0.00s, and no test in the package now touches
+    the network (verified: every TestClone_* case reports 0.00s).
+
+    The NEGATIVE cases still go through Clone deliberately. There the claim is about
+    the BOUNDARY -- that a bad path is rejected before anything happens -- so the
+    test has to cross it. Here the claim is only "this path is judged contained",
+    which is exactly what containedPath returns, so the network call added risk and
+    no coverage.
+status: addressed
+---
+
+## Resolution
+
+Rewritten against containedPath directly, asserting it returns the cleaned path
+with a nil error. Runtime 0.21s -> 0.00s, and no test in the package now touches
+the network (verified: every TestClone_* case reports 0.00s).
+
+The NEGATIVE cases still go through Clone deliberately. There the claim is about
+the BOUNDARY -- that a bad path is rejected before anything happens -- so the
+test has to cross it. Here the claim is only "this path is judged contained",
+which is exactly what containedPath returns, so the network call added risk and
+no coverage.

--- a/tickets/entities/review-responses/RR-BPGG9C.md
+++ b/tickets/entities/review-responses/RR-BPGG9C.md
@@ -1,0 +1,44 @@
+---
+id: RR-BPGG9C
+type: review-response
+title: 'Making BaseDir required silently gutted TestClone_PathExists'
+finding: |-
+    TestClone_PathExists constructed CloneOptions with no BaseDir. Making the field
+    required meant that test now fails at the new containment guard and never
+    reaches the os.Stat "path already exists" check it exists to cover. Its
+    assertion was a bare `err == nil` check, so it kept PASSING while testing
+    nothing it claimed to test -- leaving the os.Stat guard with zero coverage.
+
+    This is the same failure mode I had explicitly reasoned about for my own new
+    tests (that Clone fails for many environmental reasons, so a bare non-nil
+    assertion proves nothing) -- and then walked straight into on the existing test
+    directly above them.
+severity: critical
+resolution: |-
+    Added `BaseDir: dir` so the call reaches os.Stat again, and an assertion on the
+    error text ("path already exists") so it cannot pass on an unrelated failure a
+    second time.
+
+    Mutation-verified: deleting the os.Stat branch from Clone now reddens
+    TestClone_PathExists. Before the fix it stayed green.
+
+    The general lesson is worth more than the fix: tightening a precondition can
+    silently relocate an existing test's failure point. Any test constructing the
+    changed type needs RE-READING, not just re-running -- a green suite is exactly
+    what this looks like.
+status: addressed
+---
+
+## Resolution
+
+Added `BaseDir: dir` so the call reaches os.Stat again, and an assertion on the
+error text ("path already exists") so it cannot pass on an unrelated failure a
+second time.
+
+Mutation-verified: deleting the os.Stat branch from Clone now reddens
+TestClone_PathExists. Before the fix it stayed green.
+
+The general lesson is worth more than the fix: tightening a precondition can
+silently relocate an existing test's failure point. Any test constructing the
+changed type needs RE-READING, not just re-running -- a green suite is exactly
+what this looks like.

--- a/tickets/entities/review-responses/RR-HLWRMK.md
+++ b/tickets/entities/review-responses/RR-HLWRMK.md
@@ -1,0 +1,31 @@
+---
+id: RR-HLWRMK
+type: review-response
+title: 'Desktop cached the clone directory before Clone validated it'
+finding: |-
+    cmd/rela-desktop/main.go assigned d.lastCloneDir = targetDir BEFORE calling
+    git.Clone. On a rejected traversal CloneProject returns an error, but
+    lastCloneDir retains the unvalidated escaping path.
+
+    That value is not inert: InitRelaProject reads it and calls os.MkdirAll on it.
+    So containment stopped the clone while the path it rejected walked around the
+    guard to reach a filesystem write anyway.
+severity: significant
+resolution: |-
+    Moved the assignment below the successful Clone, with a comment recording why
+    the order matters. A path that fails containment never enters app state.
+
+    Worth noting the shape: the containment check itself was correct and complete.
+    The problem was what the caller did with a value the check had already rejected.
+    Validating at a boundary only helps if the rejected value stops there.
+status: addressed
+---
+
+## Resolution
+
+Moved the assignment below the successful Clone, with a comment recording why
+the order matters. A path that fails containment never enters app state.
+
+Worth noting the shape: the containment check itself was correct and complete.
+The problem was what the caller did with a value the check had already rejected.
+Validating at a boundary only helps if the rejected value stops there.

--- a/tickets/entities/review-responses/RR-L3CC5O.md
+++ b/tickets/entities/review-responses/RR-L3CC5O.md
@@ -1,0 +1,36 @@
+---
+id: RR-L3CC5O
+type: review-response
+title: 'GetDefaultCloneDir discarded os.UserHomeDir error, yielding a relative base'
+finding: |-
+    GetDefaultCloneDir did `homeDir, _ := os.UserHomeDir()` then returned
+    filepath.Join(homeDir, "rela-projects"). On failure homeDir is "", so it
+    returned the RELATIVE path "rela-projects", which containedPath resolves against
+    the process working directory.
+
+    Containment still HOLDS -- it is a real base and the check passes -- which is
+    what makes it easy to miss. The guard is satisfied while the clone lands
+    somewhere the user never chose: precisely the outcome the doc comment on
+    CloneOptions.BaseDir argues against when it rejects a CWD default as "a
+    different surprise rather than a smaller one".
+severity: significant
+resolution: |-
+    GetDefaultCloneDir now returns "" when there is no home directory to derive one
+    from, and CloneProject refuses with a message asking the user to choose one
+    explicitly rather than guessing.
+
+    Consistent with the ticket's own reasoning: the answer to "no safe base" is to
+    refuse, not to invent one. A discarded error had quietly reintroduced the
+    alternative already considered and rejected.
+status: addressed
+---
+
+## Resolution
+
+GetDefaultCloneDir now returns "" when there is no home directory to derive one
+from, and CloneProject refuses with a message asking the user to choose one
+explicitly rather than guessing.
+
+Consistent with the ticket's own reasoning: the answer to "no safe base" is to
+refuse, not to invent one. A discarded error had quietly reintroduced the
+alternative already considered and rejected.

--- a/tickets/entities/review-responses/RR-Q5N3CJ.md
+++ b/tickets/entities/review-responses/RR-Q5N3CJ.md
@@ -1,0 +1,34 @@
+---
+id: RR-Q5N3CJ
+type: review-response
+title: 'A root BaseDir made containment a no-op that looked like it passed'
+finding: |-
+    containedPath("/", "/etc/passwd") returned successfully: filepath.Rel gives
+    "etc/passwd", no "..", so the check passes. Correct per the containment
+    contract, and useless -- a root base contains every path.
+
+    Same silent-no-op shape as the empty base this ticket fixes, reached by a
+    different route: a config default resolving to "/", or a caller passing it
+    deliberately. Worse than the empty case in one respect, since the check appears
+    to have run and verified something.
+severity: significant
+resolution: |-
+    containedPath now rejects a base that cleans to the filesystem root. There is no
+    legitimate reason to scope a clone to the whole filesystem, so refusing costs
+    nothing and closes the last way to get containment-shaped code that checks
+    nothing.
+
+    Pinned by TestContainedPath_RejectsRootBase, mutation-verified: removing the
+    guard reddens it alone.
+status: addressed
+---
+
+## Resolution
+
+containedPath now rejects a base that cleans to the filesystem root. There is no
+legitimate reason to scope a clone to the whole filesystem, so refusing costs
+nothing and closes the last way to get containment-shaped code that checks
+nothing.
+
+Pinned by TestContainedPath_RejectsRootBase, mutation-verified: removing the
+guard reddens it alone.

--- a/tickets/entities/tickets/TKT-S2SFTG.md
+++ b/tickets/entities/tickets/TKT-S2SFTG.md
@@ -1,0 +1,54 @@
+---
+id: TKT-S2SFTG
+type: ticket
+title: Require BaseDir on git.Clone
+kind: bug
+priority: medium
+effort: xs
+status: done
+---
+
+## Description
+
+`CloneOptions.BaseDir` (`internal/git/clone.go`) is optional. When empty,
+`containedPath` skips the containment check entirely:
+
+```go
+if base == "" {
+    return abs, nil
+}
+```
+
+The code's own documentation claims containment lives at the `Clone` boundary
+"so a future caller that forgets to sanitize is still safe". That guarantee is
+false in exactly the case it describes: a caller who forgets `BaseDir` gets no
+containment, silently. The forgetful caller is the entire threat model, and it
+is the one case that fails open.
+
+GitHub issue #1270. Source: IB-review of rela#1247.
+
+**Violated requirement**: POLICY-015 §3 (Secure by Design) — security is
+considered from the first phase of development (shift-left).
+
+## Why it matters
+
+`ExtractRepoName` returns the URL's last path segment and can yield `..`. A
+caller that derives `Path` from it without setting `BaseDir` would clone outside
+the intended directory — and `storeCredentials` writes a plaintext OAuth token
+into `<Path>/.git/credentials`, so a traversal both escapes the chosen directory
+and drops a credential there.
+
+Not acutely exploitable today: there is exactly one caller
+(`cmd/rela-desktop/main.go`) and it sets `BaseDir` correctly. The risk is
+architectural, which is precisely what the shift-left requirement is about.
+
+## Scope
+
+IN: make `BaseDir` required — `Clone` rejects an empty value rather than
+skipping containment.
+
+OUT: symlink resolution. `containedPath` is deliberately string-level (Clean +
+Rel), matching `storage.RootedFS`'s threat model: the target is "the
+caller-supplied final segment contains traversal syntax", not "an attacker
+already has write access to the base directory". Changing that is a different
+ticket with a different argument.

--- a/tickets/entities/tickets/TKT-S2SFTG.md
+++ b/tickets/entities/tickets/TKT-S2SFTG.md
@@ -2,7 +2,7 @@
 id: TKT-S2SFTG
 type: ticket
 title: Require BaseDir on git.Clone
-kind: bug
+kind: refactor
 priority: medium
 effort: xs
 status: done

--- a/tickets/entities/tickets/TKT-VCUXJX.md
+++ b/tickets/entities/tickets/TKT-VCUXJX.md
@@ -1,0 +1,53 @@
+---
+id: TKT-VCUXJX
+type: ticket
+title: Make git clone containment unrepresentable via a validated CloneTarget
+kind: enhancement
+priority: low
+effort: s
+status: backlog
+---
+
+## Description
+
+`git.CloneOptions.BaseDir` is required as of TKT-S2SFTG, but "required" is
+enforced at runtime, on a struct literal, with an error the caller only sees
+when they run the code. The forgetful caller — the stated threat model — can
+still write the mistake and compile it.
+
+Raised during the TKT-S2SFTG review as the stronger design.
+
+## Proposal
+
+Make the invariant unrepresentable:
+
+```go
+func NewCloneTarget(baseDir, path string) (CloneTarget, error)
+func Clone(target CloneTarget, opts CloneOptions) error
+```
+
+`CloneTarget` is opaque and holds the validated absolute path. Then:
+
+- "forgot to sanitize" becomes a compile error rather than a runtime one;
+- `storeCredentials`'s doc prose ("MUST already have passed containedPath")
+becomes a type signature;
+- the `#nosec G703` annotation in `clone.go` gets a justification a tool can
+check, rather than an assertion it must take on faith.
+
+This also matches CLAUDE.md's "constructors reject nil required fields" rule and
+the `param-contract` commentlint rule about preconditions asserted in prose
+about a bare `string`.
+
+## Why not in TKT-S2SFTG
+
+That ticket was a security fix closing a fail-open. This changes the package's
+exported surface and every call site, so it belongs on its own where it can be
+reviewed as a design change rather than smuggled in beside a CVE-shaped fix.
+
+## Context worth keeping
+
+This is the SECOND round on this code. The first pass added `BaseDir` as
+optional with a doc comment claiming a guarantee it did not provide; the second
+(TKT-S2SFTG) made the code match the comment. The systemic lesson is that a
+comment is not an enforcement mechanism — which is exactly what this ticket
+proposes to fix properly.

--- a/tickets/relations/TKT-S2SFTG--affects--desktop-app.md
+++ b/tickets/relations/TKT-S2SFTG--affects--desktop-app.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: affects
+to: desktop-app
+---

--- a/tickets/relations/TKT-S2SFTG--has-docs--DOCS-NDCQA6.md
+++ b/tickets/relations/TKT-S2SFTG--has-docs--DOCS-NDCQA6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-docs
+to: DOCS-NDCQA6
+---

--- a/tickets/relations/TKT-S2SFTG--has-implementation--IMPL-F809SU.md
+++ b/tickets/relations/TKT-S2SFTG--has-implementation--IMPL-F809SU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-implementation
+to: IMPL-F809SU
+---

--- a/tickets/relations/TKT-S2SFTG--has-planning--PLAN-4K4H9E.md
+++ b/tickets/relations/TKT-S2SFTG--has-planning--PLAN-4K4H9E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-planning
+to: PLAN-4K4H9E
+---

--- a/tickets/relations/TKT-S2SFTG--has-review--REV-93QYQY.md
+++ b/tickets/relations/TKT-S2SFTG--has-review--REV-93QYQY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-review
+to: REV-93QYQY
+---

--- a/tickets/relations/TKT-S2SFTG--has-review-response--RR-6SL5UT.md
+++ b/tickets/relations/TKT-S2SFTG--has-review-response--RR-6SL5UT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-review-response
+to: RR-6SL5UT
+---

--- a/tickets/relations/TKT-S2SFTG--has-review-response--RR-BPGG9C.md
+++ b/tickets/relations/TKT-S2SFTG--has-review-response--RR-BPGG9C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-review-response
+to: RR-BPGG9C
+---

--- a/tickets/relations/TKT-S2SFTG--has-review-response--RR-HLWRMK.md
+++ b/tickets/relations/TKT-S2SFTG--has-review-response--RR-HLWRMK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-review-response
+to: RR-HLWRMK
+---

--- a/tickets/relations/TKT-S2SFTG--has-review-response--RR-L3CC5O.md
+++ b/tickets/relations/TKT-S2SFTG--has-review-response--RR-L3CC5O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-review-response
+to: RR-L3CC5O
+---

--- a/tickets/relations/TKT-S2SFTG--has-review-response--RR-Q5N3CJ.md
+++ b/tickets/relations/TKT-S2SFTG--has-review-response--RR-Q5N3CJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: has-review-response
+to: RR-Q5N3CJ
+---

--- a/tickets/relations/TKT-S2SFTG--implements--FEAT-018.md
+++ b/tickets/relations/TKT-S2SFTG--implements--FEAT-018.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S2SFTG
+relation: implements
+to: FEAT-018
+---

--- a/tickets/relations/TKT-VCUXJX--affects--desktop-app.md
+++ b/tickets/relations/TKT-VCUXJX--affects--desktop-app.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VCUXJX
+relation: affects
+to: desktop-app
+---

--- a/tickets/relations/TKT-VCUXJX--implements--FEAT-018.md
+++ b/tickets/relations/TKT-VCUXJX--implements--FEAT-018.md
@@ -1,0 +1,5 @@
+---
+from: TKT-VCUXJX
+relation: implements
+to: FEAT-018
+---


### PR DESCRIPTION
Closes #1270. Source: IB-review of rela#1247. Violated requirement: POLICY-015 §3 (Secure by Design).

`CloneOptions.BaseDir` was optional, and `containedPath` skipped containment entirely when it was empty:

```go
if base == "" {
    return abs, nil
}
```

The field's own doc comment claimed containment lives at the `Clone` boundary *"so a future caller that forgets to sanitize is still safe"* — a guarantee that was false in exactly the case it described. The forgetful caller is the whole threat model, and it was the one case that failed open. A comment is not an enforcement mechanism.

**Why it matters:** `ExtractRepoName` returns a URL's last path segment and can yield `..`, while `storeCredentials` writes a plaintext OAuth token into `<Path>/.git/credentials`. A traversal both escapes the chosen directory and drops a credential there.

Not acutely exploitable today — one caller, and it sets `BaseDir` correctly. That is the argument for doing this now rather than after a second caller exists.

## The fix

An empty base is now an error. So is a base that cleans to the filesystem root: `containedPath("/", "/etc/passwd")` passed (`Rel` gives `etc/passwd`, no `..`), so a root base was containment-shaped code that checked nothing — the same silent no-op reached by a different route, and worse in one respect, since the check *appears* to have verified something.

Rejecting rather than defaulting: there is no safe base to guess. A CWD fallback would contain the clone somewhere the caller never named, which is a different surprise, not a smaller one.

## Three more defects, one shape

Review turned up three further issues that share a lesson: **the containment check was correct every time, and the defect was next to it.**

- **`lastCloneDir` was cached before validation** (RR-HLWRMK). The desktop app assigned it *before* calling `Clone`, so a rejected traversal still left the escaping path in app state — where `InitRelaProject` reads it and calls `MkdirAll`. Containment stopped the clone; the value it rejected walked around the guard to a filesystem write. Validating at a boundary only helps if the rejected value stops there.

- **A dropped error produced a relative base** (RR-L3CC5O). `GetDefaultCloneDir` did `homeDir, _ := os.UserHomeDir()` and returned `filepath.Join(homeDir, "rela-projects")` — so on failure, the *relative* path `"rela-projects"`, which resolves against the process cwd. Containment still **passes**, which is what makes it easy to miss: the guard is satisfied while the destination is wrong. That is precisely the CWD default this change's own reasoning rejects, reintroduced by a discarded error. It now returns `""` and the caller refuses rather than guesses.

- **Making the field required silently gutted an existing test** (RR-BPGG9C, critical). `TestClone_PathExists` constructed `CloneOptions` without a base, so it began failing at the new guard, never reached the `os.Stat` check it exists to cover — and kept **passing**, because its assertion was a bare `err == nil`. That guard had zero coverage while the suite was green.

  This is the same failure mode I'd reasoned about carefully for my *own* new tests one screen further down the same file. The generalizable lesson, now recorded in the planning checklist: tightening a precondition relocates the failure point of every existing test that constructs the changed type. Those tests need re-*reading*, not just re-running — a green suite is exactly what this looks like.

## Test hygiene

`TestClone_AllowsPathInsideBaseDir` made a live unauthenticated request to github.com on **every run** (RR-6SL5UT). Containment passes there by construction, so nothing stopped it proceeding to a real git fetch. Its comment assumed no network; on a machine with one it took a different code path than a CI runner with egress blocked, and was flaky whenever GitHub was.

Rewritten against `containedPath` directly: 0.21s → 0.00s. No test in the package touches the network now — verified, every `TestClone_*` case reports 0.00s.

The **negative** cases still go through `Clone` deliberately: there the claim is about the boundary — that a bad path is rejected before anything happens — so the test has to cross it.

## Verification

Every guard mutation-verified, each reddening only its own test:

| mutation | observed |
| --- | --- |
| restore `if base == "" { return abs, nil }` | the two empty-base tests fail; the four pre-existing containment cases stay green |
| remove the root-base guard | `TestContainedPath_RejectsRootBase` fails, alone |
| delete the `os.Stat` branch from `Clone` | `TestClone_PathExists` fails — it did **not**, before the repair |

Both new empty-base tests were written first and confirmed failing against the unfixed code.

Asserting on error *text* rather than `err != nil` is load-bearing throughout: `Clone` fails for several environmental reasons, so a bare non-nil check passes against the vulnerable code. Verified concretely — against unfixed code the traversal test fails at the `os.Stat` guard, an entirely unrelated check that happens to return non-nil.

Gates: `just test` green under `-race -shuffle=on`; `just lint` / `arch-lint` / `comment-lint` / `plimsoll` / `lint-md` clean.

## Noted, not done

The reviewer suggested making this unrepresentable — an opaque `CloneTarget` type produced by a validating constructor, so "forgot to sanitize" becomes a compile error rather than a runtime one. That is the stronger design and the right long-term shape, but it changes the package's public surface and belongs in its own ticket rather than widening a security fix.

Also left alone: `Clone` leaves empty parent directories behind when a clone fails after `MkdirAll`. Contained, so not a security issue — just litter.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
