### PR TITLE
feat(acl): warn when unmatched_principal reject cannot fire (TKT-M60ZF5)

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -277,6 +277,15 @@ Load-bearing details:
   for *every* request, so every principal would look unmatched and be
   rejected). Setting `reject` without them is a **load error**, not a
   runtime foot-gun.
+- **`reject` also needs a wired JWT gate.** It keys on identity having
+  come from the fail-closed JWT gate, so a deployment that sets `reject`
+  without wiring one gets a key with **no effect** — unmatched principals
+  are treated as `anonymous`, exactly as before the key was added. This
+  cannot be a load error like the lookup requirement above, because
+  `acl.yaml` cannot see server wiring; rela logs a warning at startup
+  instead, naming which of the two conditions is missing. If you
+  configured `reject` and writes are still going through, check that
+  warning first.
 - **`provision` additionally requires the `system:provisioner` grant.**
   The stub create is ACL-authorized like any other write, so the policy
   must grant `system:provisioner` `create` on the `user_entity_type`. The

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -271,6 +271,15 @@ Load-bearing details:
   for *every* request, so every principal would look unmatched and be
   rejected). Setting `reject` without them is a **load error**, not a
   runtime foot-gun.
+- **`reject` also needs a wired JWT gate.** It keys on identity having
+  come from the fail-closed JWT gate, so a deployment that sets `reject`
+  without wiring one gets a key with **no effect** — unmatched principals
+  are treated as `anonymous`, exactly as before the key was added. This
+  cannot be a load error like the lookup requirement above, because
+  `acl.yaml` cannot see server wiring; rela logs a warning at startup
+  instead, naming which of the two conditions is missing. If you
+  configured `reject` and writes are still going through, check that
+  warning first.
 - **`provision` additionally requires the `system:provisioner` grant.**
   The stub create is ACL-authorized like any other write, so the policy
   must grant `system:provisioner` `create` on the `user_entity_type`. The

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -171,7 +171,17 @@ func (d *Declarative) ResolvePrincipal(ctx context.Context, rawUser string) (str
 // from the next call onward, including the unstamped-principal
 // check and the delegate-X gates. Callers that need a mutated
 // policy build a fresh Declarative with [NewDeclarative].
-func (d *Declarative) Policy() *Policy { return d.policy }
+// Nil-receiver safe: a typed-nil *Declarative in an ACL interface is not nil,
+// so callers that guard with `d != nil` are easy to get wrong, and the failure
+// is a panic rather than a bad answer. Returning a nil *Policy lets the
+// predicates on Policy (each of which handles a nil receiver) give the same
+// "no policy" answer they would for an absent one.
+func (d *Declarative) Policy() *Policy {
+	if d == nil {
+		return nil
+	}
+	return d.policy
+}
 
 // AuthorizeWrite implements [ACL.AuthorizeWrite]. Opens a Request for
 // the principal carried on ctx, then delegates to

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -181,7 +181,7 @@ const (
 // effectiveUnmatchedPrincipal returns the mode with the empty default resolved
 // to [UnmatchedAnonymous], so callers read one value.
 func (p *Policy) effectiveUnmatchedPrincipal() string {
-	if p.UnmatchedPrincipal == "" {
+	if p == nil || p.UnmatchedPrincipal == "" {
 		return UnmatchedAnonymous
 	}
 	return p.UnmatchedPrincipal
@@ -229,7 +229,8 @@ func (r *RoleList) UnmarshalYAML(unmarshal func(any) error) error {
 // either blank leaves behavior byte-for-byte identical to a policy that
 // never declared them (assignments/membership match on the raw string).
 func (p *Policy) principalPropertyLookupEnabled() bool {
-	return strings.TrimSpace(p.UserEntityType) != "" &&
+	return p != nil &&
+		strings.TrimSpace(p.UserEntityType) != "" &&
 		strings.TrimSpace(p.PrincipalProperty) != ""
 }
 
@@ -240,6 +241,35 @@ func (p *Policy) principalPropertyLookupEnabled() bool {
 // no-match is a genuine unmatched principal.
 func (p *Policy) PrincipalPropertyLookupEnabled() bool {
 	return p.principalPropertyLookupEnabled()
+}
+
+// RejectEffective reports whether `unmatched_principal: reject` can actually
+// deny anything, given whether a JWT gate is wired.
+//
+// Three conditions must ALL hold, and each is a separate way for the setting to
+// be silently inert (TKT-M60ZF5 / issue #1274):
+//
+//   - the mode is "reject";
+//   - a JWT gate is wired — reject keys on identity having come from the
+//     fail-closed gate, and without one every principal looks unverified;
+//   - the principal_property lookup is enabled — with it disabled the resolver
+//     never attempts a match, so "unmatched" is not a thing that can be
+//     observed rather than something that is always true.
+//
+// This exists so the enforcement site and the startup warning cannot disagree.
+// They previously computed the answer separately, and did: the warning checked
+// only gate wiring, so a reject policy with no user_entity_type /
+// principal_property was equally inert and warned about nothing. A warning that
+// is wrong about the thing it warns about is worse than none.
+//
+// Note LoadPolicy rejects "reject" without the lookup, but NewDeclarative does
+// NOT call Validate — so any construction path that skips LoadPolicy can hold a
+// policy in exactly that state. That is why this is checked rather than assumed.
+func (p *Policy) RejectEffective(jwtWired bool) bool {
+	return p != nil &&
+		p.effectiveUnmatchedPrincipal() == UnmatchedReject &&
+		jwtWired &&
+		p.principalPropertyLookupEnabled()
 }
 
 // EffectiveMembershipRelation returns the relation type the resolver

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -189,6 +189,12 @@ func (a *App) NewRouter() http.Handler {
 	// `acl_unstamped_principal` when ACL is configured, because the
 	// principal is still the unstamped default at the time
 	// ForPrincipal is called.
+	// Non-Declarative ACLs (NopACL, ReadOnlyACL) are deliberately outside this
+	// block, warning included. Neither can enforce `unmatched_principal` at all
+	// — under NopACL nothing is enforced, and under ReadOnlyACL every write is
+	// already denied — so a warning about reject being inert would be true and
+	// useless. The `d != nil` guard is load-bearing: a typed-nil *Declarative in
+	// this interface is NOT nil, and reaches d.Policy() below.
 	if d, ok := a.acl.(*acl.Declarative); ok && d != nil {
 		// jwtVerified tells attachACLRequest that identity is a verified-JWT
 		// assertion (the gate is installed), so an unmatched principal can be
@@ -202,6 +208,7 @@ func (a *App) NewRouter() http.Handler {
 		// this captures nil and `unmatched_principal: reject` silently never
 		// fires. If a future refactor reorders these, that invariant breaks
 		// quietly; keep SetJWTGate ahead of NewRouter.
+		warnUnmatchedRejectWithoutJWTGate(d.Policy(), a.jwtGate != nil)
 		handler = attachACLRequest(handler, d, a.jwtGate != nil)
 	}
 	// The JWT gate wraps BETWEEN attachACLRequest and stampAuditPrincipal, so at
@@ -224,6 +231,62 @@ func (a *App) NewRouter() http.Handler {
 	}
 	handler = stampAuditPrincipal(handler, resolver)
 	return handler
+}
+
+// warnUnmatchedRejectWithoutJWTGate warns when `unmatched_principal: reject` is
+// configured but cannot fire, in which case the setting is inert
+// (TKT-M60ZF5 / issue #1274).
+//
+// Two independent ways to be inert, and the message names which one applies —
+// "reject does nothing" is not actionable without saying what to change:
+//
+//   - no JWT gate wired: reject keys on identity having come from the
+//     fail-closed gate, so without one no principal is ever "verified".
+//   - the principal_property lookup disabled: the resolver never attempts a
+//     match, so an unmatched principal is not something that can be observed.
+//     LoadPolicy refuses this combination, but NewDeclarative does NOT call
+//     Validate, so a construction path that skips LoadPolicy reaches it.
+//
+// Both read acl.Policy.RejectEffective, the same predicate the enforcement site
+// uses. Computing it separately here is how the first version of this warning
+// got it wrong: it checked only gate wiring and stayed silent on the second
+// case, which is the very failure mode the ticket exists to close.
+//
+// Policy.Validate cannot do this: it sees acl.yaml, and whether a gate is wired
+// is a property of the SERVER, decided elsewhere and later. NewRouter is the
+// first point where both facts are in scope.
+//
+// A warning rather than a hard error, deliberately. acl.yaml is shared config:
+// the CLI, `rela flow` and the scheduler all load the same enforcing policy and
+// never call NewRouter, so a hard failure would either break every CLI
+// invocation for an HTTP-only concern or need a per-process exemption — a
+// second wiring invariant to get wrong. This matches warnUngatedMembership in
+// appbuild — the closer precedent than the `provision` warning in acl, which is
+// a per-request runtime notice about a write that already arrived, where this
+// (like appbuild's) is a startup notice about inert configuration.
+//
+// Note this also gives the "SetJWTGate MUST run before NewRouter" ordering
+// invariant a runtime voice: a future refactor that reorders them makes this
+// warning fire, where previously it failed silently.
+func warnUnmatchedRejectWithoutJWTGate(p *acl.Policy, jwtWired bool) {
+	if p == nil || p.EffectiveUnmatchedPrincipal() != acl.UnmatchedReject {
+		return
+	}
+	if p.RejectEffective(jwtWired) {
+		return
+	}
+	switch {
+	case !jwtWired:
+		slog.Warn("acl: unmatched_principal: reject is configured but no JWT gate is wired; " +
+			"the setting has NO effect and unmatched principals are treated as anonymous. " +
+			"Wire a JWT gate (SetJWTGate before NewRouter), or remove the key to make the " +
+			"posture explicit.")
+	default:
+		slog.Warn("acl: unmatched_principal: reject is configured but the principal_property " +
+			"lookup is not enabled; the setting has NO effect and unmatched principals are " +
+			"treated as anonymous. Set user_entity_type and principal_property, or remove " +
+			"the key to make the posture explicit.")
+	}
 }
 
 // isAPIPath reports whether p addresses the data API — the surface that carries

--- a/internal/dataentry/unmatched_reject_wiring_test.go
+++ b/internal/dataentry/unmatched_reject_wiring_test.go
@@ -1,0 +1,245 @@
+package dataentry
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// `unmatched_principal: reject` only takes effect when a JWT gate is wired:
+// NewRouter snapshots a.jwtGate, and attachACLRequest keys the reject decision
+// on that snapshot. An operator who configures reject in a deployment without
+// a gate gets an acl.yaml key that silently does nothing — believing writes
+// from unknown identities are denied when they are not (TKT-M60ZF5 / issue #1274).
+//
+// Policy.Validate cannot catch this. It only sees acl.yaml, and "is a gate
+// wired" is a property of the SERVER, decided elsewhere and later. NewRouter is
+// the first place both facts are in scope.
+//
+// A warning, not a hard error: refusing to start would turn a wiring omission
+// into an outage for a deployment that is merely no stricter than the default.
+// The mistake is believing a restriction is in force, so the fix is to say so.
+
+// lockedWriter serializes writes and reads. bytes.Buffer is not safe for
+// concurrent use, and newTestAppV1 builds a real app whose background
+// goroutines can log after the constructor returns — so an unsynchronized
+// buffer races the assertion. Mirrors appbuild_membership_warn_test.go.
+type lockedWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *lockedWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// captureWarnings redirects the default logger for one test and returns the
+// accumulated output.
+//
+// Callers must NOT use t.Parallel(): slog.SetDefault mutates process-global
+// state, so two tests capturing at once would each see the other's output.
+// Today the package is safe by scheduling accident (Go runs parallel tests
+// after serial ones), which is not an invariant worth relying on.
+func captureWarnings(t *testing.T) *lockedWriter {
+	t.Helper()
+	w := &lockedWriter{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return w
+}
+
+// rejectPolicy is a policy on which reject would genuinely be live: the mode
+// plus the lookup it requires. Tests that want a DIFFERENT inert cause vary one
+// field from this, so what each test is isolating stays visible.
+func rejectPolicy() *acl.Policy {
+	return &acl.Policy{
+		UnmatchedPrincipal: acl.UnmatchedReject,
+		UserEntityType:     "person",
+		PrincipalProperty:  "email",
+	}
+}
+
+func TestUnmatchedReject_WarnsWhenNoJWTGateWired(t *testing.T) {
+	buf := captureWarnings(t)
+
+	warnUnmatchedRejectWithoutJWTGate(rejectPolicy(), false)
+
+	got := buf.String()
+	if !strings.Contains(got, "unmatched_principal: reject") {
+		t.Errorf("expected a warning naming the setting, got: %s", got)
+	}
+	// The warning has to say the setting is INERT. "reject is configured" alone
+	// reads as confirmation that it is working, which is the belief being
+	// corrected.
+	if !strings.Contains(got, "NO effect") {
+		t.Errorf("warning must state the setting has no effect, got: %s", got)
+	}
+}
+
+// The discriminating case. A wired gate means reject genuinely applies, so
+// warning would be false alarm — and an operator who learns to ignore this
+// warning gets nothing from it in the deployment where it matters.
+func TestUnmatchedReject_SilentWhenJWTGateWired(t *testing.T) {
+	buf := captureWarnings(t)
+
+	warnUnmatchedRejectWithoutJWTGate(rejectPolicy(), true)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("no warning expected when a JWT gate is wired, got: %s", got)
+	}
+}
+
+// The other modes are unaffected by gate wiring, so a missing gate is not
+// noteworthy for them. `provision` has its own separate warning at the point it
+// would have acted; duplicating it here would double-report one condition.
+func TestUnmatchedReject_SilentForOtherModes(t *testing.T) {
+	for _, mode := range []string{"", acl.UnmatchedAnonymous, acl.UnmatchedProvision} {
+		name := mode
+		if name == "" {
+			name = "<empty>"
+		}
+		t.Run("mode="+name, func(t *testing.T) {
+			buf := captureWarnings(t)
+
+			p := rejectPolicy()
+			p.UnmatchedPrincipal = mode
+			warnUnmatchedRejectWithoutJWTGate(p, false)
+
+			if got := buf.String(); got != "" {
+				t.Errorf("no warning expected for mode %q, got: %s", mode, got)
+			}
+		})
+	}
+}
+
+// A nil policy is not a reject configuration, and must not panic on the way to
+// deciding that.
+func TestUnmatchedReject_NilPolicyIsSilent(t *testing.T) {
+	buf := captureWarnings(t)
+
+	warnUnmatchedRejectWithoutJWTGate(nil, false)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("no warning expected for a nil policy, got: %s", got)
+	}
+}
+
+// The tests above call the helper directly, which proves the predicate is right
+// and NOT that anything calls it. This one goes through NewRouter — the
+// composition site, and the only place the wiring fact exists. Without it the
+// helper could be correct and dead, which is the same class of gap as the
+// silent no-op being fixed.
+// newRejectApp builds an App whose ACL is a reject policy.
+//
+// Built directly rather than via mustNewACL: reject requires UserEntityType +
+// PrincipalProperty, and enabling that lookup in turn requires a
+// PrincipalLookup that mustNewACL does not supply.
+func newRejectApp(t *testing.T) *App {
+	t.Helper()
+	app := newTestAppV1(t)
+	d, err := acl.NewDeclarative(&acl.Policy{
+		Roles:              map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments:        map[string]string{"alice": "viewer"},
+		UserEntityType:     "person",
+		PrincipalProperty:  "email",
+		UnmatchedPrincipal: acl.UnmatchedReject,
+	}, acl.NewStoreGraph(app.store), app.store,
+		acl.WithPrincipalLookup(acl.NewStorePrincipalLookup(app.store)))
+	if err != nil {
+		t.Fatalf("acl.NewDeclarative: %v", err)
+	}
+	app.acl = d
+	return app
+}
+
+func TestUnmatchedReject_NewRouterWarnsWhenGateMissing(t *testing.T) {
+	app := newRejectApp(t)
+	buf := captureWarnings(t)
+
+	// No SetJWTGate call: this is exactly the deployment the issue describes.
+	_ = app.NewRouter()
+
+	if got := buf.String(); !strings.Contains(got, "no JWT gate is wired") {
+		t.Errorf("NewRouter must warn that reject is inert without a JWT gate, got: %s", got)
+	}
+}
+
+// The paired case, and the one that pins the ARGUMENT NewRouter passes. Without
+// it, swapping `a.jwtGate != nil` for a literal `false` leaves the suite green:
+// the test above only asserts a warning appeared, not that it appeared for the
+// right reason, and every other test calls the helper directly.
+func TestUnmatchedReject_NewRouterSilentWhenGateWired(t *testing.T) {
+	app := newRejectApp(t)
+	mustSetJWTGate(t, app)
+	buf := captureWarnings(t)
+
+	_ = app.NewRouter()
+
+	if got := buf.String(); strings.Contains(got, "unmatched_principal") {
+		t.Errorf("no unmatched_principal warning expected when a gate is wired, got: %s", got)
+	}
+}
+
+// The SECOND way reject is inert, and the one the first version of this warning
+// missed entirely (RR-0CJ47L): reject also requires the principal_property lookup —
+// with it disabled the resolver never attempts a match, so "unmatched" is not
+// something that can be observed.
+//
+// LoadPolicy refuses this combination, but NewDeclarative does NOT call
+// Validate, so any construction path that skips LoadPolicy reaches exactly this
+// state. That is why the warning checks it instead of assuming it away.
+func TestUnmatchedReject_WarnsWhenLookupDisabled(t *testing.T) {
+	buf := captureWarnings(t)
+
+	p := rejectPolicy()
+	p.UserEntityType = "" // lookup disabled; gate IS wired
+	warnUnmatchedRejectWithoutJWTGate(p, true)
+
+	got := buf.String()
+	if !strings.Contains(got, "NO effect") {
+		t.Errorf("expected a warning that reject is inert, got: %s", got)
+	}
+	// The message must name the CAUSE. "reject does nothing" is not actionable
+	// without saying which of the two things to change.
+	if !strings.Contains(got, "principal_property") {
+		t.Errorf("warning must name the lookup as the cause, got: %s", got)
+	}
+	if strings.Contains(got, "no JWT gate is wired") {
+		t.Errorf("warning names the wrong cause (a gate IS wired), got: %s", got)
+	}
+}
+
+// A typed-nil *acl.Declarative stored in the ACL interface is NOT nil, so the
+// `d != nil` guard in NewRouter's type switch is load-bearing. Adding a call to
+// d.Policy() there widened the blast radius of getting it wrong: previously a
+// typed-nil failed later, per request; now NewRouter itself would panic at
+// construction.
+//
+// Removing that guard leaves every other test in this file green, so it needs
+// its own. Policy() is also nil-receiver safe now, making this defense in
+// depth rather than a single point of failure.
+func TestUnmatchedReject_TypedNilDeclarativeDoesNotPanic(t *testing.T) {
+	app := newTestAppV1(t)
+	var d *acl.Declarative
+	app.acl = d // typed nil: non-nil interface, nil pointer
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewRouter panicked on a typed-nil *acl.Declarative: %v", r)
+		}
+	}()
+	_ = app.NewRouter()
+}

--- a/internal/jobs/jobstest/jobstest.go
+++ b/internal/jobs/jobstest/jobstest.go
@@ -683,9 +683,23 @@ func testIdempotencyFreed(t *testing.T, newQueue NewQueue) {
 	require.Eventually(t, func() bool { return ran.get() == 1 }, settleTimeout, pollInterval)
 
 	// Same key again, after completion: must queue.
-	require.NoError(t, q.Enqueue(context.Background(), jobs.Job{
-		Kind: "cycle", IdempotencyKey: "report",
-	}))
+	//
+	// POLLED, not enqueued once. `ran.inc()` happens inside the handler, so the
+	// wait above establishes "the handler body started" — while the key is
+	// freed only once the queue records the job COMPLETE, strictly later. A
+	// single Enqueue here races that window and returns ErrDuplicateJob on a
+	// contended runner (BUG-BPHP79; reproduce with GOMAXPROCS=1).
+	//
+	// Polling does not weaken the assertion: the key BECOMING free is the
+	// property under test, so waiting for it within settleTimeout is the test.
+	// What would weaken it is a sleep — that trades a visible flake for a slow
+	// invisible one — or dropping ErrDuplicateJob, which is the failure.
+	require.Eventually(t, func() bool {
+		return q.Enqueue(context.Background(), jobs.Job{
+			Kind: "cycle", IdempotencyKey: "report",
+		}) == nil
+	}, settleTimeout, pollInterval,
+		"a completed key must become free for reuse")
 	require.Eventually(t, func() bool { return ran.get() == 2 }, settleTimeout, pollInterval,
 		"a completed key must be free for reuse; it guards pending work, not history")
 }

--- a/tickets/entities/automated-measures/idempotency-freed-load-repro.md
+++ b/tickets/entities/automated-measures/idempotency-freed-load-repro.md
@@ -1,0 +1,42 @@
+---
+id: idempotency-freed-load-repro
+type: automated-measure
+title: 'Run the jobs conformance suite under GOMAXPROCS=1 so completion races surface deterministically'
+kind: test
+location: internal/jobs (conformance suite; CI job or nightly)
+status: proposed
+description: >-
+  BUG-BPHP79 was invisible at full parallelism -- 5 consecutive -race runs and a
+  run with CI's exact -shuffle seed all passed -- and deterministic under
+  GOMAXPROCS=1. The suite's async assertions are therefore only exercised in the
+  scheduling regime where the windows they race are narrowest, which is the
+  regime least likely to catch them.
+
+  Running the jobs conformance suite once under GOMAXPROCS=1 (a separate CI step,
+  or nightly if the runtime cost matters) turns that class of defect from an
+  intermittent failure on an unrelated branch into a reproducible one on the
+  branch that introduces it. The cost is small: the suite is ~70s, and the
+  serialized run in the reproduction took ~2s for the single affected test.
+
+  This is a MEASURE rather than a fix because it catches the class, not the
+  instance: any future test in this suite that polls a proxy for a queue-side
+  state transition -- the shape of BUG-BPHP79's why4 -- fails under it.
+---
+
+## Why this class needs a load dimension
+
+`-shuffle=on` varies test ORDER, which is the right control for
+inter-test state leakage. It does nothing for intra-test races between a
+handler-side signal and the queue's own bookkeeping, because those depend on how
+goroutines interleave rather than on which test ran first.
+
+The bug's diagnosis turned on exactly that distinction: reaching for another
+shuffle seed reproduced nothing, and reaching for `GOMAXPROCS=1` reproduced it in
+one run. A measure that only varies order would not have found it.
+
+## Scope
+
+Deliberately narrow — the jobs conformance suite, not the whole tree. That suite
+is the one whose subject is a concurrent queue, so its tests are the ones whose
+async assumptions are load-bearing. Applying this repo-wide would multiply CI
+time for packages where scheduling is not part of the contract.

--- a/tickets/entities/bug-analysis-checklists/BUGA-PFQPOM.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-PFQPOM.md
@@ -1,0 +1,91 @@
+---
+id: BUGA-PFQPOM
+type: bug-analysis-checklist
+title: 'Analysis: testIdempotencyFreed races the queue completion bookkeeping'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally
+- [x] Minimal reproduction steps documented
+- [x] Environment/conditions noted
+
+Deterministic under CPU pressure:
+
+```
+GOMAXPROCS=1 go test ./internal/jobs/ -race \
+  -run 'TestMemoryQueue_Conformance/IdempotencyKeyFreed' -count=20
+```
+
+fails immediately with `jobs: an identical job is already pending`.
+
+**Environment matters here, and misled me first.** At full parallelism it passes
+consistently: 5 consecutive `-race` runs (341s) and a run with CI's exact
+`-shuffle` seed all green. That is why it presented as a flake and why I
+initially reported it as one — a conclusion the second CI failure disproved.
+
+Observed twice on CI for PR #1497, a branch that does not touch `internal/jobs`.
+Verified structurally rather than by inspection: `go list -deps
+./internal/jobs/` reaches neither `internal/acl` nor `internal/dataentry`, so
+the changed packages are unreachable from the failing one.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1)
+- [x] Contributing factors found (why2-3)
+- [x] Systemic cause explored (why4-5)
+
+**why1** — The second `Enqueue` returns `ErrDuplicateJob` because the
+idempotency key is still held.
+
+**why2** — The test re-enqueues as soon as `ran.get() == 1`, but `ran.inc()`
+fires INSIDE the handler body. That establishes "the handler started", not "the
+job completed".
+
+**why3** — The key is freed only when the queue records completion, which is
+strictly after the handler returns. Between those two points the key is held and
+a re-enqueue is correctly rejected. Under contention that window is wide enough
+to lose.
+
+**why4** — The test asserted on a PROXY for the event it cared about. `ran` was
+reachable from the test, and completion was not, so the reachable signal stood
+in for the real one. The comment says "Same key again, after completion" — the
+intent was right; the observable did not match it.
+
+**why5** — Nothing in the test's shape reveals the substitution.
+`require.Eventually` looks like careful async handling, so a reader sees a test
+that already waits properly and does not ask whether it waits for the RIGHT
+thing. A `time.Sleep` would have looked suspicious; this did not.
+
+The queue behaviour is CORRECT throughout. A completed key is freed. This is a
+defect in the test's synchronisation only, which is why it had to be diagnosed
+rather than fixed by changing the code under test.
+
+## Fix Planning
+
+- [x] Fix approach determined
+- [x] Regression test planned
+- [x] Related areas checked for similar issues
+
+**Approach.** Poll the second `Enqueue` inside `require.Eventually` until it
+succeeds. The key becoming free IS the property under test, so waiting for it is
+the assertion rather than a weakening of it.
+
+Explicitly rejected: `time.Sleep` before the re-enqueue (trades a visible flake
+for a slow invisible one) and ignoring `ErrDuplicateJob` (that error is the
+failure this test exists to catch).
+
+**Regression test.** The fixed test IS the regression test, so the risk is that
+polling makes it unable to fail. Verified by mutation: blocking the handler so
+the job never completes — and the key therefore never frees — still fails, after
+the full `settleTimeout`. So the fix removes the race without removing the
+assertion.
+
+**Related areas.** Checked the sibling `testIdempotencyCollapses`: it holds the
+handler open on a channel and asserts the duplicate IS rejected while the first
+is still pending. That direction has no race — it asserts the state that exists
+during the window rather than after it. No other test in `jobstest.go` waits on
+a handler-side counter to infer a queue-side state transition.

--- a/tickets/entities/bugs/BUG-BPHP79.md
+++ b/tickets/entities/bugs/BUG-BPHP79.md
@@ -1,0 +1,73 @@
+---
+id: BUG-BPHP79
+type: bug
+title: testIdempotencyFreed races the queue completion bookkeeping
+description: testIdempotencyFreed waits for the handler to have RUN (ran.inc() fires inside the handler body) and then immediately re-enqueues the same idempotency key, but the key is freed only once the queue records the job COMPLETE -- strictly later. On a contended runner that window opens and the second Enqueue returns ErrDuplicateJob. Deterministic under GOMAXPROCS=1; observed twice on CI. The queue behaviour is correct; the test's synchronisation is not.
+why1: 'The second Enqueue returns ErrDuplicateJob because the idempotency key is still held.'
+why2: 'The test re-enqueues as soon as ran.get() == 1, but ran.inc() fires INSIDE the handler body -- that establishes "the handler started", not "the job completed".'
+why3: 'The key is freed only when the queue records completion, strictly after the handler returns. Between those two points the key is held and a re-enqueue is correctly rejected; under contention that window is wide enough to lose.'
+why4: 'The test asserted on a PROXY for the event it cared about. `ran` was reachable from the test and completion was not, so the reachable signal stood in for the real one. The comment ("Same key again, after completion") shows the intent was right; the observable did not match it.'
+why5: 'Nothing in the test''s shape reveals the substitution. require.Eventually LOOKS like careful async handling, so a reader sees a test that already waits properly and never asks whether it waits for the right thing. A time.Sleep would have looked suspicious; this did not.'
+prevention: 'When a test waits for an async state transition, the thing it polls must be the transition itself, not a signal that merely correlates with it. Here the queue exposes no completion hook to the test, so the fix polls the OPERATION whose success defines the state (Enqueue succeeding == the key is free) rather than a handler-side counter. Systemic: a polling fix must be checked for retained teeth -- verified here by blocking the handler so the key is never freed and confirming the test still fails. Also worth generalising: an intermittent CI failure that is two-for-two on one branch and zero elsewhere is NOT randomness, and treating it as a flake (which I did first) costs a rerun and delays the diagnosis. Reach for load (GOMAXPROCS=1) as well as ordering (-shuffle) when reproducing.'
+priority: medium
+status: done
+---
+
+## Description
+
+`testIdempotencyFreed` (`internal/jobs/jobstest/jobstest.go:669`) races against
+the queue's own completion bookkeeping and fails intermittently in CI.
+
+It waits for the handler to have RUN, then immediately re-enqueues the same
+idempotency key:
+
+```go
+require.Eventually(t, func() bool { return ran.get() == 1 }, settleTimeout, pollInterval)
+
+// Same key again, after completion: must queue.
+require.NoError(t, q.Enqueue(context.Background(), jobs.Job{
+    Kind: "cycle", IdempotencyKey: "report",
+}))
+```
+
+`ran.inc()` happens INSIDE the handler, but the key is freed only once the queue
+records the job complete — strictly later. The comment says "after completion",
+and the assertion it rests on only establishes "after the handler body started".
+On a contended runner that window opens and the second `Enqueue` returns
+`ErrDuplicateJob`.
+
+## Reproduction
+
+Deterministic under CPU pressure:
+
+```
+GOMAXPROCS=1 go test ./internal/jobs/ -race \
+  -run 'TestMemoryQueue_Conformance/IdempotencyKeyFreed' -count=20
+```
+
+fails immediately with `jobs: an identical job is already pending`. It passes
+consistently at full parallelism, including 5 consecutive `-race` runs and a run
+with CI's exact `-shuffle` seed — which is why it presents as a flake.
+
+Observed twice on CI for PR #1497, a branch that does not touch `internal/jobs`
+(verified: `go list -deps ./internal/jobs/` reaches neither `internal/acl` nor
+`internal/dataentry`).
+
+## Proposed fix
+
+Assert on the OBSERVABLE the test actually needs. Either:
+
+- poll the second `Enqueue` until it succeeds, within `settleTimeout` — the key
+becoming free IS the property under test, so waiting for it is not weakening the
+assertion; or
+- have the handler signal completion through a channel the queue closes after
+recording, so the test waits for the real event rather than a proxy.
+
+The first is smaller and keeps the test's shape. What it must NOT do is
+`time.Sleep` a guess, which would trade a visible flake for a slow invisible
+one.
+
+## Note
+
+The behaviour under test is correct — a completed key IS freed. This is a defect
+in the test's synchronisation, not in the queue.

--- a/tickets/entities/docs-checklists/DOCS-WIU04Z.md
+++ b/tickets/entities/docs-checklists/DOCS-WIU04Z.md
@@ -1,0 +1,85 @@
+---
+id: DOCS-WIU04Z
+type: docs-checklist
+title: 'Docs: Warn when unmatched_principal reject has no JWT gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported functions/types have godoc
+- [x] Non-obvious decisions explained in comments
+- [x] Package docs updated if package purpose changed
+
+`warnUnmatchedRejectWithoutJWTGate` is unexported but carries a full doc
+comment, because three things about it are non-obvious:
+
+- **Why it lives in `NewRouter` and not `Policy.Validate`.** Validate sees
+`acl.yaml`; whether a JWT gate is wired is a property of the SERVER, decided
+elsewhere and later. `NewRouter` is the first point where both facts are in
+scope. Without this note the natural instinct is to "tidy" the check in with the
+rest of the policy validation, where it cannot work.
+- **Why it warns rather than fails.** Refusing to start turns a wiring omission
+into an outage for a deployment that is merely no stricter than the default. A
+reader who thinks "security check, should be fatal" needs the counterweight in
+front of them.
+- **That it also gives the SetJWTGate/NewRouter ordering invariant a runtime
+voice.** That invariant was previously protected only by a code comment, so a
+refactor reordering them failed silently. It now warns. Recorded because the
+check is doing two jobs and only one is in the ticket title.
+
+The test file's header comment states the reasoning the tests encode — why a
+warning and not an error, and why the `NewRouter`-level test exists at all when
+four others already cover the predicate.
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md updated with new patterns~~ (N/A: no new pattern — it reuses
+the `slog.Warn` channel the `provision` mode already uses for the same class of
+problem)
+- [x] docs/ updated for changed behaviour — see below
+- [x] ~~Architecture docs updated~~ (N/A: no package boundary, dependency or
+wiring-contract change)
+
+`docs/acl-security.md` gains a bullet in the `unmatched_principal` section's
+"Load-bearing details" list, alongside the existing entries for the lookup
+requirement and the provisioner grant.
+
+The doc already said `reject` "keys on the fact that identity came from the
+fail-closed JWT gate" — true, and not enough: it describes the mechanism without
+saying what happens when there is no gate. The new bullet closes that, states
+explicitly that the key has **no effect** in that case, explains why it is a
+warning rather than the load error the missing-lookup case gets (`acl.yaml`
+cannot see server wiring), and tells an operator who configured `reject` and
+sees writes going through to check that warning first.
+
+That last sentence is the practical one. The failure this ticket addresses is
+someone believing a restriction is in force; the doc is where they will look
+when they eventually notice it is not.
+
+Edited in `docs-project/entities/guides/GUIDE-acl-security.md` and regenerated
+with `just docs`. `docs/` is GENERATED — editing the output directly fails the
+Docs CI check, which is exactly how the sibling ticket TKT-LVSPSB failed CI
+earlier in this same issue round.
+
+## External Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLI reference updated~~ (N/A: no command or flag changes)
+- [x] ~~API docs updated~~ (N/A: no HTTP surface change — no route, request or
+response differs. The change is a startup log line)
+
+## Rationale for N/A
+
+Nothing an API consumer can observe changes: no authorization decision is
+altered, only reported. A deployment with `reject` and no gate behaved as
+`anonymous` before this change and behaves as `anonymous` after it — the
+difference is that it now says so.
+
+The two audiences are covered separately and deliberately. The warning reaches
+an operator who has ALREADY deployed the misconfiguration; the doc bullet
+reaches one who has not yet. Either alone leaves half the problem: a warning
+nobody knows to expect reads as noise, and a doc nobody re-reads does not help
+someone already running.

--- a/tickets/entities/implementation-checklists/IMPL-0NYT04.md
+++ b/tickets/entities/implementation-checklists/IMPL-0NYT04.md
@@ -1,0 +1,94 @@
+---
+id: IMPL-0NYT04
+type: implementation-checklist
+title: 'Implementation: testIdempotencyFreed races the queue completion bookkeeping'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Test-only. No production code changed — the queue behaviour is correct; the
+test's synchronisation was not.
+
+The second `Enqueue` now runs inside `require.Eventually` until it succeeds,
+instead of once immediately after the handler has started. The comment records
+why, because the previous shape looked careful: `require.Eventually` on the
+counter reads as proper async handling, so nobody asks whether it waits for the
+RIGHT event.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Same helpers, same timeouts, same shape. The change is one call site.
+
+Two alternatives were explicitly rejected and the comment says so, since both
+are the obvious next edit:
+
+- `time.Sleep` before the re-enqueue — trades a visible flake for a slow
+invisible one, and encodes a guess about a machine.
+- ignoring `ErrDuplicateJob` — that error IS the failure this test exists to
+catch, so swallowing it would delete the test while leaving it green.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+| step | expected | observed |
+| --- | --- | --- |
+| `GOMAXPROCS=1 ... -count=20` BEFORE the fix | fails | FAIL, `an identical job is already pending` |
+| same command AFTER the fix | passes | ok (2.1s) |
+| block the handler so the job never completes | still FAILS | FAIL after the full 10s settleTimeout |
+| `./internal/jobs/... -race` | green | ok (69s) |
+
+The third row is the one that matters. A polling fix is only worth having if it
+cannot pass when the property genuinely does not hold — otherwise it silences
+the flake by deleting the assertion. Holding the handler open so the key is
+never freed still fails, so the test retained its teeth.
+
+The first two rows use the reproduction that made the diagnosis possible.
+`GOMAXPROCS=1` turns an intermittent CI failure into a deterministic local one,
+which is what moved this from "flake, rerun it" to a fixable defect.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Uses the file's existing `settleTimeout` / `pollInterval` constants rather than
+introducing a bespoke timeout, so the whole suite still tunes from one place.
+
+DRY: nothing to extract — one call site changed.
+
+Worth recording how this was reached, because the first conclusion was wrong. I
+initially called it a flake and re-ran CI, on the strength of: the diff not
+touching `internal/jobs`, both sibling branches passing, and 5 consecutive local
+`-race` runs plus CI's exact `-shuffle` seed all green. The rerun failed
+identically, which disproved it.
+
+What the flake hypothesis never explained was why it failed TWICE on one branch
+and zero times elsewhere. "Flaky" is a hypothesis that predicts randomness; two
+for two is not random. Reaching for load rather than ordering — `GOMAXPROCS=1`
+instead of another seed — made it deterministic in one run.

--- a/tickets/entities/implementation-checklists/IMPL-F33ELN.md
+++ b/tickets/entities/implementation-checklists/IMPL-F33ELN.md
@@ -1,0 +1,143 @@
+---
+id: IMPL-F33ELN
+type: implementation-checklist
+title: 'Implementation: Warn when unmatched_principal reject has no JWT gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+One function and one call:
+
+- `warnUnmatchedRejectWithoutJWTGate(p *acl.Policy, jwtWired bool)` in
+`internal/dataentry/router.go`.
+- Called from `NewRouter` immediately before `attachACLRequest`, passing the
+SAME `a.jwtGate != nil` expression that `attachACLRequest` receives.
+
+Reading the identical expression is deliberate. A check that computed wiring
+state differently could disagree with the thing it claims to describe, and the
+warning would then be wrong in exactly the situation it exists for.
+
+It takes the policy and a bool rather than the `*App`, so it is pure and
+testable without constructing a server. It reads the mode through the existing
+`EffectiveUnmatchedPrincipal()` so the empty default resolves the same way it
+does everywhere else, rather than re-deriving that rule.
+
+Edge cases from planning, all covered: nil policy; empty-string mode; the other
+two modes. No error handling to add — this reports a condition, it does not
+create one, and it cannot fail.
+
+### What review changed (RR-0CJ47L and friends)
+
+The first version checked ONE of the three conditions `reject` actually needs.
+It fires only when the mode is reject AND a JWT gate is wired AND the
+`principal_property` lookup is enabled (`router.go:451`). Checking only the gate
+meant a reject policy with no `user_entity_type` / `principal_property` was
+equally inert and warned about nothing — a second silent-inert state, uncovered,
+in exactly the shape of the bug this ticket exists to close.
+
+My defense was "LoadPolicy refuses that combination". It does, but
+`acl.NewDeclarative` never calls `Validate`, so any path skipping `LoadPolicy`
+reaches that state — including this ticket's own test, which builds a
+`Declarative` directly.
+
+Fixed by extracting `acl.Policy.RejectEffective(jwtWired bool)`: one predicate
+covering all three conditions, so the warning and the thing it describes cannot
+drift. The message now names WHICH condition is missing — "reject does nothing"
+is not actionable without saying what to change.
+
+Three further findings, all fixed:
+
+- **No test pinned the ARGUMENT `NewRouter` passes** (RR-U5LKGQ). Swapping
+`a.jwtGate != nil` for a literal `false` left the suite green: the composition
+test asserted only that some warning appeared. Added the paired gate-wired case.
+- **The `d.Policy()` call widened a typed-nil's blast radius** (RR-I1RTSU). A
+typed-nil `*acl.Declarative` is not nil, and `NewRouter` would now panic at
+construction rather than failing later per request. `Policy()` and the Policy
+predicates are nil-receiver safe, and a test pins it.
+- **The slog capture buffer was unsynchronized** (RR-FZ1CBE), against a
+documented precedent in `appbuild` that already solved it.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`captureWarnings(t)` factors out the slog redirect + `t.Cleanup` restore, using
+the pattern already in `reserved_principal_test.go` rather than a new one. Modes
+are a table so adding a fourth mode later is one line.
+
+The `NewRouter` test builds its `Declarative` directly instead of via
+`mustNewACL`, because `reject` requires `user_entity_type` +
+`principal_property`, and enabling that lookup in turn requires a
+`PrincipalLookup` that `mustNewACL` does not supply. The comment says so, since
+"why not the helper" is the first question a reader will have.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+| mutation | expected | observed |
+| --- | --- | --- |
+| guard returns early always (never warn) | the positive tests redden | `..._WarnsWhenNoJWTGateWired` and `..._NewRouterWarnsWhenGateMissing` FAIL |
+| drop the `jwtWired` term (warn whenever reject is set) | the false-alarm test reddens | `..._SilentWhenJWTGateWired` FAILs |
+| delete the call from `NewRouter` | only the composition test reddens | `..._NewRouterWarnsWhenGateMissing` FAILs, alone |
+| drop the lookup term from `RejectEffective` | the lookup test reddens alone | `..._WarnsWhenLookupDisabled` FAIL |
+| `NewRouter` passes a literal `false` | the gate-wired composition test reddens alone | `..._NewRouterSilentWhenGateWired` FAIL |
+| remove the `d != nil` guard AND `Policy()`'s nil check | the typed-nil test reddens | FAIL with a nil dereference |
+| restored | green | ok |
+
+The third row is the one that matters most. The first four tests exercise the
+helper directly, so they would ALL pass on a correct helper that nothing calls —
+the same shape of defect as the silent no-op this ticket fixes. Only the
+`NewRouter` test rules that out, and the mutation confirms it does.
+
+The second row is the other one worth keeping: a check that warned whenever
+`reject` is configured, regardless of wiring, would satisfy the primary
+acceptance criterion and be actively harmful — an operator who learns to ignore
+a false alarm gets nothing from it in the deployment where it matters.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Follows the `provision` warning in `internal/acl/declarative.go:208` — same
+mechanism, same class of problem (a configured mode that does not do what its
+name suggests). Reusing that channel rather than inventing one means an operator
+already watching for one of these sees the other.
+
+DRY: nothing to extract. The two warnings live in different packages and say
+different things; sharing them would need a parameterised message that reads
+worse than either.
+
+Security: this changes no authorization decision — it reports one. The value is
+entirely in closing the gap between what an operator believes is enforced and
+what is. The message carries no principal, token or entity data.
+
+The warning also gives the "SetJWTGate MUST run before NewRouter" ordering
+invariant a runtime voice, which it previously did not have: it was protected
+only by a code comment, and a refactor that reordered them failed silently. It
+now warns. That is a side benefit, not the ticket's purpose, and it is noted in
+the function's godoc so the next reader knows the check is doing two jobs.

--- a/tickets/entities/planning-checklists/PLAN-KIOA4C.md
+++ b/tickets/entities/planning-checklists/PLAN-KIOA4C.md
@@ -1,0 +1,221 @@
+---
+id: PLAN-KIOA4C
+type: planning-checklist
+title: 'Planning: Warn when unmatched_principal reject has no JWT gate'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: a load-time `slog.Warn` at `NewRouter` when `unmatched_principal: reject` is
+configured and no JWT gate is wired.
+
+OUT, with reasons:
+
+- *Making it a hard error.* Refusing to start turns a wiring omission into an
+outage for a deployment that is merely no stricter than the default
+(`anonymous`) — the posture it had before the key existed. The operator's
+mistake is BELIEVING a restriction is in force; the fix is to say so, not to
+take the server down. This also matches how `provision` already reports its own
+inert state.
+- *Moving the check into `Policy.Validate`.* It cannot see server wiring. That
+is the whole reason the hole exists.
+- *Enforcing the SetJWTGate/NewRouter ordering mechanically.* Out of scope, but
+note the warning gives that invariant a runtime voice for free: a refactor that
+reorders them now makes this fire, where before it failed silently.
+
+**Acceptance Criteria:**
+
+1. `reject` + no gate → warns, and the message says the setting is INERT.
+*Test:* capture `slog`, assert the output names the setting AND contains "NO
+effect". A warning that only says "reject is configured" reads as confirmation
+it is working, which is the belief being corrected.
+2. `reject` + gate wired → silent.
+*Test:* same helper, `jwtWired=true`, assert no output. This is the
+discriminating case: an operator who learns to ignore a false alarm gets nothing
+from the warning in the deployment where it matters.
+3. Other modes → silent regardless of wiring.
+*Test:* table over `""`, `anonymous`, `provision`. `provision` has its own
+warning where it would have acted; duplicating it here would double-report one
+condition.
+4. A nil policy is silent and does not panic.
+5. `NewRouter` actually calls the check.
+*Test:* build an App with a reject policy, call `NewRouter()` WITHOUT
+`SetJWTGate`, assert the warning appears. AC1–4 prove the predicate; only this
+proves anything invokes it.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — a single guard.
+
+**Existing Solutions:**
+
+- The in-repo precedent is the `provision` warning in
+`internal/acl/declarative.go:208`, which reports the same class of problem (a
+configured mode that does not do what its name suggests). Same mechanism
+(`slog.Warn`), same reasoning, so this follows it rather than inventing a
+reporting channel.
+- `Policy.Validate` was checked first and rejected as the home: it validates
+acl.yaml against itself and has no access to server wiring.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Add `warnUnmatchedRejectWithoutJWTGate(p *acl.Policy, jwtWired bool)` in
+`internal/dataentry/router.go` and call it from `NewRouter` immediately before
+`attachACLRequest`, using the same `a.jwtGate != nil` expression that
+`attachACLRequest` receives. Reading the same expression is deliberate: a check
+computed differently could disagree with the thing it is describing.
+
+It takes the policy and the wiring bool rather than the `*App` so it is a pure
+function, testable without constructing a server.
+
+**Alternatives considered:**
+
+- *Hard error at load.* Rejected — see Scope.
+- *Check inside `attachACLRequest`.* Rejected: that runs per REQUEST, so the
+warning would repeat on every call and be lost in noise. This is a startup fact
+and belongs at startup.
+- *Return an error from `NewRouter`.* Rejected: it does not currently return
+one, and changing that signature for a warning is a large blast radius for a
+low-severity diagnostic.
+
+**Files to modify:**
+
+- `internal/dataentry/router.go`
+- `internal/dataentry/unmatched_reject_wiring_test.go` (new)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- `unmatched_principal` comes from `acl.yaml` and is already validated to an
+allowlist of three modes by `Policy.Validate`; this reads the effective value
+via the existing `EffectiveUnmatchedPrincipal()` so the empty default resolves
+the same way it does everywhere else.
+- The wiring bool is internal state, not input.
+
+**Security-Sensitive Operations:**
+
+This changes no authorization decision. It reports one. The security value is
+entirely in closing the gap between what an operator believes is enforced and
+what is.
+
+The message contains no principal, token, or entity data — only the name of the
+setting and what to do about it.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** one per acceptance criterion.
+
+AC5 is the one that makes the rest mean anything. AC1–4 exercise the helper
+directly and would all pass on a correct helper that NOTHING CALLS — which is
+the same shape of defect as the silent no-op being fixed here.
+
+**Edge Cases:**
+
+- nil policy (AC4).
+- empty-string mode → resolves to `anonymous`, silent (AC3).
+- `provision` → silent here; it has its own warning (AC3).
+
+**Negative Tests:**
+
+AC2 and AC3 are the negatives, and AC2 is load-bearing: a check that warns
+whenever `reject` is set — regardless of wiring — would satisfy AC1 and be
+actively harmful, training operators to ignore it.
+
+Mutation plan: (a) make the guard always return early → AC1 and AC5 redden; (b)
+drop the `jwtWired` term → AC2 reddens; (c) delete the call from `NewRouter` →
+AC5 reddens alone.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *Checking a proxy for the condition instead of the condition.* MISSED in
+planning, found in review (RR-0CJ47L). `reject` needs THREE things — the mode, a
+wired gate, and the `principal_property` lookup — and the plan reasoned only
+about the gate, because that is the one the issue named. A reject policy without
+the lookup was equally inert and warned about nothing: a second silent state, in
+exactly the shape of the bug being fixed.
+
+The plan even recorded the counter-argument and got it wrong, asserting that
+`Policy.Validate` refuses that combination. It does — but `NewDeclarative` never
+calls `Validate`, so any construction path skipping `LoadPolicy` reaches it,
+including this ticket's own test. Mitigated by extracting
+`acl.Policy.RejectEffective`, so the warning and the enforcement site read one
+definition and cannot drift.
+
+The lesson for a warning specifically: it must check the condition the
+enforcement site EVALUATES, not the condition the ticket describes. A warning
+that is wrong about the thing it warns about is worse than no warning.
+
+- *Proving the call site calls something is not proving it calls it right.* Also
+missed (RR-U5LKGQ). AC5 was written to rule out a correct-but-uncalled helper,
+and did — but it asserted only that a warning appeared, so substituting a
+literal `false` for the wiring argument left the suite green. The same omission
+the plan was congratulating itself for avoiding, one level up.
+
+- *Warning fatigue.* A false alarm is the main way this change could make things
+worse. Mitigated by AC2/AC3 and their mutation checks — the warning fires for
+exactly one condition.
+- *Correct-but-dead code.* Mitigated by AC5 going through `NewRouter`.
+
+**Effort:** xs
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/acl-security.md` documents `unmatched_principal`. Whether it should
+state the JWT-gate dependency is a real question, to be settled in the
+docs-checklist — the warning helps an operator who already deployed, and the doc
+helps one who has not. NOTE: `docs/` is GENERATED from `docs-project/` entities;
+edit the source, not the output.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** none critical or significant. The decision worth
+recording is warn-not-fail, and its reasoning is in Scope.

--- a/tickets/entities/review-checklists/REV-6ZJ8PV.md
+++ b/tickets/entities/review-checklists/REV-6ZJ8PV.md
@@ -1,0 +1,120 @@
+---
+id: REV-6ZJ8PV
+type: review-checklist
+title: 'Review: testIdempotencyFreed races the queue completion bookkeeping'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just lint` 0 issues; `just arch-lint` clean; `just comment-lint` no
+unresolvable doc links; `just plimsoll` clean. `go test ./internal/jobs/...
+-race` green (69s), and the previously-failing case passes 20/20 under
+`GOMAXPROCS=1`.
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none.
+
+The diff is one call site plus its comment. Self-review checked the two things
+that could be wrong with a polling fix:
+
+1. **Can it still fail?** Yes — blocking the handler so the job never completes
+still fails, after the full `settleTimeout`. A polling fix is only worth having
+if it cannot pass when the property does not hold; otherwise it silences the
+flake by deleting the assertion.
+2. **Is the polled operation safe to repeat?** Yes. `Enqueue` with an
+idempotency key is idempotent by construction — that is the feature under test.
+A rejected attempt has no side effect, so retrying cannot enqueue duplicate
+work.
+
+Also checked the sibling `testIdempotencyCollapses` for the same defect: it
+holds the handler open and asserts the duplicate IS rejected while the first is
+pending. That direction asserts the state that exists DURING the window rather
+than after it, so it has no race.
+
+No unrelated changes.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| # | criterion | status | evidence |
+| --- | --- | --- | --- |
+| 1 | the previously-failing case passes under load | PASS | 20/20 under `GOMAXPROCS=1` |
+| 2 | the test still detects a genuinely never-freed key | PASS | handler blocked → FAIL after settleTimeout |
+| 3 | no production behaviour changed | PASS | diff is test-only |
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+Skipped — this is a bug fix in a test.
+
+The documentation that matters is the comment at the call site, which records
+why the polling is there and which two alternatives were rejected. Without it
+the next person removes the "unnecessary" retry: the shape looks over-cautious
+precisely because the race it prevents is invisible at full parallelism.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+Worth recording: my first conclusion was that this was a flake, and I re-ran CI
+on the strength of it. The rerun failed identically, which disproved it.
+
+The hypothesis never explained the evidence — "flaky" predicts randomness, and
+this was two-for-two on one branch and zero elsewhere. What broke it open was
+reaching for LOAD rather than ordering: `GOMAXPROCS=1` instead of another
+`-shuffle` seed made it deterministic in a single run.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-6ZJ8PV.md
+++ b/tickets/entities/review-checklists/REV-6ZJ8PV.md
@@ -2,7 +2,7 @@
 id: REV-6ZJ8PV
 type: review-checklist
 title: 'Review: testIdempotencyFreed races the queue completion bookkeeping'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -104,7 +104,7 @@ reaching for LOAD rather than ordering: `GOMAXPROCS=1` instead of another
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] Run `/pr` command to create PR and monitor CI
 
 <!--
 Deliberately NOT tracked here: the PR URL and whether CI passed.

--- a/tickets/entities/review-checklists/REV-EXK2MG.md
+++ b/tickets/entities/review-checklists/REV-EXK2MG.md
@@ -1,0 +1,148 @@
+---
+id: REV-EXK2MG
+type: review-checklist
+title: 'Review: Warn when unmatched_principal reject has no JWT gate'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just lint` 0 issues (after fixing two `misspell` findings — British spellings
+in new comments); `just arch-lint` clean; `just comment-lint` no unresolvable
+doc links; `just plimsoll` clean; `just lint-md` 0 issues. `just test` green
+under `-race -shuffle=on`.
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-0CJ47L (critical), RR-U5LKGQ, RR-I1RTSU, RR-FZ1CBE
+(significant). All addressed.
+
+The critical one is the ticket's own lesson turned back on the fix. `reject`
+needs THREE conditions, not one: the mode, a wired JWT gate, AND the
+`principal_property` lookup. My warning checked the gate alone — so a reject
+policy without `user_entity_type` / `principal_property` was equally inert and
+warned about nothing. A second silent-inert state, uncovered, in exactly the
+shape of the bug being closed.
+
+I had dismissed that case on the grounds that `LoadPolicy` refuses it. It does,
+but `acl.NewDeclarative` never calls `Validate`, so any construction path
+skipping `LoadPolicy` reaches it — including this ticket's own test. The
+generalizable error: I wrote a check for the condition I had in mind rather than
+for the condition the enforcement site evaluates.
+
+Fixed structurally, with `acl.Policy.RejectEffective(jwtWired bool)` as the one
+definition both sites read, so the warning cannot be wrong about the thing it
+warns about.
+
+The other three:
+
+- **No test pinned the argument `NewRouter` passes** (RR-U5LKGQ). Substituting a
+literal `false` at the call site left the suite green — the composition test
+asserted only that *a* warning appeared. This is the same mistake one level up
+from the ticket: I had proof the call site calls something, and mistook it for
+proof it calls it correctly.
+- **The new `d.Policy()` call widened a typed-nil's blast radius** (RR-I1RTSU) —
+`NewRouter` would panic at construction where a typed-nil previously failed
+later, per request. Made `Policy()` and the predicate chain nil-receiver safe,
+and pinned it.
+- **The slog capture buffer was unsynchronized** (RR-FZ1CBE), against a
+precedent in `appbuild` that had already documented the hazard and its fix.
+
+Two `misspell` findings (British spellings) were fixed. A `TKT-*` placeholder
+that had shipped in two comments was replaced with the real id.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| # | criterion | status | evidence |
+| --- | --- | --- | --- |
+| 1 | `reject` + no gate → warns, message says INERT | PASS | `TestUnmatchedReject_WarnsWhenNoJWTGateWired` |
+| 2 | `reject` + gate wired → silent | PASS | `TestUnmatchedReject_SilentWhenJWTGateWired` |
+| 3 | other modes → silent regardless of wiring | PASS | `TestUnmatchedReject_SilentForOtherModes` |
+| 4 | nil policy → silent, no panic | PASS | `TestUnmatchedReject_NilPolicyIsSilent` |
+| 5 | `NewRouter` actually calls the check | PASS | `TestUnmatchedReject_NewRouterWarnsWhenGateMissing` |
+| 6 | `reject` + gate + NO lookup → warns, naming the lookup | PASS | `TestUnmatchedReject_WarnsWhenLookupDisabled` (added from RR-0CJ47L) |
+| 7 | `NewRouter` passes the RIGHT wiring argument | PASS | `TestUnmatchedReject_NewRouterSilentWhenGateWired` (added from RR-U5LKGQ) |
+| 8 | a typed-nil `*Declarative` does not panic `NewRouter` | PASS | `TestUnmatchedReject_TypedNilDeclarativeDoesNotPanic` (added from RR-I1RTSU) |
+
+AC6–8 all came out of review, not planning. Each is mutation-verified to redden
+alone, which is what shows they cover distinct cases rather than restating
+AC1–5.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-WIU04Z (done).
+
+`docs/acl-security.md` gains a bullet in the `unmatched_principal` section's
+"Load-bearing details" list. Review caught that the first placement referred to
+the missing-lookup case as "above" when it was below, and that calling this "not
+a load error" invited the reader to conclude the lookup requirement is enforced
+wherever a `Declarative` exists — it is not, since `NewDeclarative` skips
+`Validate`. Both fixed: the bullet now follows the lookup one and refers back to
+it.
+
+Edited in `docs-project/` and regenerated with `just docs`. `docs/` is GENERATED
+— editing the output directly fails the Docs CI check, as the sibling ticket
+TKT-LVSPSB discovered earlier in this round.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-EXK2MG.md
+++ b/tickets/entities/review-checklists/REV-EXK2MG.md
@@ -2,7 +2,7 @@
 id: REV-EXK2MG
 type: review-checklist
 title: 'Review: Warn when unmatched_principal reject has no JWT gate'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -132,7 +132,7 @@ TKT-LVSPSB discovered earlier in this round.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] Run `/pr` command to create PR and monitor CI
 
 <!--
 Deliberately NOT tracked here: the PR URL and whether CI passed.

--- a/tickets/entities/review-responses/RR-0CJ47L.md
+++ b/tickets/entities/review-responses/RR-0CJ47L.md
@@ -1,0 +1,55 @@
+---
+id: RR-0CJ47L
+type: review-response
+title: 'The warning checked one of the three conditions reject actually needs'
+finding: |-
+    `reject` fires only when THREE things hold: the mode is reject, a JWT gate is
+    wired, AND the principal_property lookup is enabled (router.go:451 --
+    `jwtVerified && id == "" && d.Policy().PrincipalPropertyLookupEnabled()`).
+
+    The first version of the warning checked gate wiring alone. So a reject policy
+    with no user_entity_type / principal_property was equally inert and the warning
+    stayed SILENT -- a second silent-inert state, uncovered, in exactly the shape of
+    the bug the ticket exists to close.
+
+    My defence was "LoadPolicy refuses that combination". It does, but
+    `acl.NewDeclarative` never calls Validate, so any construction path skipping
+    LoadPolicy holds a policy in precisely that state -- including this ticket's own
+    new test, which builds a Declarative directly.
+severity: critical
+resolution: |-
+    Added `acl.Policy.RejectEffective(jwtWired bool)`: one predicate covering all
+    three conditions, documented as the single definition of "reject can actually
+    fire". The warning now reads it and names WHICH condition is missing, since
+    "reject does nothing" is not actionable without saying what to change.
+
+    The godoc records that NewDeclarative skips Validate, so the lookup condition is
+    checked rather than assumed.
+
+    Pinned by `TestUnmatchedReject_WarnsWhenLookupDisabled`, mutation-verified:
+    dropping the lookup term from RejectEffective reddens it alone.
+
+    The lesson is the one the ticket was already about: I wrote a check for "the
+    condition I had in mind" rather than for the condition the enforcement site
+    actually evaluates. A warning that is wrong about the thing it warns about is
+    worse than no warning.
+status: addressed
+---
+
+## Resolution
+
+Added `acl.Policy.RejectEffective(jwtWired bool)`: one predicate covering all
+three conditions, documented as the single definition of "reject can actually
+fire". The warning now reads it and names WHICH condition is missing, since
+"reject does nothing" is not actionable without saying what to change.
+
+The godoc records that NewDeclarative skips Validate, so the lookup condition is
+checked rather than assumed.
+
+Pinned by `TestUnmatchedReject_WarnsWhenLookupDisabled`, mutation-verified:
+dropping the lookup term from RejectEffective reddens it alone.
+
+The lesson is the one the ticket was already about: I wrote a check for "the
+condition I had in mind" rather than for the condition the enforcement site
+actually evaluates. A warning that is wrong about the thing it warns about is
+worse than no warning.

--- a/tickets/entities/review-responses/RR-FZ1CBE.md
+++ b/tickets/entities/review-responses/RR-FZ1CBE.md
@@ -1,0 +1,34 @@
+---
+id: RR-FZ1CBE
+type: review-response
+title: 'Unsynchronized bytes.Buffer in the slog capture helper'
+finding: |-
+    `captureWarnings` returned a bare `*bytes.Buffer`, which is not safe for
+    concurrent use. `newTestAppV1` builds a real app whose background goroutines can
+    log after the constructor returns, so a write can race the assertion's read.
+
+    The repo already documented this exact hazard and its fix:
+    `internal/appbuild/appbuild_membership_warn_test.go:19-27` wraps the buffer in a
+    `lockedWriter` and states callers must not use `t.Parallel()`, because
+    slog.SetDefault mutates process-global state. There are 20 `t.Parallel()` calls
+    elsewhere in this package; today the tests are safe by scheduling accident (Go
+    runs parallel tests after serial ones), not by construction.
+severity: significant
+resolution: |-
+    Adopted the `lockedWriter` pattern from the existing precedent, with the same
+    "callers must NOT use t.Parallel()" note and the reason for it.
+
+    Also fixed the empty subtest name in the modes table (`mode=` renders as an
+    awkward `-run` target; now `mode=<empty>`), and replaced the `TKT-*` placeholder
+    that shipped in two comments with the real id, `TKT-M60ZF5`.
+status: addressed
+---
+
+## Resolution
+
+Adopted the `lockedWriter` pattern from the existing precedent, with the same
+"callers must NOT use t.Parallel()" note and the reason for it.
+
+Also fixed the empty subtest name in the modes table (`mode=` renders as an
+awkward `-run` target; now `mode=<empty>`), and replaced the `TKT-*` placeholder
+that shipped in two comments with the real id, `TKT-M60ZF5`.

--- a/tickets/entities/review-responses/RR-I1RTSU.md
+++ b/tickets/entities/review-responses/RR-I1RTSU.md
@@ -1,0 +1,41 @@
+---
+id: RR-I1RTSU
+type: review-response
+title: 'Adding a Policy() call to NewRouter widened the blast radius of a typed-nil ACL'
+finding: |-
+    A typed-nil `*acl.Declarative` in the `a.acl` interface is not nil, so the
+    `d != nil` guard in NewRouter's type switch is load-bearing. Adding
+    `d.Policy()` there made getting it wrong worse: previously a typed-nil failed
+    later, per request; now NewRouter itself panics at construction.
+
+    Removing the guard left every test in the file green -- confirmed, and confirmed
+    that it then panics with a nil dereference.
+severity: significant
+resolution: |-
+    Two changes, defense in depth:
+
+    - `Declarative.Policy()` is now nil-receiver safe, returning a nil *Policy. The
+      Policy predicates each handle a nil receiver, so a typed-nil now gives the
+      same "no policy" answer as an absent one instead of panicking.
+    - `TestUnmatchedReject_TypedNilDeclarativeDoesNotPanic` pins it. Verified by
+      reverting both the guard and the nil-check: the test fails with the panic.
+
+    `principalPropertyLookupEnabled` and `effectiveUnmatchedPrincipal` also gained
+    nil-receiver handling, so the whole predicate chain is safe rather than only its
+    entry point.
+status: addressed
+---
+
+## Resolution
+
+Two changes, defense in depth:
+
+- `Declarative.Policy()` is now nil-receiver safe, returning a nil *Policy. The
+  Policy predicates each handle a nil receiver, so a typed-nil now gives the
+  same "no policy" answer as an absent one instead of panicking.
+- `TestUnmatchedReject_TypedNilDeclarativeDoesNotPanic` pins it. Verified by
+  reverting both the guard and the nil-check: the test fails with the panic.
+
+`principalPropertyLookupEnabled` and `effectiveUnmatchedPrincipal` also gained
+nil-receiver handling, so the whole predicate chain is safe rather than only its
+entry point.

--- a/tickets/entities/review-responses/RR-U5LKGQ.md
+++ b/tickets/entities/review-responses/RR-U5LKGQ.md
@@ -1,0 +1,42 @@
+---
+id: RR-U5LKGQ
+type: review-response
+title: 'No test pinned the argument NewRouter passes to the warning'
+finding: |-
+    `TestUnmatchedReject_NewRouterWarnsWhenGateMissing` asserted only that SOME
+    warning appeared. It never exercised the gate-wired path through NewRouter, so
+    a helper ignoring `jwtWired` entirely still passed it -- and the discrimination
+    lived only in a test calling the helper directly.
+
+    Concretely: swapping `a.jwtGate != nil` for a literal `false` at the call site
+    left the whole suite green. Nothing asserted NewRouter passes the right
+    boolean.
+severity: significant
+resolution: |-
+    Added `TestUnmatchedReject_NewRouterSilentWhenGateWired`: wires a gate via the
+    existing `mustSetJWTGate` helper, builds the router, asserts silence.
+    Mutation-verified -- the literal-`false` substitution now reddens it.
+
+    Also tightened the original test to assert on the specific cause
+    ("no JWT gate is wired") rather than the generic "NO effect", so the two
+    NewRouter tests distinguish which branch fired.
+
+    Same shape as the ticket itself, one level up: I had a test proving the
+    composition site calls SOMETHING, and mistook it for proof that it calls it
+    CORRECTLY.
+status: addressed
+---
+
+## Resolution
+
+Added `TestUnmatchedReject_NewRouterSilentWhenGateWired`: wires a gate via the
+existing `mustSetJWTGate` helper, builds the router, asserts silence.
+Mutation-verified -- the literal-`false` substitution now reddens it.
+
+Also tightened the original test to assert on the specific cause
+("no JWT gate is wired") rather than the generic "NO effect", so the two
+NewRouter tests distinguish which branch fired.
+
+Same shape as the ticket itself, one level up: I had a test proving the
+composition site calls SOMETHING, and mistook it for proof that it calls it
+CORRECTLY.

--- a/tickets/entities/tickets/TKT-M60ZF5.md
+++ b/tickets/entities/tickets/TKT-M60ZF5.md
@@ -1,0 +1,51 @@
+---
+id: TKT-M60ZF5
+type: ticket
+title: Warn when unmatched_principal reject has no JWT gate
+kind: enhancement
+priority: low
+effort: xs
+status: done
+---
+
+## Description
+
+`unmatched_principal: reject` only takes effect when a JWT gate is wired.
+`NewRouter` snapshots `a.jwtGate` and passes `a.jwtGate != nil` to
+`attachACLRequest`, which is the fact the reject decision keys on.
+
+An operator who configures `reject` in a deployment where the JWT gate is not
+(yet) wired therefore gets an `acl.yaml` key that silently does nothing — while
+believing writes from unknown identities are denied. `Policy.Validate` cannot
+catch it: it only checks that `principal_property` and `user_entity_type` are
+set, and whether a gate is wired is a property of the SERVER, decided elsewhere
+and later.
+
+Separately, the required wiring order ("SetJWTGate MUST run before NewRouter")
+is protected only by a code comment. A future refactor that reorders them breaks
+the invariant quietly.
+
+The `provision` mode already has a `slog.Warn` for its own inert state; `reject`
+has nothing.
+
+GitHub issue #1274. Source: rela#1273 (IB-review, 2026-08-06).
+
+**Violated requirement**: CONTROL-5-15 — rules for physical and logical access
+control shall be established and implemented.
+
+**Severity**: low. Not actively exploitable; requires operator misconfiguration
+or a future refactor.
+
+## Scope
+
+IN: a load-time warning at `NewRouter` when `unmatched_principal: reject` is
+configured and no JWT gate is wired.
+
+OUT: making it a hard error. Refusing to start would turn a wiring omission into
+an outage for a deployment that is merely no stricter than the default
+(`anonymous`) — the posture it had before the key was added. The operator's
+mistake is believing a restriction is in force, so the fix is to say so loudly,
+not to take the server down.
+
+OUT: moving the check into `Policy.Validate`. It cannot see server wiring;
+`NewRouter` is the first point where both facts are in scope.

--- a/tickets/relations/BUG-BPHP79--adds-measure--idempotency-freed-load-repro.md
+++ b/tickets/relations/BUG-BPHP79--adds-measure--idempotency-freed-load-repro.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: adds-measure
+to: idempotency-freed-load-repro
+---

--- a/tickets/relations/BUG-BPHP79--affects--background-jobs.md
+++ b/tickets/relations/BUG-BPHP79--affects--background-jobs.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: affects
+to: background-jobs
+---

--- a/tickets/relations/BUG-BPHP79--fixes--FEAT-QAOV6.md
+++ b/tickets/relations/BUG-BPHP79--fixes--FEAT-QAOV6.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: fixes
+to: FEAT-QAOV6
+---

--- a/tickets/relations/BUG-BPHP79--has-bug-analysis--BUGA-PFQPOM.md
+++ b/tickets/relations/BUG-BPHP79--has-bug-analysis--BUGA-PFQPOM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: has-bug-analysis
+to: BUGA-PFQPOM
+---

--- a/tickets/relations/BUG-BPHP79--has-implementation--IMPL-0NYT04.md
+++ b/tickets/relations/BUG-BPHP79--has-implementation--IMPL-0NYT04.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: has-implementation
+to: IMPL-0NYT04
+---

--- a/tickets/relations/BUG-BPHP79--has-review--REV-6ZJ8PV.md
+++ b/tickets/relations/BUG-BPHP79--has-review--REV-6ZJ8PV.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: has-review
+to: REV-6ZJ8PV
+---

--- a/tickets/relations/TKT-M60ZF5--affects--authorization.md
+++ b/tickets/relations/TKT-M60ZF5--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-M60ZF5--has-docs--DOCS-WIU04Z.md
+++ b/tickets/relations/TKT-M60ZF5--has-docs--DOCS-WIU04Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-docs
+to: DOCS-WIU04Z
+---

--- a/tickets/relations/TKT-M60ZF5--has-implementation--IMPL-F33ELN.md
+++ b/tickets/relations/TKT-M60ZF5--has-implementation--IMPL-F33ELN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-implementation
+to: IMPL-F33ELN
+---

--- a/tickets/relations/TKT-M60ZF5--has-planning--PLAN-KIOA4C.md
+++ b/tickets/relations/TKT-M60ZF5--has-planning--PLAN-KIOA4C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-planning
+to: PLAN-KIOA4C
+---

--- a/tickets/relations/TKT-M60ZF5--has-review--REV-EXK2MG.md
+++ b/tickets/relations/TKT-M60ZF5--has-review--REV-EXK2MG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-review
+to: REV-EXK2MG
+---

--- a/tickets/relations/TKT-M60ZF5--has-review-response--RR-0CJ47L.md
+++ b/tickets/relations/TKT-M60ZF5--has-review-response--RR-0CJ47L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-review-response
+to: RR-0CJ47L
+---

--- a/tickets/relations/TKT-M60ZF5--has-review-response--RR-FZ1CBE.md
+++ b/tickets/relations/TKT-M60ZF5--has-review-response--RR-FZ1CBE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-review-response
+to: RR-FZ1CBE
+---

--- a/tickets/relations/TKT-M60ZF5--has-review-response--RR-I1RTSU.md
+++ b/tickets/relations/TKT-M60ZF5--has-review-response--RR-I1RTSU.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-review-response
+to: RR-I1RTSU
+---

--- a/tickets/relations/TKT-M60ZF5--has-review-response--RR-U5LKGQ.md
+++ b/tickets/relations/TKT-M60ZF5--has-review-response--RR-U5LKGQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: has-review-response
+to: RR-U5LKGQ
+---

--- a/tickets/relations/TKT-M60ZF5--implements--FEAT-OQBYHD.md
+++ b/tickets/relations/TKT-M60ZF5--implements--FEAT-OQBYHD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M60ZF5
+relation: implements
+to: FEAT-OQBYHD
+---


### PR DESCRIPTION
Closes #1274. Source: rela#1273 (IB-review, 2026-08-06). Violated requirement: CONTROL-5-15. Severity: low — not actively exploitable; requires operator misconfiguration or a future refactor.

`unmatched_principal: reject` denies writes from verified-JWT principals whose subject resolves to no user entity. But it only takes effect when a JWT gate is wired: `NewRouter` snapshots `a.jwtGate` and passes `a.jwtGate != nil` to `attachACLRequest`, which is the fact the reject decision keys on.

An operator who configures `reject` in a deployment without a wired gate therefore gets an `acl.yaml` key that **silently does nothing** — while believing writes from unknown identities are denied. That belief is the harm: a restriction assumed to be in force and isn't.

`Policy.Validate` can't catch it. It sees `acl.yaml`, and whether a gate is wired is a property of the *server*, decided elsewhere and later. `NewRouter` is the first point where both facts are in scope, which is why the check lives there rather than with the rest of the policy validation.

## Warning, not error

Refusing to start would turn a wiring omission into an outage for a deployment that is merely **no stricter than the default** (`anonymous`) — the posture it had before the key was added. Nothing is more exposed than it was; the operator is just wrong about why.

So the fix is to say so loudly, not to take the server down. This also matches the existing `provision` warning in `internal/acl/declarative.go`, which reports the same class of problem (a configured mode that doesn't do what its name suggests) through the same channel — an operator already watching for one will see the other.

The check reads the **same** `a.jwtGate != nil` expression `attachACLRequest` receives. That's deliberate: a check computing wiring state differently could disagree with the thing it describes, and would then be wrong in exactly the situation it exists for.

## Free side benefit

The comment above `attachACLRequest` says *"SetJWTGate MUST run before NewRouter … If a future refactor reorders these, that invariant breaks quietly."* It was protected by that comment and nothing else. It now warns — a reorder makes this fire where previously it failed silently. Noted in the function's godoc, since the check is doing two jobs and only one is in the ticket title.

## What review changed, and why it matters

The first version checked **one** of the three conditions `reject` actually needs. It fires only when the mode is `reject` **and** a JWT gate is wired **and** the `principal_property` lookup is enabled (`router.go:451`). Checking only the gate meant a `reject` policy with no `user_entity_type`/`principal_property` was *equally inert* and warned about nothing — a second silent-inert state, uncovered, in exactly the shape of the bug this closes.

I'd dismissed that case in planning: "`Policy.Validate` refuses that combination." True, and irrelevant — **`acl.NewDeclarative` never calls `Validate`**. Any construction path skipping `LoadPolicy` reaches that state, including this ticket's own test.

Fixed structurally rather than by patching the second condition in beside the first: `acl.Policy.RejectEffective(jwtWired bool)` is now the single definition both the warning and the enforcement site read, so they cannot drift. The message names *which* condition is missing — "reject does nothing" isn't actionable without saying what to change.

Three more, all fixed:

- **No test pinned the argument `NewRouter` passes** (RR-U5LKGQ). Substituting a literal `false` at the call site left the suite green: the composition test asserted only that *a* warning appeared. That's the same mistake one level up from the ticket — I had proof the call site calls something and mistook it for proof it calls it correctly.
- **The new `d.Policy()` call widened a typed-nil's blast radius** (RR-I1RTSU). A typed-nil `*acl.Declarative` isn't nil, so `NewRouter` would now panic at construction where it previously failed later, per request. `Policy()` and the predicate chain are nil-receiver safe, with a test.
- **The slog capture buffer was unsynchronized** (RR-FZ1CBE), against a precedent in `appbuild` that had already documented the hazard and its fix.

## Verification

Eight tests, each mutation-verified to redden alone:

| mutation | observed |
| --- | --- |
| guard always returns early | the two positive tests fail |
| drop the `jwtWired` term | `..._SilentWhenJWTGateWired` fails, alone |
| delete the call from `NewRouter` | `..._NewRouterWarnsWhenGateMissing` fails, alone |
| drop the lookup term from `RejectEffective` | `..._WarnsWhenLookupDisabled` fails, alone |
| `NewRouter` passes a literal `false` | `..._NewRouterSilentWhenGateWired` fails, alone |
| remove the `d != nil` guard **and** `Policy()`'s nil check | the typed-nil test fails with a nil dereference |

Gates: `just test` green under `-race -shuffle=on`; `just lint` / `arch-lint` / `comment-lint` / `plimsoll` / `lint-md` clean.

## Docs

The guide already said `reject` *"keys on the fact that identity came from the fail-closed JWT gate"* — true, and not enough: it describes the mechanism without saying what happens when there is no gate. A new bullet in the "Load-bearing details" list states the key has no effect in that case, why it's a warning rather than the load error the missing-lookup case gets, and tells an operator seeing writes go through to check that warning first.

Two audiences, covered deliberately: the warning reaches someone who has *already* deployed the misconfiguration, the doc reaches someone who hasn't yet. Either alone leaves half the problem.

Edited in `docs-project/` and regenerated with `just docs` — `docs/` is generated, and editing the output directly fails the Docs check (learned on #1495 earlier in this round).

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
