### PR TITLE
fix(jobs): stop testIdempotencyFreed racing the queue's completion bookkeeping (BUG-BPHP79)

### DIFF
--- a/internal/jobs/jobstest/jobstest.go
+++ b/internal/jobs/jobstest/jobstest.go
@@ -683,9 +683,23 @@ func testIdempotencyFreed(t *testing.T, newQueue NewQueue) {
 	require.Eventually(t, func() bool { return ran.get() == 1 }, settleTimeout, pollInterval)
 
 	// Same key again, after completion: must queue.
-	require.NoError(t, q.Enqueue(context.Background(), jobs.Job{
-		Kind: "cycle", IdempotencyKey: "report",
-	}))
+	//
+	// POLLED, not enqueued once. `ran.inc()` happens inside the handler, so the
+	// wait above establishes "the handler body started" — while the key is
+	// freed only once the queue records the job COMPLETE, strictly later. A
+	// single Enqueue here races that window and returns ErrDuplicateJob on a
+	// contended runner (BUG-BPHP79; reproduce with GOMAXPROCS=1).
+	//
+	// Polling does not weaken the assertion: the key BECOMING free is the
+	// property under test, so waiting for it within settleTimeout is the test.
+	// What would weaken it is a sleep — that trades a visible flake for a slow
+	// invisible one — or dropping ErrDuplicateJob, which is the failure.
+	require.Eventually(t, func() bool {
+		return q.Enqueue(context.Background(), jobs.Job{
+			Kind: "cycle", IdempotencyKey: "report",
+		}) == nil
+	}, settleTimeout, pollInterval,
+		"a completed key must become free for reuse")
 	require.Eventually(t, func() bool { return ran.get() == 2 }, settleTimeout, pollInterval,
 		"a completed key must be free for reuse; it guards pending work, not history")
 }

--- a/tickets/entities/automated-measures/idempotency-freed-load-repro.md
+++ b/tickets/entities/automated-measures/idempotency-freed-load-repro.md
@@ -1,0 +1,42 @@
+---
+id: idempotency-freed-load-repro
+type: automated-measure
+title: 'Run the jobs conformance suite under GOMAXPROCS=1 so completion races surface deterministically'
+kind: test
+location: internal/jobs (conformance suite; CI job or nightly)
+status: proposed
+description: >-
+  BUG-BPHP79 was invisible at full parallelism -- 5 consecutive -race runs and a
+  run with CI's exact -shuffle seed all passed -- and deterministic under
+  GOMAXPROCS=1. The suite's async assertions are therefore only exercised in the
+  scheduling regime where the windows they race are narrowest, which is the
+  regime least likely to catch them.
+
+  Running the jobs conformance suite once under GOMAXPROCS=1 (a separate CI step,
+  or nightly if the runtime cost matters) turns that class of defect from an
+  intermittent failure on an unrelated branch into a reproducible one on the
+  branch that introduces it. The cost is small: the suite is ~70s, and the
+  serialized run in the reproduction took ~2s for the single affected test.
+
+  This is a MEASURE rather than a fix because it catches the class, not the
+  instance: any future test in this suite that polls a proxy for a queue-side
+  state transition -- the shape of BUG-BPHP79's why4 -- fails under it.
+---
+
+## Why this class needs a load dimension
+
+`-shuffle=on` varies test ORDER, which is the right control for
+inter-test state leakage. It does nothing for intra-test races between a
+handler-side signal and the queue's own bookkeeping, because those depend on how
+goroutines interleave rather than on which test ran first.
+
+The bug's diagnosis turned on exactly that distinction: reaching for another
+shuffle seed reproduced nothing, and reaching for `GOMAXPROCS=1` reproduced it in
+one run. A measure that only varies order would not have found it.
+
+## Scope
+
+Deliberately narrow — the jobs conformance suite, not the whole tree. That suite
+is the one whose subject is a concurrent queue, so its tests are the ones whose
+async assumptions are load-bearing. Applying this repo-wide would multiply CI
+time for packages where scheduling is not part of the contract.

--- a/tickets/entities/bug-analysis-checklists/BUGA-PFQPOM.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-PFQPOM.md
@@ -1,0 +1,91 @@
+---
+id: BUGA-PFQPOM
+type: bug-analysis-checklist
+title: 'Analysis: testIdempotencyFreed races the queue completion bookkeeping'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally
+- [x] Minimal reproduction steps documented
+- [x] Environment/conditions noted
+
+Deterministic under CPU pressure:
+
+```
+GOMAXPROCS=1 go test ./internal/jobs/ -race \
+  -run 'TestMemoryQueue_Conformance/IdempotencyKeyFreed' -count=20
+```
+
+fails immediately with `jobs: an identical job is already pending`.
+
+**Environment matters here, and misled me first.** At full parallelism it passes
+consistently: 5 consecutive `-race` runs (341s) and a run with CI's exact
+`-shuffle` seed all green. That is why it presented as a flake and why I
+initially reported it as one — a conclusion the second CI failure disproved.
+
+Observed twice on CI for PR #1497, a branch that does not touch `internal/jobs`.
+Verified structurally rather than by inspection: `go list -deps
+./internal/jobs/` reaches neither `internal/acl` nor `internal/dataentry`, so
+the changed packages are unreachable from the failing one.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1)
+- [x] Contributing factors found (why2-3)
+- [x] Systemic cause explored (why4-5)
+
+**why1** — The second `Enqueue` returns `ErrDuplicateJob` because the
+idempotency key is still held.
+
+**why2** — The test re-enqueues as soon as `ran.get() == 1`, but `ran.inc()`
+fires INSIDE the handler body. That establishes "the handler started", not "the
+job completed".
+
+**why3** — The key is freed only when the queue records completion, which is
+strictly after the handler returns. Between those two points the key is held and
+a re-enqueue is correctly rejected. Under contention that window is wide enough
+to lose.
+
+**why4** — The test asserted on a PROXY for the event it cared about. `ran` was
+reachable from the test, and completion was not, so the reachable signal stood
+in for the real one. The comment says "Same key again, after completion" — the
+intent was right; the observable did not match it.
+
+**why5** — Nothing in the test's shape reveals the substitution.
+`require.Eventually` looks like careful async handling, so a reader sees a test
+that already waits properly and does not ask whether it waits for the RIGHT
+thing. A `time.Sleep` would have looked suspicious; this did not.
+
+The queue behaviour is CORRECT throughout. A completed key is freed. This is a
+defect in the test's synchronisation only, which is why it had to be diagnosed
+rather than fixed by changing the code under test.
+
+## Fix Planning
+
+- [x] Fix approach determined
+- [x] Regression test planned
+- [x] Related areas checked for similar issues
+
+**Approach.** Poll the second `Enqueue` inside `require.Eventually` until it
+succeeds. The key becoming free IS the property under test, so waiting for it is
+the assertion rather than a weakening of it.
+
+Explicitly rejected: `time.Sleep` before the re-enqueue (trades a visible flake
+for a slow invisible one) and ignoring `ErrDuplicateJob` (that error is the
+failure this test exists to catch).
+
+**Regression test.** The fixed test IS the regression test, so the risk is that
+polling makes it unable to fail. Verified by mutation: blocking the handler so
+the job never completes — and the key therefore never frees — still fails, after
+the full `settleTimeout`. So the fix removes the race without removing the
+assertion.
+
+**Related areas.** Checked the sibling `testIdempotencyCollapses`: it holds the
+handler open on a channel and asserts the duplicate IS rejected while the first
+is still pending. That direction has no race — it asserts the state that exists
+during the window rather than after it. No other test in `jobstest.go` waits on
+a handler-side counter to infer a queue-side state transition.

--- a/tickets/entities/bugs/BUG-BPHP79.md
+++ b/tickets/entities/bugs/BUG-BPHP79.md
@@ -1,0 +1,73 @@
+---
+id: BUG-BPHP79
+type: bug
+title: testIdempotencyFreed races the queue completion bookkeeping
+description: testIdempotencyFreed waits for the handler to have RUN (ran.inc() fires inside the handler body) and then immediately re-enqueues the same idempotency key, but the key is freed only once the queue records the job COMPLETE -- strictly later. On a contended runner that window opens and the second Enqueue returns ErrDuplicateJob. Deterministic under GOMAXPROCS=1; observed twice on CI. The queue behaviour is correct; the test's synchronisation is not.
+why1: 'The second Enqueue returns ErrDuplicateJob because the idempotency key is still held.'
+why2: 'The test re-enqueues as soon as ran.get() == 1, but ran.inc() fires INSIDE the handler body -- that establishes "the handler started", not "the job completed".'
+why3: 'The key is freed only when the queue records completion, strictly after the handler returns. Between those two points the key is held and a re-enqueue is correctly rejected; under contention that window is wide enough to lose.'
+why4: 'The test asserted on a PROXY for the event it cared about. `ran` was reachable from the test and completion was not, so the reachable signal stood in for the real one. The comment ("Same key again, after completion") shows the intent was right; the observable did not match it.'
+why5: 'Nothing in the test''s shape reveals the substitution. require.Eventually LOOKS like careful async handling, so a reader sees a test that already waits properly and never asks whether it waits for the right thing. A time.Sleep would have looked suspicious; this did not.'
+prevention: 'When a test waits for an async state transition, the thing it polls must be the transition itself, not a signal that merely correlates with it. Here the queue exposes no completion hook to the test, so the fix polls the OPERATION whose success defines the state (Enqueue succeeding == the key is free) rather than a handler-side counter. Systemic: a polling fix must be checked for retained teeth -- verified here by blocking the handler so the key is never freed and confirming the test still fails. Also worth generalising: an intermittent CI failure that is two-for-two on one branch and zero elsewhere is NOT randomness, and treating it as a flake (which I did first) costs a rerun and delays the diagnosis. Reach for load (GOMAXPROCS=1) as well as ordering (-shuffle) when reproducing.'
+priority: medium
+status: done
+---
+
+## Description
+
+`testIdempotencyFreed` (`internal/jobs/jobstest/jobstest.go:669`) races against
+the queue's own completion bookkeeping and fails intermittently in CI.
+
+It waits for the handler to have RUN, then immediately re-enqueues the same
+idempotency key:
+
+```go
+require.Eventually(t, func() bool { return ran.get() == 1 }, settleTimeout, pollInterval)
+
+// Same key again, after completion: must queue.
+require.NoError(t, q.Enqueue(context.Background(), jobs.Job{
+    Kind: "cycle", IdempotencyKey: "report",
+}))
+```
+
+`ran.inc()` happens INSIDE the handler, but the key is freed only once the queue
+records the job complete — strictly later. The comment says "after completion",
+and the assertion it rests on only establishes "after the handler body started".
+On a contended runner that window opens and the second `Enqueue` returns
+`ErrDuplicateJob`.
+
+## Reproduction
+
+Deterministic under CPU pressure:
+
+```
+GOMAXPROCS=1 go test ./internal/jobs/ -race \
+  -run 'TestMemoryQueue_Conformance/IdempotencyKeyFreed' -count=20
+```
+
+fails immediately with `jobs: an identical job is already pending`. It passes
+consistently at full parallelism, including 5 consecutive `-race` runs and a run
+with CI's exact `-shuffle` seed — which is why it presents as a flake.
+
+Observed twice on CI for PR #1497, a branch that does not touch `internal/jobs`
+(verified: `go list -deps ./internal/jobs/` reaches neither `internal/acl` nor
+`internal/dataentry`).
+
+## Proposed fix
+
+Assert on the OBSERVABLE the test actually needs. Either:
+
+- poll the second `Enqueue` until it succeeds, within `settleTimeout` — the key
+becoming free IS the property under test, so waiting for it is not weakening the
+assertion; or
+- have the handler signal completion through a channel the queue closes after
+recording, so the test waits for the real event rather than a proxy.
+
+The first is smaller and keeps the test's shape. What it must NOT do is
+`time.Sleep` a guess, which would trade a visible flake for a slow invisible
+one.
+
+## Note
+
+The behaviour under test is correct — a completed key IS freed. This is a defect
+in the test's synchronisation, not in the queue.

--- a/tickets/entities/implementation-checklists/IMPL-0NYT04.md
+++ b/tickets/entities/implementation-checklists/IMPL-0NYT04.md
@@ -1,0 +1,94 @@
+---
+id: IMPL-0NYT04
+type: implementation-checklist
+title: 'Implementation: testIdempotencyFreed races the queue completion bookkeeping'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Test-only. No production code changed — the queue behaviour is correct; the
+test's synchronisation was not.
+
+The second `Enqueue` now runs inside `require.Eventually` until it succeeds,
+instead of once immediately after the handler has started. The comment records
+why, because the previous shape looked careful: `require.Eventually` on the
+counter reads as proper async handling, so nobody asks whether it waits for the
+RIGHT event.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Same helpers, same timeouts, same shape. The change is one call site.
+
+Two alternatives were explicitly rejected and the comment says so, since both
+are the obvious next edit:
+
+- `time.Sleep` before the re-enqueue — trades a visible flake for a slow
+invisible one, and encodes a guess about a machine.
+- ignoring `ErrDuplicateJob` — that error IS the failure this test exists to
+catch, so swallowing it would delete the test while leaving it green.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+| step | expected | observed |
+| --- | --- | --- |
+| `GOMAXPROCS=1 ... -count=20` BEFORE the fix | fails | FAIL, `an identical job is already pending` |
+| same command AFTER the fix | passes | ok (2.1s) |
+| block the handler so the job never completes | still FAILS | FAIL after the full 10s settleTimeout |
+| `./internal/jobs/... -race` | green | ok (69s) |
+
+The third row is the one that matters. A polling fix is only worth having if it
+cannot pass when the property genuinely does not hold — otherwise it silences
+the flake by deleting the assertion. Holding the handler open so the key is
+never freed still fails, so the test retained its teeth.
+
+The first two rows use the reproduction that made the diagnosis possible.
+`GOMAXPROCS=1` turns an intermittent CI failure into a deterministic local one,
+which is what moved this from "flake, rerun it" to a fixable defect.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Uses the file's existing `settleTimeout` / `pollInterval` constants rather than
+introducing a bespoke timeout, so the whole suite still tunes from one place.
+
+DRY: nothing to extract — one call site changed.
+
+Worth recording how this was reached, because the first conclusion was wrong. I
+initially called it a flake and re-ran CI, on the strength of: the diff not
+touching `internal/jobs`, both sibling branches passing, and 5 consecutive local
+`-race` runs plus CI's exact `-shuffle` seed all green. The rerun failed
+identically, which disproved it.
+
+What the flake hypothesis never explained was why it failed TWICE on one branch
+and zero times elsewhere. "Flaky" is a hypothesis that predicts randomness; two
+for two is not random. Reaching for load rather than ordering — `GOMAXPROCS=1`
+instead of another seed — made it deterministic in one run.

--- a/tickets/entities/review-checklists/REV-6ZJ8PV.md
+++ b/tickets/entities/review-checklists/REV-6ZJ8PV.md
@@ -1,0 +1,120 @@
+---
+id: REV-6ZJ8PV
+type: review-checklist
+title: 'Review: testIdempotencyFreed races the queue completion bookkeeping'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just lint` 0 issues; `just arch-lint` clean; `just comment-lint` no
+unresolvable doc links; `just plimsoll` clean. `go test ./internal/jobs/...
+-race` green (69s), and the previously-failing case passes 20/20 under
+`GOMAXPROCS=1`.
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none.
+
+The diff is one call site plus its comment. Self-review checked the two things
+that could be wrong with a polling fix:
+
+1. **Can it still fail?** Yes — blocking the handler so the job never completes
+still fails, after the full `settleTimeout`. A polling fix is only worth having
+if it cannot pass when the property does not hold; otherwise it silences the
+flake by deleting the assertion.
+2. **Is the polled operation safe to repeat?** Yes. `Enqueue` with an
+idempotency key is idempotent by construction — that is the feature under test.
+A rejected attempt has no side effect, so retrying cannot enqueue duplicate
+work.
+
+Also checked the sibling `testIdempotencyCollapses` for the same defect: it
+holds the handler open and asserts the duplicate IS rejected while the first is
+pending. That direction asserts the state that exists DURING the window rather
+than after it, so it has no race.
+
+No unrelated changes.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| # | criterion | status | evidence |
+| --- | --- | --- | --- |
+| 1 | the previously-failing case passes under load | PASS | 20/20 under `GOMAXPROCS=1` |
+| 2 | the test still detects a genuinely never-freed key | PASS | handler blocked → FAIL after settleTimeout |
+| 3 | no production behaviour changed | PASS | diff is test-only |
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+Skipped — this is a bug fix in a test.
+
+The documentation that matters is the comment at the call site, which records
+why the polling is there and which two alternatives were rejected. Without it
+the next person removes the "unnecessary" retry: the shape looks over-cautious
+precisely because the race it prevents is invisible at full parallelism.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+Worth recording: my first conclusion was that this was a flake, and I re-ran CI
+on the strength of it. The rerun failed identically, which disproved it.
+
+The hypothesis never explained the evidence — "flaky" predicts randomness, and
+this was two-for-two on one branch and zero elsewhere. What broke it open was
+reaching for LOAD rather than ordering: `GOMAXPROCS=1` instead of another
+`-shuffle` seed made it deterministic in a single run.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-6ZJ8PV.md
+++ b/tickets/entities/review-checklists/REV-6ZJ8PV.md
@@ -2,7 +2,7 @@
 id: REV-6ZJ8PV
 type: review-checklist
 title: 'Review: testIdempotencyFreed races the queue completion bookkeeping'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -104,7 +104,7 @@ reaching for LOAD rather than ordering: `GOMAXPROCS=1` instead of another
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] Run `/pr` command to create PR and monitor CI
 
 <!--
 Deliberately NOT tracked here: the PR URL and whether CI passed.

--- a/tickets/relations/BUG-BPHP79--adds-measure--idempotency-freed-load-repro.md
+++ b/tickets/relations/BUG-BPHP79--adds-measure--idempotency-freed-load-repro.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: adds-measure
+to: idempotency-freed-load-repro
+---

--- a/tickets/relations/BUG-BPHP79--affects--background-jobs.md
+++ b/tickets/relations/BUG-BPHP79--affects--background-jobs.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: affects
+to: background-jobs
+---

--- a/tickets/relations/BUG-BPHP79--fixes--FEAT-QAOV6.md
+++ b/tickets/relations/BUG-BPHP79--fixes--FEAT-QAOV6.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: fixes
+to: FEAT-QAOV6
+---

--- a/tickets/relations/BUG-BPHP79--has-bug-analysis--BUGA-PFQPOM.md
+++ b/tickets/relations/BUG-BPHP79--has-bug-analysis--BUGA-PFQPOM.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: has-bug-analysis
+to: BUGA-PFQPOM
+---

--- a/tickets/relations/BUG-BPHP79--has-implementation--IMPL-0NYT04.md
+++ b/tickets/relations/BUG-BPHP79--has-implementation--IMPL-0NYT04.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: has-implementation
+to: IMPL-0NYT04
+---

--- a/tickets/relations/BUG-BPHP79--has-review--REV-6ZJ8PV.md
+++ b/tickets/relations/BUG-BPHP79--has-review--REV-6ZJ8PV.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BPHP79
+relation: has-review
+to: REV-6ZJ8PV
+---


### PR DESCRIPTION
Fixes a pre-existing race in `testIdempotencyFreed` that fails intermittently in CI. **No production code changed** — the queue behaviour is correct; the test's synchronisation was not.

## The defect

```go
require.Eventually(t, func() bool { return ran.get() == 1 }, ...)

// Same key again, after completion: must queue.
require.NoError(t, q.Enqueue(...))
```

`ran.inc()` fires **inside the handler body**, but the key is freed only once the queue records the job complete — strictly later. The assertion establishes *"the handler started"*; the comment claims *"after completion"*. Between those two points the key is held and a re-enqueue is **correctly** rejected with `ErrDuplicateJob`. On a contended runner that window opens.

## Reproduction

Deterministic under CPU pressure:

```
GOMAXPROCS=1 go test ./internal/jobs/ -race \
  -run 'TestMemoryQueue_Conformance/IdempotencyKeyFreed' -count=20
```

fails immediately with `jobs: an identical job is already pending`.

## The fix, and why it still has teeth

The second `Enqueue` now polls inside `require.Eventually` until it succeeds. The key *becoming free* is the property under test, so waiting for it within `settleTimeout` **is** the assertion rather than a weakening of it. `Enqueue` with an idempotency key is idempotent by construction, so retrying has no side effect.

A polling fix is only worth having if it can still fail. Verified by mutation: blocking the handler so the job never completes — and the key therefore never frees — **still fails**, after the full timeout.

Two alternatives were rejected, and the comment says so because both are the obvious next edit:
- `time.Sleep` before the re-enqueue — trades a visible flake for a slow invisible one, and encodes a guess about a machine.
- ignoring `ErrDuplicateJob` — that error *is* the failure this test exists to catch, so swallowing it would delete the test while leaving it green.

## How this was found, including the wrong turn

It surfaced on PR #1497, a branch that doesn't touch `internal/jobs`. I first called it a flake and re-ran CI, on the strength of: the diff not touching that package (verified structurally — `go list -deps ./internal/jobs/` reaches neither changed package), both sibling branches passing, 5 consecutive local `-race` runs green, and a run with CI's exact `-shuffle` seed green.

**The rerun failed identically, which disproved it.**

What the flake hypothesis never explained was the evidence: *"flaky"* predicts randomness, and this was two-for-two on one branch and zero elsewhere. Reaching for **load** rather than ordering — `GOMAXPROCS=1` instead of another seed — made it deterministic in a single run.

That's the generalisable bit, and it's written into the bug's prevention field: an intermittent failure with a non-random distribution isn't a flake, and treating it as one costs a rerun and delays the diagnosis.

Full analysis in `BUG-BPHP79` (5-whys) and `BUGA-PFQPOM`.

Gates: `go test ./internal/jobs/... -race` green; 20/20 under `GOMAXPROCS=1`; `just lint` / `arch-lint` / `comment-lint` / `plimsoll` clean.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
