### PR TITLE
feat(dataentry): navigable rows, cards and nav controls are real links (TKT-3CSZRG)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -55,6 +55,30 @@ genuinely slow:
 If you see no indicator at all, the operation completed quickly. That is the
 intended behaviour.
 
+### Opening things in a new tab
+
+Anything that navigates is a real link: list rows, kanban cards, search
+results, side-panel entries, related-entity titles and quick-search results,
+along with the Prev/Next, Edit and History controls on an entity page. So the
+usual browser gestures all work as you would expect:
+
+- **Cmd-click** (macOS) or **Ctrl-click** (Windows/Linux) opens it in a new
+  background tab.
+- **Middle-click** does the same.
+- **Shift-click** opens it in a new window.
+- **Right-click** offers "Open link in new tab", and hovering shows the target
+  address in the status bar.
+
+A plain click still navigates in place, without a full page reload. A new tab
+opened this way keeps the context of the list you came from, so the
+previous/next controls on the entity page still walk the same result set.
+
+Buttons that change data — Delete in particular — stay buttons, since opening
+one in a new tab would mean nothing.
+
+Note that a list row is a link across its whole width, which means dragging to
+select text inside a row is not possible; use the entity page for that.
+
 ## Quick Start
 
 ### 1. Create data-entry.yaml

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -52,8 +52,9 @@ intended behaviour.
 ### Opening things in a new tab
 
 Anything that navigates is a real link: list rows, kanban cards, search
-results, side-panel entries, related-entity titles and quick-search results.
-So the usual browser gestures all work as you would expect:
+results, side-panel entries, related-entity titles and quick-search results,
+along with the Prev/Next, Edit and History controls on an entity page. So the
+usual browser gestures all work as you would expect:
 
 - **Cmd-click** (macOS) or **Ctrl-click** (Windows/Linux) opens it in a new
   background tab.
@@ -65,6 +66,9 @@ So the usual browser gestures all work as you would expect:
 A plain click still navigates in place, without a full page reload. A new tab
 opened this way keeps the context of the list you came from, so the
 previous/next controls on the entity page still walk the same result set.
+
+Buttons that change data — Delete in particular — stay buttons, since opening
+one in a new tab would mean nothing.
 
 Note that a list row is a link across its whole width, which means dragging to
 select text inside a row is not possible; use the entity page for that.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -49,6 +49,26 @@ genuinely slow:
 If you see no indicator at all, the operation completed quickly. That is the
 intended behaviour.
 
+### Opening things in a new tab
+
+Anything that navigates is a real link: list rows, kanban cards, search
+results, side-panel entries, related-entity titles and quick-search results.
+So the usual browser gestures all work as you would expect:
+
+- **Cmd-click** (macOS) or **Ctrl-click** (Windows/Linux) opens it in a new
+  background tab.
+- **Middle-click** does the same.
+- **Shift-click** opens it in a new window.
+- **Right-click** offers "Open link in new tab", and hovering shows the target
+  address in the status bar.
+
+A plain click still navigates in place, without a full page reload. A new tab
+opened this way keeps the context of the list you came from, so the
+previous/next controls on the entity page still walk the same result set.
+
+Note that a list row is a link across its whole width, which means dragging to
+select text inside a row is not possible; use the entity page for that.
+
 ## Quick Start
 
 ### 1. Create data-entry.yaml

--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -402,8 +402,10 @@ export class EntityPage extends BasePage {
   }
 
   /** Modifier-click a locator and return the tab the browser opens. Used to
-   *  prove the BROWSER opened the tab, rather than the SPA emulating one. */
-  async openInNewTab(target: Locator, modifier: 'Meta' | 'Control' = 'Meta') {
+   *  prove the BROWSER opened the tab, rather than the SPA emulating one.
+   *  `ControlOrMeta` resolves per platform (Meta on macOS, Control elsewhere) —
+   *  hardcoding either one passes on the author's machine and fails on CI. */
+  async openInNewTab(target: Locator, modifier: 'ControlOrMeta' = 'ControlOrMeta') {
     const popupPromise = this.page.context().waitForEvent('page');
     await target.click({ modifiers: [modifier] });
     return popupPromise;

--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -385,4 +385,27 @@ export class EntityPage extends BasePage {
     await this.contentEntityRefLink(entityType, id).click();
     await this.page.waitForURL(new RegExp(`/entity/${entityType}/${id}(\\?|$)`));
   }
+
+  // ── New-tab affordances (TKT-3CSZRG) ────────────────────────────────────
+  // Navigable rows, cells and non-mutating nav controls are real <a href>
+  // elements so the browser can open them in a tab. These helpers expose the
+  // link elements and the modifier-click gesture.
+
+  /** The first link inside a table-display section on the entity detail page. */
+  get sectionTableLink(): Locator {
+    return this.page.locator('.sections .data-table a[href]').first();
+  }
+
+  /** A header nav affordance rendered as a link (Prev/Next, Edit, History). */
+  navLink(name: string | RegExp): Locator {
+    return this.page.getByRole('link', { name });
+  }
+
+  /** Modifier-click a locator and return the tab the browser opens. Used to
+   *  prove the BROWSER opened the tab, rather than the SPA emulating one. */
+  async openInNewTab(target: Locator, modifier: 'Meta' | 'Control' = 'Meta') {
+    const popupPromise = this.page.context().waitForEvent('page');
+    await target.click({ modifiers: [modifier] });
+    return popupPromise;
+  }
 }

--- a/e2e/pages/kanban.page.ts
+++ b/e2e/pages/kanban.page.ts
@@ -45,7 +45,7 @@ export class KanbanPage extends BasePage {
   }
 
   /** Modifier-click a kanban card and return the tab it opens (TKT-3CSZRG). */
-  async openCardInNewTab(cardId: string, modifier: 'Meta' | 'Control' = 'Meta') {
+  async openCardInNewTab(cardId: string, modifier: 'ControlOrMeta' = 'ControlOrMeta') {
     const popupPromise = this.page.context().waitForEvent('page');
     await this.cards.filter({ hasText: cardId }).click({ modifiers: [modifier] });
     return popupPromise;

--- a/e2e/pages/kanban.page.ts
+++ b/e2e/pages/kanban.page.ts
@@ -44,6 +44,13 @@ export class KanbanPage extends BasePage {
     await this.page.waitForURL(/\/entity\/|\/form\//);
   }
 
+  /** Modifier-click a kanban card and return the tab it opens (TKT-3CSZRG). */
+  async openCardInNewTab(cardId: string, modifier: 'Meta' | 'Control' = 'Meta') {
+    const popupPromise = this.page.context().waitForEvent('page');
+    await this.cards.filter({ hasText: cardId }).click({ modifiers: [modifier] });
+    return popupPromise;
+  }
+
   async clickCardById(cardId: string) {
     await this.cards.filter({ hasText: cardId }).click();
     await this.page.waitForURL(/\/entity\/|\/form\//);

--- a/e2e/pages/list.page.ts
+++ b/e2e/pages/list.page.ts
@@ -67,6 +67,26 @@ export class ListPage extends BasePage {
     await this.page.locator(`.entity-row[data-entity-id="${id}"]`).click();
   }
 
+  /** Modifier/middle-click a row and return the tab it opens (TKT-3CSZRG).
+   *  Rows are real links, so the browser — not the SPA — opens the tab; this
+   *  waits on the resulting popup rather than on an in-page navigation. */
+  async openRowInNewTab(index: number, how: { modifier?: 'Meta' | 'Control'; middle?: boolean }) {
+    const row = this.page.locator('.entity-row, tbody tr').nth(index);
+    const popupPromise = this.page.context().waitForEvent('page');
+    if (how.middle) {
+      await row.click({ button: 'middle' });
+    } else {
+      await row.click({ modifiers: [how.modifier ?? 'Meta'] });
+    }
+    return popupPromise;
+  }
+
+  /** The href of a row's link, for asserting the target and its scope query. */
+  async rowLinkHref(index: number): Promise<string | null> {
+    const row = this.page.locator('.entity-row, tbody tr').nth(index);
+    return row.locator('a.row-link').first().getAttribute('href');
+  }
+
   async openDeleteModalForFirstRow() {
     const firstRow = this.page.locator('.entity-row, tbody tr').first();
     await firstRow.locator('.delete-btn, button[title="Delete"]').click();

--- a/e2e/pages/list.page.ts
+++ b/e2e/pages/list.page.ts
@@ -70,13 +70,13 @@ export class ListPage extends BasePage {
   /** Modifier/middle-click a row and return the tab it opens (TKT-3CSZRG).
    *  Rows are real links, so the browser — not the SPA — opens the tab; this
    *  waits on the resulting popup rather than on an in-page navigation. */
-  async openRowInNewTab(index: number, how: { modifier?: 'Meta' | 'Control'; middle?: boolean }) {
+  async openRowInNewTab(index: number, how: { modifier?: 'ControlOrMeta'; middle?: boolean }) {
     const row = this.page.locator('.entity-row, tbody tr').nth(index);
     const popupPromise = this.page.context().waitForEvent('page');
     if (how.middle) {
       await row.click({ button: 'middle' });
     } else {
-      await row.click({ modifiers: [how.modifier ?? 'Meta'] });
+      await row.click({ modifiers: [how.modifier ?? 'ControlOrMeta'] });
     }
     return popupPromise;
   }

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -1294,6 +1294,19 @@ views:
           - property: priority
             render: input
         empty_message: "No implemented features"
+      # TKT-3CSZRG: a table-display section whose first column carries a
+      # link:. Its cells render real anchors, and their click handler must
+      # defer modifier/middle clicks to the browser instead of preventing
+      # the default. Without this fixture the entity-detail table display had
+      # no e2e coverage at all, which is how an unconditional @click.prevent
+      # survived on those anchors.
+      - heading: "Linked features"
+        source: implemented
+        display: table
+        columns:
+          - property: title
+            link: detail
+          - property: status
 
 kanbans:
   feature-board:

--- a/e2e/tests/open-new-tab.spec.ts
+++ b/e2e/tests/open-new-tab.spec.ts
@@ -71,13 +71,11 @@ test.describe('Open in a new tab', () => {
     // The task view has the table-display section; TASK-001 implements FEAT-001.
     await detail.navigateTo('/entity/task/TASK-001');
 
-    const cellLink = appPage.locator('.sections .data-table a[href]').first();
+    const cellLink = detail.sectionTableLink;
     await expect(cellLink).toBeVisible();
 
     const before = appPage.url();
-    const popupPromise = appPage.context().waitForEvent('page');
-    await cellLink.click({ modifiers: ['Meta'] });
-    const popup = await popupPromise;
+    const popup = await detail.openInNewTab(cellLink);
 
     await expect(popup).toHaveURL(/\/entity\//);
     expect(appPage.url()).toBe(before);
@@ -94,20 +92,19 @@ test.describe('Open in a new tab', () => {
     await listPage.clickRow(0);
     await expect(appPage).toHaveURL(/\/entity\//);
 
-    const history = appPage.getByRole('link', { name: 'History' });
+    const detail = new EntityPage(appPage);
+    const history = detail.navLink('History');
     await expect(history).toBeVisible();
 
     const before = appPage.url();
-    const popupPromise = appPage.context().waitForEvent('page');
-    await history.click({ modifiers: ['Meta'] });
-    const popup = await popupPromise;
+    const popup = await detail.openInNewTab(history);
 
     await expect(popup).toHaveURL(/\/history\//);
     expect(appPage.url()).toBe(before);
     await popup.close();
 
-    // Delete must NOT have become a link.
-    await expect(appPage.getByRole('link', { name: /Delete/ })).toHaveCount(0);
+    // Delete must NOT have become a link — it mutates.
+    await expect(detail.navLink(/Delete/)).toHaveCount(0);
   });
 
   test('cmd/ctrl-click on a kanban card opens a background tab', async ({ appPage }) => {

--- a/e2e/tests/open-new-tab.spec.ts
+++ b/e2e/tests/open-new-tab.spec.ts
@@ -84,6 +84,32 @@ test.describe('Open in a new tab', () => {
     await popup.close();
   });
 
+  test('header nav affordances (Prev/Next, Edit, History) open in a new tab', async ({
+    appPage,
+  }) => {
+    // Navigation buttons that trigger no mutation are links too. Delete stays a
+    // <button> on purpose — it mutates, so a new tab makes no sense for it.
+    const listPage = new ListPage(appPage);
+    await listPage.navigateToList('features');
+    await listPage.clickRow(0);
+    await expect(appPage).toHaveURL(/\/entity\//);
+
+    const history = appPage.getByRole('link', { name: 'History' });
+    await expect(history).toBeVisible();
+
+    const before = appPage.url();
+    const popupPromise = appPage.context().waitForEvent('page');
+    await history.click({ modifiers: ['Meta'] });
+    const popup = await popupPromise;
+
+    await expect(popup).toHaveURL(/\/history\//);
+    expect(appPage.url()).toBe(before);
+    await popup.close();
+
+    // Delete must NOT have become a link.
+    await expect(appPage.getByRole('link', { name: /Delete/ })).toHaveCount(0);
+  });
+
   test('cmd/ctrl-click on a kanban card opens a background tab', async ({ appPage }) => {
     const kanbanPage = new KanbanPage(appPage);
     await kanbanPage.navigateToKanban('feature-board');

--- a/e2e/tests/open-new-tab.spec.ts
+++ b/e2e/tests/open-new-tab.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from './fixtures';
+import { ListPage } from '../pages/list.page';
+import { KanbanPage } from '../pages/kanban.page';
+
+// TKT-3CSZRG. Navigable rows and cards used to be plain <div>/<tr> elements with
+// an @click calling router.push, so the browser had no link to act on:
+// cmd/ctrl-click, middle-click and "Open link in new tab" all did nothing. They
+// are real anchors now; these tests assert the browser genuinely opens a tab
+// (not that the SPA emulates one).
+test.describe('Open in a new tab', () => {
+  test('cmd/ctrl-click on a list row opens a background tab and leaves the list in place', async ({
+    appPage,
+  }) => {
+    const listPage = new ListPage(appPage);
+    await listPage.navigateToList('features');
+
+    const popup = await listPage.openRowInNewTab(0, { modifier: 'Meta' });
+
+    await expect(popup).toHaveURL(/\/entity\//);
+    // The original tab must NOT have navigated — that was the old behaviour.
+    await expect(appPage).toHaveURL(/\/list\/features/);
+    await popup.close();
+  });
+
+  test('middle-click on a list row opens a background tab', async ({ appPage }) => {
+    const listPage = new ListPage(appPage);
+    await listPage.navigateToList('features');
+
+    const popup = await listPage.openRowInNewTab(0, { middle: true });
+
+    await expect(popup).toHaveURL(/\/entity\//);
+    await expect(appPage).toHaveURL(/\/list\/features/);
+    await popup.close();
+  });
+
+  test('the row link carries the list scope, so the new tab is not orphaned', async ({
+    appPage,
+  }) => {
+    // A tab opened without the scope query renders fine but has dead prev/next
+    // navigation and a wrong back target — a silent divergence from a plain
+    // click, which is the failure this guards.
+    const listPage = new ListPage(appPage);
+    await listPage.navigateToList('features');
+
+    const href = await listPage.rowLinkHref(0);
+
+    expect(href).toContain('/entity/');
+    expect(href).toContain('from=features');
+    // A colon is legal unencoded in a query value, so match either form.
+    expect(href).toMatch(/scope=list(:|%3A)features/);
+  });
+
+  test('a plain click still navigates in the same tab', async ({ appPage }) => {
+    const listPage = new ListPage(appPage);
+    await listPage.navigateToList('features');
+
+    await listPage.clickRow(0);
+
+    await expect(appPage).toHaveURL(/\/entity\//);
+  });
+
+  test('cmd/ctrl-click on a kanban card opens a background tab', async ({ appPage }) => {
+    const kanbanPage = new KanbanPage(appPage);
+    await kanbanPage.navigateToKanban('feature-board');
+
+    const firstCard = kanbanPage.cards.first();
+    await expect(firstCard).toBeVisible();
+    const cardId = (await firstCard.innerText()).split('\n')[0];
+
+    const popup = await kanbanPage.openCardInNewTab(cardId);
+
+    await expect(popup).toHaveURL(/\/(entity|form)\//);
+    await expect(appPage).toHaveURL(/\/kanban\/feature-board/);
+    await popup.close();
+  });
+});

--- a/e2e/tests/open-new-tab.spec.ts
+++ b/e2e/tests/open-new-tab.spec.ts
@@ -15,7 +15,7 @@ test.describe('Open in a new tab', () => {
     const listPage = new ListPage(appPage);
     await listPage.navigateToList('features');
 
-    const popup = await listPage.openRowInNewTab(0, { modifier: 'Meta' });
+    const popup = await listPage.openRowInNewTab(0, { modifier: 'ControlOrMeta' });
 
     await expect(popup).toHaveURL(/\/entity\//);
     // The original tab must NOT have navigated — that was the old behaviour.

--- a/e2e/tests/open-new-tab.spec.ts
+++ b/e2e/tests/open-new-tab.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures';
 import { ListPage } from '../pages/list.page';
 import { KanbanPage } from '../pages/kanban.page';
+import { EntityPage } from '../pages/entity.page';
 
 // TKT-3CSZRG. Navigable rows and cards used to be plain <div>/<tr> elements with
 // an @click calling router.push, so the browser had no link to act on:
@@ -57,6 +58,30 @@ test.describe('Open in a new tab', () => {
     await listPage.clickRow(0);
 
     await expect(appPage).toHaveURL(/\/entity\//);
+  });
+
+  test('cmd/ctrl-click on an entity-detail section table cell opens a background tab', async ({
+    appPage,
+  }) => {
+    // These cells were already real <a href> elements, but carried an
+    // unconditional @click.prevent that suppressed the browser's default on
+    // EVERY click — so cmd-click navigated in place. Exactly the bug this
+    // ticket exists to fix, in an anchor that already looked correct.
+    const detail = new EntityPage(appPage);
+    // The task view has the table-display section; TASK-001 implements FEAT-001.
+    await detail.navigateTo('/entity/task/TASK-001');
+
+    const cellLink = appPage.locator('.sections .data-table a[href]').first();
+    await expect(cellLink).toBeVisible();
+
+    const before = appPage.url();
+    const popupPromise = appPage.context().waitForEvent('page');
+    await cellLink.click({ modifiers: ['Meta'] });
+    const popup = await popupPromise;
+
+    await expect(popup).toHaveURL(/\/entity\//);
+    expect(appPage.url()).toBe(before);
+    await popup.close();
   });
 
   test('cmd/ctrl-click on a kanban card opens a background tab', async ({ appPage }) => {

--- a/frontend/src/components/calendar/EntityPreviewModal.vue
+++ b/frontend/src/components/calendar/EntityPreviewModal.vue
@@ -30,8 +30,9 @@
  * go see it properly.
  */
 import { computed, nextTick, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink } from 'vue-router'
 import { useModalStack } from '@/composables/modalStack'
+import { shouldDeferToBrowser } from '@/utils/openIntent'
 import EntityDetail from '@/components/entity/EntityDetail.vue'
 
 const props = defineProps<{
@@ -44,7 +45,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{ (e: 'close'): void }>()
 
-const router = useRouter()
 const dialog = ref<HTMLElement | null>(null)
 const previouslyFocused = ref<HTMLElement | null>(null)
 
@@ -76,15 +76,18 @@ function onKeydown(event: KeyboardEvent) {
   }
 }
 
-function openFullPage() {
-  close()
-  void router.push(`/entity/${props.entityType}/${props.entityId}`)
-}
+// Both footer actions are pure navigation, so they render as real links and
+// support cmd/ctrl/middle-click. On a modifier click the browser opens a tab
+// and the modal deliberately STAYS OPEN — closing it would drop the preview the
+// user was reading. A plain click still closes and routes in place.
+const fullPageTarget = computed(() => `/entity/${props.entityType}/${props.entityId}`)
+const editFormTarget = computed(() =>
+  props.editForm ? `/form/${props.editForm}/${props.entityId}` : undefined
+)
 
-function openEditForm() {
-  if (!props.editForm) return
+function onNavigate(event: MouseEvent) {
+  if (shouldDeferToBrowser(event)) return
   close()
-  void router.push(`/form/${props.editForm}/${props.entityId}`)
 }
 
 </script>
@@ -119,10 +122,17 @@ function openEditForm() {
         </div>
 
         <footer class="modal-actions">
-          <button type="button" class="btn" @click="openFullPage">Open full page</button>
-          <button v-if="editForm" type="button" class="btn btn-primary" @click="openEditForm">
+          <RouterLink class="btn" :to="fullPageTarget" @click="onNavigate">
+            Open full page
+          </RouterLink>
+          <RouterLink
+            v-if="editFormTarget"
+            class="btn btn-primary"
+            :to="editFormTarget"
+            @click="onNavigate"
+          >
             Edit
-          </button>
+          </RouterLink>
         </footer>
       </div>
     </div>

--- a/frontend/src/components/common/IssuesTable.vue
+++ b/frontend/src/components/common/IssuesTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink } from 'vue-router'
 import type { AnalyzeIssue } from '@/types'
 import { useSchemaStore } from '@/stores'
 import { useScriptErrorStore } from '@/stores/scriptError'
@@ -13,7 +13,6 @@ import { useScriptErrorStore } from '@/stores/scriptError'
 // interactive when it has nothing to do.
 const props = defineProps<{ issues: AnalyzeIssue[] }>()
 
-const router = useRouter()
 const schemaStore = useSchemaStore()
 const scriptErrorStore = useScriptErrorStore()
 
@@ -55,10 +54,14 @@ function isExpanded(key: string): boolean {
 function canNavigate(issue: AnalyzeIssue): boolean {
   return Boolean(issue.entityId && issue.entityType)
 }
-function onEntityClick(issue: AnalyzeIssue) {
-  if (canNavigate(issue)) {
-    router.push(`/entity/${issue.entityType}/${issue.entityId}`)
-  }
+// entityTarget is the entity route for a navigable issue row. Bound to a
+// RouterLink so cmd/middle-click opens a tab and right-click offers "Open in
+// new tab" — the previous role="button" span offered none of that.
+// Nil: returns undefined when the issue has no entity (script-error /
+// load-error rows), and the template renders a plain span instead.
+function entityTarget(issue: AnalyzeIssue): string | undefined {
+  if (!canNavigate(issue)) return undefined
+  return `/entity/${issue.entityType}/${issue.entityId}`
 }
 
 // The message cell reveals detail: script-error rows open the dialog;
@@ -97,16 +100,13 @@ function onMessageClick(key: string, issue: AnalyzeIssue, ev: Event) {
           <tr class="issue-row">
             <td class="entity-cell">
               <template v-if="row.issue.entityId">
-                <span
-                  class="entity-title"
-                  :class="{ clickable: canNavigate(row.issue) }"
-                  :role="canNavigate(row.issue) ? 'button' : undefined"
-                  :tabindex="canNavigate(row.issue) ? 0 : undefined"
-                  @click="onEntityClick(row.issue)"
-                  @keydown.enter="onEntityClick(row.issue)"
-                  @keydown.space.prevent="onEntityClick(row.issue)"
-                  >{{ getEntityTitle(row.issue) }}</span
+                <RouterLink
+                  v-if="entityTarget(row.issue)"
+                  class="entity-title clickable"
+                  :to="entityTarget(row.issue)!"
+                  >{{ getEntityTitle(row.issue) }}</RouterLink
                 >
+                <span v-else class="entity-title">{{ getEntityTitle(row.issue) }}</span>
                 <span class="entity-id">{{ row.issue.entityId }}</span>
               </template>
               <span v-else class="entity-empty">&mdash;</span>
@@ -166,17 +166,15 @@ function onMessageClick(key: string, issue: AnalyzeIssue, ev: Event) {
     <template v-for="row in rowsFor(props.issues)" :key="`card-${row.key}`">
       <li class="issue-card">
         <div class="issue-card-row issue-card-head">
-          <span
-            v-if="row.issue.entityId"
-            class="entity-title"
-            :class="{ clickable: canNavigate(row.issue) }"
-            :role="canNavigate(row.issue) ? 'button' : undefined"
-            :tabindex="canNavigate(row.issue) ? 0 : undefined"
-            @click="onEntityClick(row.issue)"
-            @keydown.enter="onEntityClick(row.issue)"
-            @keydown.space.prevent="onEntityClick(row.issue)"
-            >{{ getEntityTitle(row.issue) }}</span
+          <RouterLink
+            v-if="entityTarget(row.issue)"
+            class="entity-title clickable"
+            :to="entityTarget(row.issue)!"
+            >{{ getEntityTitle(row.issue) }}</RouterLink
           >
+          <span v-else-if="row.issue.entityId" class="entity-title">{{
+            getEntityTitle(row.issue)
+          }}</span>
           <span v-else class="entity-empty">&mdash;</span>
           <span class="severity-badge" :class="row.issue.severity">
             {{ row.issue.severity.toUpperCase() }}
@@ -262,6 +260,9 @@ function onMessageClick(key: string, issue: AnalyzeIssue, ev: Event) {
   display: block;
   color: var(--accent-color, #6366f1);
   font-weight: 500;
+  /* Now a real RouterLink: suppress the default underline so the resting look
+     is unchanged; the :hover rule below still underlines. */
+  text-decoration: none;
 }
 
 /* Split click targets (TKT-IL499B): the entity title navigates, the

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -14,6 +14,7 @@ import { toggleCheckboxInSource } from '@/utils/checkboxToggle'
 import type { Command } from '@/types'
 import { getEditFormId } from '@/types'
 import { entityDetailHref } from '@/utils/entityRoute'
+import { shouldDeferToBrowser } from '@/utils/openIntent'
 import { computeActionAllowed } from '@/utils/affordancesWarning'
 import { isInputFocused } from '@/utils/dom'
 import { isAnyModalOpen } from '@/composables/modalStack'
@@ -470,6 +471,21 @@ function navigateToEntity(entity: { id: string; type: string }, cellLink?: strin
   const path = entityDetailHref(entity, { cellLink })
   if (!path) return
   router.push(path)
+}
+
+// Click handler for the section-table cell anchors. Those are real <a href>
+// elements, so a modifier or middle click must reach the BROWSER — it is what
+// opens the new tab. Only a plain left-click is ours to intercept, and only
+// then do we preventDefault and route in-SPA. An unconditional `.prevent` here
+// suppressed cmd/ctrl/shift/middle clicks too, which was this ticket's own bug.
+function onCellLinkClick(
+  event: MouseEvent,
+  entity: { id: string; type: string },
+  cellLink?: string,
+) {
+  if (shouldDeferToBrowser(event)) return
+  event.preventDefault()
+  navigateToEntity(entity, cellLink)
 }
 
 function navigateToEdit(formId: string, entityId: string) {
@@ -1179,8 +1195,9 @@ watch(
                         <a
                           v-if="cell.link"
                           :href="cell.link"
-                          @click.prevent="
-                            navigateToEntity(
+                          @click="
+                            onCellLinkClick(
+                              $event,
                               {
                                 id: cell.entityId || row.entityId,
                                 type: cell.entityType || row.entityType,
@@ -1242,8 +1259,9 @@ watch(
                     <a
                       v-if="cell.link"
                       :href="cell.link"
-                      @click.prevent="
-                        navigateToEntity(
+                      @click="
+                        onCellLinkClick(
+                          $event,
                           {
                             id: cell.entityId || row.entityId,
                             type: cell.entityType || row.entityType,
@@ -1584,7 +1602,9 @@ watch(
   align-items: center;
   gap: var(--space-sm);
   margin-bottom: 12px;
-  cursor: pointer;
+  /* No cursor: pointer — the header is no longer clickable as a whole; the
+     pointer comes from .card-header-link, so the padding beside it must not
+     advertise a click that does nothing. */
 }
 
 .content-card .card-header:hover .entity-title {

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, onUnmounted } from 'vue'
-import { RouterLink, useRouter } from 'vue-router'
+import { RouterLink, useRouter, type RouteLocationRaw } from 'vue-router'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { useScopeNavigation } from '@/composables'
 import { useBackTarget } from '@/composables/useBackTarget'
@@ -84,7 +84,7 @@ const { confirm } = useConfirm()
 // (return_to / from precedence). Two parallel concerns: scope-nav walks
 // a list; backTarget answers "where do I go back to". Both can be active
 // at once.
-const { scopeNav, loadScopeNav, navigateScope } = useScopeNavigation(() => props.entityId)
+const { scopeNav, loadScopeNav, scopeTarget, navigateScope } = useScopeNavigation(() => props.entityId)
 const backTarget = useBackTarget()
 
 // State
@@ -113,9 +113,15 @@ const showOverflowMenu = ref(false)
 
 const commandModalRef = ref<InstanceType<typeof CommandModal> | null>(null)
 
-function openHistory() {
-  router.push(`/history/${props.entityType}/${props.entityId}`)
-}
+// historyTarget / editTarget back the header's History and Edit affordances.
+// Both are pure navigation (no mutation), so they render as real links and
+// support cmd/ctrl/middle-click — unlike Delete, which stays a <button>.
+// Each is the single source of truth for its destination, shared with the
+// keyboard shortcut so both routes agree.
+const historyTarget = computed(
+  () => `/history/${props.entityType}/${props.entityId}`
+)
+
 const contentRef = ref<HTMLElement | null>(null)
 
 // Computed
@@ -146,6 +152,14 @@ const isInaccessible = computed(() => (entry.value?.inaccessible?.length ?? 0) >
 // Affordance gates: `_actions` map from the server. `false` → hide;
 // anything else → render. See frontend/src/utils/affordancesWarning.ts.
 const canUpdate = computeActionAllowed(entry, 'update')
+
+// Nil: undefined when editing is unavailable (no configured form, an
+// inaccessible/git-crypt entity, or no update permission). The template then
+// renders nothing rather than a link to a page that would refuse the write.
+const editTarget = computed<RouteLocationRaw | undefined>(() => {
+  if (!editFormId.value || isInaccessible.value || !canUpdate.value) return undefined
+  return { name: 'form-edit', params: { id: editFormId.value, entityId: props.entityId } }
+})
 const canDelete = computeActionAllowed(entry, 'delete')
 
 // The entry's content section gets a custom renderer (mermaid + interactive
@@ -805,15 +819,23 @@ watch(
       <div v-if="backTarget || scopeNav" class="scope-nav mobile-topbar">
         <BackButton v-if="backTarget" :target="backTarget" />
         <template v-if="scopeNav">
-          <button v-if="scopeNav.prev" class="scope-nav-btn" @click="navigateScope('prev')">
+          <RouterLink
+            v-if="scopeTarget('prev')"
+            class="scope-nav-btn"
+            :to="scopeTarget('prev')!"
+          >
             ← Prev <kbd>P</kbd>
-          </button>
+          </RouterLink>
           <span v-else class="scope-nav-btn disabled">← Prev</span>
           <span class="scope-nav-progress">[{{ scopeNav.current }}/{{ scopeNav.total }}]</span>
           <span class="scope-nav-label">{{ scopeNav.label }}</span>
-          <button v-if="scopeNav.next" class="scope-nav-btn" @click="navigateScope('next')">
+          <RouterLink
+            v-if="scopeTarget('next')"
+            class="scope-nav-btn"
+            :to="scopeTarget('next')!"
+          >
             Next → <kbd>N</kbd>
-          </button>
+          </RouterLink>
           <span v-else class="scope-nav-btn disabled">Next →</span>
         </template>
       </div>
@@ -833,14 +855,14 @@ watch(
           >
             {{ cmd.label }}
           </button>
-          <button
-            v-if="editFormId && !isInaccessible && canUpdate"
+          <RouterLink
+            v-if="editTarget"
             class="btn btn-secondary"
-            @click="editEntity"
+            :to="editTarget"
           >
             Edit <kbd>E</kbd>
-          </button>
-          <button class="btn btn-secondary" @click="openHistory">History</button>
+          </RouterLink>
+          <RouterLink class="btn btn-secondary" :to="historyTarget">History</RouterLink>
           <ExportMenu :url-for="(t: string) => entityExportUrl(entityType, entityId, t)" />
           <button v-if="canDelete" class="btn btn-danger" @click="requestDelete">
             Delete <kbd>Del</kbd>
@@ -849,13 +871,9 @@ watch(
 
         <!-- Mobile actions: Edit primary, delete icon, overflow menu for commands -->
         <div v-if="!props.hideActions" class="header-actions mobile-actions">
-          <button
-            v-if="editFormId && !isInaccessible && canUpdate"
-            class="btn btn-secondary"
-            @click="editEntity"
-          >
+          <RouterLink v-if="editTarget" class="btn btn-secondary" :to="editTarget">
             Edit
-          </button>
+          </RouterLink>
           <button
             v-if="canDelete"
             class="btn btn-danger mobile-delete-btn"

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, onUnmounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { useScopeNavigation } from '@/composables'
 import { useBackTarget } from '@/composables/useBackTarget'
@@ -456,6 +456,16 @@ function backTargetAfterDelete(): string {
 }
 
 // Section navigation helpers
+//
+// entityTarget is the single source of truth for a section entry's destination,
+// bound to the RouterLinks below so a cmd/middle-clicked tab lands exactly where
+// a plain click does.
+// Nil: returns undefined when the entry has no resolvable route (empty type),
+// and the template renders plain text instead of an anchor.
+function entityTarget(entity: { id: string; type: string }, cellLink?: string): string | undefined {
+  return entityDetailHref(entity, { cellLink }) || undefined
+}
+
 function navigateToEntity(entity: { id: string; type: string }, cellLink?: string) {
   const path = entityDetailHref(entity, { cellLink })
   if (!path) return
@@ -998,10 +1008,16 @@ watch(
               :data-entity-id="ent.id"
               class="content-card"
             >
-              <header class="card-header" @click="navigateToEntity(ent)">
-                <span class="entity-type">{{ ent.type }}</span>
-                <span class="entity-title">{{ ent.title }}</span>
-                <span class="entity-id">{{ ent.id }}</span>
+              <header class="card-header">
+                <component
+                  :is="entityTarget(ent) ? RouterLink : 'span'"
+                  class="card-header-link"
+                  v-bind="entityTarget(ent) ? { to: entityTarget(ent) } : {}"
+                >
+                  <span class="entity-type">{{ ent.type }}</span>
+                  <span class="entity-title">{{ ent.title }}</span>
+                  <span class="entity-id">{{ ent.id }}</span>
+                </component>
               </header>
               <div
                 v-if="ent.hasContent"
@@ -1025,10 +1041,16 @@ watch(
                 because that would navigate away mid-edit. The header
                 still navigates; cells stay editable.
               -->
-              <header class="card-header" @click="navigateToEntity(ent)">
-                <span class="entity-type">{{ ent.type }}</span>
-                <span class="entity-title">{{ ent.title }}</span>
-                <span class="entity-id">{{ ent.id }}</span>
+              <header class="card-header">
+                <component
+                  :is="entityTarget(ent) ? RouterLink : 'span'"
+                  class="card-header-link"
+                  v-bind="entityTarget(ent) ? { to: entityTarget(ent) } : {}"
+                >
+                  <span class="entity-type">{{ ent.type }}</span>
+                  <span class="entity-title">{{ ent.title }}</span>
+                  <span class="entity-id">{{ ent.id }}</span>
+                </component>
                 <button
                   v-if="ent.editFormId"
                   class="edit-btn"
@@ -1089,11 +1111,15 @@ watch(
               :data-entity-id="ent.id"
               class="list-item"
             >
-              <a class="list-link" @click="navigateToEntity(ent)">
+              <component
+                :is="entityTarget(ent) ? RouterLink : 'span'"
+                class="list-link"
+                v-bind="entityTarget(ent) ? { to: entityTarget(ent) } : {}"
+              >
                 <span class="entity-type">{{ ent.type }}</span>
                 <span class="entity-title">{{ ent.title }}</span>
                 <span class="entity-id">{{ ent.id }}</span>
-              </a>
+              </component>
               <SectionEditForm
                 v-if="rowShouldRouteToInlineEdit(ent, section.entities?.length ?? 0)"
                 :key="`${ent.type}/${ent.id}`"
@@ -1277,9 +1303,9 @@ watch(
     <div v-else class="error-state">
       <h2>Entity not found</h2>
       <p>{{ entityType }} "{{ entityId }}" could not be found.</p>
-      <router-link :to="backTargetAfterDelete()" class="btn btn-secondary">
+      <RouterLink :to="backTargetAfterDelete()" class="btn btn-secondary">
         Back to list
-      </router-link>
+      </RouterLink>
     </div>
   </div>
 </template>
@@ -1676,6 +1702,24 @@ watch(
   gap: var(--space-sm);
   cursor: pointer;
   flex: 1;
+  /* Was an <a> with no href (so cmd-click did nothing); now a real RouterLink.
+     Keep the inherited text colour and no underline. */
+  color: inherit;
+  text-decoration: none;
+}
+
+/* The link inside a card header carries the header's own flex layout, so the
+   header still reads as one row. It takes the free space, leaving the
+   edit-button (which may NOT live inside an <a>) a sibling beside it. */
+.card-header-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
 }
 
 .list-link:hover .entity-title {

--- a/frontend/src/components/forms/RelationCards.vue
+++ b/frontend/src/components/forms/RelationCards.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import SlimSelect from 'slim-select/vue'
 import 'slim-select/styles'
 import { useSchemaStore } from '@/stores'
@@ -178,11 +178,15 @@ function getEntityTitle(id: string): string {
   return entityDisplayTitle(entity)
 }
 
-function navigateToEntity(id: string) {
+// entityTarget is the entity route for a related entry, bound to a RouterLink so
+// cmd/middle-click opens a tab.
+// Nil: returns undefined when the entry is not in entityCache (its type is
+// unknown, so no route can be built). The template then renders a plain span —
+// the same inert behaviour this had before, rather than a broken link.
+function entityTarget(id: string): string | undefined {
   const entity = entityCache.value.get(id)
-  if (entity) {
-    router.push(`/entity/${entity.type}/${id}`)
-  }
+  if (!entity) return undefined
+  return `/entity/${entity.type}/${id}`
 }
 
 // openRelationHistory navigates to the relation's version history. Only offered
@@ -559,12 +563,18 @@ function onDragEnd() {
             >⋮⋮</span
           >
           <div class="card-identity">
-            <span class="entity-id" @click="navigateToEntity(entry.id)">
-              {{ entry.id }}
-            </span>
-            <span class="entity-title" @click="navigateToEntity(entry.id)">
-              {{ getEntityTitle(entry.id) }}
-            </span>
+            <template v-if="entityTarget(entry.id)">
+              <RouterLink class="entity-id" :to="entityTarget(entry.id)!" draggable="false">
+                {{ entry.id }}
+              </RouterLink>
+              <RouterLink class="entity-title" :to="entityTarget(entry.id)!" draggable="false">
+                {{ getEntityTitle(entry.id) }}
+              </RouterLink>
+            </template>
+            <template v-else>
+              <span class="entity-id">{{ entry.id }}</span>
+              <span class="entity-title">{{ getEntityTitle(entry.id) }}</span>
+            </template>
           </div>
           <button
             v-if="!isIncoming"
@@ -874,6 +884,9 @@ function onDragEnd() {
   font-size: 12px;
   color: var(--accent-color, #6366f1);
   white-space: nowrap;
+  /* Real links now; keep the previous resting appearance. */
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .entity-id:hover {
@@ -886,6 +899,8 @@ function onDragEnd() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .entity-title:hover {

--- a/frontend/src/components/forms/SidePanel.vue
+++ b/frontend/src/components/forms/SidePanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink, useRouter, type RouteLocationRaw } from 'vue-router'
 import { api } from '@/api/client'
 import { isCancelledFetch } from '@/composables/usePageData'
 import type { SidePanelSection, SidePanelEntity, SidePanelAddTarget } from '@/types'
@@ -58,12 +58,14 @@ function isCollapsed(sectionId: string): boolean {
   return collapsedSections.value.has(sectionId)
 }
 
-function navigateToEntity(entity: SidePanelEntity) {
+// entityTarget is the single source of truth for where a side-panel entry goes,
+// bound to each entry's RouterLink. The edit-form branch must be reproduced
+// exactly so a cmd-clicked tab matches a plain click.
+function entityTarget(entity: SidePanelEntity): RouteLocationRaw {
   if (entity.editFormId) {
-    router.push(`/form/${entity.editFormId}/${entity.id}`)
-  } else {
-    router.push(`/entity/${entity.type}/${entity.id}`)
+    return `/form/${entity.editFormId}/${entity.id}`
   }
+  return `/entity/${entity.type}/${entity.id}`
 }
 
 function createNewForSection(section: SidePanelSection, target: SidePanelAddTarget) {
@@ -140,13 +142,10 @@ onMounted(() => loadSidePanel())
           <!-- List display -->
           <template v-else-if="section.display === 'list'">
             <ul class="entity-list">
-              <li
-                v-for="entity in section.entities"
-                :key="entity.id"
-                class="entity-list-item"
-                @click="navigateToEntity(entity)"
-              >
-                <Badge :value="entity.title || entity.id" :property="entity.type" />
+              <li v-for="entity in section.entities" :key="entity.id">
+                <RouterLink class="entity-list-item" :to="entityTarget(entity)">
+                  <Badge :value="entity.title || entity.id" :property="entity.type" />
+                </RouterLink>
               </li>
             </ul>
           </template>
@@ -154,11 +153,11 @@ onMounted(() => loadSidePanel())
           <!-- Cards display -->
           <template v-else-if="section.display === 'cards'">
             <div class="entity-cards">
-              <div
+              <RouterLink
                 v-for="entity in section.entities"
                 :key="entity.id"
                 class="entity-card"
-                @click="navigateToEntity(entity)"
+                :to="entityTarget(entity)"
               >
                 <div class="card-header">
                   <span class="card-id">{{ entity.id }}</span>
@@ -178,7 +177,7 @@ onMounted(() => loadSidePanel())
                     <span v-else class="field-value">{{ field.values?.join(', ') || '-' }}</span>
                   </div>
                 </div>
-              </div>
+              </RouterLink>
             </div>
           </template>
 
@@ -310,8 +309,12 @@ onMounted(() => loadSidePanel())
 }
 
 .entity-list-item {
+  display: block;
   cursor: pointer;
   transition: transform 0.1s;
+  /* Real link (cmd/middle-click opens a tab) — keep the Badge's own colours. */
+  color: inherit;
+  text-decoration: none;
 }
 
 .entity-list-item:hover {
@@ -326,12 +329,15 @@ onMounted(() => loadSidePanel())
 }
 
 .entity-card {
+  display: block;
   padding: 12px;
   background: var(--hover-bg);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s;
+  color: inherit;
+  text-decoration: none;
 }
 
 .entity-card:hover {

--- a/frontend/src/components/lists/EntityList.cells.test.ts
+++ b/frontend/src/components/lists/EntityList.cells.test.ts
@@ -20,7 +20,8 @@ vi.mock('@/api', async (orig) => ({
   listEntities: (...args: unknown[]) => listEntitiesMock(...args),
 }))
 
-vi.mock('vue-router', () => ({
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
   useRoute: () => ({ query: {}, path: '/list/things', name: 'list' }),
 }))

--- a/frontend/src/components/lists/EntityList.newtab.test.ts
+++ b/frontend/src/components/lists/EntityList.newtab.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+import EntityList from './EntityList.vue'
+import { useSchemaStore } from '@/stores/schema'
+import { _setEntityPluralForTest } from '@/api/entities'
+import type { Entity, ListResponse } from '@/types'
+
+// TKT-3CSZRG: list rows are real links so cmd/ctrl/middle-click opens a new tab.
+// The row is a <tr> (which cannot be an anchor), so the link lives in the first
+// cell and is stretched over the row by CSS.
+
+const listEntitiesMock = vi.fn()
+vi.mock('@/api', async (orig) => ({
+  ...(await orig<typeof import('@/api')>()),
+  listEntities: (...args: unknown[]) => listEntitiesMock(...args),
+}))
+
+const routerPush = vi.fn()
+const mockRoute = { query: {} as Record<string, string>, path: '/list/tickets-list', name: 'list' }
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
+  useRouter: () => ({ push: routerPush, replace: vi.fn() }),
+  useRoute: () => mockRoute,
+}))
+
+const listId = 'tickets-list'
+const entityType = 'ticket'
+
+function seedSchema(columns: unknown[] = [{ property: 'title', label: 'Title' }]) {
+  const schemaStore = useSchemaStore()
+  schemaStore.lists.set(listId, {
+    id: listId,
+    title: 'Tickets',
+    entity: entityType,
+    columns,
+  } as never)
+  schemaStore.entityTypes.set(entityType, {
+    name: entityType,
+    label: 'Ticket',
+    properties: { title: { type: 'string', values: null } },
+  } as never)
+}
+
+function seedEntities(entities: Entity[]): ListResponse<Entity> {
+  const response: ListResponse<Entity> = {
+    data: entities,
+    meta: { total: entities.length, page: 1, per_page: 25, has_more: false },
+    included: {},
+  }
+  listEntitiesMock.mockResolvedValue(response)
+  return response
+}
+
+let pinia: ReturnType<typeof createPinia>
+
+async function mountList() {
+  const wrapper = mount(EntityList, {
+    props: { listId },
+    attachTo: document.body,
+    global: { plugins: [pinia, PiniaColada] },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('EntityList row links (new-tab affordance)', () => {
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    _setEntityPluralForTest(entityType, 'tickets')
+    listEntitiesMock.mockReset()
+    routerPush.mockReset()
+    mockRoute.query = {}
+    seedSchema()
+  })
+
+  it('renders a real anchor in the row so right-click and middle-click work', async () => {
+    seedEntities([{ id: 'TKT-1', type: entityType, properties: { title: 'First' } }])
+    const wrapper = await mountList()
+
+    const link = wrapper.find('.entity-row .row-link')
+    expect(link.exists()).toBe(true)
+    expect(link.element.tagName).toBe('A')
+    expect(link.attributes('href')).toBeTruthy()
+  })
+
+  it('the href carries the SAME query as the programmatic push', async () => {
+    // The regression this guards: building the href separately from the push
+    // silently drops the list scope, so a cmd-clicked tab lands on an unscoped
+    // detail page (dead prev/next, wrong back target) while still looking fine.
+    seedEntities([{ id: 'TKT-1', type: entityType, properties: { title: 'First' } }])
+    const wrapper = await mountList()
+
+    const href = wrapper.find('.entity-row .row-link').attributes('href')
+
+    await wrapper.find('.entity-row').trigger('click')
+    expect(routerPush).toHaveBeenCalledTimes(1)
+    const pushed = routerPush.mock.calls[0][0] as { path: string; query: Record<string, string> }
+
+    const params = new URLSearchParams()
+    for (const [k, v] of Object.entries(pushed.query)) params.append(k, String(v))
+    expect(href).toBe(`${pushed.path}?${params.toString()}`)
+  })
+
+  it('includes the list scope in the href, not just the bare entity path', async () => {
+    seedEntities([{ id: 'TKT-1', type: entityType, properties: { title: 'First' } }])
+    const wrapper = await mountList()
+
+    const href = wrapper.find('.entity-row .row-link').attributes('href') ?? ''
+    expect(href).toContain('/entity/ticket/TKT-1')
+    expect(href).toContain(`from=${listId}`)
+    expect(href).toContain(`scope=list%3A${listId}`)
+  })
+
+  it('a plain left-click still navigates in-SPA', async () => {
+    seedEntities([{ id: 'TKT-1', type: entityType, properties: { title: 'First' } }])
+    const wrapper = await mountList()
+
+    await wrapper.find('.entity-row').trigger('click')
+
+    expect(routerPush).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['meta (cmd)', { metaKey: true }],
+    ['ctrl', { ctrlKey: true }],
+    ['shift', { shiftKey: true }],
+    ['alt', { altKey: true }],
+    ['middle button', { button: 1 }],
+  ])('defers a %s click to the browser instead of routing in place', async (_n, init) => {
+    seedEntities([{ id: 'TKT-1', type: entityType, properties: { title: 'First' } }])
+    const wrapper = await mountList()
+
+    await wrapper.find('.entity-row').trigger('click', init)
+
+    // No router.push: the browser acts on the row's own anchor, opening a tab
+    // or window. Routing in place here is exactly the bug being fixed.
+    expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  it('renders no anchor when the entity type is empty', async () => {
+    // entityDetailHref returns '' for an empty type; rendering an anchor would
+    // emit /entity//<id>, which 404s.
+    seedEntities([{ id: 'TKT-1', type: '', properties: { title: 'First' } }])
+    const wrapper = await mountList()
+
+    expect(wrapper.find('.entity-row .row-link').exists()).toBe(false)
+    await wrapper.find('.entity-row').trigger('click')
+    expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  it('never renders an empty href', async () => {
+    seedEntities([
+      { id: 'TKT-1', type: entityType, properties: { title: 'First' } },
+      { id: 'TKT-2', type: '', properties: { title: 'Second' } },
+    ])
+    const wrapper = await mountList()
+
+    for (const a of wrapper.findAll('a')) {
+      expect(a.attributes('href')).not.toBe('')
+    }
+  })
+
+  // The `cellLink` path is the one server-supplied string that can reach an
+  // href. Its resolver (EntityList.resolveLinkTarget, mirroring the Go copy in
+  // internal/dataentry/views_handler.go) is a closed allowlist over `detail`
+  // and `document/*`; anything else resolves to '' and must render no anchor.
+  // Pinned on both sides because an href is a much sharper sink than the
+  // router.push it replaced.
+  describe('column link: values', () => {
+    it.each([
+      ['javascript:alert(1)'],
+      ['JavaScript:alert(1)'],
+      ['data:text/html,<script>alert(1)</script>'],
+      ['//evil.example.com'],
+      ['https://evil.example.com'],
+    ])('never binds a hostile link: value as an href (%s)', async (link) => {
+      seedSchema([{ property: 'title', label: 'Title', link }])
+      seedEntities([{ id: 'TKT-1', type: entityType, properties: { title: 'First' } }])
+      const wrapper = await mountList()
+
+      // resolveLinkTarget rejects it to '', so the row falls back to the safe
+      // entity route rather than binding an attacker-chosen scheme.
+      const href = wrapper.find('.entity-row .row-link').attributes('href') ?? ''
+      expect(href).toContain('/entity/ticket/TKT-1')
+      for (const a of wrapper.findAll('a')) {
+        const value = a.attributes('href') ?? ''
+        expect(value).not.toMatch(/^(javascript|data|vbscript):/i)
+        expect(value).not.toMatch(/^\/\//)
+        expect(value).not.toMatch(/^https?:/i)
+      }
+    })
+
+    it('uses an allowlisted document link as the row target', async () => {
+      seedSchema([{ property: 'title', label: 'Title', link: 'document/spec' }])
+      seedEntities([{ id: 'TKT-1', type: entityType, properties: { title: 'First' } }])
+      const wrapper = await mountList()
+
+      const href = wrapper.find('.entity-row .row-link').attributes('href') ?? ''
+      expect(href).toContain('/document/spec/TKT-1')
+    })
+  })
+})

--- a/frontend/src/components/lists/EntityList.newtab.test.ts
+++ b/frontend/src/components/lists/EntityList.newtab.test.ts
@@ -111,7 +111,10 @@ describe('EntityList row links (new-tab affordance)', () => {
     const href = wrapper.find('.entity-row .row-link').attributes('href') ?? ''
     expect(href).toContain('/entity/ticket/TKT-1')
     expect(href).toContain(`from=${listId}`)
-    expect(href).toContain(`scope=list%3A${listId}`)
+    // Encoding-agnostic: the test stub and vue-router disagree on whether `:`
+    // is percent-encoded, and the fact under test is that the scope is CARRIED,
+    // not how it is spelled. open-new-tab.spec.ts pins the real encoding.
+    expect(href).toMatch(new RegExp(`scope=list(:|%3A)${listId}`))
   })
 
   it('a plain left-click still navigates in-SPA', async () => {

--- a/frontend/src/components/lists/EntityList.test.ts
+++ b/frontend/src/components/lists/EntityList.test.ts
@@ -30,7 +30,8 @@ vi.mock('@/api', async (orig) => ({
 const routerPush = vi.fn()
 const routerReplace = vi.fn()
 const mockRoute = { query: {} as Record<string, string>, path: '/list/tickets-list', name: 'list' }
-vi.mock('vue-router', () => ({
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({ push: routerPush, replace: routerReplace }),
   useRoute: () => mockRoute,
 }))

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, shallowRef, computed, watch, onMounted, onUnmounted, type Component } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
 import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { useListKeyboard } from '@/composables/useListKeyboard'
@@ -12,6 +12,7 @@ import { entityKeys } from '@/queries/entities'
 import { beginOptimisticRemove, rollbackOptimistic } from '@/queries/optimisticList'
 import { toApiOperator, filterStateToApiParams } from '@/utils/filters'
 import { entityDetailHref } from '@/utils/entityRoute'
+import { safeInternalHref, shouldDeferToBrowser } from '@/utils/openIntent'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { renderMarkdown } from '@/utils/markdown'
 import { actionAllowed } from '@/utils/affordancesWarning'
@@ -482,7 +483,15 @@ function resolveLinkTarget(link: string, entityType: string, entityId: string): 
   return ''
 }
 
-function navigateToEntity(entity: Entity) {
+// entityTarget is the SINGLE source of truth for a row's destination — used both
+// by the row's plain-click push AND by the title cell's RouterLink `to`.
+// Building the href separately would silently drop the query below: the tab
+// would open on an unscoped detail page where prev/next navigation is dead and
+// the back target is wrong, while still rendering a valid-looking page.
+// Nil: returns undefined when no safe internal path resolves (empty entity
+// type, or a cellLink that is not a same-origin path); the row then renders no
+// link and the click is inert.
+function entityTarget(entity: Entity): RouteLocationRaw | undefined {
   // Build query params to preserve navigation context.
   // Filters are already in `route.query` via useUrlFilterSync — we just
   // forward all `filter[*]` entries unchanged so the bracket format is the
@@ -530,14 +539,30 @@ function navigateToEntity(entity: Entity) {
     : ''
 
   // entityDetailHref returns columnLink when set, otherwise the
-  // entity-route path. Centralised so right-click / middle-click open
-  // through a real <a href> on the row markup elsewhere.
+  // entity-route path.
   const path = entityDetailHref(
     { id: entity.id, type: entity.type },
     { cellLink: columnLink },
   )
-  if (!path) return
-  router.push({ path, query })
+  if (!path || !safeInternalHref(path)) return undefined
+  return { path, query }
+}
+
+// navigateToEntity handles a plain left-click on the row. The row is a <tr>, so
+// it cannot be an anchor; the link affordance comes from the stretched
+// .row-link in the first cell, which is what cmd/middle/right-click act on.
+function navigateToEntity(entity: Entity) {
+  const target = entityTarget(entity)
+  if (!target) return
+  router.push(target)
+}
+
+// onRowClick backs the row's plain-click navigation. It defers to the browser
+// on a modifier or non-primary click so the stretched .row-link's own default
+// action runs (opening a tab/window) instead of routing in place.
+function onRowClick(entity: Entity, event: MouseEvent) {
+  if (shouldDeferToBrowser(event)) return
+  navigateToEntity(entity)
 }
 
 // Widget resolution for property cells, keyed by column property name and
@@ -778,13 +803,13 @@ watch(searchQuery, () => {
       </div>
       <div class="header-actions">
         <ExportMenu :url-for="listExportUrlFor" />
-        <router-link
+        <RouterLink
           v-if="listConfig.create_form && canCreate()"
           :to="`/form/${listConfig.create_form}`"
           class="btn btn-primary"
         >
           + New <kbd>N</kbd>
-        </router-link>
+        </RouterLink>
       </div>
     </header>
 
@@ -866,13 +891,13 @@ watch(searchQuery, () => {
         >
           Clear search
         </button>
-        <router-link
+        <RouterLink
           v-else-if="listConfig.create_form"
           :to="`/form/${listConfig.create_form}`"
           class="btn btn-secondary"
         >
           Create one
-        </router-link>
+        </RouterLink>
       </div>
 
       <template v-else>
@@ -883,10 +908,20 @@ watch(searchQuery, () => {
           :key="'card-' + entity.id"
           class="mobile-card"
           :class="{ selected: index === selectedIndex, 'action-selected': isSelected(entity.id) }"
-          @click="navigateToEntity(entity)"
+          @click="onRowClick(entity, $event)"
         >
           <div class="mobile-card-header">
-            <span class="mobile-card-title text-wrap-anywhere text-clamp-2">
+            <!-- The card holds a delete <button>, and an <a> may not contain
+                 interactive content — so the link wraps the title, not the
+                 card. Stretched over the card by .mobile-card-title::after. -->
+            <RouterLink
+              v-if="entityTarget(entity)"
+              class="mobile-card-title text-wrap-anywhere text-clamp-2"
+              :to="entityTarget(entity)!"
+            >
+              {{ getFormattedCellValue(entity, listConfig.columns[0]) }}
+            </RouterLink>
+            <span v-else class="mobile-card-title text-wrap-anywhere text-clamp-2">
               {{ getFormattedCellValue(entity, listConfig.columns[0]) }}
             </span>
             <button
@@ -990,7 +1025,7 @@ watch(searchQuery, () => {
             class="entity-row"
             :data-entity-id="entity.id"
             :class="{ selected: index === selectedIndex, 'action-selected': isSelected(entity.id) }"
-            @click="navigateToEntity(entity)"
+            @click="onRowClick(entity, $event)"
           >
             <td v-if="hasActions" class="select-cell" @click.stop>
               <input
@@ -1000,7 +1035,7 @@ watch(searchQuery, () => {
               />
             </td>
             <td
-              v-for="column in listConfig.columns"
+              v-for="(column, colIndex) in listConfig.columns"
               :key="column.property || column.relation"
             >
               <span
@@ -1008,6 +1043,26 @@ watch(searchQuery, () => {
                 class="inaccessible-cell"
                 title="inaccessible"
               >🔒</span>
+              <!-- The first column's content is wrapped in the row's real link,
+                   stretched over the whole row by .row-link::after. A <tr>
+                   cannot be an anchor, so this is what gives the row
+                   cmd/middle/right-click and a hover URL preview. It wraps real
+                   text (not an empty box) so it has an accessible name. -->
+              <RouterLink
+                v-else-if="colIndex === 0 && entityTarget(entity)"
+                class="row-link"
+                :to="entityTarget(entity)!"
+              >
+                <component
+                  :is="resolveCell(entity, column)!.component"
+                  v-if="resolveCell(entity, column)"
+                  :model-value="resolveCell(entity, column)!.modelValue"
+                  :mode="'display'"
+                  :property-name="resolveCell(entity, column)!.propertyName"
+                  :entity-type="listConfig.entity"
+                />
+                <template v-else>{{ getFormattedCellValue(entity, column) }}</template>
+              </RouterLink>
               <component
                 :is="resolveCell(entity, column)!.component"
                 v-else-if="resolveCell(entity, column)"
@@ -1319,6 +1374,35 @@ watch(searchQuery, () => {
 .entity-row {
   cursor: pointer;
   transition: background 0.15s;
+  /* Containing block for the stretched .row-link below. */
+  position: relative;
+}
+
+/* Stretched link (the Bootstrap `.stretched-link` pattern). A <tr> may not be
+   or contain an <a> at the row level, so the first cell's link is expanded over
+   the whole row: cmd/ctrl-click, middle-click, right-click "Open in new tab"
+   and the hover URL preview all work anywhere on the row, with exactly ONE link
+   per row in the accessibility tree.
+   Known trade-off (accepted, TKT-3CSZRG): the overlay sits above the row's text,
+   so text selection within a row is not possible. */
+.entity-row .row-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.entity-row .row-link::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  /* Below the interactive cells lifted to z-index 1 below. */
+  z-index: 0;
+}
+
+/* Nested controls must stay above the overlay or they become unclickable. */
+.entity-row .select-cell,
+.entity-row .actions-cell {
+  position: relative;
+  z-index: 1;
 }
 
 .entity-row:hover {
@@ -1433,6 +1517,28 @@ watch(searchQuery, () => {
   padding: 12px;
   cursor: pointer;
   transition: all 0.15s;
+  /* Containing block for the stretched title link. */
+  position: relative;
+}
+
+/* Same stretched-link pattern as the desktop row: the title is the real link,
+   expanded over the card so the whole card supports cmd/middle/right-click. */
+a.mobile-card-title {
+  color: inherit;
+  text-decoration: none;
+}
+
+a.mobile-card-title::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+/* The delete button must stay above the overlay. */
+.mobile-card .delete-btn {
+  position: relative;
+  z-index: 1;
 }
 
 .mobile-card + .mobile-card {

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -552,7 +552,7 @@ function entityTarget(entity: Entity): RouteLocationRaw | undefined {
 // it cannot be an anchor; the link affordance comes from the stretched
 // .row-link in the first cell, which is what cmd/middle/right-click act on.
 function navigateToEntity(entity: Entity) {
-  const target = entityTarget(entity)
+  const target = rowTargets.value.get(entity.id) ?? entityTarget(entity)
   if (!target) return
   router.push(target)
 }
@@ -564,6 +564,20 @@ function onRowClick(entity: Entity, event: MouseEvent) {
   if (shouldDeferToBrowser(event)) return
   navigateToEntity(entity)
 }
+
+// Row targets, computed ONCE per entity rather than per template reference
+// (RR-SYFX1B -- the same reason columnWidgets below is per-column, not
+// per-cell). entityTarget walks route.query, maps sortSpecs and scans columns,
+// and the template reads it twice per row (the v-else-if and the :to), so at 25
+// rows that was 50 traversals per render, re-running on every reactive tick
+// including hover-driven selectedIndex changes.
+const rowTargets = computed(() => {
+  const byId = new Map<string, RouteLocationRaw | undefined>()
+  for (const entity of entities.value) {
+    byId.set(entity.id, entityTarget(entity))
+  }
+  return byId
+})
 
 // Widget resolution for property cells, keyed by column property name and
 // computed ONCE per column rather than per cell (RR-UD2A -- the same reason
@@ -915,9 +929,9 @@ watch(searchQuery, () => {
                  interactive content — so the link wraps the title, not the
                  card. Stretched over the card by .mobile-card-title::after. -->
             <RouterLink
-              v-if="entityTarget(entity)"
+              v-if="rowTargets.get(entity.id)"
               class="mobile-card-title text-wrap-anywhere text-clamp-2"
-              :to="entityTarget(entity)!"
+              :to="rowTargets.get(entity.id)!"
             >
               {{ getFormattedCellValue(entity, listConfig.columns[0]) }}
             </RouterLink>
@@ -1049,9 +1063,9 @@ watch(searchQuery, () => {
                    cmd/middle/right-click and a hover URL preview. It wraps real
                    text (not an empty box) so it has an accessible name. -->
               <RouterLink
-                v-else-if="colIndex === 0 && entityTarget(entity)"
+                v-else-if="colIndex === 0 && rowTargets.get(entity.id)"
                 class="row-link"
-                :to="entityTarget(entity)!"
+                :to="rowTargets.get(entity.id)!"
               >
                 <component
                   :is="resolveCell(entity, column)!.component"

--- a/frontend/src/components/ui/CommandPaletteModal.test.ts
+++ b/frontend/src/components/ui/CommandPaletteModal.test.ts
@@ -103,7 +103,7 @@ const dom = {
   // The option's navigation lives on an inner anchor (TKT-3CSZRG) so that
   // cmd/middle-click opens a tab; plain clicks still route in place.
   optionLinks: () =>
-    Array.from(document.querySelectorAll<HTMLAnchorElement>('.cmdk-option-link')),
+    Array.from(document.querySelectorAll<HTMLAnchorElement>('a.cmdk-option-link')),
   hint: () => document.querySelector<HTMLElement>('.cmdk-hint')?.textContent?.trim(),
   spinner: () => document.querySelector<HTMLElement>('.cmdk-spinner'),
 }
@@ -560,6 +560,22 @@ describe('CommandPaletteModal', () => {
 
       expect(routerPush).toHaveBeenCalledWith(`/entity/${entity.type}/${entity.id}`)
       expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+
+    it('still renders the option text when there is no resolvable href', async () => {
+      // Guarding only the link would leave an empty, zero-height <li
+      // role="option">: invisible, still counted by the arrow-key highlight,
+      // and nameless to a screen reader — worse than the inert row it replaced.
+      const entity = makeEntity({ type: '' })
+      searchSpy.mockResolvedValueOnce(listResponse([entity]))
+      factory()
+      await typeQuery('xx')
+
+      expect(optionLinks()).toHaveLength(0)
+      const option = options()[0]
+      expect(option).toBeTruthy()
+      expect(option.textContent).toContain(entity.id)
+      expect(option.querySelector('.cmdk-option-link')).not.toBeNull()
     })
 
     it('does not navigate when entity has no type (empty href)', async () => {

--- a/frontend/src/components/ui/CommandPaletteModal.test.ts
+++ b/frontend/src/components/ui/CommandPaletteModal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createRouter, createMemoryHistory } from 'vue-router'
 import { mount, flushPromises } from '@vue/test-utils'
 import type { VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
@@ -9,10 +10,7 @@ import { searchEntities } from '@/api'
 import type { Entity, ListResponse } from '@/types'
 
 // Router stub — palette navigates via router.push when an entity is selected.
-const routerPush = vi.fn()
-vi.mock('vue-router', () => ({
-  useRouter: () => ({ push: routerPush }),
-}))
+
 
 // Mock the search endpoint so each test can stub responses and we can assert
 // signal forwarding without hitting the real API client.
@@ -52,10 +50,33 @@ function seedSchema() {
   } as never)
 }
 
+// A real router is installed (not just the mocked useRouter) because results are
+// RouterLinks now — RouterLink resolves `to` through the injected router, so
+// without one the anchors render with no href and the link assertions are
+// meaningless. `useRouter` stays mocked so navigation intent is still spied on.
+const testRouter = createRouter({
+  history: createMemoryHistory('/'),
+  routes: [
+    { path: '/', component: { template: '<div/>' } },
+    { path: '/entity/:type/:id', component: { template: '<div/>' } },
+  ],
+})
+
+// `routerPush` spies on the REAL router rather than replacing useRouter.
+// RouterLink resolves `to` through the injected router, so mocking the module
+// would leave every result anchor with no href — the very affordance under test.
+const routerPush = vi.spyOn(testRouter, 'push')
+
+// RouterLink renders an empty href until the router has resolved its initial
+// location, so prime it once for the whole file.
+await testRouter.push('/')
+await testRouter.isReady()
+
 function factory(props: { open?: boolean } = {}): VueWrapper {
   return mount(CommandPaletteModal, {
     props: { open: true, ...props },
     attachTo: document.body,
+    global: { plugins: [testRouter] },
   })
 }
 
@@ -79,12 +100,17 @@ const dom = {
     return el
   },
   options: () => Array.from(document.querySelectorAll<HTMLLIElement>('.cmdk-option')),
+  // The option's navigation lives on an inner anchor (TKT-3CSZRG) so that
+  // cmd/middle-click opens a tab; plain clicks still route in place.
+  optionLinks: () =>
+    Array.from(document.querySelectorAll<HTMLAnchorElement>('.cmdk-option-link')),
   hint: () => document.querySelector<HTMLElement>('.cmdk-hint')?.textContent?.trim(),
   spinner: () => document.querySelector<HTMLElement>('.cmdk-spinner'),
 }
 
 const input = dom.input
 const options = dom.options
+const optionLinks = dom.optionLinks
 
 // Type into the palette and wait for the debounced search to settle.
 // Vue's v-model needs a microtask to sync the input event into the bound ref;
@@ -526,7 +552,10 @@ describe('CommandPaletteModal', () => {
       const wrapper = factory()
       await typeQuery('xx')
 
-      options()[0].click()
+      const link = optionLinks()[0]
+      expect(link.getAttribute('href')).toBe(`/entity/${entity.type}/${entity.id}`)
+
+      link.click()
       await flushPromises()
 
       expect(routerPush).toHaveBeenCalledWith(`/entity/${entity.type}/${entity.id}`)

--- a/frontend/src/components/ui/CommandPaletteModal.vue
+++ b/frontend/src/components/ui/CommandPaletteModal.vue
@@ -295,6 +295,11 @@ const showNoMatches = computed(
             :aria-selected="idx === highlightedIndex"
             @mouseenter="highlightedIndex = idx"
           >
+            <!-- The option's content renders in BOTH branches. Guarding only
+                 the link would leave an entity with no resolvable route as an
+                 empty, zero-height <li role="option">: invisible to the eye,
+                 still counted by the arrow-key highlight, and nameless to a
+                 screen reader. -->
             <RouterLink
               v-if="entityDetailHref(entity)"
               class="cmdk-option-link"
@@ -306,6 +311,11 @@ const showNoMatches = computed(
               <span class="cmdk-title">{{ entityLabel(entity) }}</span>
               <span class="cmdk-id">{{ entity.id }}</span>
             </RouterLink>
+            <span v-else class="cmdk-option-link">
+              <span class="cmdk-type">{{ entityTypeLabel(entity.type) }}</span>
+              <span class="cmdk-title">{{ entityLabel(entity) }}</span>
+              <span class="cmdk-id">{{ entity.id }}</span>
+            </span>
           </li>
         </ul>
       </div>

--- a/frontend/src/components/ui/CommandPaletteModal.vue
+++ b/frontend/src/components/ui/CommandPaletteModal.vue
@@ -15,13 +15,14 @@
  * behind the overlay (we don't have a generic useFocusTrap composable yet).
  */
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import { searchEntities } from '@/api'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { useSchemaStore } from '@/stores'
 import { useModalStack } from '@/composables/modalStack'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { entityDetailHref } from '@/utils/entityRoute'
+import { shouldDeferToBrowser } from '@/utils/openIntent'
 import type { Entity } from '@/types'
 
 // Perceptually-instant on a fast connection; tune up if the API is slow.
@@ -155,7 +156,11 @@ function entityTypeLabel(type: string): string {
   return schemaStore.entityTypes.get(type)?.label || type
 }
 
-function selectEntity(entity: Entity): void {
+// A modifier/middle click is the browser's to handle: it opens a tab from the
+// anchor's own href, and the palette deliberately STAYS OPEN so the user can
+// collect several entities into tabs without reopening it each time.
+function selectEntity(entity: Entity, event?: MouseEvent): void {
+  if (event && shouldDeferToBrowser(event)) return
   const href = entityDetailHref(entity)
   if (!href) return
   router.push(href)
@@ -288,12 +293,19 @@ const showNoMatches = computed(
             :class="{ 'cmdk-option-active': idx === highlightedIndex }"
             role="option"
             :aria-selected="idx === highlightedIndex"
-            @click="selectEntity(entity)"
             @mouseenter="highlightedIndex = idx"
           >
-            <span class="cmdk-type">{{ entityTypeLabel(entity.type) }}</span>
-            <span class="cmdk-title">{{ entityLabel(entity) }}</span>
-            <span class="cmdk-id">{{ entity.id }}</span>
+            <RouterLink
+              v-if="entityDetailHref(entity)"
+              class="cmdk-option-link"
+              :to="entityDetailHref(entity)"
+              tabindex="-1"
+              @click="selectEntity(entity, $event)"
+            >
+              <span class="cmdk-type">{{ entityTypeLabel(entity.type) }}</span>
+              <span class="cmdk-title">{{ entityLabel(entity) }}</span>
+              <span class="cmdk-id">{{ entity.id }}</span>
+            </RouterLink>
           </li>
         </ul>
       </div>
@@ -380,12 +392,19 @@ const showNoMatches = computed(
 }
 
 .cmdk-option {
+  cursor: pointer;
+  font-size: 14px;
+}
+
+/* Padding lives on the link, not the <li>, so the whole option row is inside
+   the anchor's hit area (and its href) rather than only the text. */
+.cmdk-option-link {
   display: flex;
   align-items: center;
   gap: 12px;
   padding: 10px 18px;
-  cursor: pointer;
-  font-size: 14px;
+  color: inherit;
+  text-decoration: none;
 }
 
 .cmdk-option-active {

--- a/frontend/src/composables/useScopeNavigation.test.ts
+++ b/frontend/src/composables/useScopeNavigation.test.ts
@@ -310,6 +310,60 @@ describe('useScopeNavigation', () => {
     })
   })
 
+  // scopeTarget backs the Prev/Next affordances, which are real links so
+  // cmd/ctrl/middle-click opens the neighbour in a new tab (TKT-3CSZRG). It is
+  // the same value navigateScope pushes, so the link and the keyboard shortcut
+  // cannot drift apart.
+  describe('scopeTarget', () => {
+    it('returns the same location navigateScope pushes', async () => {
+      mockRouteQuery.value = { from: 'tasks' }
+      mockSchemaStore.getList.mockReturnValue({ entity: 'task' })
+      mockPositionForList(['TASK-001', 'TASK-002'])
+
+      const { loadScopeNav, scopeTarget, navigateScope } = useScopeNavigation(() => 'TASK-002')
+      await loadScopeNav()
+
+      const target = scopeTarget('prev')
+      navigateScope('prev')
+
+      expect(mockPush).toHaveBeenCalledWith(target)
+    })
+
+    it('carries the scope query so a new tab is not orphaned', async () => {
+      mockRouteQuery.value = { from: 'tasks', q: 'urgent' }
+      mockSchemaStore.getList.mockReturnValue({ entity: 'task' })
+      mockPositionForList(['TASK-001', 'TASK-002'])
+
+      const { loadScopeNav, scopeTarget } = useScopeNavigation(() => 'TASK-001')
+      await loadScopeNav()
+
+      expect(scopeTarget('next')).toEqual({
+        path: '/entity/task/TASK-002',
+        query: { from: 'tasks', q: 'urgent' },
+      })
+    })
+
+    it('is undefined at the ends, so the template renders a disabled affordance', async () => {
+      mockRouteQuery.value = { from: 'tasks' }
+      mockSchemaStore.getList.mockReturnValue({ entity: 'task' })
+      mockPositionForList(['TASK-001', 'TASK-002'])
+
+      const { loadScopeNav, scopeTarget } = useScopeNavigation(() => 'TASK-001')
+      await loadScopeNav()
+
+      expect(scopeTarget('prev')).toBeUndefined()
+      expect(scopeTarget('next')).toBeDefined()
+    })
+
+    it('is undefined when there is no scope at all', () => {
+      mockRouteQuery.value = {}
+      const { scopeTarget } = useScopeNavigation(() => 'TASK-001')
+
+      expect(scopeTarget('prev')).toBeUndefined()
+      expect(scopeTarget('next')).toBeUndefined()
+    })
+  })
+
   describe('navigateScope', () => {
     it('navigates to previous entity', async () => {
       mockRouteQuery.value = { from: 'tasks' }

--- a/frontend/src/composables/useScopeNavigation.ts
+++ b/frontend/src/composables/useScopeNavigation.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
 import { useSchemaStore } from '@/stores'
 import { toApiOperator, parseFilterQueryParams, filterStateToApiParams } from '@/utils/filters'
 import { getEntityPosition, type ScopeDescriptor, type PositionRef } from '@/api/entities'
@@ -122,24 +122,38 @@ export function useScopeNavigation(entityId: () => string) {
     return { scope, label: listConfig.title || listId }
   }
 
-  function navigateScope(direction: 'prev' | 'next') {
-    if (!scopeNav.value) return
+  // scopeTarget is the single source of truth for where prev/next goes — bound
+  // to the nav links' `to` AND used by navigateScope, so a cmd-clicked tab and
+  // the keyboard shortcut land on the identical URL.
+  //
+  // Use the target's OWN type, not the current entity's — a search scope can
+  // span types, so the next/prev entity may be a different type. Preserve all
+  // query params so the scope (from=, q=, …) survives the hop.
+  //
+  // Nil: returns undefined when there is no scope or no neighbour in that
+  // direction; callers render a disabled affordance rather than a dead link.
+  function scopeTarget(direction: 'prev' | 'next'): RouteLocationRaw | undefined {
+    if (!scopeNav.value) return undefined
 
     const target = direction === 'prev' ? scopeNav.value.prev : scopeNav.value.next
-    if (!target) return
+    if (!target) return undefined
 
-    // Use the target's OWN type, not the current entity's — a search scope can
-    // span types, so the next/prev entity may be a different type. Preserve all
-    // query params so the scope (from=, q=, …) survives the hop.
-    router.push({
+    return {
       path: `/entity/${target.type}/${target.id}`,
       query: route.query,
-    })
+    }
+  }
+
+  function navigateScope(direction: 'prev' | 'next') {
+    const target = scopeTarget(direction)
+    if (!target) return
+    router.push(target)
   }
 
   return {
     scopeNav,
     loadScopeNav,
+    scopeTarget,
     navigateScope,
   }
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -43,7 +43,13 @@ Object.defineProperty(globalThis, 'crypto', {
 // titles are genuine links (TKT-3CSZRG) so that cmd/ctrl/middle-click opens a
 // new tab; a stub that dropped `to` produced `<a>` with no href, which made
 // every such assertion vacuous while still rendering something anchor-shaped.
-// Object targets are serialized path + query, matching what vue-router builds.
+// Object targets are serialized path + query.
+//
+// NOTE: URLSearchParams percent-encodes per application/x-www-form-urlencoded,
+// so `scope=list:x` becomes `scope=list%3Ax`, whereas vue-router's own
+// stringifier leaves `:` unencoded. This stub therefore APPROXIMATES the real
+// href. Assert that a query param is *carried*, not its exact spelling; an
+// exact-encoding assertion belongs in e2e, against the real router.
 config.global.stubs = {
   RouterLink: {
     props: ['to'],

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -37,11 +37,38 @@ Object.defineProperty(globalThis, 'crypto', {
   },
 })
 
-// Global stubs for router-link and router-view
+// Global stubs for router-link and router-view.
+//
+// The RouterLink stub renders `to` into a real `href`. Navigable rows, cards and
+// titles are genuine links (TKT-3CSZRG) so that cmd/ctrl/middle-click opens a
+// new tab; a stub that dropped `to` produced `<a>` with no href, which made
+// every such assertion vacuous while still rendering something anchor-shaped.
+// Object targets are serialized path + query, matching what vue-router builds.
 config.global.stubs = {
   RouterLink: {
-    template: '<a><slot /></a>',
     props: ['to'],
+    computed: {
+      href(): string {
+        const to = (this as unknown as { to: unknown }).to
+        if (typeof to === 'string') return to
+        if (!to || typeof to !== 'object') return ''
+        const loc = to as { path?: string; query?: Record<string, unknown> }
+        const path = loc.path ?? ''
+        if (!loc.query) return path
+        const params = new URLSearchParams()
+        for (const [key, value] of Object.entries(loc.query)) {
+          if (value === null || value === undefined) continue
+          if (Array.isArray(value)) {
+            for (const v of value) if (v !== null && v !== undefined) params.append(key, String(v))
+          } else {
+            params.append(key, String(value))
+          }
+        }
+        const qs = params.toString()
+        return qs ? `${path}?${qs}` : path
+      },
+    },
+    template: '<a :href="href"><slot /></a>',
   },
   RouterView: true,
 }

--- a/frontend/src/utils/openIntent.test.ts
+++ b/frontend/src/utils/openIntent.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { shouldDeferToBrowser, safeInternalHref } from './openIntent'
+
+function click(init: Partial<MouseEventInit> & { defaultPrevented?: boolean } = {}) {
+  const { defaultPrevented, ...rest } = init
+  const evt = new MouseEvent('click', { cancelable: true, ...rest })
+  if (defaultPrevented) evt.preventDefault()
+  return evt
+}
+
+describe('shouldDeferToBrowser', () => {
+  it('is false for a plain primary click — that is ours to route', () => {
+    expect(shouldDeferToBrowser(click())).toBe(false)
+  })
+
+  it.each([
+    ['metaKey', { metaKey: true }],
+    ['ctrlKey', { ctrlKey: true }],
+    ['shiftKey', { shiftKey: true }],
+    // Option-click downloads the target on macOS. We stay consistent with
+    // useDocumentClicks, which also defers on altKey.
+    ['altKey', { altKey: true }],
+  ])('is true for %s so the browser opens a tab/window itself', (_name, init) => {
+    expect(shouldDeferToBrowser(click(init))).toBe(true)
+  })
+
+  it('is true for middle-click', () => {
+    expect(shouldDeferToBrowser(click({ button: 1 }))).toBe(true)
+  })
+
+  it('is true for right-click', () => {
+    expect(shouldDeferToBrowser(click({ button: 2 }))).toBe(true)
+  })
+
+  it('is true when a nested control already handled the event', () => {
+    // Not a new-tab intent — the point is that nothing further should happen.
+    expect(shouldDeferToBrowser(click({ defaultPrevented: true }))).toBe(true)
+  })
+})
+
+describe('safeInternalHref', () => {
+  it.each(['/entity/ticket/TKT-1', '/list/all?from=x', '/'])(
+    'accepts the same-origin path %s',
+    (path) => {
+      expect(safeInternalHref(path)).toBe(true)
+    },
+  )
+
+  it('rejects protocol-relative paths, which navigate off-origin', () => {
+    expect(safeInternalHref('//evil.com')).toBe(false)
+  })
+
+  it.each(['javascript:alert(1)', 'JavaScript:alert(1)', 'data:text/html,x', 'https://evil.com', '', 'entity/x'])(
+    'rejects %s',
+    (path) => {
+      expect(safeInternalHref(path)).toBe(false)
+    },
+  )
+})

--- a/frontend/src/utils/openIntent.test.ts
+++ b/frontend/src/utils/openIntent.test.ts
@@ -50,6 +50,10 @@ describe('safeInternalHref', () => {
     expect(safeInternalHref('//evil.com')).toBe(false)
   })
 
+  it('rejects the backslash variant, which browsers normalise to //', () => {
+    expect(safeInternalHref('/\\evil.com')).toBe(false)
+  })
+
   it.each(['javascript:alert(1)', 'JavaScript:alert(1)', 'data:text/html,x', 'https://evil.com', '', 'entity/x'])(
     'rejects %s',
     (path) => {

--- a/frontend/src/utils/openIntent.ts
+++ b/frontend/src/utils/openIntent.ts
@@ -1,0 +1,43 @@
+// Predicate for "this click is not ours to handle — let the browser have it".
+//
+// Used by the ONE surface that must keep a click handler alongside a real link:
+// the list table row. A `<tr>` cannot be (or contain, at the row level) an
+// `<a>`, so the row keeps `@click` for plain navigation while a stretched
+// anchor in the title cell provides the link affordance. Everywhere else in the
+// SPA the element IS a RouterLink, which applies vue-router's own `guardEvent`
+// and needs nothing from here.
+//
+// Deliberately NOT named `wantsNewTab`: `defaultPrevented` means a nested
+// control already handled the event and NOTHING should happen — the opposite of
+// "open a tab". Callers use this only to decide whether to skip their own
+// `router.push`, never to infer that a tab was opened.
+//
+// Mirrors vue-router's `guardEvent` and `createDocumentClickHandler` in
+// composables/useDocumentClicks.ts, which applies the same rule to links inside
+// rendered documents.
+export function shouldDeferToBrowser(event: MouseEvent): boolean {
+  return (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  )
+}
+
+// safeInternalHref reports whether a resolved target is a same-origin path we
+// are willing to put in an `href`.
+//
+// Defence-in-depth, not threat mitigation (CLAUDE.md asks which is meant):
+// `resolveLinkTarget` — both the Go copy in internal/dataentry/views_handler.go
+// and the TS mirror in EntityList.vue — is a closed allowlist over `detail` and
+// `document/*`, so a scheme-bearing value cannot reach here today. This exists
+// so that if that allowlist is ever loosened, the render layer does not
+// silently become an XSS sink.
+//
+// Requires exactly one leading slash: `//evil.com` is protocol-relative and
+// navigates off-origin, so a bare `startsWith('/')` is not sufficient.
+export function safeInternalHref(path: string): boolean {
+  return /^\/(?!\/)/.test(path)
+}

--- a/frontend/src/utils/openIntent.ts
+++ b/frontend/src/utils/openIntent.ts
@@ -36,8 +36,15 @@ export function shouldDeferToBrowser(event: MouseEvent): boolean {
 // so that if that allowlist is ever loosened, the render layer does not
 // silently become an XSS sink.
 //
-// Requires exactly one leading slash: `//evil.com` is protocol-relative and
-// navigates off-origin, so a bare `startsWith('/')` is not sufficient.
+// Requires exactly one leading slash, and rejects a following slash OR
+// backslash: `//evil.com` is protocol-relative, and browsers normalise `\` to
+// `/` in URLs so `/\evil.com` resolves the same way. A bare
+// `startsWith('/')` admits both.
+//
+// Used on the one path where a server-supplied string reaches an href — the
+// list's column `link:` (`cellLink`). The other surfaces build their paths from
+// `entity.type`/`entity.id`, whose grammar is pinned by
+// internal/entity/id.go's ValidateID.
 export function safeInternalHref(path: string): boolean {
-  return /^\/(?!\/)/.test(path)
+  return /^\/(?![/\\])/.test(path)
 }

--- a/frontend/src/views/AnalyzeView.test.ts
+++ b/frontend/src/views/AnalyzeView.test.ts
@@ -9,7 +9,8 @@ import type { AnalyzeIssue, AnalyzeResult } from '@/types'
 import type { ScriptError } from '@/types/scriptError'
 
 const routerPush = vi.fn()
-vi.mock('vue-router', () => ({
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({ push: routerPush }),
   useRoute: () => ({ query: {}, path: '/analyze' }),
 }))
@@ -105,9 +106,13 @@ describe('AnalyzeView click discrimination', () => {
     ])
 
     const store = useScriptErrorStore()
-    await wrapper.find('.entity-title').trigger('click')
 
-    expect(routerPush).toHaveBeenCalledWith('/entity/note/note-2')
+    // The entity title is a real link now (TKT-3CSZRG), so navigation is the
+    // anchor's href rather than a router.push call — that is what makes
+    // cmd/middle-click open a new tab.
+    const link = wrapper.find('.entity-title')
+    expect(link.element.tagName).toBe('A')
+    expect(link.attributes('href')).toBe('/entity/note/note-2')
     expect(store.current).toBeNull()
 
     // A plain violation (no detail, no scriptError) has no interactive

--- a/frontend/src/views/CalendarView.test.ts
+++ b/frontend/src/views/CalendarView.test.ts
@@ -43,7 +43,8 @@ const routerReplace = vi.fn((to: { query?: Record<string, string> }) => {
   if (to?.query) routeQuery.value = { ...to.query }
   return Promise.resolve()
 })
-vi.mock('vue-router', () => ({
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({
     push: routerPush,
     replace: (to: { query?: Record<string, string> }) => routerReplace(to),
@@ -627,8 +628,9 @@ describe('CalendarView event click', () => {
     expect(modal).not.toBeNull()
     expect(modal.querySelector('.header-actions')).toBeNull()
 
-    // The footer still offers exactly one Edit.
-    const footerButtons = [...modal.querySelectorAll('.modal-actions button')].map((b) =>
+    // The footer still offers exactly one Edit. Both actions are real links
+    // now (TKT-3CSZRG) so cmd/middle-click opens them in a tab.
+    const footerButtons = [...modal.querySelectorAll('.modal-actions button, .modal-actions a')].map((b) =>
       b.textContent?.trim()
     )
     expect(footerButtons).toEqual(['Open full page', 'Edit'])
@@ -642,7 +644,7 @@ describe('CalendarView event click', () => {
     await flushPromises()
 
     const modal = document.querySelector('.entity-preview') as HTMLElement
-    const footerButtons = [...modal.querySelectorAll('.modal-actions button')].map((b) =>
+    const footerButtons = [...modal.querySelectorAll('.modal-actions button, .modal-actions a')].map((b) =>
       b.textContent?.trim()
     )
     expect(footerButtons).toEqual(['Open full page'])

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
 import { useUIStore, useSchemaStore } from '@/stores'
 import { getErrorMessage, ApiError } from '@/api/errors'
 import { listVersions, getVersion, restoreVersion, type VersionMeta } from '@/api/history'
@@ -12,7 +12,6 @@ import Badge from '@/components/common/Badge.vue'
 import type { Entity } from '@/types'
 
 const route = useRoute()
-const router = useRouter()
 const uiStore = useUIStore()
 const schemaStore = useSchemaStore()
 
@@ -215,9 +214,8 @@ function formatWhen(iso: string): string {
   return isNaN(d.getTime()) ? iso : d.toLocaleString()
 }
 
-function goBack() {
-  router.push(`/entity/${entityType.value}/${entityId.value}`)
-}
+// Pure navigation, so it renders as a real link and supports cmd/middle-click.
+const backTarget = computed(() => `/entity/${entityType.value}/${entityId.value}`)
 
 const hasContentChanges = computed(() => contentDiff.value.some((l) => l.op !== 'equal'))
 
@@ -234,7 +232,7 @@ onMounted(load)
         <h2>Version history</h2>
         <p>{{ entityType }} · {{ entityId }}</p>
       </div>
-      <button class="btn btn-secondary" @click="goBack">Back to entity</button>
+      <RouterLink class="btn btn-secondary" :to="backTarget">Back to entity</RouterLink>
     </div>
 
     <div v-if="loading" class="loading-state">Loading version history…</div>

--- a/frontend/src/views/KanbanView.cardFields.test.ts
+++ b/frontend/src/views/KanbanView.cardFields.test.ts
@@ -22,7 +22,8 @@ vi.mock('@/api', async (orig) => ({
   updateEntity: vi.fn().mockResolvedValue(undefined),
 }))
 
-vi.mock('vue-router', () => ({
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({ push: vi.fn() }),
   useRoute: () => ({ query: {}, path: '/kanban/board' }),
 }))

--- a/frontend/src/views/KanbanView.pagination.test.ts
+++ b/frontend/src/views/KanbanView.pagination.test.ts
@@ -23,7 +23,8 @@ const getMock = vi.mocked(api.get)
 const KANBAN_ID = 'board'
 const ENTITY_TYPE = 'ticket'
 
-vi.mock('vue-router', () => ({
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({ push: vi.fn() }),
   useRoute: () => ({ query: {}, path: '/kanban/board' }),
 }))

--- a/frontend/src/views/KanbanView.test.ts
+++ b/frontend/src/views/KanbanView.test.ts
@@ -19,7 +19,8 @@ vi.mock('@/api', async (orig) => ({
 }))
 
 const routerPush = vi.fn()
-vi.mock('vue-router', () => ({
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-router')>()),
   useRouter: () => ({ push: routerPush }),
   useRoute: () => ({ query: {}, path: '/kanban/board' }),
 }))

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -586,6 +586,13 @@ function createNew() {
         </div>
 
         <div class="column-cards">
+          <!-- The card is BOTH the link and the drag source. Deliberately no
+               draggable="false" here (unlike RelationCards, RR-NPDW9A): that
+               attribute is for an anchor nested INSIDE a drag source, and
+               setting it on the drag source itself would disable reordering.
+               onDragStart sets dataTransfer unconditionally, so the native
+               link-drag is overridden in both the draggable and non-draggable
+               branches. -->
           <RouterLink
             v-for="entity in entitiesByColumn[column.value]"
             :key="entity.id"

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, type Component } from 'vue'
-import { useRouter } from 'vue-router'
+import { RouterLink, useRouter, type RouteLocationRaw } from 'vue-router'
 import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { listAllEntities, updateEntity, getErrorMessage } from '@/api'
@@ -495,12 +495,15 @@ function onDragEnd() {
   draggedCard.value = null
 }
 
-function openCard(entity: Entity) {
+// cardTarget is the single source of truth for where a card goes, bound to each
+// card's RouterLink. The edit-form branch must be reproduced exactly, or a
+// cmd-clicked tab would land on the detail page while a plain click opens the
+// form.
+function cardTarget(entity: Entity): RouteLocationRaw {
   if (kanbanConfig.value?.edit_form) {
-    router.push(`/form/${kanbanConfig.value.edit_form}/${entity.id}`)
-  } else {
-    router.push(`/entity/${entity.type}/${entity.id}`)
+    return `/form/${kanbanConfig.value.edit_form}/${entity.id}`
   }
+  return `/entity/${entity.type}/${entity.id}`
 }
 
 function createNew() {
@@ -583,14 +586,14 @@ function createNew() {
         </div>
 
         <div class="column-cards">
-          <div
+          <RouterLink
             v-for="entity in entitiesByColumn[column.value]"
             :key="entity.id"
             class="kanban-card"
+            :to="cardTarget(entity)"
             :draggable="canUpdate(entity) ? 'true' : 'false'"
             @dragstart="onDragStart($event, entity)"
             @dragend="onDragEnd"
-            @click="openCard(entity)"
           >
             <div class="card-id">{{ entity.id }}</div>
             <div class="card-title text-wrap-anywhere">{{ getCardTitle(entity) }}</div>
@@ -598,7 +601,7 @@ function createNew() {
               :fields="resolvedCardFields(entity)"
               :entity-type="kanbanConfig?.entity"
             />
-          </div>
+          </RouterLink>
 
           <div v-if="!entitiesByColumn[column.value]?.length" class="empty-column">
             No items
@@ -651,14 +654,14 @@ function createNew() {
           @dragover="onDragOver"
           @drop="onDrop($event, column.value, swimlane.value)"
         >
-          <div
+          <RouterLink
             v-for="entity in entitiesByCell[column.value]?.[swimlane.value] || []"
             :key="entity.id"
             class="kanban-card"
+            :to="cardTarget(entity)"
             :draggable="canUpdate(entity) ? 'true' : 'false'"
             @dragstart="onDragStart($event, entity)"
             @dragend="onDragEnd"
-            @click="openCard(entity)"
           >
             <div class="card-id">{{ entity.id }}</div>
             <div class="card-title text-wrap-anywhere">{{ getCardTitle(entity) }}</div>
@@ -666,7 +669,7 @@ function createNew() {
               :fields="resolvedCardFields(entity)"
               :entity-type="kanbanConfig?.entity"
             />
-          </div>
+          </RouterLink>
           <div v-if="!(entitiesByCell[column.value]?.[swimlane.value]?.length)" class="empty-cell">
             —
           </div>
@@ -857,12 +860,17 @@ function createNew() {
 }
 
 .kanban-card {
+  display: block;
   background: var(--card-bg);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   padding: 12px;
   cursor: grab;
   transition: all 0.15s;
+  /* The card is a real link so cmd/middle-click opens a tab; it must not pick
+     up link colour or underline. */
+  color: inherit;
+  text-decoration: none;
 }
 
 .kanban-card:hover {

--- a/frontend/src/views/RelationHistoryView.vue
+++ b/frontend/src/views/RelationHistoryView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
 import { useUIStore } from '@/stores'
 import { getErrorMessage, ApiError } from '@/api/errors'
 import {
@@ -13,7 +13,6 @@ import { lineDiff, propertyDiff, type DiffLine, type PropertyChange } from '@/ut
 import { useVersionSelectionSync, type Side } from '@/composables/useVersionSelectionSync'
 
 const route = useRoute()
-const router = useRouter()
 const uiStore = useUIStore()
 
 // A relation is addressed by fromType/from/relType/to (fromType lets the read
@@ -195,9 +194,8 @@ function formatWhen(iso: string): string {
   return isNaN(d.getTime()) ? iso : d.toLocaleString()
 }
 
-function goBack() {
-  router.push(`/entity/${fromType.value}/${from.value}`)
-}
+// Pure navigation, so it renders as a real link and supports cmd/middle-click.
+const backTarget = computed(() => `/entity/${fromType.value}/${from.value}`)
 
 const hasContentChanges = computed(() => contentDiff.value.some((l) => l.op !== 'equal'))
 const versionsNewestFirst = computed(() => [...versions.value].reverse())
@@ -214,7 +212,7 @@ onMounted(load)
           {{ from }} <span class="rel-arrow">—{{ relType }}→</span> {{ to }}
         </p>
       </div>
-      <button class="btn btn-secondary" @click="goBack">Back to entity</button>
+      <RouterLink class="btn btn-secondary" :to="backTarget">Back to entity</RouterLink>
     </div>
 
     <div v-if="loading" class="loading-state">Loading relation history…</div>

--- a/frontend/src/views/SearchView.vue
+++ b/frontend/src/views/SearchView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
 import { searchEntities } from '@/api'
 import { useSchemaStore } from '@/stores'
 import { parseFilterQueryParams } from '@/utils/filters'
@@ -236,18 +236,27 @@ function focusInput() {
   })
 }
 
-function navigateToResult(index: number) {
-  const entity = results.value[index]
-  if (!entity) return
-  // Pass the search scope so the detail page can show prev/next across the
-  // exact result set the user saw (#844 / scope.go). `from=search` selects the
-  // search origin in useScopeNavigation; `q` is the *full* query string
-  // (including any type:/prop: chips), so the backend's executeQuery
-  // reproduces the identical ordered, possibly-mixed-type result.
+// resultTarget is the SINGLE source of truth for where a result goes — bound to
+// the RouterLink's `to` AND used by the keyboard handler's push, so a
+// cmd-clicked tab and an Enter press land on the identical URL. Building the
+// href separately from the push is how the scope below silently goes missing.
+//
+// Pass the search scope so the detail page can show prev/next across the exact
+// result set the user saw (#844 / scope.go). `from=search` selects the search
+// origin in useScopeNavigation; `q` is the *full* query string (including any
+// type:/prop: chips), so the backend's executeQuery reproduces the identical
+// ordered, possibly-mixed-type result.
+function resultTarget(entity: Entity): RouteLocationRaw {
   const scopeQuery: Record<string, string> = { from: 'search' }
   const full = fullSearchQuery.value
   if (full) scopeQuery.q = full
-  router.push({ path: `/entity/${entity.type}/${entity.id}`, query: scopeQuery })
+  return { path: `/entity/${entity.type}/${entity.id}`, query: scopeQuery }
+}
+
+function navigateToResult(index: number) {
+  const entity = results.value[index]
+  if (!entity) return
+  router.push(resultTarget(entity))
 }
 
 // Clear selection when results change
@@ -427,17 +436,17 @@ watch(
       <p class="results-count">{{ results.length }} result{{ results.length !== 1 ? 's' : '' }} found</p>
 
       <div class="results-list">
-        <div
+        <RouterLink
           v-for="(entity, index) in results"
           :key="entity.id"
           class="result-item"
           :class="{ selected: index === selectedIndex }"
-          @click="navigateToResult(index)"
+          :to="resultTarget(entity)"
         >
           <span class="result-type">{{ getEntityTypeLabel(entity.type) }}</span>
           <span class="result-id">{{ entity.id }}</span>
           <span class="result-title">{{ getEntityLabel(entity) }}</span>
-        </div>
+        </RouterLink>
       </div>
     </div>
   </div>

--- a/internal/dataentry/link_target_test.go
+++ b/internal/dataentry/link_target_test.go
@@ -9,7 +9,7 @@ import "testing"
 //
 // Nothing in the current code can produce one, which is exactly why this test
 // exists: it fails if someone later adds a passthrough branch, rather than
-// leaving the SPA's defence-in-depth check as the only thing standing between a
+// leaving the SPA's defense-in-depth check as the only thing standing between a
 // config value and a `javascript:` URL.
 func TestResolveLinkTarget_RejectsEverythingOutsideTheAllowlist(t *testing.T) {
 	hostile := []string{

--- a/internal/dataentry/link_target_test.go
+++ b/internal/dataentry/link_target_test.go
@@ -1,0 +1,64 @@
+package dataentry
+
+import "testing"
+
+// resolveLinkTarget is a closed allowlist, and that is load-bearing: its output
+// is rendered into an `href` by the SPA (TKT-3CSZRG made list rows real links so
+// cmd/middle-click opens a tab). An `href` is a far more dangerous sink than the
+// `router.push` it replaced — a scheme-bearing value there would be an XSS.
+//
+// Nothing in the current code can produce one, which is exactly why this test
+// exists: it fails if someone later adds a passthrough branch, rather than
+// leaving the SPA's defence-in-depth check as the only thing standing between a
+// config value and a `javascript:` URL.
+func TestResolveLinkTarget_RejectsEverythingOutsideTheAllowlist(t *testing.T) {
+	hostile := []string{
+		"javascript:alert(1)",
+		"JavaScript:alert(1)",
+		"  javascript:alert(1)",
+		"data:text/html,<script>alert(1)</script>",
+		"//evil.example.com",
+		"https://evil.example.com",
+		"http://evil.example.com",
+		"vbscript:msgbox(1)",
+		"/entity/other/INJECTED",
+		"../../etc/passwd",
+		"detail/../..",
+		"Detail",
+		"DOCUMENT/x",
+	}
+
+	for _, link := range hostile {
+		t.Run(link, func(t *testing.T) {
+			if got := resolveLinkTarget(link, "ticket", "TKT-1"); got != "" {
+				t.Fatalf("resolveLinkTarget(%q) = %q, want \"\" — only \"detail\" and \"document/*\" may resolve", link, got)
+			}
+		})
+	}
+}
+
+func TestResolveLinkTarget_AllowlistedShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		link string
+		want string
+	}{
+		{name: "empty", link: "", want: ""},
+		{name: "detail", link: "detail", want: "/entity/ticket/TKT-1"},
+		{name: "document", link: "document/spec", want: "/document/spec/TKT-1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveLinkTarget(tc.link, "ticket", "TKT-1")
+			if got != tc.want {
+				t.Fatalf("resolveLinkTarget(%q) = %q, want %q", tc.link, got, tc.want)
+			}
+			// Every non-empty result must be a same-origin absolute path: one
+			// leading slash, never protocol-relative.
+			if got != "" && (got[0] != '/' || (len(got) > 1 && got[1] == '/')) {
+				t.Fatalf("resolveLinkTarget(%q) = %q, which is not a single-slash absolute path", tc.link, got)
+			}
+		})
+	}
+}

--- a/tickets/entities/docs-checklists/DOCS-WP2LNF.md
+++ b/tickets/entities/docs-checklists/DOCS-WP2LNF.md
@@ -1,0 +1,54 @@
+---
+id: DOCS-WP2LNF
+type: docs-checklist
+title: 'Docs: Ctrl/Cmd-click should open data-entry rows and cards in a new browser tab'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] New/changed functions have doc comments
+- [x] Complex logic explained with WHY comments
+- [x] Nil contracts documented where relevant
+
+`openIntent.ts` documents why the helper is named `shouldDeferToBrowser` rather
+than `wantsNewTab` (it also covers `defaultPrevented`, which means the opposite
+of "open a tab"), and why `safeInternalHref` rejects a following slash OR
+backslash. `entityTarget` in each component states that it is the single source
+of truth for both the link and any push, and what silently breaks otherwise. Nil
+contracts are stated where a helper returns `undefined` (RelationCards' uncached
+entry, IssuesTable's entity-less rows, EntityDetail's unresolvable target). The
+Kanban card carries a comment saying why it deliberately has NO
+`draggable="false"`, so the next reader does not "fix" it and break reordering.
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` updated
+- [x] ~~docs/metamodel.md, docs/cli-reference.md, README.md~~ (N/A: no
+metamodel, command or project-level surface change)
+- [x] ~~CLAUDE.md~~ (N/A: no new cross-cutting convention; the change follows the
+existing `DashboardView` precedent rather than introducing a pattern)
+
+New "Opening things in a new tab" section under Overview: which gestures work,
+that a new tab keeps the list context so prev/next still walks the same result
+set, and the accepted trade-off that a list row is a link across its full width
+so text selection inside a row is not possible.
+
+## External Documentation
+
+- [x] ~~API docs~~ (N/A: no API surface change — this is SPA markup only)
+- [x] ~~Migration notes~~ (N/A: no config, schema or data change; nothing for an
+operator to do)
+
+## Test Documentation
+
+- [x] Non-obvious test setups explained
+
+`test/setup.ts` explains why the global RouterLink stub emits a real `href` (the
+previous `<a><slot/></a>` dropped `to`, making every href assertion vacuous) and
+warns that its `URLSearchParams` encoding only APPROXIMATES vue-router, so
+exact-encoding assertions belong in e2e. The new e2e fixture section states that
+the entity-detail table display previously had no coverage at all, which is how
+an unconditional `@click.prevent` survived on those anchors.

--- a/tickets/entities/implementation-checklists/IMPL-92ILKV.md
+++ b/tickets/entities/implementation-checklists/IMPL-92ILKV.md
@@ -1,0 +1,98 @@
+---
+id: IMPL-92ILKV
+type: implementation-checklist
+title: 'Implementation: Ctrl/Cmd-click (and middle-click) should open data-entry rows and cards in a new browser tab'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Ten surfaces converted from `router.push`-on-a-`<div>` to real links. Nine use
+`RouterLink` directly and need no click handler at all; only the list `<tr>`
+(which HTML forbids being an anchor) keeps a handler, guarded by
+`shouldDeferToBrowser`.
+
+New: `frontend/src/utils/openIntent.ts` (`shouldDeferToBrowser`,
+`safeInternalHref`) + 18 unit tests.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+The central test derives BOTH sides from the component rather than asserting a
+literal: it reads the rendered href, triggers the click, and asserts the href
+equals the pushed target's serialized path+query. A new query param cannot make
+the two diverge without failing.
+
+**Mutation-verified** (both reverted after):
+
+1. Replaced `:to="entityTarget(entity)"` with a bare `/entity/${type}/${id}` —
+the two scope tests failed, exactly the RR-6PBTF1 regression.
+2. Removed the `shouldDeferToBrowser` guard — all five modifier-click tests
+failed.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Driven in a real Chromium against a live `rela-server`:
+
+```
+ROW HREF:  /entity/feature/FEAT-001?from=features&scope=list:features
+POPUP URL: http://localhost:50269/entity/feature/FEAT-001?from=features&scope=list:features
+ORIGINAL UNCHANGED: true
+```
+
+- **AC1/AC2** cmd-click and middle-click each opened a real browser tab
+(`context.waitForEvent('page')`), and the originating tab did not navigate.
+- **AC7** the popup URL matches the href character-for-character INCLUDING
+`from=` and `scope=` — the divergence RR-6PBTF1 warned about does not occur.
+- **AC4** `a.row-link` is present with a resolved href.
+- **AC5** plain click still routes in-SPA (`list.spec.ts:187` still green).
+- **AC6** screenshot review: rows render identically to before — no link
+colour, no underline, delete buttons and checkboxes unaffected.
+
+Screenshot confirmed the visual result is unchanged; the links are invisible to
+the eye and real to the browser, which is the intent.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities
+
+Followed `DashboardView.vue:263-272`, the existing in-repo precedent for
+navigating table cells via `<router-link>`. Each surface exposes one
+`entityTarget()` used by both the link and any push, rather than duplicating
+route construction.
+
+**Full results:** 2059 frontend unit tests pass (127 files), 270 e2e pass / 8
+skipped / 0 fail, `npm run typecheck` clean, `npx eslint src/` 0 errors, `just
+arch-lint` OK, `go build ./...` clean.
+
+**One shared-fixture fix:** `frontend/src/test/setup.ts` globally stubbed
+`RouterLink` as `<a><slot/></a>`, silently discarding `to`. Every href assertion
+would have been vacuous against an anchor-shaped element with no href. The stub
+now serializes `to` (string or path+query object) into a real `href`.
+
+## Documentation
+
+- [x] `docs/data-entry.md` — new "Opening things in a new tab" section, incl.
+the accepted text-selection trade-off on list rows.
+- [x] ~~docs/metamodel.md, docs/cli-reference.md, README.md~~ (N/A: no
+metamodel, command or project-level surface change)

--- a/tickets/entities/planning-checklists/PLAN-58CVCA.md
+++ b/tickets/entities/planning-checklists/PLAN-58CVCA.md
@@ -1,0 +1,371 @@
+---
+id: PLAN-58CVCA
+type: planning-checklist
+title: 'Planning: Ctrl/Cmd-click (and middle-click) should open data-entry rows and cards in a new browser tab'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+The data-entry SPA navigates from non-anchor elements (`<tr @click>`, `<div
+@click>`, `<li @click>`, `<span @click>`) by calling `router.push`. With no `<a
+href>` the browser has nothing to act on: no background tab on cmd/ctrl-click,
+nothing on middle-click, no "Open link in new tab" context menu, no hover URL
+preview.
+
+**The fix is to use real links.** Not a modifier-key interception layer — an `<a
+href>` / `<RouterLink>`, which gets every one of those behaviours from the
+browser for free. `RouterLink` already implements the whole modifier-click
+contract internally (`guardEvent`), so for most surfaces there is no guard code
+to write at all.
+
+**Revised after review** (an earlier draft proposed a `wantsNewTab()` helper at
+all 10 surfaces — that was over-engineered; 9 of 10 need only an anchor).
+
+**Scope:**
+
+IN — replace programmatic `router.push` with a real link:
+
+| File | Element | Conversion |
+|---|---|---|
+| `views/KanbanView.vue` (:593, :661) | `.kanban-card` | whole card → `RouterLink` (no interactive descendants; the only `<button>` is the toolbar "New" at :525, outside) |
+| `views/SearchView.vue` (:435) | `.result-item` | whole item → `RouterLink` |
+| `components/forms/SidePanel.vue` (:147, :161) | `.entity-list-item`, `.entity-card` | whole entry → `RouterLink` (no per-item controls) |
+| `components/common/IssuesTable.vue` (:105, :175) | `.entity-title` span, **desktop AND mobile** | → `RouterLink`; drop `role="button"`/`tabindex`/both keydown handlers |
+| `components/entity/EntityDetail.vue` (:1092) | `<a class="list-link">` — already an anchor, **missing `href`** | add `:to`; smallest fix in the ticket |
+| `components/entity/EntityDetail.vue` (:1001, :1028) | `.card-header` | anchor the **title spans only** — the header contains `.edit-btn` (`@click.stop`, :1036) and an `<a>` may not contain a `<button>` |
+| `components/forms/RelationCards.vue` (:562, :565) | `.entity-id` / `.entity-title` spans | → `RouterLink` + `draggable="false"` (inside a drag source) |
+| `components/ui/CommandPaletteModal.vue` (:291) | `.cmdk-option` | anchor inside the `<li>`, `tabindex="-1"` (it is a `role="option"` in a `role="listbox"`) |
+| `components/lists/EntityList.vue` (:884) | `.mobile-card` | anchor the **title span only** — card contains a delete `<button>` (:892) |
+| `components/lists/EntityList.vue` (:993) | `<tr class="entity-row">` | title-cell anchor + **stretched-link overlay** (see below) |
+
+OUT:
+
+- **Calendar event chips** — the click opens `EntityPreviewModal`, not a route.
+No URL exists to put in a tab. Unchanged.
+- Surfaces already using `<router-link>`: `DashboardView.vue`,
+`NextActionCard/Offers.vue`, `Sidebar.vue`, `StatusBar.vue`, `BackButton.vue`,
+`+ New` buttons. Already correct.
+- `useDocumentClicks.ts` — already correct.
+- Non-navigating clicks: checkboxes, delete buttons, sort headers, filter chips,
+collapse toggles, drag handles, pagination.
+- Keyboard shortcuts (`j`/`k`/Enter) — unchanged.
+- **Converting tables to CSS grid — explicitly rejected.** See below.
+
+**Decision: no table → CSS-grid conversion.**
+
+Counted: 7 `<table>` elements across 5 files, but **only ONE has clickable
+rows** (`EntityList`). ConflictsView (×2), DashboardView, EntityDetail (×2) and
+IssuesTable have zero `<tr @click>`. So there is no "table problem" category —
+there is one table. Grid was considered because a grid row can be a single `<a
+display:grid>`, needing no overlay. Rejected because:
+
+- It discards native table semantics (screen readers announce "row 3 of 47,
+column Status" from the markup); a grid must hand-rebuild
+`role="table"`/`"row"`/`"cell"`, which is easier to get subtly wrong.
+- It discards content-based column sizing. `EntityList` columns are configured
+per-list in `data-entry.yaml`, so the count is unknown at build time — a grid
+would need a runtime-generated `grid-template-columns` and lose auto-fit.
+- It is a large markup+CSS refactor to solve what 4 lines of CSS solve.
+
+**Precedent already in-repo:** `DashboardView.vue:263-272` keeps its `<table>`
+and puts a `<router-link>` in the `<td>`. That is this codebase's existing
+answer for navigating table cells, and it ctrl-clicks correctly today. We follow
+it; the only difference in `EntityList` is that the whole *row* is the target,
+not one cell — hence the overlay.
+
+**Decision: stretched-link for the one clickable table (approved).**
+
+HTML forbids an `<a>` wrapping or nesting directly inside a `<tr>` — the parser
+discards a misplaced anchor. So a row-wide link is not expressible directly.
+Chosen: a single title-cell anchor stretched over the row.
+
+```css
+.entity-row { position: relative; }
+.entity-row .row-link::after { content: ''; position: absolute; inset: 0; }
+.entity-row .select-cell, .entity-row .actions-cell { position: relative; z-index: 1; }
+```
+
+One real link per row in the a11y tree, whole row cmd-clickable, native table
+semantics kept. **Accepted cost: text selection within a row is blocked** —
+approved, since selecting text out of a list view is not a common action here.
+
+**Acceptance Criteria:**
+
+1. Cmd/Ctrl-click on a list row (anywhere), kanban card, search result,
+side-panel entry, relation-card title, issues-table entity cell (desktop and
+mobile), palette option and entity-detail card/list entry opens the target in a
+new background tab; the current tab does NOT navigate.
+2. Middle-click does the same on those surfaces.
+3. Shift-click opens a new window.
+4. Right-click offers "Open link in new tab" — a real `a[href]` is in the DOM.
+5. Plain left-click is unchanged: in-SPA navigation, no full reload, identical
+destination **including query params**.
+6. Nested controls unaffected: row checkbox, delete button, kanban drag,
+relation-card drag-reorder, side-panel add, palette roving focus.
+7. The href carries the SAME query the programmatic push built (list
+`from`/`scope`/`sort`/`filter[*]`/`q`; search `from=search`+`q`; kanban
+`edit_form` branch).
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the fix is "use the platform's link element"; a research
+entity would add nothing.
+
+**Existing Solutions:**
+
+- **`DashboardView.vue:263-272`** — in-repo precedent: `<router-link>` inside a
+`<td>`, table kept. Directly reused for `IssuesTable`.
+- **vue-router `<RouterLink>`** — already implements the modifier-click contract
+(`guardEvent`: metaKey/altKey/ctrlKey/shiftKey, `button !== 0`,
+`defaultPrevented`). This is why no custom helper is needed at 9 of 10 sites.
+Where custom click logic must coexist with a link, `<RouterLink custom v-slot="{
+href, navigate }">` supplies both without hand-rolling the guard.
+- **`useDocumentClicks.ts:26-40`** — correct modifier handling for rendered-doc
+links; the reference for the ONE remaining hand-written guard (the `<tr>`).
+- **`utils/entityRoute.ts`** — `entityDetailHref()` with `cellLink` priority,
+returns `''` for empty type/id. Imported by `EntityList.vue:14`,
+`CommandPaletteModal.vue:24` **and `EntityDetail.vue:16`** (a review claim that
+EntityDetail does not import it was checked and is wrong).
+- **Bootstrap `.stretched-link`** — the overlay pattern; `display: contents` is
+already used 4× in this repo, so neither idiom is foreign here.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+*1. One shared target function per surface (RR-6PBTF1 — mandatory, not
+optional).*
+
+Each surface exposes `entityTarget(entity): RouteLocationRaw` returning path AND
+query. `router.push(target)` and the link's `:to="target"` consume the SAME
+value. This is the highest-risk item: `EntityList.navigateToEntity` (`:485-541`)
+builds ~40 lines of reactive query state (`from`, `scope`, `sort` from live
+`sortSpecs` else `default_sort`, every `filter[*]` incl. arrays, `q`). A
+separately-built href would silently drop all of it — both paths still render a
+page, so the divergence is invisible in review while `useScopeNavigation`
+prev/next dies and the back target is wrong.
+
+Binding `:to` (a location object) rather than a pre-stringified href also means
+vue-router serializes the query and applies `BASE_URL` (`router/index.ts:116`
+uses `createWebHistory(import.meta.env.BASE_URL)`).
+
+*2. Real links, element chosen by what HTML allows.*
+
+An `<a>` may not contain interactive content, and may not wrap a `<tr>`. Per
+surface: wrap the whole container where it has no interactive descendants
+(kanban, search result, side-panel entry); otherwise wrap the title/identity
+element only (EntityList mobile card, EntityDetail card-header, RelationCards);
+for the `<tr>`, title-cell anchor + overlay.
+
+*3. `draggable="false"` on anchors inside drag sources (RR-NPDW9A).*
+
+Anchors are natively draggable. `RelationCards.onDragStart` (`:458`)
+early-returns when `!isOrderable`, so without this an anchor there gets the
+browser's default link-drag — a behaviour that does not exist today. Kanban
+cards need it too: `:draggable="false"` on the card does not stop an anchor
+child being independently draggable.
+
+*4. The one hand-written guard.* Only the `<tr>` keeps a click handler alongside
+a link (the overlay anchor covers the row, but the handler remains for the
+plain-click path). It early-returns on modifier/non-primary clicks. Named
+`shouldDeferToBrowser` — NOT `wantsNewTab` (RR-Z0AHAY: it also covers
+`defaultPrevented`, which means "nothing should happen", the opposite of "open a
+tab").
+
+**Files to modify:**
+
+- `frontend/src/utils/openIntent.ts` (+ test) — NEW, small: `shouldDeferToBrowser`.
+- `frontend/src/components/lists/EntityList.vue` — `entityTarget()`; title-cell
+anchor + overlay CSS; mobile-card title anchor; fix the stale comment at :532.
+- `frontend/src/views/KanbanView.vue` — cards → `RouterLink` + `draggable="false"`.
+- `frontend/src/views/SearchView.vue` — result → `RouterLink` with scope query.
+- `frontend/src/components/forms/SidePanel.vue` — entries → `RouterLink`.
+- `frontend/src/components/forms/RelationCards.vue` — id/title spans →
+`RouterLink` + `draggable="false"`.
+- `frontend/src/components/common/IssuesTable.vue` — desktop **and mobile**
+spans → `RouterLink`; remove role/tabindex/keydown.
+- `frontend/src/components/entity/EntityDetail.vue` — `:to` on `.list-link`;
+title-span anchors in both card-headers (keep `.edit-btn` a sibling; do not move
+the header handler — TKT-IHC7C / RR-FC1B).
+- `frontend/src/components/ui/CommandPaletteModal.vue` — anchor with
+`tabindex="-1"`; keep palette open on modifier-click.
+- `e2e/pages/*.page.ts` + `e2e/tests/open-new-tab.spec.ts` — NEW.
+
+**Alternatives considered:**
+
+- *`wantsNewTab` guard at every surface* — rejected: reimplements what
+`RouterLink` already does; 10 copies of a five-way check to keep in sync.
+- *CSS-grid tables* — rejected, see Scope.
+- *`window.open()` on modifier* — rejected: popup-blocker bait, loses
+background/foreground tab conventions, still no context menu or hover preview.
+- *Anchor in every `<td>`* — rejected: 7 links per row in the a11y tree,
+fragments row text.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- *Entity id / type* — already flow into `router.push`; trust unchanged. Path
+safety comes from the **ID grammar**, not from encoding:
+`internal/entity/id.go:134` pins every ID to `^[A-Za-z0-9][A-Za-z0-9_-]*$` and
+`ValidateID` is documented as the single validity rule codebase-wide
+(TKT-IZGF7T). `#`, `?`, `/`, spaces and unicode cannot occur, so
+`encodeURIComponent` is a no-op here. Cite the grammar (RR-Z0AHAY) so a future
+relaxation trips the right wire.
+- *Column `link:` (`cellLink`)* — **verified closed allowlist in BOTH copies**:
+Go `internal/dataentry/views_handler.go:713-725` and TS `EntityList.vue:475-483`
+accept only `""`, `detail`, `document/*`; everything else returns `""`.
+`javascript:`, `data:`, `//evil.com`, `JavaScript:` all hit the default branch.
+**There is no new XSS sink** — an earlier draft claimed otherwise and was wrong
+(RR-0PEI9F).
+- No new network calls, auth changes, file access or crypto.
+
+**Security-Sensitive Operations:**
+
+- **`:href`/`:to` as a sink — defence-in-depth, NOT threat mitigation.** Per
+CLAUDE.md's "write down which of the two you mean": this is **integrity /
+invariant preservation, explicitly not confidentiality**. Config being
+non-secret is irrelevant; the relevant fact is that editing `data-entry.yaml`
+already requires repo write access. The guard exists so that if
+`resolveLinkTarget`'s allowlist is later loosened, the render layer does not
+silently become an XSS sink. Predicate is `/^\/(?!\/)/` — a single leading
+slash, which **excludes protocol-relative `//evil.com`** (the plain
+`startsWith('/')` in the earlier draft admitted it). A non-matching value
+renders no anchor (click-only fallback).
+- **Unit test pinning `resolveLinkTarget` returns `""` for unknown input** —
+this is what actually protects the invariant; it fails if a passthrough branch
+is ever added.
+- **No ACL change.** A link is not an authorization decision: the target route
+re-fetches through the same gated read path, and a hidden entity 404s
+identically. Rows only render for entities the list already returned.
+- All targets are same-origin SPA routes; no `target="_blank"`, no `rel`
+handling needed.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+| AC | Test | Level |
+|---|---|---|
+| 7 (and 1,5) | **`expect(router.resolve(anchorTo).fullPath).toBe(router.resolve(pushedTarget).fullPath)`** per surface — one invariant subsuming the scope/`from=search`/`edit_form`/`cellLink` string tests, and it stays true when a param is added later (RR-6PBTF1 / L1) | component |
+| 1,2,3 | Playwright `context.waitForEvent('page')` after `click({ modifiers:['Meta'] })` and `{ button:'middle' }`; assert new-page URL AND that the original page URL is unchanged | e2e |
+| 4 | assert `a[href]` present with expected resolved path per surface | component |
+| 5 | existing `list.spec.ts:187` row-click test + component regression on push args | e2e + component |
+| 6 | click checkbox → selection toggles, no nav; delete → dialog, no nav; kanban + relation-card drag-reorder still work; palette arrow-key roving focus intact | component + e2e |
+| — | `resolveLinkTarget` returns `""` for unknown/scheme-bearing input (Go + TS) | unit |
+| — | `shouldDeferToBrowser` truth table | unit |
+
+Component tests mount a real router over `createMemoryHistory('/')`
+(`StatusBar.test.ts` convention). E2E must add page-object methods, never inline
+locators (`e2e/tests/AGENTS.md`, eslint-enforced).
+
+**Edge Cases:**
+
+- Empty/missing entity `type` → `entityDetailHref` returns `''` → render NO
+anchor; plain click stays inert (never `/entity//id`).
+- `cellLink` set → target is the cell link, not the entity route.
+- `cellLink` malformed/server-supplied — the genuinely untested input (IDs are
+grammar-constrained; `cellLink` is not). Assert no anchor rendered.
+- RelationCards entry **not in `entityCache`** (`:181` no-ops today) → no anchor,
+click still inert. No broken href.
+- IssuesTable row with no entity (`canNavigate()` false) → plain `<span>`, no
+role/tabindex.
+- Kanban/RelationCards drag from the title → reorder works, no link-drag ghost.
+- Modifier-click on checkbox cell / delete button → no tab, no navigation.
+- Alt-click: on macOS Option-click *downloads* the target. Consistent with
+`useDocumentClicks.ts:33`, which already includes `altKey`. Consequence noted
+(RR-Z0AHAY M2).
+- Right-click (`button === 2`) → no navigation, context menu shows.
+- Palette modifier-click → tab opens AND palette stays open; plain click closes.
+
+**Negative Tests:**
+
+- Plain left-click must NOT open a tab.
+- `defaultPrevented` event → no navigation.
+- No `a[href=""]` rendered anywhere.
+- No surface uses `target="_blank"`.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+| Risk | Mitigation |
+|---|---|
+| href/push divergence silently drops scope (RR-6PBTF1) | Single `entityTarget()`; the `resolve().fullPath` equality test |
+| Overlay blocks text selection in rows | **Accepted and approved** — selecting text from list views is not a common action here |
+| Overlay swallows nested controls | `select-cell`/`actions-cell` get `position:relative; z-index:1`; component tests click each |
+| Nested `.stop` guards done imperatively — `handleDelete` calls `stopPropagation()` in JS (`:688`), invisible to a `.stop` grep | Enumerate controls per surface from the code survey, not by grepping |
+| Anchors in drag sources break reorder (RR-NPDW9A) | `draggable="false"` on those anchors; drag tests for kanban + relation cards |
+| `<a>` containing `<button>` = invalid HTML | Title-only anchors on mobile card, card-header, relation cards |
+| Re-breaking TKT-IHC7C / RR-FC1B in EntityDetail | Anchor wraps text spans only; header handler untouched; re-read `:1017-1023` before editing |
+| Anchor inside `role="option"` breaks listbox roving focus (RR-UHNHX4) | `tabindex="-1"` on the palette anchor |
+| Row tab-stops go 0 → N per page (RR-Z0AHAY M4) | Deliberate: links should be reachable. One anchor per row, not per cell; row itself stays non-focusable |
+| Link styling leaks into rows/cards | `color: inherit; text-decoration: none`; visual check light+dark |
+| E2E new-tab flakiness | `context.waitForEvent('page')` with explicit timeout, assert on popup URL (available pre-load); no sleeps |
+
+**Effort:** m — ten surfaces, but each is mechanical once `entityTarget()` and
+the overlay exist. Test surface is the bulk of it.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] `docs/data-entry.md` — rows/cards are real links; cmd/ctrl/middle-click
+opens a new tab.
+- [x] ~~docs/metamodel.md, docs/cli-reference.md, README.md~~ (N/A: no
+metamodel, command or project-level surface changes)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** 6 responses. All resolved in this revision; the
+revision also simplified the approach well beyond what the review asked.
+
+| ID | Severity | Resolution |
+|---|---|---|
+| RR-6PBTF1 | critical | Shared `entityTarget()` is now mandatory; pinned by the `resolve().fullPath` equality test |
+| RR-I4WQPX | critical | Incorrect DOM-event claim removed. Stretched-link overlay chosen (approved), so cmd-click works row-wide and AC 1 is honest |
+| RR-NPDW9A | critical | `draggable="false"` on anchors in drag sources; drag tests for both kanban and relation cards |
+| RR-0PEI9F | significant | Prose corrected (no new sink — closed allowlist verified in Go and TS); reframed as integrity defence-in-depth per CLAUDE.md; predicate tightened to `/^\/(?!\/)/`; pinning unit tests added |
+| RR-UHNHX4 | significant | Both IssuesTable variants (desktop + **mobile**) in scope; role/tabindex/keydown removal specified; palette anchor gets `tabindex="-1"` |
+| RR-Z0AHAY | minor | Cites `entity/id.go` `ValidateID` instead of encoding; helper renamed `shouldDeferToBrowser`; tab-stop 0→N called out as a deliberate decision |
+
+**Rejected as incorrect:** the review claimed `EntityDetail.vue` does not import
+`entityDetailHref`. It does — `EntityDetail.vue:16`, used at `:460`.

--- a/tickets/entities/review-checklists/REV-299VJY.md
+++ b/tickets/entities/review-checklists/REV-299VJY.md
@@ -1,0 +1,83 @@
+---
+id: REV-299VJY
+type: review-checklist
+title: 'Review: Ctrl/Cmd-click (and middle-click) should open data-entry rows and cards in a new browser tab'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-299VJY.md
+++ b/tickets/entities/review-checklists/REV-299VJY.md
@@ -2,82 +2,87 @@
 id: REV-299VJY
 type: review-checklist
 title: 'Review: Ctrl/Cmd-click (and middle-click) should open data-entry rows and cards in a new browser tab'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Comment lint gate clean (`just comment-lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
 
-**Comment findings.** `just comment-report` lists the advisory rules
-(duplication, nil-contract, param-contract, restatement). They are not a merge
-gate, but a finding your diff *introduces* should be fixed or suppressed — don't
-grow the backlog.
+| Gate | Result |
+|---|---|
+| Frontend unit | **2067 pass** / 127 files |
+| E2E (Playwright) | **272 pass**, 8 skipped, 0 fail |
+| `vue-tsc --noEmit` | clean |
+| `eslint src/` | 0 errors |
+| `just comment-lint` | no unresolvable doc links across 11426 comments |
+| `just coverage-check` | PASS — package 50% and total 65% thresholds satisfied (78.8% total) |
+| `just arch-lint` | OK — no warnings |
+| `go build ./...` | clean |
 
-Every rule is a heuristic over prose, so false positives are expected. To
-suppress one, prefer the inline form on the declaration line, which travels with
-the code and is reviewed in this diff:
+One e2e flake (`forms-id-controls.spec.ts`, unrelated to this change) failed
+once under parallel load; passed in isolation and on a clean full re-run.
 
-```go
-func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
-```
-
-Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
-same prose recurs across many sites. A reason is required either way — an
-unexplained suppression is a finding nobody can re-evaluate later.
+**Comment findings:** none introduced.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:** two rounds, 13 total, all addressed.
+
+*Design review (pre-implementation)* — RR-6PBTF1, RR-I4WQPX, RR-NPDW9A
+(critical); RR-0PEI9F, RR-UHNHX4 (significant); RR-Z0AHAY (minor). These
+reshaped the plan: the shared-target refactor became mandatory, the
+stretched-link was chosen over a title-only anchor, and a security claim was
+withdrawn as incorrect.
+
+*Code review (post-implementation)* — RR-BRVI7N, RR-88510Z (critical);
+RR-HIYJHR, RR-SYFX1B, RR-WEJM54, RR-PB8DO8 (significant); RR-5Z83S0 (minor).
+
+The two critical ones were real bugs the implementation had missed:
+
+- **RR-88510Z** is the most serious: `EntityDetail.vue:1182/:1245` were real
+`<a href>` anchors carrying unconditional `@click.prevent`, suppressing the
+browser default on EVERY click — **this ticket's own bug, still live in a file
+this ticket edited.** Missed because the survey looked for `@click` on
+NON-anchor elements. Confirmed live in a browser before the fix
+(`defaultPrevented=true` at bubble phase, current tab navigated) and after (zero
+`preventDefault` calls, tab opens). The entity-detail table-display section had
+NO e2e coverage at all, which is *why* it survived — a fixture and a test now
+exist.
+- **RR-BRVI7N**: the palette guarded only the inner `RouterLink`, so an entity
+with no resolvable route rendered an empty zero-height `<li role="option">` —
+invisible, still counted by the arrow-key highlight, nameless to a screen
+reader. Worse than the inert row it replaced.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
 
-## Documentation (enhancements only)
+| AC | Status | Evidence |
+|---|---|---|
+| 1 — cmd/ctrl-click opens a background tab | **PASS** | e2e `context.waitForEvent('page')` on list row, kanban card and entity-detail section cell; original tab URL unchanged |
+| 2 — middle-click opens a background tab | **PASS** | e2e `click({ button: 'middle' })` |
+| 3 — shift-click opens a new window | **PASS** | browser-native once the element is a real anchor; guard covers `shiftKey` (unit) |
+| 4 — right-click offers "Open in new tab" | **PASS** | `a[href]` asserted present per surface |
+| 5 — plain click unchanged | **PASS** | pre-existing `list.spec.ts:187` still green; component tests assert unchanged push args |
+| 6 — nested controls unaffected | **PASS** | `crud.spec.ts` delete-from-list + cancel, `checkboxes.spec.ts`, `kanban.spec.ts` 15/15 incl. drag, `relation-cards.spec.ts` 12/12 |
+| 7 — href carries the same query as the push | **PASS** | live browser: href and popup URL match character-for-character incl. `from=`/`scope=`; unit test derives expectation from the actual push payload |
 
-Skip this section for bugs and internal refactors.
-
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
-
-## Final Checks
-
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
-
-## Pull Request
-
-- [ ] Run `/pr` command to create PR and monitor CI
-
-<!--
-Deliberately NOT tracked here: the PR URL and whether CI passed.
-
-Both post-date this checklist. `/pr` requires the ticket to be `done` and
-validating clean before it opens the PR, and a `done` review-checklist may have
-no unchecked items — so an item asking for the PR URL can only be satisfied by a
-PR that does not exist yet. Checking it early would mean asserting "CI passed"
-before CI ran, which turns the checklist from evidence into a formality.
-
-GitHub records both authoritatively, and the branch and commit messages carry
-the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
-here. See TKT-UFV01M. -->
+**Mutation-verified** (each reverted after): dropping the query from the href
+fails the two scope tests; removing the modifier guard fails all five
+modifier-click tests; removing the palette's `v-else` fallback fails the
+empty-option test. The C2 e2e test was confirmed to fail against the unfixed
+bundle before the fix landed.

--- a/tickets/entities/review-responses/RR-0PEI9F.md
+++ b/tickets/entities/review-responses/RR-0PEI9F.md
@@ -1,0 +1,33 @@
+---
+id: RR-0PEI9F
+type: review-response
+title: 'link: security prose misplaces the protection; startsWith(''/'') admits //evil.com'
+severity: significant
+status: addressed
+---
+
+**Finding (S1, significant).** The plan's security prose misidentifies where the
+protection lives, which is how the real allowlist gets relaxed later.
+
+Verified: `resolveLinkTarget` is a closed allowlist over two literal shapes in
+**both** copies — Go (`internal/dataentry/views_handler.go:713-725`) and TS
+(`EntityList.vue:475-483`). Input space is `{"", "detail", "document/*"}`;
+everything else returns `""`. `javascript:`, `data:`, `//evil.com`,
+`JavaScript:` all hit the default branch. An operator cannot express a
+scheme-bearing link today, so there is **no new XSS sink** — the plan's original
+claim that this was "the one genuinely new security check" was wrong and has
+been corrected.
+
+Two consequences:
+
+- Keep a check, but framed as a **render-layer defence-in-depth invariant**, never as mitigation for a live threat. A future reader who believes the href check is load-bearing may conclude `resolveLinkTarget`'s allowlist is safe to loosen.
+- The stated rule `startsWith('/')` is **incomplete**: it admits protocol-relative `//evil.com`. Correct predicate is `/^\/(?!\/)/`.
+
+What actually protects this is a unit test on `resolveLinkTarget` (both copies)
+pinning that unknown input returns `""` — that fails if someone adds a
+passthrough branch.
+
+Per CLAUDE.md's "write down which of the two you mean": this is **integrity /
+invariant preservation, explicitly not confidentiality**. "Config is not secret"
+is irrelevant here; the relevant fact is that editing `data-entry.yaml` already
+requires repo write access.

--- a/tickets/entities/review-responses/RR-0PEI9F.md
+++ b/tickets/entities/review-responses/RR-0PEI9F.md
@@ -2,7 +2,9 @@
 id: RR-0PEI9F
 type: review-response
 title: 'link: security prose misplaces the protection; startsWith(''/'') admits //evil.com'
+finding: 'The plan claimed column link: values become a new javascript: XSS sink. Verified false: resolveLinkTarget is a closed allowlist over ''detail'' and ''document/*'' in BOTH the Go copy (internal/dataentry/views_handler.go:713-725) and the TS mirror (EntityList.vue:475-483); everything else returns empty. Separately, the stated guard startsWith(''/'') admits protocol-relative //evil.com.'
 severity: significant
+resolution: 'Security prose corrected — the plan now records this as integrity/defence-in-depth, explicitly NOT confidentiality, per CLAUDE.md''s ''write down which of the two you mean''. Predicate tightened to /^\/(?![/\\])/ (also rejecting the backslash variant, RR-5Z83S0) and wired into EntityList.entityTarget, the one path where a server-supplied cellLink reaches an href. The allowlist itself is now pinned on both sides: a new Go test (internal/dataentry/link_target_test.go) asserts 13 hostile inputs resolve to empty, and TS tests assert no hostile link: value is ever bound as an href.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-5Z83S0.md
+++ b/tickets/entities/review-responses/RR-5Z83S0.md
@@ -1,0 +1,30 @@
+---
+id: RR-5Z83S0
+type: review-response
+title: safeInternalHref backslash variant; stale cursor:pointer; untested branches
+finding: 'Three minor items: (M1) safeInternalHref''s /^\/(?!\/)/ misses the backslash variant /\evil.com, which browsers normalise to // and resolve protocol-relative; its doc comment also implied a general guard when it protects the cellLink path specifically. (M5) .content-card .card-header kept cursor:pointer although the header no longer has a click handler. Plus untested branches noted by the reviewer.'
+severity: minor
+resolution: 'M1: tightened to /^\/(?![/\\])/ with a test for the backslash variant, and the doc comment now names cellLink as the guarded path and cites internal/entity/id.go''s ValidateID as the guarantee for the other surfaces. M5: removed the stale cursor:pointer with a comment saying why. The untested branches called out (palette empty-href, EntityDetail cell anchors) both now have tests — see RR-BRVI7N and RR-88510Z.'
+status: addressed
+---
+
+**Finding (minor cluster).** Three small items.
+
+**M1 — `safeInternalHref` misses a backslash variant.** `/^\/(?!\/)/` correctly
+rejects `//evil.com`, `javascript:`, `data:`, `https:`, `''` and `entity/x`. But
+browsers normalise `\` to `/` in URLs, so `/\evil.com` can resolve
+protocol-relative. Tighten to `(?![/\\])`. Low severity: the function is
+defence-in-depth over a closed allowlist that already cannot emit such a value.
+Its doc comment should also say it guards the `cellLink` path specifically — the
+other nine surfaces build paths from `entity.type`/`entity.id` directly and do
+not use it.
+
+**M5 — stale `cursor: pointer`.** `EntityDetail.vue:1614` `.card-header` keeps
+`cursor: pointer` although the header no longer has a click handler; the pointer
+now comes from `.card-header-link`. The padding around the link will look
+clickable when it is not. (`.entity-row` / `.mobile-card` keep theirs correctly
+— those still have handlers.)
+
+**Untested branches** noted by review: the palette's empty-href branch (C1), the
+two EntityDetail `.prevent` anchors (C2 — which is *why* the bug survived), and
+the mobile-card stretched link's delete-button-over-overlay behaviour.

--- a/tickets/entities/review-responses/RR-6PBTF1.md
+++ b/tickets/entities/review-responses/RR-6PBTF1.md
@@ -2,6 +2,7 @@
 id: RR-6PBTF1
 type: review-response
 title: Title-cell href silently drops the query/scope context router.push builds
+finding: 'The plan left ''extend entityDetailHref to build path + query'' as possibly optional. EntityList.navigateToEntity builds ~40 lines of reactive query state (from, scope, sort from live sortSpecs else default_sort, every filter[*] including arrays, and q). An href built separately in the template would be a bare /entity/<type>/<id>, so a plain click would carry the full scope and a cmd-click would not. The failure is silent: both paths render a valid page, but the new tab has dead prev/next and a wrong back target. Same applies to SearchView (from=search + q) and Kanban''s edit_form branch.'
 severity: critical
 resolution: 'Made mandatory rather than optional. Each surface now exposes one entityTarget()/cardTarget()/resultTarget() returning path AND query, consumed by both router.push and the link''s :to. Pinned by a test that derives the expectation from the actual push payload rather than a literal, so a new query param cannot make the two diverge silently. Mutation-verified: replacing :to with a bare /entity/type/id fails the two scope tests. Confirmed live in a browser — the popup URL matches the href character-for-character including from= and scope=.'
 status: addressed

--- a/tickets/entities/review-responses/RR-6PBTF1.md
+++ b/tickets/entities/review-responses/RR-6PBTF1.md
@@ -3,6 +3,7 @@ id: RR-6PBTF1
 type: review-response
 title: Title-cell href silently drops the query/scope context router.push builds
 severity: critical
+resolution: 'Made mandatory rather than optional. Each surface now exposes one entityTarget()/cardTarget()/resultTarget() returning path AND query, consumed by both router.push and the link''s :to. Pinned by a test that derives the expectation from the actual push payload rather than a literal, so a new query param cannot make the two diverge silently. Mutation-verified: replacing :to with a bare /entity/type/id fails the two scope tests. Confirmed live in a browser — the popup URL matches the href character-for-character including from= and scope=.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-6PBTF1.md
+++ b/tickets/entities/review-responses/RR-6PBTF1.md
@@ -1,0 +1,33 @@
+---
+id: RR-6PBTF1
+type: review-response
+title: Title-cell href silently drops the query/scope context router.push builds
+severity: critical
+status: addressed
+---
+
+**Finding (C1, critical).** The plan leaves "extend `entityDetailHref` to build
+path + query" as *possibly* optional. It must be mandatory.
+
+`EntityList.navigateToEntity` (`:485-541`) builds ~40 lines of reactive query
+state: `from`, `scope`, `sort` (live `sortSpecs` else `default_sort`), every
+`filter[*]` key forwarded from `route.query` including array values, and `q`. If
+the anchor href is built separately in the template it will be a bare
+`/entity/<type>/<id>`.
+
+Failure mode is silent: plain click carries full scope, cmd-click does not. The
+new tab renders fine but `useScopeNavigation` prev/next is dead and the back
+target is wrong. Nobody catches it in review because both paths navigate
+successfully. Same applies to `SearchView.navigateToResult` (`from=search` +
+`q`) and Kanban's `edit_form` branch.
+
+**Resolution:** each surface exposes one `entityTarget(entity):
+RouteLocationRaw`; `router.push(target)` and `router.resolve(target).href` both
+consume it. Test the invariant, not the string:
+
+```ts
+expect(router.resolve(anchorHref).fullPath).toBe(router.resolve(pushedTarget).fullPath)
+```
+
+That one assertion subsumes the AC-7, `from=search`, `edit_form` and
+`cellLink`-priority tests, and stays true when a query param is added later.

--- a/tickets/entities/review-responses/RR-88510Z.md
+++ b/tickets/entities/review-responses/RR-88510Z.md
@@ -1,0 +1,27 @@
+---
+id: RR-88510Z
+type: review-response
+title: EntityDetail section-table anchors use unconditional click.prevent - the ticket's own bug still live
+finding: EntityDetail.vue:1182 and :1245 are real <a :href=cell.link> anchors carrying unconditional @click.prevent, which calls preventDefault on EVERY click including cmd/ctrl/shift/middle. So cmd-clicking a section-table cell navigates the current tab and middle-click does nothing — verbatim the 'Actual' column of this ticket's own problem table, still live in a file the ticket edited. Missed because the code survey looked for @click on NON-anchor elements; these are anchors, so they appeared already correct. openIntent.ts was never imported into EntityDetail.
+severity: critical
+resolution: 'Both anchors now route through a new onCellLinkClick(event, entity, cellLink) which calls shouldDeferToBrowser first and only preventDefaults on a plain left-click; openIntent is now imported into EntityDetail. Confirmed live in a real browser BEFORE the fix (cmd-click navigated the current tab, defaultPrevented=true at bubble phase) and fixed after (zero preventDefault calls, tab opens). Pinned by a new e2e test plus a new e2e fixture: the entity-detail table-display section had NO coverage at all, which is how the bug survived.'
+status: addressed
+---
+
+**Finding (C2, critical).** `EntityDetail.vue:1182` and `:1245` are real `<a
+:href="cell.link">` anchors carrying unconditional `@click.prevent`.
+
+`.prevent` calls `preventDefault()` on EVERY click — including cmd-, ctrl-,
+shift- and middle-click. The browser would do the right thing with these
+anchors; the handler actively suppresses it. So cmd-clicking a section-table
+cell navigates the current tab and middle-click does nothing.
+
+That is verbatim the "Actual" column of this ticket's own problem table, still
+live in a file this ticket edited. They were missed because the survey looked
+for `@click` on NON-anchor elements; these are anchors, so they appeared already
+correct. They are not — and `openIntent.ts` was never imported into
+EntityDetail, so `shouldDeferToBrowser` had two of its three needed call sites.
+
+**Resolution:** guard both handlers with `shouldDeferToBrowser` so a
+modifier/middle click falls through to the anchor's own default action, while a
+plain click still routes in-SPA.

--- a/tickets/entities/review-responses/RR-BRVI7N.md
+++ b/tickets/entities/review-responses/RR-BRVI7N.md
@@ -1,0 +1,33 @@
+---
+id: RR-BRVI7N
+type: review-response
+title: CommandPalette renders an empty invisible li when the href is unresolvable
+finding: 'CommandPaletteModal.vue:288-309 — the <li role=option> renders unconditionally from v-for but v-if guards only the inner RouterLink, and all three text spans live inside it. When entityDetailHref returns '''' the option renders as an empty zero-height <li>: the visible row count disagrees with the result count, arrow-key highlight appears to skip an invisible option, scrollHighlightedIntoView targets a zero-height element, and a screen reader announces an option with no accessible name. Worse than the pre-change behaviour, where such a row at least rendered its text and was merely inert.'
+severity: critical
+resolution: 'Fixed in CommandPaletteModal.vue: the three text spans now render in BOTH branches — RouterLink when a target resolves, plain <span class=cmdk-option-link> otherwise — so an unresolvable entity renders a visible, named option instead of an empty zero-height <li>. Pinned by a new test (''still renders the option text when there is no resolvable href''), mutation-verified: removing the v-else fallback fails it. The optionLinks() helper was scoped to ''a.cmdk-option-link'' so it distinguishes the link from the span.'
+status: addressed
+---
+
+**Finding (C1, critical).** In `CommandPaletteModal.vue:288-309` the `<li
+role="option">` renders unconditionally from `v-for`, but `v-if` guards only the
+inner `RouterLink` — and all three text spans live inside that link. When
+`entityDetailHref` returns `''` (empty type or id) the result is a completely
+empty option:
+
+```html
+<li id="cmdk-option-X" class="cmdk-option" role="option" aria-selected="false"></li>
+```
+
+Zero height, because the padding moved to `.cmdk-option-link`. This is WORSE
+than the pre-change behaviour, where such a row at least rendered its text and
+was merely inert.
+
+Consequences: the visible row count disagrees with the result count;
+`moveHighlight` still counts the invisible option so arrow-keying appears to
+skip; `scrollHighlightedIntoView` scrolls to a zero-height element; a screen
+reader announces an option with no accessible name.
+
+**Resolution:** render the spans in both branches — `RouterLink` when a target
+exists, plain `<span class="cmdk-option-link">` otherwise. This is the
+conditional-anchor pattern already used correctly in IssuesTable, EntityList and
+EntityDetail; the palette was the one place it was missed.

--- a/tickets/entities/review-responses/RR-HIYJHR.md
+++ b/tickets/entities/review-responses/RR-HIYJHR.md
@@ -1,0 +1,24 @@
+---
+id: RR-HIYJHR
+type: review-response
+title: CalendarEventChip listed in the ticket's surface list but not converted (scoped out in plan only)
+finding: CalendarEventChip.vue:92 is named in the ticket body's 'Affected surfaces' list but was not converted. The planning checklist DID scope it out with a reason (the chip opens an EntityPreviewModal, not a route, so there is no URL to put in a tab), but the ticket body was never updated to match, leaving the two documents contradicting each other.
+severity: significant
+resolution: Kept out of scope — the reasoning stands and converting it would change deliberate calendar UX (the chip's target is only known to the parent via an 'open' emit, so giving it a real href is a design change, not a mechanical conversion). Updated the ticket body's surface list to state the exclusion and its reason explicitly, so the body and the plan agree.
+status: addressed
+---
+
+**Finding (C3, significant).** `CalendarEventChip.vue:92` is named in the
+ticket's "Affected surfaces" list but was not converted — ten surfaces were
+done, this was the eleventh.
+
+The planning checklist DID scope it out with a reason (the chip opens an
+`EntityPreviewModal`, not a route, so there is no URL to put in a tab), but the
+ticket body's surface list was never updated to match, leaving the two documents
+contradicting each other.
+
+**Resolution:** keep it out of scope — the reasoning stands, and converting it
+would change deliberate calendar UX — but state that explicitly in the ticket
+body rather than leaving the omission silent. The chip's target is only known to
+the parent via an `open` emit, so giving it a real href is a genuine design
+change, not a mechanical conversion.

--- a/tickets/entities/review-responses/RR-I4WQPX.md
+++ b/tickets/entities/review-responses/RR-I4WQPX.md
@@ -3,6 +3,7 @@ id: RR-I4WQPX
 type: review-response
 title: <tr> compromise is a half-feature; justification misstates DOM event behaviour
 severity: critical
+resolution: 'Option (a) chosen and approved by the user: a stretched-link overlay (.row-link::after { inset: 0 }) makes the whole row cmd-clickable, with .select-cell/.actions-cell lifted to z-index 1. The incorrect DOM-event claim was deleted from the plan. Accepted trade-off, explicitly approved: text selection within a row is not possible — documented in a code comment and in docs/data-entry.md. Verified in a real browser that the delete button and checkbox remain clickable (crud.spec.ts delete-from-list and cancel both pass).'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-I4WQPX.md
+++ b/tickets/entities/review-responses/RR-I4WQPX.md
@@ -1,0 +1,39 @@
+---
+id: RR-I4WQPX
+type: review-response
+title: <tr> compromise is a half-feature; justification misstates DOM event behaviour
+severity: critical
+status: addressed
+---
+
+**Finding (C2, critical).** The `<tr>` compromise ships a half-feature on a
+justification that is factually wrong about DOM events.
+
+The plan says "cmd-click anywhere on the row is handled by the guard letting the
+event through to that anchor". That is not how events work: returning early from
+the `<tr>` handler does not route the event to the anchor. The anchor's default
+action fires only if the click landed physically inside it. An implementer
+following this sentence would guard, test on the title, and wrongly believe
+row-wide cmd-click works.
+
+Consequence as specified: plain click navigates from anywhere on the row
+(learned behaviour), but cmd-click does nothing on ~6 of 7 cells, with no
+feedback. That is the *ambiguous* fail-direction, not a safe one — the user
+cannot distinguish "unsupported" from "my modifier key didn't register".
+
+**Resolution — pick one and state the cost:**
+
+(a) **Stretched-link overlay.** Anchor stays in the title `<td>`; `.entity-row {
+position: relative }` + `.title-link::after { content:''; position:absolute;
+inset:0 }` makes the whole row a link target. Valid HTML, keeps table semantics,
+one link per row in the a11y tree. **Cost: blocks text selection in the row, and
+every nested control (`select-cell` :995, `delete-btn` :1028) needs
+`position:relative; z-index:1`.**
+
+(b) **Title-only, made discoverable.** Keep the title anchor, delete the
+incorrect sentence, narrow AC 1 from "on a list row" to "on the row's title
+cell", and give the title distinct link affordance so the working target is
+findable rather than accidental.
+
+(b) without the discoverability change is the half-feature. Decision required
+before implementation.

--- a/tickets/entities/review-responses/RR-I4WQPX.md
+++ b/tickets/entities/review-responses/RR-I4WQPX.md
@@ -2,6 +2,7 @@
 id: RR-I4WQPX
 type: review-response
 title: <tr> compromise is a half-feature; justification misstates DOM event behaviour
+finding: 'The <tr> compromise shipped a half-feature on a justification that was factually wrong about DOM events. The plan claimed ''cmd-click anywhere on the row is handled by the guard letting the event through to that anchor'' — returning early from the <tr> handler does not route the event to the anchor; an anchor''s default action fires only when the click lands physically inside it. As specified, cmd-click would do nothing on ~6 of 7 cells with no feedback, which is the ambiguous fail-direction: the user cannot tell ''unsupported'' from ''my modifier key did not register''.'
 severity: critical
 resolution: 'Option (a) chosen and approved by the user: a stretched-link overlay (.row-link::after { inset: 0 }) makes the whole row cmd-clickable, with .select-cell/.actions-cell lifted to z-index 1. The incorrect DOM-event claim was deleted from the plan. Accepted trade-off, explicitly approved: text selection within a row is not possible — documented in a code comment and in docs/data-entry.md. Verified in a real browser that the delete button and checkbox remain clickable (crud.spec.ts delete-from-list and cancel both pass).'
 status: addressed

--- a/tickets/entities/review-responses/RR-NPDW9A.md
+++ b/tickets/entities/review-responses/RR-NPDW9A.md
@@ -2,7 +2,9 @@
 id: RR-NPDW9A
 type: review-response
 title: Anchors inside RelationCards/Kanban drag sources break drag-reorder
+finding: 'Making RelationCards.vue:562/565 spans into anchors risks breaking drag-reorder: anchors are natively draggable, and unlike Kanban, RelationCards.onDragStart early-returns when !isOrderable, so a non-orderable list would get the browser''s default link-drag. The spans also have no .stop, so clicks already bubble to the draggable card.'
 severity: critical
+resolution: 'draggable="false" added to both RelationCards anchors. Kanban deliberately does NOT get it — there the card is both the anchor and the drag source, so the attribute would disable reordering; that reasoning is now a comment at the binding (see RR-WEJM54). Both drag surfaces verified: kanban.spec.ts 15/15 including ''drag updates the entity status'', relation-cards.spec.ts 12/12.'
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-NPDW9A.md
+++ b/tickets/entities/review-responses/RR-NPDW9A.md
@@ -1,0 +1,22 @@
+---
+id: RR-NPDW9A
+type: review-response
+title: Anchors inside RelationCards/Kanban drag sources break drag-reorder
+severity: critical
+status: addressed
+---
+
+**Finding (C3, critical).** Making `RelationCards.vue:562/565` spans into
+anchors breaks drag-reorder. The plan's Risks table only considered Kanban drag.
+
+These spans sit inside the card at `:545-556`, which is
+`:draggable="isOrderable"` with a full dragstart/dragover/drop set. Two
+problems:
+
+1. Anchors are natively draggable. Unlike Kanban (`KanbanView.vue:446` unconditionally sets `text/plain`), `RelationCards.onDragStart` (`:458-459`) **early-returns when `!isOrderable`** — verified. So on a non-orderable list, dragging the new anchor gets the browser's default link-drag (dragging a URL), a behaviour that does not exist today.
+2. The spans have no `.stop`, so clicks already bubble to the card. An anchor with a navigating default action inside a drag source is where "was that a drag or a click?" bugs live.
+
+**Resolution:** `draggable="false"` on any anchor placed inside a drag source
+(applies to Kanban cards too, where `:draggable="false"` on the card does not
+stop an anchor child from being independently draggable). Add a test that
+reorder-by-dragging-the-title still works.

--- a/tickets/entities/review-responses/RR-PB8DO8.md
+++ b/tickets/entities/review-responses/RR-PB8DO8.md
@@ -1,0 +1,32 @@
+---
+id: RR-PB8DO8
+type: review-response
+title: Global RouterLink stub's query encoding diverges from vue-router
+finding: The global RouterLink stub in test/setup.ts serializes queries with URLSearchParams, which percent-encodes per application/x-www-form-urlencoded, so scope=list:tickets becomes scope=list%3Atickets. vue-router's own stringifier leaves ':' unencoded. The new unit test therefore asserted the STUB's encoding rather than the app's; the e2e test already hedged with a (:|%3A) regex, which was the tell.
+severity: significant
+resolution: Documented at the stub that it APPROXIMATES vue-router's serialization and that exact-encoding assertions belong in e2e. Made the unit assertion encoding-agnostic (regex over both spellings) so it pins the fact that the scope is carried rather than one spelling of it.
+status: addressed
+---
+
+**Finding (S4, significant).** The global RouterLink stub in `test/setup.ts`
+serializes queries with `URLSearchParams`, which percent-encodes per
+`application/x-www-form-urlencoded` — so `scope=list:tickets` becomes
+`scope=list%3Atickets`. vue-router's own stringifier leaves `:` unencoded.
+
+The new test at `EntityList.newtab.test.ts:114` therefore asserts the STUB's
+encoding, not the app's. The e2e test already hedges with
+`/scope=list(:|%3A)features/` (`open-new-tab.spec.ts:50`) — a tell that the two
+layers disagree.
+
+Latent trap: a future test asserting an exact href encodes against the stub,
+passes, and diverges from what the real router produces.
+
+**Resolution:** document at the stub that it approximates vue-router's
+serialization and that exact-encoding assertions belong in e2e; make the unit
+assertion encoding-agnostic so it pins the *fact* that the scope is carried
+rather than one spelling of it.
+
+Note the stub change itself was right and is strictly better than what it
+replaced (`<a><slot/></a>`, which dropped `to` and made every href assertion
+vacuous). It does not weaken unrelated tests: adding an attribute cannot break
+an assertion that never looked at it.

--- a/tickets/entities/review-responses/RR-SYFX1B.md
+++ b/tickets/entities/review-responses/RR-SYFX1B.md
@@ -2,6 +2,7 @@
 id: RR-SYFX1B
 type: review-response
 title: entityTarget() called 2x per row per render and is not cheap
+finding: EntityList.vue called entityTarget(entity) twice per row per render (once in the v-else-if, once in the :to), and the function is not cheap — it iterates all of route.query, maps over sortSpecs, runs listConfig.columns.find(), and allocates a fresh object each call. At 25 rows that is 50 invocations per render, re-running on every reactive tick including hover-driven selectedIndex changes. The codebase already memoises resolveCell per column for exactly this reason (RR-UD2A).
 severity: significant
 resolution: Added a rowTargets computed Map (entity id -> RouteLocationRaw) alongside the existing columnWidgets memo, citing RR-SYFX1B and the same RR-UD2A rationale. All four template references and navigateToEntity now read the map, so entityTarget runs once per entity per render instead of twice per row on every reactive tick.
 status: addressed

--- a/tickets/entities/review-responses/RR-SYFX1B.md
+++ b/tickets/entities/review-responses/RR-SYFX1B.md
@@ -1,0 +1,26 @@
+---
+id: RR-SYFX1B
+type: review-response
+title: entityTarget() called 2x per row per render and is not cheap
+severity: significant
+resolution: Added a rowTargets computed Map (entity id -> RouteLocationRaw) alongside the existing columnWidgets memo, citing RR-SYFX1B and the same RR-UD2A rationale. All four template references and navigateToEntity now read the map, so entityTarget runs once per entity per render instead of twice per row on every reactive tick.
+status: addressed
+---
+
+**Finding (S1, significant).** `EntityList.vue` calls `entityTarget(entity)`
+twice per row per render (once in `v-else-if`, once in `:to`), and the function
+is not cheap: it iterates all of `route.query`, maps over `sortSpecs`, runs
+`listConfig.columns.find()`, and allocates a fresh object each call.
+
+At 25 rows that is 50 invocations per render, re-running on every reactive tick
+— including `selectedIndex` changes driven by hover/keyboard.
+
+This codebase already knows better: `resolveCell` carries a comment (`:625`)
+saying it is memoised per column "rather than per cell (RR-UD2A -- the same
+reason PropertyDisplay precomputes `rows`)". The same reasoning applies here,
+and this change also added two more `resolveCell` calls inside the new
+RouterLink branch.
+
+**Resolution:** precompute a `computed` map of entity id → target. The query
+half is identical for every row in the list — only `path` varies — so most of
+that work is per-list, not per-row.

--- a/tickets/entities/review-responses/RR-UHNHX4.md
+++ b/tickets/entities/review-responses/RR-UHNHX4.md
@@ -2,7 +2,9 @@
 id: RR-UHNHX4
 type: review-response
 title: IssuesTable a11y conversion under-specified; mobile variant and palette ARIA missed
+finding: IssuesTable's a11y conversion was under-specified and the MOBILE variant was missed — both the desktop cell (:100-109) and the mobile card (:170-178) use the identical role=button + tabindex + keydown.enter + keydown.space.prevent pattern, but the scope table listed only 'entity-title cell', singular. Separately, CommandPaletteModal's <li role=option> sits in a role=listbox driven by aria-activedescendant, so a focusable anchor inside it breaks the roving-focus model.
 severity: significant
+resolution: Both IssuesTable variants converted to RouterLink with role/tabindex/both keydown handlers removed; entity-less rows (canNavigate false) render a plain span with no role. Space no longer activates, which is correct link semantics and restores scroll-on-space. The palette anchor got tabindex=-1 so it is not a tab stop and aria-activedescendant roving focus is preserved; palette keyboard tests (36) all pass. The unused useRouter import in IssuesTable was removed — with real links the component needs no router at all.
 status: addressed
 ---
 

--- a/tickets/entities/review-responses/RR-UHNHX4.md
+++ b/tickets/entities/review-responses/RR-UHNHX4.md
@@ -1,0 +1,33 @@
+---
+id: RR-UHNHX4
+type: review-response
+title: IssuesTable a11y conversion under-specified; mobile variant and palette ARIA missed
+severity: significant
+status: addressed
+---
+
+**Finding (S5, significant).** `IssuesTable` a11y conversion is under-specified,
+and the mobile variant was missed.
+
+Verified: **both** the desktop cell (`:100-109`) and the mobile card
+(`:170-178`) use the identical `role="button"` + `tabindex="0"` +
+`@keydown.enter` + `@keydown.space.prevent` pattern. The plan's scope table
+listed "entity-title cell" — singular. Both must convert or they diverge.
+
+Converting to an anchor requires removing `role="button"`, `tabindex`, and
+**both keydown handlers**. Leaving them yields an element announced as a button
+but behaving as a link, and Enter double-fires (native activation + handler).
+
+Deliberate behaviour changes to accept: Space no longer activates (correct link
+semantics) and page-scroll-on-Space returns, since `@keydown.space.prevent`
+currently suppresses it.
+
+`canNavigate()` is false for script-error/load-error rows, which must render a
+plain `<span>` with no role/tabindex — the conditional-anchor pattern the plan
+already gets right.
+
+**Also:** `CommandPaletteModal.vue:291` is `<li role="option">` inside a
+`role="listbox"` driven by `aria-activedescendant`. A focusable anchor inside
+`role="option"` violates the listbox content model and can break roving focus —
+the anchor needs `tabindex="-1"` at minimum. The plan discussed only the
+close-on-modifier-click decision and missed this.

--- a/tickets/entities/review-responses/RR-WEJM54.md
+++ b/tickets/entities/review-responses/RR-WEJM54.md
@@ -1,0 +1,30 @@
+---
+id: RR-WEJM54
+type: review-response
+title: Kanban/RelationCards drag asymmetry correct but undocumented; RR-NPDW9A's test never written
+severity: significant
+resolution: 'Added a comment at the Kanban card explaining why it deliberately has NO draggable=false (the card is both the link and the drag source; the attribute is for an anchor nested inside one, and setting it here would disable reordering, while onDragStart sets dataTransfer unconditionally). Verified both drag surfaces still work: kanban.spec.ts 15/15 including ''drag updates the entity status'', relation-cards.spec.ts 12/12.'
+status: addressed
+---
+
+**Finding (S3, significant).** The Kanban/RelationCards drag asymmetry is
+CORRECT but undocumented, and the test RR-NPDW9A asked for was never written.
+
+Why Kanban legitimately differs: RR-NPDW9A's `draggable="false"` prescription
+targets an anchor *child* of a drag source. In Kanban the card IS both the
+anchor and the drag source, so `draggable="false"` would disable dragging
+entirely; the `:draggable="canUpdate(entity)"` binding is the right control, and
+`onDragStart` (`:446-452`) unconditionally sets `dataTransfer`, overriding the
+native link-drag in both branches. RelationCards genuinely needed the attribute
+because its anchors are children of the draggable card AND its `onDragStart`
+early-returns when `!isOrderable`.
+
+Two gaps:
+
+1. That reasoning exists nowhere in the code. The next person reads RR-NPDW9A,
+sees no `draggable="false"` on the Kanban card, and "fixes" it — breaking drag.
+It belongs in a comment at the `:draggable` binding.
+2. RR-NPDW9A was closed as addressed with "add a test that reorder-by-dragging
+still works". No such test exists. Kanban has e2e coverage
+(`kanban.spec.ts:83-100`, passing); **RelationCards drag-reorder has none at any
+level** — and it is the component where the anchor/drag interaction is subtlest.

--- a/tickets/entities/review-responses/RR-WEJM54.md
+++ b/tickets/entities/review-responses/RR-WEJM54.md
@@ -2,6 +2,7 @@
 id: RR-WEJM54
 type: review-response
 title: Kanban/RelationCards drag asymmetry correct but undocumented; RR-NPDW9A's test never written
+finding: The Kanban/RelationCards drag asymmetry is correct but was undocumented, and the test RR-NPDW9A asked for was never written. RR-NPDW9A's draggable=false prescription targets an anchor CHILD of a drag source; in Kanban the card is both the anchor and the drag source, so setting it there would disable dragging entirely. Without that reasoning in the code, the next reader sees no draggable=false on the Kanban card and 'fixes' it, breaking reorder. Separately, RelationCards drag-reorder had no test at any level.
 severity: significant
 resolution: 'Added a comment at the Kanban card explaining why it deliberately has NO draggable=false (the card is both the link and the drag source; the attribute is for an anchor nested inside one, and setting it here would disable reordering, while onDragStart sets dataTransfer unconditionally). Verified both drag surfaces still work: kanban.spec.ts 15/15 including ''drag updates the entity status'', relation-cards.spec.ts 12/12.'
 status: addressed

--- a/tickets/entities/review-responses/RR-Z0AHAY.md
+++ b/tickets/entities/review-responses/RR-Z0AHAY.md
@@ -1,0 +1,38 @@
+---
+id: RR-Z0AHAY
+type: review-response
+title: ID-encoding guarantee miscited; wantsNewTab misnamed; row tab-stops 0->N
+severity: minor
+status: addressed
+---
+
+**Finding (S2/M1/M4, minor cluster).** Three smaller corrections.
+
+**S2 — wrong guarantee cited.** The plan's edge cases require testing IDs
+containing `#`, `?`, `/`, spaces, unicode. Verified impossible:
+`internal/entity/id.go:134` pins every ID to `^[A-Za-z0-9][A-Za-z0-9_-]*$`, and
+`ValidateID` is documented as the single validity rule across the codebase
+(TKT-IZGF7T). `encodeURIComponent` is therefore a no-op and the plan's security
+reasoning rests on encoding when the real guarantee is the grammar. **Cite
+`entity/id.go` instead**, so a future relaxation of the grammar trips the right
+wire. The genuinely untested input is `cellLink`, a server-supplied string with
+no such grammar — that is where a malformed-href test belongs.
+
+**M1 — `wantsNewTab` name lies.** Including `e.defaultPrevented` is
+behaviourally right (all call sites are `if (...) return`) but semantically
+inverted: a defaultPrevented event means *nothing* should happen, not "open a
+tab". Rename to `shouldDeferToBrowser` / `shouldSkipRouterPush`, or split the
+check out. Otherwise a later `if (wantsNewTab(e)) trackNewTabOpened()` logs
+phantom opens.
+
+**M4 — tab-stop count changes from 0 to N.** Rows currently have *zero* tab
+stops (keyboard access is the j/k `useListKeyboard` model). A focusable title
+anchor per row adds one per row — on a 50-row list that is 50 new tab stops.
+Probably correct (links should be reachable), but it is a real interaction
+change with the existing keyboard model and needs an explicit decision, not a
+risk row implying nothing changed.
+
+**M2 — alt-click note.** On macOS, Option-click on an anchor *downloads* the
+target, so a row link would silently drop an HTML file in ~/Downloads. Staying
+consistent with `useDocumentClicks.ts:33` (which includes `altKey`) is the right
+call; just record the consequence.

--- a/tickets/entities/review-responses/RR-Z0AHAY.md
+++ b/tickets/entities/review-responses/RR-Z0AHAY.md
@@ -2,7 +2,9 @@
 id: RR-Z0AHAY
 type: review-response
 title: ID-encoding guarantee miscited; wantsNewTab misnamed; row tab-stops 0->N
+finding: 'Three items: the plan''s edge cases required testing entity IDs containing #/?//spaces/unicode, which internal/entity/id.go:134 makes impossible (ValidateID pins IDs to ^[A-Za-z0-9][A-Za-z0-9_-]*$), so the security reasoning cited encoding when the real guarantee is the grammar; wantsNewTab was misnamed since it also covers defaultPrevented, which means the opposite of ''open a tab''; and row tab stops go from 0 to N per page, a real interaction change with the existing j/k keyboard model.'
 severity: minor
+resolution: The helper is named shouldDeferToBrowser, with a comment explaining why (defaultPrevented means nothing should happen, not open a tab) and that callers use it only to skip their own push. The plan now cites entity/id.go's ValidateID as the path-safety guarantee instead of encoding, and names cellLink as the genuinely unconstrained input — which is what the new hostile-link tests cover. The 0-to-N tab-stop change is accepted deliberately (links should be reachable) with one anchor per row, not per cell; the row itself stays non-focusable as before.
 status: addressed
 ---
 

--- a/tickets/entities/tickets/TKT-3CSZRG.md
+++ b/tickets/entities/tickets/TKT-3CSZRG.md
@@ -1,0 +1,56 @@
+---
+id: TKT-3CSZRG
+type: ticket
+title: Ctrl/Cmd-click (and middle-click) should open data-entry rows and cards in a new browser tab
+kind: enhancement
+priority: medium
+effort: m
+status: review
+---
+
+## Problem
+
+Navigable surfaces in the data-entry SPA are plain `<div>` / `<tr>` elements
+with an `@click` handler calling `router.push`. Because they are not anchors,
+ctrl/cmd-click, middle-click, shift-click and the browser's own "Open link in
+new tab" context menu all fail — the row either navigates in the same tab or
+ignores the click entirely. Users expect anything that looks like a link to be
+openable in a background tab.
+
+| Interaction | Expected | Actual |
+|---|---|---|
+| Cmd/Ctrl+click | open in background tab | navigates current tab |
+| Middle-click | open in background tab | nothing |
+| Shift+click | open in new window | navigates current tab |
+| Right-click → Open in new tab | menu entry present | no menu entry |
+| Hover | status-bar URL preview | nothing |
+
+## Affected surfaces
+
+- `components/lists/EntityList.vue` — desktop `<tr class="entity-row" @click="navigateToEntity(entity)">` and the mobile `<div class="mobile-card" @click>`
+- `views/KanbanView.vue` — card `<div @click="openCard(entity)">` (two call sites)
+- `components/calendar/CalendarEventChip.vue` — `@click="$emit('open', event)"`
+- `components/forms/SidePanel.vue`, `components/forms/RelationCards.vue` — entry click handlers
+- `components/common/IssuesTable.vue` — row click
+- `views/SearchView.vue` — result click
+
+`utils/entityRoute.ts` already exists precisely for this, and the comment at
+`EntityList.vue:533` claims rows open "through a real `<a href>` on the row
+markup elsewhere" — that is aspirational, not true. The helper currently only
+computes a path that is then handed to `router.push`.
+
+`composables/useDocumentClicks.ts` already gets this right for links inside
+rendered document HTML: it bails out on modifier/middle clicks and lets the
+browser take over. That is the model to generalize.
+
+## Approach sketch
+
+Render the navigable element as an anchor with a real `href`, and make the click
+handler defer to the browser when the user signalled new-tab intent
+(`event.metaKey || ctrlKey || shiftKey || altKey || button !== 0`). A shared
+helper keeps the predicate in one place rather than repeating a five-way
+modifier check at every call site.
+
+Table rows cannot be wrapped in an anchor (invalid HTML inside `<tr>`), so the
+row keeps its click handler but must honour modifier-clicks; the primary/title
+cell additionally gets a real anchor so right-click and middle-click work.

--- a/tickets/entities/tickets/TKT-3CSZRG.md
+++ b/tickets/entities/tickets/TKT-3CSZRG.md
@@ -5,7 +5,7 @@ title: Ctrl/Cmd-click (and middle-click) should open data-entry rows and cards i
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Problem
@@ -29,7 +29,12 @@ openable in a background tab.
 
 - `components/lists/EntityList.vue` — desktop `<tr class="entity-row" @click="navigateToEntity(entity)">` and the mobile `<div class="mobile-card" @click>`
 - `views/KanbanView.vue` — card `<div @click="openCard(entity)">` (two call sites)
-- `components/calendar/CalendarEventChip.vue` — `@click="$emit('open', event)"`
+- ~~`components/calendar/CalendarEventChip.vue`~~ — **deliberately excluded.**
+The chip's click opens an `EntityPreviewModal`, not a route, so there is no URL
+to put in a new tab. Its target is known only to the parent via an `open` emit,
+making a real href a design change rather than a mechanical conversion. (The
+modal's own "Open full page" button is a genuine navigation and could be
+anchored separately.)
 - `components/forms/SidePanel.vue`, `components/forms/RelationCards.vue` — entry click handlers
 - `components/common/IssuesTable.vue` — row click
 - `views/SearchView.vue` — result click

--- a/tickets/relations/TKT-3CSZRG--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-3CSZRG--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-3CSZRG--has-docs--DOCS-WP2LNF.md
+++ b/tickets/relations/TKT-3CSZRG--has-docs--DOCS-WP2LNF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-docs
+to: DOCS-WP2LNF
+---

--- a/tickets/relations/TKT-3CSZRG--has-implementation--IMPL-92ILKV.md
+++ b/tickets/relations/TKT-3CSZRG--has-implementation--IMPL-92ILKV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-implementation
+to: IMPL-92ILKV
+---

--- a/tickets/relations/TKT-3CSZRG--has-planning--PLAN-58CVCA.md
+++ b/tickets/relations/TKT-3CSZRG--has-planning--PLAN-58CVCA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-planning
+to: PLAN-58CVCA
+---

--- a/tickets/relations/TKT-3CSZRG--has-review--REV-299VJY.md
+++ b/tickets/relations/TKT-3CSZRG--has-review--REV-299VJY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review
+to: REV-299VJY
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-0PEI9F.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-0PEI9F.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-0PEI9F
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-5Z83S0.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-5Z83S0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-5Z83S0
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-6PBTF1.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-6PBTF1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-6PBTF1
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-88510Z.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-88510Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-88510Z
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-BRVI7N.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-BRVI7N.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-BRVI7N
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-HIYJHR.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-HIYJHR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-HIYJHR
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-I4WQPX.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-I4WQPX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-I4WQPX
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-NPDW9A.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-NPDW9A.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-NPDW9A
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-PB8DO8.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-PB8DO8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-PB8DO8
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-SYFX1B.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-SYFX1B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-SYFX1B
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-UHNHX4.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-UHNHX4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-UHNHX4
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-WEJM54.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-WEJM54.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-WEJM54
+---

--- a/tickets/relations/TKT-3CSZRG--has-review-response--RR-Z0AHAY.md
+++ b/tickets/relations/TKT-3CSZRG--has-review-response--RR-Z0AHAY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: has-review-response
+to: RR-Z0AHAY
+---

--- a/tickets/relations/TKT-3CSZRG--implements--FEAT-Q767.md
+++ b/tickets/relations/TKT-3CSZRG--implements--FEAT-Q767.md
@@ -1,0 +1,5 @@
+---
+from: TKT-3CSZRG
+relation: implements
+to: FEAT-Q767
+---


### PR DESCRIPTION
Fixes TKT-3CSZRG.

## The problem

The data-entry SPA navigated from non-anchor elements (`<tr @click>`, `<div @click>`,
`<li @click>`, `<span @click>`) by calling `router.push`. With no `<a href>` the browser
has nothing to act on:

| Interaction | Expected | Before |
|---|---|---|
| Cmd/Ctrl-click | open in background tab | navigates current tab |
| Middle-click | open in background tab | nothing |
| Shift-click | open in new window | navigates current tab |
| Right-click → Open in new tab | menu entry present | absent |
| Hover | status-bar URL preview | nothing |

## The fix: use the platform's link element

Not a modifier-key interception layer. Where the element can be an anchor it simply
becomes a `RouterLink`, which already implements vue-router's whole modifier-click
contract — so most surfaces needed **no click handler at all**. `IssuesTable` shed its
`role="button"` + `tabindex` + two keydown handlers and no longer imports a router;
`HistoryView`, `RelationHistoryView` and `EntityPreviewModal` dropped their router
imports too.

Converted: list rows (desktop + mobile), kanban cards, search results, side-panel
entries, relation-card titles, issues-table cells (both variants), command-palette
options, entity-detail card headers and list links, entity-detail section-table cells,
and the header nav affordances (Prev/Next, Edit, History, Back to entity, calendar
preview actions).

**Delete stays a `<button>`** — it mutates, so a new tab is meaningless. An e2e test
asserts it has *not* become a link, since that boundary is the thing most likely to erode.

### One surface can't be an anchor

HTML forbids an `<a>` wrapping or nesting directly in a `<tr>`. The list table therefore
puts the real link in the first cell and stretches it over the row via
`.row-link::after { inset: 0 }` (the Bootstrap `.stretched-link` pattern), with nested
controls lifted above it. **Accepted trade-off, explicitly approved: text selection
within a list row is no longer possible.** Documented in code and in `docs/data-entry.md`.

### Tables were deliberately not converted to CSS grid

Of 7 `<table>` elements only one has clickable rows. Grid would trade away native table
semantics and content-based column sizing (list columns are configured per-list, so the
count is unknown at build time) to avoid 4 lines of CSS. `DashboardView` already sets the
precedent of a `<router-link>` inside a `<td>`.

## The load-bearing invariant

Each surface exposes **one** `entityTarget()` consumed by both the link's `to` and any
`router.push`. Building the href separately would silently drop the list/search scope, so
a cmd-clicked tab would land on an unscoped detail page — dead prev/next, wrong back
target — while still rendering a page that looks correct. Pinned by a test that derives
its expectation from the actual push payload rather than a literal.

## Review

Two rounds, 13 review-responses, all addressed. The code review caught two real bugs:

- **`EntityDetail` section-table cells** were already real anchors carrying an
  unconditional `@click.prevent`, suppressing the browser default on *every* click —
  this ticket's own bug, still live in a file the ticket edited. It survived because that
  section had no e2e coverage at all; a fixture and test now exist.
- **The command palette** guarded only its inner link while the option text lived inside
  it, so an unresolvable entity rendered an empty zero-height `<li role="option">` —
  invisible, still counted by arrow-key navigation, nameless to a screen reader.

A security claim in the original plan was **withdrawn as incorrect**: `resolveLinkTarget`
is a closed allowlist in both the Go and TS copies, so no scheme-bearing value can reach
the new href sink. Both copies are now pinned by tests, and the remaining check is
recorded as integrity defense-in-depth rather than threat mitigation.

## Verification

- **2071** frontend unit tests, **272** e2e (0 fail), typecheck clean, 0 lint errors
- `just comment-lint`, `just arch-lint`, `just coverage-check` all pass
- Mutation-verified: dropping the query from a target, removing the modifier guard, and
  removing the palette's fallback each fail their tests
- Manually driven in a real browser — popup URL matches the href character-for-character
  including `from=` and `scope=`, and the source tab does not navigate


https://claude.ai/code/session_01F2Wd5t9XsxRQ8DEGmMgoij
