### PR TITLE
fix(git): refuse a Windows volume root as the clone base (TKT-T7G7LT)

### DIFF
--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -141,7 +141,7 @@ func containedPath(base, path string) (string, error) {
 	// as the empty base above, reached by a different route (a config default
 	// that resolves to "/", or a caller passing it deliberately). Refuse it:
 	// there is no legitimate reason to scope a clone to the whole filesystem.
-	if absBase == string(filepath.Separator) {
+	if isFilesystemRoot(filepath.VolumeName(absBase), absBase, filepath.Separator) {
 		return "", errors.New("clone base directory must not be the filesystem root")
 	}
 
@@ -155,6 +155,49 @@ func containedPath(base, path string) (string, error) {
 		return "", fmt.Errorf("clone path %q escapes base directory %q", path, base)
 	}
 	return abs, nil
+}
+
+// isFilesystemRoot reports whether cleanedPath is a volume root: the volume
+// name followed by a separator and nothing else, or — on Windows only — a
+// volume name with nothing after it at all. The three arguments describe ONE
+// platform's view of one path: pass [filepath.VolumeName](p), an absolute p
+// passed through [filepath.Clean], and [filepath.Separator].
+//
+// Taking them as parameters rather than reaching for the filepath package
+// directly is deliberate, and is what makes the Windows case testable
+// (TKT-T7G7LT / issue #1498). All three differ per platform, and a test running
+// on Linux cannot obtain the Windows values from its own filepath: Linux sees
+// `C:\` as an ordinary relative filename with no volume, and its Separator is
+// '/'. A test written against a path alone would therefore report coverage of a
+// branch it never entered. Handed the triple a Windows filepath would produce,
+// this function performs exactly the comparison it performs there.
+//
+// The volume term is NOT dead weight on Unix, even though it always reads as
+// "". [filepath.VolumeName] returns "" on every non-Windows platform, so the
+// first clause degenerates to `cleanedPath == "/"` — the original Unix-only
+// check from issue #1270, subsumed rather than duplicated. On Windows it
+// catches a drive root (`C:` + `\`) and the trailing-separator spelling of a
+// share root (`\\host\share` + `\`).
+//
+// The second clause exists because [filepath.Clean] does NOT always leave a
+// trailing separator on a Windows root. When the entire path is the volume —
+// `\\host\share`, `\\?\UNC\host\share`, `\\?\C:` — Clean returns it verbatim
+// (there is no remainder to root), so the first clause misses it while
+// [filepath.Rel] goes on to treat it as an absolute base and reports every path
+// on the share as contained. Rel says so itself: it rewrites an empty
+// post-volume base to a separator "for any targetpath matching `\\host\share`".
+// A bare volume is therefore a root in fact, and refusing it is the whole point
+// of this guard.
+//
+// Nil: never returns an error — a pure comparison over three strings.
+func isFilesystemRoot(volumeName, cleanedPath string, separator rune) bool {
+	if volumeName != "" && cleanedPath == volumeName {
+		// Windows only: on Unix volumeName is always "", and an empty
+		// cleanedPath is not a root (Clean never yields one, and the guard
+		// must not claim otherwise).
+		return true
+	}
+	return cleanedPath == volumeName+string(separator)
 }
 
 // credentialFileMode is owner-only: the credentials file holds the access token

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -249,3 +249,115 @@ func TestContainedPath_RejectsRootBase(t *testing.T) {
 		t.Errorf("containedPath error = %v, want it to name the filesystem root", err)
 	}
 }
+
+// The root-base guard must recognise a WINDOWS root too (TKT-T7G7LT / issue
+// #1498). rela-desktop ships as a Windows MSI, and until this test existed the
+// guard compared only against "/" — so on Windows a base of `C:\` sailed
+// through, filepath.Rel succeeded for every path on the drive, and the
+// containment check returned "contained" for anything at all. That is exactly
+// the fail-open PR #1496 was written to close, still open on a shipped
+// platform.
+//
+// This test runs on Linux CI, which is the whole difficulty: Linux filepath has
+// no concept of a volume, so it Cleans `C:\` to the relative filename `C:\` and
+// Abs would prefix it with the working directory. Driving the Windows case
+// through containedPath here would therefore assert on a path that never
+// entered the branch under test — a green result proving nothing.
+//
+// So the table addresses isFilesystemRoot directly, feeding it the
+// (VolumeName, Clean, Separator) triples a Windows filepath WOULD produce — all
+// three vary per platform, which is why all three are parameters. The values
+// come from the stdlib's own rules: volumeNameLen returns 2 for a drive-letter
+// path and the full `\\host\share` prefix for UNC; Clean copies the volume
+// verbatim; Separator is '\\' on Windows.
+//
+// The limit of this technique is worth stating, because it bit once already.
+// Every input here is a hand transcription of what Clean is believed to return,
+// and nothing in this file verifies that belief — so a wrong transcription
+// yields a green test over a string Windows never emits. That is exactly what
+// happened with `\\server\share` (RR-Q73HKS): the table asserted the
+// trailing-separator form, Clean actually returns the bare volume, and the real
+// spelling went unguarded. TestIsFilesystemRoot_RealWindowsPaths in
+// clone_windows_test.go is the counterweight — it derives the triples from the
+// host filepath instead of from memory. It does not run on Linux CI, which is
+// precisely why this table exists too; neither is sufficient alone.
+func TestIsFilesystemRoot(t *testing.T) {
+	const (
+		unixSep    = '/'
+		windowsSep = '\\'
+	)
+
+	tests := []struct {
+		name    string
+		volume  string
+		cleaned string
+		sep     rune
+		want    bool
+	}{
+		// Unix: the case #1496 already handled, kept as a row so a future
+		// rewrite of the predicate cannot drop it silently.
+		{"unix root", "", "/", unixSep, true},
+		{"unix directory", "", "/home/dev", unixSep, false},
+		{"unix nested directory", "", "/home/dev/clones", unixSep, false},
+
+		// Windows drive roots: the defect this ticket fixes.
+		{"windows drive root", "C:", `C:\`, windowsSep, true},
+		{"windows drive root lowercase", "c:", `c:\`, windowsSep, true},
+		{"windows directory on drive", "C:", `C:\Users\dev`, windowsSep, false},
+		{"windows nested directory on drive", "C:", `C:\Users\dev\clones`, windowsSep, false},
+
+		// UNC share roots are roots in the same sense: everything on the share
+		// is below them, so a base of `\\server\share` constrains nothing.
+		//
+		// BOTH spellings must be caught, and the second is the one that
+		// actually occurs. Clean(`\\server\share`) returns it UNCHANGED — the
+		// whole string is the volume name, so there is no remainder to root and
+		// no trailing separator is appended. An earlier version of this table
+		// listed only the `\` form, asserting on a string Windows never
+		// produces for that input; it passed green while the real form went
+		// unguarded and filepath.Rel reported every path on the share as
+		// contained. Found in code review (RR-Q73HKS).
+		{"unc share root trailing separator", `\\server\share`, `\\server\share\`, windowsSep, true},
+		{"unc share root bare volume", `\\server\share`, `\\server\share`, windowsSep, true},
+		{"unc directory on share", `\\server\share`, `\\server\share\repos`, windowsSep, false},
+
+		// Same bare-volume shape in the extended-length spellings, which Clean
+		// also returns verbatim.
+		{"extended unc share root", `\\?\UNC\server\share`, `\\?\UNC\server\share`, windowsSep, true},
+		{"extended drive volume", `\\?\C:`, `\\?\C:`, windowsSep, true},
+		{"extended drive root", `\\?\C:`, `\\?\C:\`, windowsSep, true},
+
+		// Drive-relative `C:foo` has a volume but is NOT a root: it names a
+		// path relative to the drive's working directory. The bare-volume
+		// clause must not swallow it.
+		{"windows drive relative", "C:", "C:foo", windowsSep, false},
+
+		// A relative base is not a root. The predicate must not over-claim:
+		// containedPath rejects this later via Abs/Rel, and a predicate that
+		// swallowed it would report the wrong reason.
+		{"relative base", "", ".", unixSep, false},
+
+		// The bare-volume clause is guarded on a non-empty volume, so an empty
+		// cleaned path is not a root on Unix. Clean never produces one, but the
+		// predicate should not lie about an input it can be handed.
+		{"empty path no volume", "", "", unixSep, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFilesystemRoot(tt.volume, tt.cleaned, tt.sep); got != tt.want {
+				t.Errorf("isFilesystemRoot(%q, %q, %q) = %v, want %v",
+					tt.volume, tt.cleaned, string(tt.sep), got, tt.want)
+			}
+		})
+	}
+}
+
+// Deliberately absent: a Linux test asserting that containedPath consults
+// isFilesystemRoot. Any such test can only reach the predicate through "/",
+// where the old `absBase == string(filepath.Separator)` check and the new one
+// agree — so it would pass identically before and after this change, which
+// makes it evidence of nothing while looking like a wiring guarantee.
+// TestContainedPath_RejectsRootBase above already covers the "/" wiring, and
+// TestContainedPath_RejectsWindowsRootBases (clone_windows_test.go) covers the
+// wiring for the roots that actually distinguish the two implementations.

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -250,7 +250,7 @@ func TestContainedPath_RejectsRootBase(t *testing.T) {
 	}
 }
 
-// The root-base guard must recognise a WINDOWS root too (TKT-T7G7LT / issue
+// The root-base guard must recognize a WINDOWS root too (TKT-T7G7LT / issue
 // #1498). rela-desktop ships as a Windows MSI, and until this test existed the
 // guard compared only against "/" — so on Windows a base of `C:\` sailed
 // through, filepath.Rel succeeded for every path on the drive, and the
@@ -329,7 +329,7 @@ func TestIsFilesystemRoot(t *testing.T) {
 		// in volumeNameLen keys on the `.` form, so the `?` form falls to the
 		// generic `\\?` branch and the volume is `\\?\UNC` rather than the
 		// share — which would make `\\?\UNC\host\share` a path UNDER a volume,
-		// not a root. That is a claim about stdlib behaviour this file cannot
+		// not a root. That is a claim about stdlib behavior this file cannot
 		// verify (it is not in the stdlib's own test table either), and the
 		// whole point of RR-S2X70O is that unverified transcriptions pass green
 		// while being wrong. Left out rather than guessed.

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -321,9 +321,18 @@ func TestIsFilesystemRoot(t *testing.T) {
 		{"unc share root bare volume", `\\server\share`, `\\server\share`, windowsSep, true},
 		{"unc directory on share", `\\server\share`, `\\server\share\repos`, windowsSep, false},
 
-		// Same bare-volume shape in the extended-length spellings, which Clean
-		// also returns verbatim.
-		{"extended unc share root", `\\?\UNC\server\share`, `\\?\UNC\server\share`, windowsSep, true},
+		// Extended-length drive spelling. VolumeName(`\\?\C:`) is the whole
+		// string (the stdlib's own volumenametests pins `\\?\x` → `\\?\x`), so
+		// both the bare and trailing-separator forms are volume roots.
+		//
+		// NOT asserted here: `\\?\UNC\host\share`. The `\\.\UNC` special case
+		// in volumeNameLen keys on the `.` form, so the `?` form falls to the
+		// generic `\\?` branch and the volume is `\\?\UNC` rather than the
+		// share — which would make `\\?\UNC\host\share` a path UNDER a volume,
+		// not a root. That is a claim about stdlib behaviour this file cannot
+		// verify (it is not in the stdlib's own test table either), and the
+		// whole point of RR-S2X70O is that unverified transcriptions pass green
+		// while being wrong. Left out rather than guessed.
 		{"extended drive volume", `\\?\C:`, `\\?\C:`, windowsSep, true},
 		{"extended drive root", `\\?\C:`, `\\?\C:\`, windowsSep, true},
 

--- a/internal/git/clone_windows_test.go
+++ b/internal/git/clone_windows_test.go
@@ -22,7 +22,7 @@ import (
 // the input and feeds the result straight through, so it cannot inherit a
 // mistaken belief about Clean. It does not run on Linux CI, so it is not a
 // replacement for the table — it is what stops the table drifting from reality
-// the next time Clean's behaviour moves, and what a maintainer on Windows can
+// the next time Clean's behavior moves, and what a maintainer on Windows can
 // run to check the claim directly.
 //
 // `\\?\UNC\host\share` is deliberately absent. volumeNameLen's `\\.\UNC`

--- a/internal/git/clone_windows_test.go
+++ b/internal/git/clone_windows_test.go
@@ -1,0 +1,82 @@
+//go:build windows
+
+package git
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestIsFilesystemRoot_RealWindowsPaths asks the real Windows filepath for the
+// values isFilesystemRoot compares, instead of asserting on its behalf.
+//
+// TestIsFilesystemRoot (clone_test.go) hand-transcribes what filepath.Clean is
+// believed to return for each Windows path, because Linux CI cannot produce
+// those values. That is the only way to exercise the branch there, and it has a
+// known failure mode: a wrong transcription passes green over a string Windows
+// never emits. It did — the first version of that table gave `\\server\share`
+// a trailing separator that Clean does not add, so the spelling that actually
+// occurs went unguarded (RR-Q73HKS).
+//
+// This file is the counterweight. It never spells out a cleaned form; it Cleans
+// the input and feeds the result straight through, so it cannot inherit a
+// mistaken belief about Clean. It does not run on Linux CI, so it is not a
+// replacement for the table — it is what stops the table drifting from reality
+// the next time Clean's behaviour moves, and what a maintainer on Windows can
+// run to check the claim directly.
+func TestIsFilesystemRoot_RealWindowsPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"drive root", `C:\`, true},
+		{"drive root lowercase", `c:\`, true},
+		{"drive root via traversal", `C:\Users\..`, true},
+		{"directory on drive", `C:\Users`, false},
+		{"nested directory on drive", `C:\Users\dev\clones`, false},
+		{"drive relative", `C:foo`, false},
+
+		// The bare UNC volume: the form Clean leaves without a trailing
+		// separator, and the one the Linux table originally got wrong.
+		{"unc share root bare", `\\server\share`, true},
+		{"unc share root trailing separator", `\\server\share\`, true},
+		{"directory on share", `\\server\share\repos`, false},
+
+		{"extended drive root", `\\?\C:\`, true},
+		{"extended unc share root", `\\?\UNC\server\share`, true},
+		{"directory under extended drive", `\\?\C:\Users`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned := filepath.Clean(tt.path)
+			volume := filepath.VolumeName(cleaned)
+			got := isFilesystemRoot(volume, cleaned, filepath.Separator)
+			if got != tt.want {
+				t.Errorf("isFilesystemRoot(%q, %q, %q) = %v, want %v (from input %q)",
+					volume, cleaned, string(filepath.Separator), got, tt.want, tt.path)
+			}
+		})
+	}
+}
+
+// containedPath must refuse a real Windows root outright, rather than accepting
+// it and letting filepath.Rel report every path on the volume as contained.
+//
+// This is the end-to-end half: TestIsFilesystemRoot_RealWindowsPaths proves the
+// predicate is right about real Windows values, and this proves containedPath
+// still consults it. On Linux the equivalent wiring is covered by
+// TestContainedPath_RejectsRootBase.
+func TestContainedPath_RejectsWindowsRootBases(t *testing.T) {
+	bases := []string{`C:\`, `\\server\share`, `\\server\share\`}
+
+	for _, base := range bases {
+		t.Run(base, func(t *testing.T) {
+			_, err := containedPath(base, filepath.Join(base, "repo"))
+			if err == nil {
+				t.Fatalf("containedPath(%q, ...) = nil error, want the root-base rejection", base)
+			}
+		})
+	}
+}

--- a/internal/git/clone_windows_test.go
+++ b/internal/git/clone_windows_test.go
@@ -24,6 +24,13 @@ import (
 // replacement for the table — it is what stops the table drifting from reality
 // the next time Clean's behaviour moves, and what a maintainer on Windows can
 // run to check the claim directly.
+//
+// `\\?\UNC\host\share` is deliberately absent. volumeNameLen's `\\.\UNC`
+// special case keys on the `.` form, so the `?` form takes the generic `\\?`
+// branch and its volume is `\\?\UNC` — making the share a path under a volume
+// rather than a root. Neither this file nor the stdlib's own volumenametests
+// pins that, so asserting either answer would be the same unverified guess the
+// bare-UNC row already cost us once.
 func TestIsFilesystemRoot_RealWindowsPaths(t *testing.T) {
 	tests := []struct {
 		name string
@@ -44,7 +51,7 @@ func TestIsFilesystemRoot_RealWindowsPaths(t *testing.T) {
 		{"directory on share", `\\server\share\repos`, false},
 
 		{"extended drive root", `\\?\C:\`, true},
-		{"extended unc share root", `\\?\UNC\server\share`, true},
+		{"extended drive volume", `\\?\C:`, true},
 		{"directory under extended drive", `\\?\C:\Users`, false},
 	}
 

--- a/tickets/entities/docs-checklists/DOCS-ZFWTD6.md
+++ b/tickets/entities/docs-checklists/DOCS-ZFWTD6.md
@@ -1,0 +1,95 @@
+---
+id: DOCS-ZFWTD6
+type: docs-checklist
+title: 'Docs: Root-base guard misses the Windows drive root'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+- [x] Function/type docs if public API
+
+The godoc is a real deliverable here, because the code it describes looks wrong
+on the only platform most contributors will ever run it on. On Linux,
+`filepath.VolumeName` returns `""` unconditionally, so `isFilesystemRoot`'s
+`volumeName` term reads as concatenating nothing — an obvious simplification
+target, and deleting it silently restores the exact fail-open this ticket closes.
+The doc comment therefore states the two facts a person needs before touching it:
+that `VolumeName` is `""` only on non-Windows platforms, and that on Windows the
+same expression catches a drive root and a UNC share root.
+
+It also records why the function takes three parameters instead of reading
+`filepath.VolumeName` and `filepath.Separator` itself, which is the other thing
+that reads as needless indirection. All three values are platform-dependent, and
+a Linux test cannot obtain the Windows ones from its own `filepath` — so the
+parameters are what let CI execute the Windows comparison at all. Without that
+note the natural "tidy-up" is to inline them, which would leave the Windows
+branch permanently untested while the suite stayed green.
+
+The test carries the same argument from the other side. `TestIsFilesystemRoot`'s
+comment explains why the table supplies `(volume, cleaned, separator)` triples
+rather than calling `containedPath("C:\\", ...)`: on Linux that call never enters
+the branch under test — `C:\` is just a relative filename there — so it would
+report coverage it does not have. The comment also records that the Windows
+values are derived from the stdlib's `volumeNameLen` and `Clean`, not invented,
+because a reader has no other way to check that the table models Windows
+faithfully.
+
+Two further comments carry real load, and both were written because review found
+the thing they warn about.
+
+`clone_windows_test.go` opens by saying why it exists at all, given that it never
+runs on CI. A build-tagged test file that the pipeline skips looks like dead
+weight, and the reason it is not — the Linux table hand-transcribes what `Clean`
+is believed to return, and got `\\server\share` wrong exactly that way — is not
+recoverable from the code. The comment names the incident so the file's value is
+legible to someone deciding whether to delete it.
+
+And where `TestContainedPath_UsesIsFilesystemRoot` used to be, there is now a
+comment saying why no Linux wiring test exists: any such test can only reach the
+predicate through `/`, where the old and new checks agree, so it would pass
+against the unfixed code while reading as a guarantee. Documenting a deliberate
+absence matters more than usual here, because writing that test is the obvious
+next move and it looks like an improvement.
+
+## Project Documentation
+
+- [x] ~~README updated (if applicable)~~ (N/A: no project-level change — no new
+command, flag, dependency or supported platform; the Windows MSI already shipped)
+- [x] ~~CLAUDE.md updated (if new patterns)~~ (N/A: no new pattern. It makes an
+existing containment boundary hold on a platform where it did not, and the
+`storage.RootedFS` threat model it follows is already documented there)
+- [x] ~~Help text accurate (if CLI changes)~~ (N/A: `internal/git` is reached
+from the desktop clone flow, not from any CLI command; no help text mentions it)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no user-observable change. Every base an
+operator can realistically configure behaves identically before and after — the
+desktop caller derives its base from `os.UserHomeDir`, which is never a volume
+root. A changelog line would describe a behaviour change users cannot observe)
+- [x] ~~API docs updated (if applicable)~~ (N/A: `internal/git` is internal by
+construction and has no published API surface)
+
+## Rationale for N/A
+
+Nothing an operator or user configures, invokes or sees changes. The one in-tree
+caller (`cmd/rela-desktop/main.go`) passes a home-directory-derived base on every
+platform, so no existing path behaves differently.
+
+What changes is the failure mode for a base that a future caller, a future config
+default, or a hand-edited setting could supply: on Windows, `C:\` used to be
+accepted as a base and silently made the containment check unconditional, and now
+it is refused with the same error `/` already produced. The audience for that is a
+maintainer reading the godoc, not a user reading `docs/` — which is why the whole
+documentation effort went into the comments.
+
+One thing is deliberately NOT written down anywhere user-facing: the concrete
+exploitation path (that `storeCredentials` drops a plaintext OAuth token under the
+clone path, so a defeated containment check is a credential disclosure). It stays
+in the godoc, where a maintainer needs it to understand why the guard cannot be
+relaxed. Publishing it in a guide would hand over the recipe for no operator
+benefit. Same call as DOCS-NDCQA6 made for #1496, and for the same reason.

--- a/tickets/entities/implementation-checklists/IMPL-33H5RI.md
+++ b/tickets/entities/implementation-checklists/IMPL-33H5RI.md
@@ -118,10 +118,11 @@ pre-fix code was right on Unix.
 Reddened `TestContainedPath_RejectsRootBase`. This is the mutation a predicate
 table alone cannot catch: a correct predicate that nothing calls.
 3. *Bare-volume clause disabled* — `if false && volumeName != "" && ...`
-(clone.go:194). Reddened exactly `unc share root bare volume`,
-`extended unc share root` and `extended drive volume`, and nothing else. This is
-the mutation that pins RR-0DTTMS: before that fix, all three of those rows were
-the failing state of real code.
+(clone.go:194). Reddened exactly `unc share root bare volume` and
+`extended drive volume`, and nothing else. This is the mutation that pins
+RR-0DTTMS: before that fix, both rows were the failing state of real code.
+Re-run after the RR-IX0Q97 row removal, to confirm the narrowed table had not
+lost its grip on the fix — it had not.
 4. *Non-empty-volume guard dropped* — `if cleanedPath == volumeName`
 (clone.go:194). Reddened `empty path no volume`
 (`isFilesystemRoot("", "", "/") = true, want false`). This is the over-refusal

--- a/tickets/entities/implementation-checklists/IMPL-33H5RI.md
+++ b/tickets/entities/implementation-checklists/IMPL-33H5RI.md
@@ -1,0 +1,162 @@
+---
+id: IMPL-33H5RI
+type: implementation-checklist
+title: 'Implementation: Root-base guard misses the Windows drive root'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+The change is one predicate plus its seam:
+
+```go
+if isFilesystemRoot(filepath.VolumeName(absBase), absBase, filepath.Separator) {
+    return "", errors.New("clone base directory must not be the filesystem root")
+}
+
+func isFilesystemRoot(volumeName, cleanedPath string, separator rune) bool {
+    if volumeName != "" && cleanedPath == volumeName {
+        return true
+    }
+    return cleanedPath == volumeName+string(separator)
+}
+```
+
+The second clause was NOT in the plan and was added in review (RR-0DTTMS). The
+plan assumed `Clean` always leaves a trailing separator on a root; it does not
+when the whole path is the volume (`\\server\share`, `\\?\C:`), and `Rel` then
+treats that base as absolute — so the share root was still accepted. See the
+mutation notes below.
+
+The error text is unchanged, so the pre-existing `TestContainedPath_RejectsRootBase`
+assertion on "filesystem root" still holds — deliberate: a Windows drive root IS
+the filesystem root of its volume, and inventing a second message would fork the
+caller's error handling for no distinction that matters.
+
+**Deviation from plan.** `separator` was added as a third parameter during
+implementation. The plan had the predicate read `filepath.Separator` itself, and
+the first test run showed why that fails: `filepath.Separator` is a build
+constant, so on Linux `isFilesystemRoot("C:", "C:\\")` compared `C:\` against
+`C:/`. Recorded in PLAN-5TC5UQ under Technical Approach, because the wrong shape
+was the plausible one and a later reader will consider "simplifying" back to it.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+`TestIsFilesystemRoot` is a table over `(volume, cleaned, separator, want)`; each
+row carries only those four, and the failure message interpolates the row's own
+values rather than a literal. `windowsSep`/`unixSep` are named constants so a row
+declares which platform it models instead of repeating an opaque `'\\'`.
+
+`clone_windows_test.go` (`//go:build windows`) is the deliberate opposite of the
+table: it never writes a cleaned form, it Cleans the input and passes the result
+through. That is the point — it cannot inherit a mistaken belief about `Clean`,
+which is exactly what the table did for `\\server\share` (RR-0DTTMS). It does not
+run on Linux CI, so it does not replace the table; the two are complementary and
+both files say so in their comments.
+
+A test was also REMOVED. `TestContainedPath_UsesIsFilesystemRoot` walked
+`filepath.Dir` up to the root and asserted `containedPath` rejects it, but on
+Linux that root is always `/` — the one case where the old and new checks agree
+— so it passed identically against unfixed code (RR-T1XVAX). A comment now sits
+in its place explaining why no such Linux test exists, since writing it is the
+obvious next move for the next person.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+*Stdlib claims verified before relying on them.* A scratch program on the host
+confirmed `filepath.VolumeName` returns `""` for `/`, `/etc`, `C:\` and
+`\\server\share` on darwin, and `internal/filepathlite/path_unix.go` defines
+`volumeNameLen` as constant 0. The Windows `Clean` behaviour (volume copied
+verbatim, trailing separator retained for `C:\` and `\\host\share\`) was read
+from `internal/filepathlite/path.go` and `path_windows.go`. So the table's
+Windows rows are derived, not imagined, and "the volume-aware form subsumes the
+Unix one" is checked rather than assumed.
+
+*Acceptance criteria.* AC1 (drive root) → rows `windows drive root`,
+`windows drive root lowercase`, plus `extended drive volume` / `extended drive
+root`. AC2 (UNC share root) → rows `unc share root trailing separator` AND
+`unc share root bare volume`; the second is the spelling `Clean` actually
+produces and the first implementation missed it (RR-0DTTMS). AC3 (Unix
+preserved, by the same predicate) → row `unix root` plus the unmodified
+`TestContainedPath_RejectsRootBase`. AC4 (no over-refusal) → the six `false`
+rows — including `windows drive relative` (`C:foo`) and `empty path no volume`,
+which are what stop the new bare-volume clause over-reaching — plus the
+unmodified `TestClone_AllowsPathInsideBaseDir`. AC5 → whole `internal/git` suite
+green with `-count=1`.
+
+*Mutation testing.* Four mutations, each verified to have landed in EXECUTABLE
+code by re-reading the mutated line and its line number before running — a
+mutation that lands in a comment leaves the suite green and proves nothing.
+
+1. *Volume term dropped* — `return cleanedPath == string(separator)`
+(clone.go:183). Reddened exactly three subtests:
+`isFilesystemRoot("C:", "C:\\", "\\") = false, want true`, the lowercase drive
+variant, and the UNC form. Every Unix row and every pre-existing test stayed
+green — the correct signal, since this mutation IS the pre-fix code and the
+pre-fix code was right on Unix.
+2. *Call site disabled* — `if false && isFilesystemRoot(...)` (clone.go:144).
+Reddened `TestContainedPath_RejectsRootBase`. This is the mutation a predicate
+table alone cannot catch: a correct predicate that nothing calls.
+3. *Bare-volume clause disabled* — `if false && volumeName != "" && ...`
+(clone.go:194). Reddened exactly `unc share root bare volume`,
+`extended unc share root` and `extended drive volume`, and nothing else. This is
+the mutation that pins RR-0DTTMS: before that fix, all three of those rows were
+the failing state of real code.
+4. *Non-empty-volume guard dropped* — `if cleanedPath == volumeName`
+(clone.go:194). Reddened `empty path no volume`
+(`isFilesystemRoot("", "", "/") = true, want false`). This is the over-refusal
+direction, and it is the one that proves the fix narrows only to genuine roots
+rather than becoming a blanket refusal. Without a negative row it would have
+passed silently.
+
+All restored from pre-mutation copies; `go test -count=1 ./internal/git/...`
+green afterwards.
+
+*Cross-compilation.* `GOOS=windows go vet ./internal/git/` passes, so
+`clone_windows_test.go` stays compiling on CI even though Linux never runs it.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+The extraction is the one place this could have been over-engineered. It earns
+its keep for a reason other than tidiness: it is the only way to execute the
+Windows comparison on the runner CI actually uses. A predicate inlined at the
+call site would be untestable there, and the alternative — adding a Windows CI
+job — is disproportionate to a one-expression fix.
+
+`string(filepath.Separator)` still appears in `containedPath`'s `..` prefix check
+below the guard. Deliberately not folded together: that one is about the
+separator *inside* a relative path, a different question from "is this the volume
+root", and merging them would couple two checks that only look alike.
+
+Security: the change strictly narrows what is accepted, so it cannot admit a base
+that was previously refused. The AC4 negative rows are what pin that it narrows
+only to roots.

--- a/tickets/entities/planning-checklists/PLAN-5TC5UQ.md
+++ b/tickets/entities/planning-checklists/PLAN-5TC5UQ.md
@@ -1,0 +1,333 @@
+---
+id: PLAN-5TC5UQ
+type: planning-checklist
+title: 'Planning: Root-base guard misses the Windows drive root'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `containedPath` refuses a Windows drive root (`C:\`) and UNC share root
+(`\\server\share\`) as a clone base, using ONE expression that is also correct
+on Unix rather than a platform special case bolted beside the existing check.
+
+OUT, with reasons:
+
+- *Symlink resolution.* Unchanged from TKT-S2SFTG: `containedPath` is
+deliberately string-level (Clean + Rel), matching `storage.RootedFS`'s threat
+model. Widening that is a different ticket.
+- *Windows path normalisation beyond `Clean`* — short (8.3) names, case folding,
+`\\?\` extended-length rewriting. `filepath.VolumeName` already treats `\\?\C:\`
+as a volume, so its root is refused; going further would need a Windows runner to
+verify and cannot be honestly tested on Linux CI. Claiming it without testing it
+is exactly the failure mode this ticket is fixing.
+
+**Acceptance Criteria:**
+
+1. A Windows drive root is refused as a base.
+*Test:* the root predicate returns true for `("C:", "C:\")`. Must be exercised
+ON LINUX CI — see the Test Plan; a test that calls `containedPath("C:\\", ...)`
+on Linux proves nothing, because Linux `filepath` sees `C:\` as an ordinary
+relative filename.
+2. A UNC share root is refused as a base, in BOTH spellings.
+*Test:* the predicate returns true for `("\\\\server\\share", "\\\\server\\share\\")`
+and for `("\\\\server\\share", "\\\\server\\share")`. **The second was missing
+from this plan** and added after review (RR-0DTTMS) — it is the form
+`filepath.Clean` actually returns, and the first implementation accepted it,
+leaving the fail-open open for shares.
+3. The Unix root refusal from #1496 is preserved, and preserved BY THE SAME
+expression rather than by a leftover branch.
+*Test:* the existing `TestContainedPath_RejectsRootBase` still passes unmodified,
+plus a predicate-table row `("", "/")` → true.
+4. Non-root bases are still accepted — the fix must not turn the guard into a
+blanket refusal.
+*Test:* predicate rows for `("C:", "C:\Users\dev")`, `("\\\\srv\\share", "\\\\srv\\share\\repos")`
+and `("", "/home/dev")` all return false, and the existing
+`TestClone_AllowsPathInsideBaseDir` still passes.
+5. Every existing containment behaviour is unchanged.
+*Test:* the whole pre-existing `internal/git` suite passes unmodified.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — a one-expression change.
+
+**Existing Solutions:**
+
+- No library needed. `path/filepath` already exposes everything required:
+`VolumeName` returns the leading volume (`C:` for a drive path,
+`\\host\share` for UNC) on Windows and **`""` on every other platform**.
+- That last fact was VERIFIED, not assumed: `internal/filepathlite/path_unix.go`
+defines `volumeNameLen` as a constant `0`, and a scratch program on darwin
+confirmed `VolumeName` is `""` for `/`, `/etc`, `C:\` and `\\server\share`
+alike. So `VolumeName(b)+string(Separator) == b` degenerates on Unix to
+`""+"/" == b`, i.e. exactly the `b == "/"` check #1496 wrote. The volume-aware
+form SUBSUMES the existing one; it does not merely sit next to it.
+- The `Clean` half was verified against the stdlib too
+(`internal/filepathlite/path.go`): on Windows `Clean("C:\\")` keeps the trailing
+separator (volume is copied verbatim, the rooted remainder cleans to `\`), and
+`Clean("\\\\server\\share\\")` likewise. So the compared forms genuinely occur
+after the `Clean` that `containedPath` already performs.
+- In-repo prior art for path containment is `storage.RootedFS`, already cited by
+`containedPath`'s comment. This ticket does not change that model.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Extract the predicate into a tiny pure function that takes the values it
+compares:
+
+```go
+func isFilesystemRoot(volumeName, cleanedPath string, separator rune) bool {
+    return cleanedPath == volumeName+string(separator)
+}
+```
+
+called as
+`isFilesystemRoot(filepath.VolumeName(absBase), absBase, filepath.Separator)`.
+
+Extraction is not decoration — it is what makes the Windows branch TESTABLE on a
+Linux runner (see Test Plan). The parameters are the seam: a test supplies the
+triple a Windows `filepath` would have produced, without needing a Windows
+filesystem.
+
+**Correction made during implementation.** The plan first took only
+`(volumeName, cleanedPath)` and read `filepath.Separator` internally. That was
+wrong, and the test caught it immediately: `filepath.Separator` is a
+build-constant, `/` on Linux, so `isFilesystemRoot("C:", "C:\\")` compared
+`C:\` against `C:/` and returned false. Two of the three values the predicate
+compares are platform-dependent, not one — so a seam that parameterises only one
+of them still cannot express the Windows case, and the "Windows" rows would have
+had to be written with a Unix separator to pass, i.e. testing a string that
+Windows never produces. Passing the separator too is what makes the extraction
+honest rather than merely present. Worth recording because the first shape LOOKED
+sufficient and would have been kept had the table not been written first.
+
+**Alternatives considered:**
+
+- *Add a second `||` clause beside the existing check* (`absBase == sep ||
+filepath.VolumeName(absBase)+sep == absBase`). Rejected: the first clause becomes
+dead once the second exists on Unix, so the code would carry a redundant branch
+that reads as though it handles a case the other does not. The issue explicitly
+suggested "in addition to"; the stronger answer, once `VolumeName == ""` on Unix
+is verified rather than assumed, is one expression that is correct everywhere.
+- *`runtime.GOOS == "windows"` special case.* Rejected: it hard-codes at runtime
+what the build already decided, cannot be exercised on the other platform's CI,
+and would need its own dead branch on Linux.
+- *Compare against `filepath.Separator` and `os.PathSeparator` both.* Rejected —
+they are the same constant; it addresses nothing.
+- *Leave it and document Windows as unsupported for clone.* Rejected: the MSI is
+shipped (`.github/workflows/release.yml`, `os_name: windows`), so the platform is
+supported in fact.
+
+**Files to modify:**
+
+- `internal/git/clone.go`
+- `internal/git/clone_test.go`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- `BaseDir` is caller/operator-supplied and mandatory since TKT-S2SFTG. This
+ticket adds the second half of "and it must actually constrain something": a base
+that contains the entire volume constrains nothing.
+- `Path` is caller-supplied and its final segment can derive from a
+remote-controlled URL (`ExtractRepoName`). Unchanged.
+- The base check is a refusal of one degenerate value, evaluated on the CLEANED
+absolute form so that `C:\`, `C:\.`, `C:\foo\..` all reduce to the same question.
+The containment check it protects remains an allowlist (one subtree via
+`filepath.Rel`), not a blocklist of bad substrings.
+
+**Security-Sensitive Operations:**
+
+`storeCredentials` writes a plaintext OAuth token to `<Path>/.git/credentials`.
+That is what makes a defeated containment check a credential disclosure rather
+than a misplaced directory, and it is why the guard has to hold on every platform
+the binary ships to, not just the one the tests happen to run on.
+
+The error names the base directory, which the caller supplied — no disclosure.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+The load-bearing design decision here is *how to get real coverage of the Windows
+branch on a Linux runner*. The naive test — `containedPath("C:\\", "C:\\x")` on
+Linux — proves NOTHING: Linux `filepath` treats `C:\` as an ordinary relative
+filename with no volume, so `Abs` prefixes the CWD and the assertion passes or
+fails for reasons that have nothing to do with Windows. A test like that is worse
+than no test, because it reports coverage of a branch it never entered.
+
+So the predicate is extracted to take `(volumeName, cleanedPath)` as plain
+strings, and a table test feeds it the pairs a **Windows** `filepath` would
+produce. Those pairs are not invented: each is justified above from the stdlib
+source (`volumeNameLen` for the volume, `Clean` for the trailing separator). The
+predicate is total and platform-independent — string equality — so a Linux run
+exercises precisely the code a Windows run would.
+
+Table rows, each mapping to an acceptance criterion:
+
+| volume | cleaned base | root? | AC |
+|---|---|---|---|
+| `""` | `/` | yes | 3 |
+| `""` | `/home/dev` | no | 4 |
+| `C:` | `C:\` | yes | 1 |
+| `C:` | `C:\Users\dev` | no | 4 |
+| `c:` | `c:\` | yes | 1 (lowercase drive letter) |
+| `\\server\share` | `\\server\share\` | yes | 2 |
+| `\\server\share` | `\\server\share` | yes | 2 — **added in review**, RR-0DTTMS |
+| `\\server\share` | `\\server\share\repos` | no | 4 |
+| `\\?\UNC\server\share` | same | yes | 1/2 — **added in review** |
+| `\\?\C:` | same | yes | 1 — **added in review** |
+| `C:` | `C:foo` | no | 4 — **added in review** (drive-relative is not a root) |
+| `""` | `.` | no | 4 (relative base, refused later by Rel, not here) |
+| `""` | `""` | no | 4 — **added in review** (guards the new clause) |
+
+Plus the platform-native end-to-end case kept as-is
+(`TestContainedPath_RejectsRootBase`), so the wiring from `containedPath` into
+the predicate is covered on the runner's own platform (AC3, AC5).
+
+**What this plan got wrong, and the limit of the technique.** The table above
+originally listed `\\server\share\` only. `filepath.Clean` does NOT append a
+trailing separator when the whole path is the volume, so the row asserted a
+string Windows never produces while the spelling that does occur went unguarded
+— and `filepath.Rel` treats that bare base as absolute, so containment passed for
+every path on the share. Found in code review (RR-0DTTMS), fixed by a second
+clause in the predicate.
+
+The general lesson, recorded because the plan reasoned right up to it and
+stopped: parameterising the predicate makes the Windows branch EXECUTE on Linux,
+but every input is still a hand transcription of believed `Clean` behaviour, and
+nothing on Linux can check that belief. Executing a branch with inputs the
+platform cannot produce is coverage without verification. The answer is a
+build-tagged `clone_windows_test.go` that derives its triples from the host
+`filepath` instead of from memory (RR-S2X70O) — it does not run on Linux CI, so
+it complements the table rather than replacing it, but it is what stops the table
+drifting from reality.
+
+**Edge Cases:**
+
+- Lowercase drive letter (`c:`) — Windows accepts it; the predicate is a plain
+comparison so it holds without a case rule.
+- UNC share root vs. a directory under the share (AC2 vs AC4) — the boundary
+where the volume prefix ends is exactly what could be got wrong.
+- Relative base (`.`): NOT a root, and deliberately still rejected further down by
+`filepath.Rel`/`Abs` semantics rather than here. The predicate must not
+over-claim.
+- Empty cleaned path cannot occur — `filepath.Clean("")` is `"."` and
+`containedPath` has already run `Abs`.
+
+**Negative Tests:**
+
+The AC4 rows are the ones that stop the fix over-reaching. A guard that refused
+every base would pass AC1–AC3 and break every real caller; without the negative
+rows the table would not notice.
+
+Mutation check (mandatory before review): revert the predicate body to the
+pre-fix `cleanedPath == string(filepath.Separator)` and confirm that exactly the
+Windows/UNC root rows redden with a message naming the pair, and that the Unix
+rows stay green. Verify the mutation landed in executable code and not in a
+comment — a suite that stays green after a "mutation" has only proved the
+mutation missed.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *A test that appears to cover Windows but does not.* This was correctly named
+as the primary risk — and the mitigation named here was INSUFFICIENT, which is
+the most useful thing in this document. Taking the values as parameters and
+mutation-testing them does prove the branch executes. It does not prove the
+inputs are ones Windows can produce, and they were not: the `\\server\share` row
+asserted a `Clean` output that does not exist (RR-0DTTMS), passing green over a
+case that cannot occur while the real case went unguarded. "Verifying nothing"
+has two failure modes — a branch that never runs, and a branch that runs on
+fiction — and this plan only defended against the first. Now also mitigated by
+`clone_windows_test.go`, which derives its inputs from the host `filepath`
+(RR-S2X70O).
+
+- *Writing a test that cannot distinguish the fix from the bug.* MISSED in
+planning, found in review (RR-T1XVAX). `TestContainedPath_UsesIsFilesystemRoot`
+was added to pin the wiring, but on Linux it can only reach the predicate
+through `/`, where old and new checks agree — so it passed identically against
+unfixed code while reading as a guarantee. The check to apply to any new test on
+a security fix is not "does it pass" but "does it fail against the code I am
+replacing"; mutation testing asks exactly that, and this test was written after
+the mutation runs rather than subjected to one.
+- *Asserting `VolumeName` returns `""` on Unix without checking.* Would make the
+"one expression subsumes both" claim load-bearing and unverified. Mitigated by
+reading `internal/filepathlite/path_unix.go` and running a scratch program on the
+host before writing the fix — recorded under Research.
+- *Over-refusal breaking the one real caller.* `cmd/rela-desktop/main.go` derives
+its base from `os.UserHomeDir`, which is never a volume root on any platform.
+Covered by the AC4 negative rows.
+- *A future reader "simplifying" the predicate back to a bare separator
+comparison,* since on a Linux dev machine the volume term always looks like dead
+weight. Mitigated by a comment at the predicate stating that the volume term IS
+the Windows case and is `""` on Unix — the two facts a person needs before
+deleting it — and by the table rows that fail if they do.
+
+**Effort:** xs
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] N/A — `internal/git` is not a public API, no command, flag or configuration
+changes, and no observable behaviour change for any base an operator would
+realistically use. The documentation that matters is the godoc on the predicate,
+which is where the "why the volume term is not dead code on Linux" reasoning
+goes.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** none critical or significant. Two decisions worth
+recording. First, rejecting the "add a second clause" shape the issue text
+suggested, in favour of one subsuming expression — the added clause would leave a
+permanently-dead branch on both platforms. Second, extracting the predicate for
+testability rather than testing through `containedPath` alone: without the seam
+there is no honest way to exercise the Windows case on the runner CI actually
+uses, and the alternative (a Windows CI job) is far more machinery than an
+`xs` fix warrants.

--- a/tickets/entities/review-checklists/REV-9P8DVO.md
+++ b/tickets/entities/review-checklists/REV-9P8DVO.md
@@ -1,0 +1,109 @@
+---
+id: REV-9P8DVO
+type: review-checklist
+title: 'Review: Root-base guard misses the Windows drive root'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just arch-lint`, `just plimsoll` and `just lint-md` also clean.
+
+One comment-lint finding was raised by this diff and FIXED rather than
+suppressed: the godoc wrote `[filepath.Clean]ed`, and the trailing suffix makes
+the doc link unresolvable so godoc renders the brackets literally. Reworded to
+"an absolute p passed through [filepath.Clean]". The rule was right; suppressing
+it would have shipped visibly broken godoc on the one comment this change exists
+to leave behind.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-0DTTMS (critical, addressed), RR-S2X70O (significant,
+addressed), RR-T1XVAX (minor, addressed).
+
+The critical finding was that the first implementation still failed open for UNC
+shares: `filepath.Clean` returns `\\server\share` unchanged (the whole string is
+the volume name, so there is no remainder to root and no separator is appended),
+and the predicate only matched `volume+separator`. `filepath.Rel` then treats
+that bare base as absolute — its own source comment says so — so every path on
+the share was reported contained. Fixed with a second, volume-guarded clause.
+
+Worth stating plainly: the test table had ASSERTED the wrong `Clean` output, so
+it passed green over a string Windows never produces while the string it does
+produce went unguarded. That is the same defect shape as the ticket itself,
+reproduced one level up in the tests. RR-S2X70O is the structural answer.
+
+Diff self-review: three files, all in `internal/git`. No unrelated changes. The
+`tickets/` entities are workflow bookkeeping, not product code.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 (Windows drive root refused) — PASS. `windows drive root`,
+`windows drive root lowercase`, `extended drive volume`, `extended drive root`.
+- AC2 (UNC share root refused) — PASS, after correction. BOTH
+`unc share root trailing separator` and `unc share root bare volume`; the latter
+is the spelling that actually occurs and was added in review.
+- AC3 (Unix refusal preserved by the same predicate) — PASS. Row `unix root`
+plus the unmodified `TestContainedPath_RejectsRootBase`.
+- AC4 (no over-refusal) — PASS. Six negative rows, including `windows drive
+relative` and `empty path no volume`, plus the unmodified
+`TestClone_AllowsPathInsideBaseDir`.
+- AC5 (existing behaviour unchanged) — PASS. Full `internal/git` suite green with
+`-count=1`; no pre-existing test was edited.
+
+Mutation evidence for all of the above is in IMPL-33H5RI: four mutations, each
+confirmed to have landed on a numbered line of executable code before running,
+each reddening a specific and expected subset.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] ~~User-facing documentation updated~~ (N/A: no user-observable change —
+`internal/git` has no published surface, no command or flag changes, and the one
+in-tree caller derives its base from `os.UserHomeDir`, which is never a volume
+root on any platform. Full reasoning in DOCS-ZFWTD6)
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-ZFWTD6
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-checklists/REV-9P8DVO.md
+++ b/tickets/entities/review-checklists/REV-9P8DVO.md
@@ -31,7 +31,7 @@ to leave behind.
 - [x] Self-reviewed the diff for unrelated changes
 
 **Review Responses:** RR-0DTTMS (critical, addressed), RR-S2X70O (significant,
-addressed), RR-T1XVAX (minor, addressed).
+addressed), RR-IX0Q97 (significant, addressed), RR-T1XVAX (minor, addressed).
 
 The critical finding was that the first implementation still failed open for UNC
 shares: `filepath.Clean` returns `\\server\share` unchanged (the whole string is
@@ -45,6 +45,21 @@ it passed green over a string Windows never produces while the string it does
 produce went unguarded. That is the same defect shape as the ticket itself,
 reproduced one level up in the tests. RR-S2X70O is the structural answer.
 
+And then it happened AGAIN, inside the fix for it (RR-IX0Q97): a
+`\\?\UNC\server\share` row was added to both files by pattern-matching from the
+bare-UNC case, without checking `volumeNameLen`. The `\\.\UNC` special case keys
+on the `.` form, so the `?` form yields a volume of `\\?\UNC` and the row would
+have failed on Windows. Caught by re-deriving it from the stdlib rather than by
+any check in the pipeline — the Linux table is self-consistent whatever it
+claims, and the Windows file does not run on CI. Removed rather than corrected,
+since the correct answer is not pinned by the stdlib's own tests either.
+
+The recurrence is the honest finding of this ticket. The technique gets the
+Windows branch executing on Linux; it does not make the inputs true, and there
+is no automated backstop for that on a Linux runner. Every Windows value in
+these tests is only as good as the stdlib reading behind it, and two of them
+were wrong on first writing.
+
 Diff self-review: three files, all in `internal/git`. No unrelated changes. The
 `tickets/` entities are workflow bookkeeping, not product code.
 
@@ -57,6 +72,8 @@ Diff self-review: three files, all in `internal/git`. No unrelated changes. The
 
 - AC1 (Windows drive root refused) — PASS. `windows drive root`,
 `windows drive root lowercase`, `extended drive volume`, `extended drive root`.
+`\\?\UNC` is deliberately unasserted (RR-IX0Q97) — an unverifiable claim is not
+coverage.
 - AC2 (UNC share root refused) — PASS, after correction. BOTH
 `unc share root trailing separator` and `unc share root bare volume`; the latter
 is the spelling that actually occurs and was added in review.

--- a/tickets/entities/review-responses/RR-0DTTMS.md
+++ b/tickets/entities/review-responses/RR-0DTTMS.md
@@ -1,0 +1,74 @@
+---
+id: RR-0DTTMS
+type: review-response
+title: 'Bare UNC volume root missed: Clean does not append a trailing separator'
+finding: |-
+    isFilesystemRoot missed the bare UNC volume `\\server\share`, which is the form
+    filepath.Clean actually returns for that input.
+
+    The predicate compared cleanedPath against volumeName+separator only. For
+    `\\server\share` the ENTIRE string is the volume name (uncLen finds no second
+    separator after the `\\` prefix and returns len(path)), so Clean hits its
+    `path == ""` branch and returns the input unchanged -- with no trailing
+    separator. The comparison was therefore `\\server\share` vs `\\server\share\`,
+    which is false.
+
+    That is a live fail-open, not a theoretical gap: filepath.Rel deliberately
+    treats a bare `\\host\share` base as absolute (its own comment says so), so
+    containedPath accepted the share root and then reported every path on the share
+    as contained -- exactly the condition this ticket exists to close, on the exact
+    platform it is about.
+
+    Worse, the test table ASSERTED the wrong form. Its `unc share root` row supplied
+    `\\server\share\`, a string Windows never produces for that input, so the row
+    passed green over a case that could not occur while the case that does occur
+    went unguarded. Same failure mode as the defect: something shaped like a check
+    that verifies nothing.
+severity: critical
+resolution: |-
+    isFilesystemRoot gained a second clause matching the bare-volume form, guarded
+    on a non-empty volume so it is Windows-only. Verified against the stdlib
+    (uncLen, Clean's empty-remainder branch, Rel's own comment about
+    `\\host\share`) rather than assumed. The wrong table row was corrected and the
+    real form added beside it, plus the extended-length spellings Clean also
+    returns verbatim.
+
+    Mutation-verified: disabling the clause reddens exactly the three bare-volume
+    rows; dropping the non-empty-volume guard reddens the empty-path row.
+status: addressed
+---
+
+## Resolution
+
+`isFilesystemRoot` gained a second clause for the bare-volume form:
+
+```go
+if volumeName != "" && cleanedPath == volumeName {
+    return true
+}
+return cleanedPath == volumeName+string(separator)
+```
+
+The `volumeName != ""` guard confines the new clause to Windows — on Unix
+`VolumeName` is always `""`, and an empty cleaned path must not be called a
+root.
+
+Verified against the stdlib rather than assumed, since assuming is what caused
+the defect. `uncLen` (`internal/filepathlite/path_windows.go:279`) scans for a
+SECOND separator after the `\\` prefix and returns `len(path)` when it finds
+none, so `volumeNameLen("\\\\server\\share")` is the whole string. `Clean` then
+takes its `path == ""` branch and returns the input verbatim — no trailing
+separator appended. And `filepath.Rel` (`path/filepath/path.go:197-200`)
+explicitly rewrites an empty post-volume base to a separator "for any targetpath
+matching `\\host\share`", which is the stdlib confirming in its own comment that
+it treats the bare share as an absolute base. So every path on the share was
+reported contained.
+
+Also covered in the same clause: `\\?\UNC\server\share` and `\\?\C:`, which
+Clean likewise returns verbatim.
+
+Mutation-verified: disabling the new clause reddens exactly the three
+bare-volume rows (`unc share root bare volume`, `extended unc share root`,
+`extended drive volume`) and nothing else. Dropping the `volumeName != ""` guard
+instead reddens `empty path no volume`, which is what pins that the fix narrows
+only to genuine roots.

--- a/tickets/entities/review-responses/RR-IX0Q97.md
+++ b/tickets/entities/review-responses/RR-IX0Q97.md
@@ -1,0 +1,51 @@
+---
+id: RR-IX0Q97
+type: review-response
+title: Extended-length UNC row asserted an unverified VolumeName result
+finding: |-
+    While adding clone_windows_test.go for RR-S2X70O, both test files gained a row
+    claiming `\\?\UNC\server\share` is a volume root. That claim was never checked
+    against the stdlib -- it was pattern-matched from the bare-UNC case.
+
+    It is wrong. volumeNameLen's `\\.\UNC` special case keys on the `.` form
+    (pathHasPrefixFold(path, `\\.\UNC`)), so the `?` form falls through to the
+    generic `\\?` branch, which cuts at the first separator after the 4-byte
+    prefix and yields a volume of `\\?\UNC`. The share would therefore be a path
+    UNDER a volume, not a root, and the row in clone_windows_test.go -- the file
+    that derives values from the real filepath -- would have FAILED on Windows.
+
+    The irony is the point: this is the exact defect RR-S2X70O had just been raised
+    about, committed in the fix for it. The Linux table cannot catch it (it supplies
+    the volume itself, so it is self-consistent whatever it says) and the Windows
+    file that could catch it does not run on CI. Nothing in the pipeline would have
+    reported this.
+severity: significant
+resolution: |-
+    The `\\?\UNC` row was REMOVED from both files rather than corrected, and each
+    file now carries a comment saying why it is absent: the behaviour is not pinned
+    by the stdlib's own volumenametests either, so asserting either answer would be
+    another unverified guess.
+
+    Removing beats guessing here. A wrong assertion in the Windows file is a test
+    that fails on the only platform it runs on; a wrong assertion in the Linux
+    table is a green test that means nothing. Neither is better than silence about
+    a form no caller uses.
+
+    `\\?\C:` (bare and with trailing separator) is kept, because the stdlib's
+    volumenametests DOES pin the generic branch: `\\?\x` maps to `\\?\x`. Verified
+    claims stay, guessed ones go.
+status: addressed
+---
+
+## Resolution
+
+Removed the `\\?\UNC\server\share` row from `clone_test.go` and
+`clone_windows_test.go`, replacing it in each with a comment recording why the
+case is deliberately unasserted.
+
+Kept `\\?\C:` in both, since the stdlib's own `volumenametests` pins the generic
+`\\?` branch (`\\?\x` → `\\?\x`), so that one is verified rather than assumed.
+
+Mutation re-run after the correction: disabling the bare-volume clause still
+reddens `unc share root bare volume` and `extended drive volume`, so the
+narrowed table has not lost its grip on the fix.

--- a/tickets/entities/review-responses/RR-S2X70O.md
+++ b/tickets/entities/review-responses/RR-S2X70O.md
@@ -1,0 +1,46 @@
+---
+id: RR-S2X70O
+type: review-response
+title: Hand-transcribed Windows values can be wrong and still pass green
+finding: |-
+    The parameterised-predicate technique gets the Windows branch EXECUTING on Linux
+    CI, which was the goal, but it does not make the test true. Every input in
+    TestIsFilesystemRoot is a hand transcription of what filepath.Clean and
+    filepath.VolumeName are BELIEVED to return on Windows, and nothing in the
+    package checks that belief. A wrong transcription produces a green test over a
+    string Windows never emits.
+
+    This is not hypothetical: it is exactly how the bare-UNC defect (RR-0DTTMS)
+    survived the first implementation. The table asserted `\\server\share\`, Clean
+    returns `\\server\share`, and the row passed while the real form went unguarded.
+
+    The ticket's own framing invited this. It treated "the branch executes on Linux
+    CI" as the property to achieve, and that property was achieved by a test whose
+    inputs were fiction. Executing a branch with inputs the platform cannot produce
+    is coverage without verification.
+severity: significant
+resolution: |-
+    Added internal/git/clone_windows_test.go (//go:build windows), which never
+    spells out a cleaned form: it Cleans the input and feeds the result straight
+    into the predicate, so it cannot inherit a mistaken belief about Clean. It
+    covers the drive root, both UNC spellings, the extended-length forms,
+    drive-relative C:foo, and the end-to-end containedPath refusal.
+
+    It does NOT run on Linux CI, so it does not replace the table -- the two are
+    deliberately complementary, and both test files say so. The table is what runs
+    on every PR; the Windows file is what stops the table drifting from reality and
+    is runnable by a maintainer on Windows to check the claim directly. GOOS=windows
+    go vet keeps it compiling on CI even though it does not execute there.
+status: addressed
+---
+
+## Resolution
+
+Added `internal/git/clone_windows_test.go` behind `//go:build windows`. It
+derives the `(volume, cleaned, separator)` triple from the host `filepath`
+instead of from memory, so it cannot repeat a transcription error. Both test
+files now document the split: the Linux table is what executes on CI, the
+Windows file is what keeps the table honest.
+
+`GOOS=windows go vet ./internal/git/` passes, so the file stays compiling on CI
+even though it does not run there.

--- a/tickets/entities/review-responses/RR-T1XVAX.md
+++ b/tickets/entities/review-responses/RR-T1XVAX.md
@@ -1,0 +1,43 @@
+---
+id: RR-T1XVAX
+type: review-response
+title: TestContainedPath_UsesIsFilesystemRoot proved nothing the existing test did not
+finding: |-
+    The new wiring test walked filepath.Dir up from t.TempDir() to find the root,
+    then asserted containedPath rejects it. On Linux that root is always "/", which
+    is precisely the case the PRE-EXISTING TestContainedPath_RejectsRootBase already
+    covers -- and the case where the old check (absBase == string(Separator)) and
+    the new one agree exactly.
+
+    So the test passes identically against the unfixed code. It reads as a
+    guarantee that containedPath consults the new predicate, while being incapable
+    of distinguishing the new predicate from the old one. That is the same
+    check-shaped-but-empty pattern this ticket is fixing, reintroduced in the tests
+    that fix it.
+
+    Its extra machinery (the Dir walk, the setup self-assertion) also implied it was
+    reaching somewhere the simpler test could not, which was not true on the
+    platform CI runs.
+severity: minor
+resolution: |-
+    Removed, and replaced with a comment at the same location saying why no such
+    Linux test exists -- otherwise the obvious next move is to write it again.
+
+    The wiring is covered where it can actually be distinguished:
+    TestContainedPath_RejectsRootBase for "/" (unchanged, and mutation-verified: a
+    disabled call site reddens it), and TestContainedPath_RejectsWindowsRootBases in
+    clone_windows_test.go for the roots that separate old behaviour from new.
+status: addressed
+---
+
+## Resolution
+
+Removed the test. A comment now sits where it was, recording that any Linux test
+of this wiring can only reach the predicate through `"/"` — where the old and
+new checks agree — so it would be evidence of nothing while looking like a
+guarantee.
+
+Coverage of the wiring lives in two places that can tell the implementations
+apart: `TestContainedPath_RejectsRootBase` for the Unix root (mutation-verified —
+disabling the call site reddens it), and `TestContainedPath_RejectsWindowsRootBases`
+in the build-tagged Windows file for the drive and share roots.

--- a/tickets/entities/tickets/TKT-T7G7LT.md
+++ b/tickets/entities/tickets/TKT-T7G7LT.md
@@ -1,0 +1,79 @@
+---
+id: TKT-T7G7LT
+type: ticket
+title: Root-base guard misses the Windows drive root
+kind: refactor
+priority: medium
+effort: xs
+status: done
+---
+
+## Description
+
+The root-base guard in `containedPath()` (`internal/git/clone.go`, added by PR
+#1496 / TKT-S2SFTG) compares the cleaned base directory against the Unix form of
+the separator only:
+
+```go
+if absBase == string(filepath.Separator) {
+    return "", errors.New("clone base directory must not be the filesystem root")
+}
+```
+
+A Windows drive root (`C:\` after `filepath.Clean`) is therefore not recognised
+as a root. `rela-desktop` ships as a Windows MSI
+(`.github/workflows/release.yml`, `os_name: windows`), so on that supported
+platform exactly the scenario PR #1496 set out to close remains open: a root
+base that makes the containment check pass unconditionally while appearing to
+have verified something.
+
+GitHub issue #1498. Source: IB-review of rela#1496.
+
+**Violated requirement**: POLICY-015 §3 (Secure by Design) — security is
+considered from the first phase of development (shift-left), and OWASP Top 10
+risks are structurally addressed.
+
+## Why it matters
+
+The root-base guard is not decoration. `containedPath` is the boundary that
+stops a caller-supplied `Path` — whose final segment can derive from a
+remote-controlled URL via `ExtractRepoName` — from escaping the directory the
+operator chose. `storeCredentials` then writes a plaintext OAuth token into
+`<Path>/.git/credentials`, so a defeated containment check is a credential
+disclosure, not merely a misplaced directory.
+
+With `BaseDir = "C:\"` on Windows, `filepath.Rel` succeeds for every absolute
+path on that drive and never yields a `..` prefix, so the containment check
+returns "contained" for `C:\Windows\System32`, `C:\Users\victim`, anything. The
+guard reads as present and does nothing — the identical silent-no-op shape that
+the empty-base and Unix-root cases were both refused for.
+
+Severity is low in the same sense #1496's was: the one in-tree caller
+(`cmd/rela-desktop/main.go`) derives its base from `os.UserHomeDir`, which is
+never a drive root. The defect is that the boundary's guarantee is
+platform-dependent, which is precisely what a shift-left requirement is about.
+
+## Scope
+
+IN: recognise every Windows volume root as an invalid base — the drive root
+(`C:\`), the UNC share root in BOTH spellings (`\\server\share\` and the bare
+`\\server\share`, which is what `filepath.Clean` actually returns), and the
+extended-length forms `\\?\C:` and `\\?\UNC\server\share`. One predicate,
+correct on both platforms, rather than a bolted-on platform special case.
+
+The bare-volume spelling was missed by the first implementation and found in
+code review (RR-0DTTMS): `filepath.Clean` appends no trailing separator when the
+whole path IS the volume, and `filepath.Rel` then treats that base as absolute,
+so the share root was accepted and every path on the share reported contained.
+
+OUT:
+
+- Symlink resolution. `containedPath` stays deliberately string-level (Clean +
+Rel), matching `storage.RootedFS`'s threat model. Unchanged from TKT-S2SFTG.
+- Case-insensitive matching and 8.3 short-name expansion on Windows. Those
+change what counts as the SAME path, not what counts as a root, and neither can
+be settled without a Windows runner. A different ticket with a different
+argument.
+- Drive-relative bases (`C:foo`). Not a root — it names a path relative to the
+drive's working directory — and it is refused further down by `Abs`/`Rel` rather
+than here. Pinned negatively so the guard does not over-claim.

--- a/tickets/relations/TKT-T7G7LT--affects--desktop-app.md
+++ b/tickets/relations/TKT-T7G7LT--affects--desktop-app.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: affects
+to: desktop-app
+---

--- a/tickets/relations/TKT-T7G7LT--has-docs--DOCS-ZFWTD6.md
+++ b/tickets/relations/TKT-T7G7LT--has-docs--DOCS-ZFWTD6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-docs
+to: DOCS-ZFWTD6
+---

--- a/tickets/relations/TKT-T7G7LT--has-implementation--IMPL-33H5RI.md
+++ b/tickets/relations/TKT-T7G7LT--has-implementation--IMPL-33H5RI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-implementation
+to: IMPL-33H5RI
+---

--- a/tickets/relations/TKT-T7G7LT--has-planning--PLAN-5TC5UQ.md
+++ b/tickets/relations/TKT-T7G7LT--has-planning--PLAN-5TC5UQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-planning
+to: PLAN-5TC5UQ
+---

--- a/tickets/relations/TKT-T7G7LT--has-review--REV-9P8DVO.md
+++ b/tickets/relations/TKT-T7G7LT--has-review--REV-9P8DVO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-review
+to: REV-9P8DVO
+---

--- a/tickets/relations/TKT-T7G7LT--has-review-response--RR-0DTTMS.md
+++ b/tickets/relations/TKT-T7G7LT--has-review-response--RR-0DTTMS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-review-response
+to: RR-0DTTMS
+---

--- a/tickets/relations/TKT-T7G7LT--has-review-response--RR-IX0Q97.md
+++ b/tickets/relations/TKT-T7G7LT--has-review-response--RR-IX0Q97.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-review-response
+to: RR-IX0Q97
+---

--- a/tickets/relations/TKT-T7G7LT--has-review-response--RR-S2X70O.md
+++ b/tickets/relations/TKT-T7G7LT--has-review-response--RR-S2X70O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-review-response
+to: RR-S2X70O
+---

--- a/tickets/relations/TKT-T7G7LT--has-review-response--RR-T1XVAX.md
+++ b/tickets/relations/TKT-T7G7LT--has-review-response--RR-T1XVAX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: has-review-response
+to: RR-T1XVAX
+---

--- a/tickets/relations/TKT-T7G7LT--implements--FEAT-018.md
+++ b/tickets/relations/TKT-T7G7LT--implements--FEAT-018.md
@@ -1,0 +1,5 @@
+---
+from: TKT-T7G7LT
+relation: implements
+to: FEAT-018
+---


### PR DESCRIPTION
Fixes #1498 (TKT-T7G7LT). IB-review finding on #1496.

## The problem

The root-base guard `containedPath` gained in #1496 compared the cleaned base
against `string(filepath.Separator)` only:

```go
if absBase == string(filepath.Separator) {
```

That recognises the Unix root `/` and nothing else. On Windows a base of `C:\`
or `\\server\share` passed the guard; `filepath.Rel` then succeeded for every
path on that volume and never produced a `..` prefix, so containment returned
"contained" for anything at all. rela-desktop ships as a Windows MSI
(`.github/workflows/release.yml`, `os_name: windows`), so the fail-open #1496
closed was still open on a supported platform — and `storeCredentials` writes a
plaintext OAuth token under the clone path, which is what makes a defeated
containment check a credential disclosure rather than a misplaced directory.

## The fix

One predicate, correct on both platforms:

```go
func isFilesystemRoot(volumeName, cleanedPath string, separator rune) bool {
	if volumeName != "" && cleanedPath == volumeName {
		return true
	}
	return cleanedPath == volumeName+string(separator)
}
```

`filepath.VolumeName` returns `""` on every non-Windows platform (verified:
`internal/filepathlite/path_unix.go` defines `volumeNameLen` as constant `0`),
so on Unix the second clause degenerates to `cleanedPath == "/"` — the original
check, **subsumed rather than duplicated**. The issue suggested adding a clause
"in addition to" the existing one; once the `""` behaviour is checked rather
than assumed, one expression is the stronger answer and leaves no dead branch.

The first clause exists because **`filepath.Clean` does not always leave a
trailing separator on a root**. When the whole path *is* the volume
(`\\server\share`, `\\?\C:`) it returns the input verbatim, and `filepath.Rel`
then treats that base as absolute — its own source says so, rewriting an empty
post-volume base to a separator "for any targetpath matching `\\host\share`". A
bare volume is a root in fact. My first implementation matched only
`volume+separator` and left UNC shares wide open; code review caught it.

## How the Windows branch gets real coverage on Linux CI

This was the interesting part of the ticket, and I got it wrong twice before
getting it right, so the reasoning is worth spelling out.

**The naive test proves nothing.** `containedPath("C:\\", ...)` on Linux never
enters the branch under test: Linux `filepath` sees `C:\` as an ordinary
relative filename with no volume, and `Abs` prefixes it with the CWD. It would
pass or fail for reasons unrelated to Windows.

**Step 1 — parameterise the values.** `isFilesystemRoot` takes
`(volumeName, cleanedPath, separator)` instead of reaching for `filepath`
itself. All three differ per platform (`Separator` is a build constant — my
first attempt passed only the first two and compared `C:\` against `C:/`), so
all three are parameters. A table test then feeds it the triples a Windows
`filepath` would produce, and since the predicate is plain string equality,
evaluating it on Linux is *the same computation* Windows performs.

**Step 2 — the limit of step 1, which bit me.** Parameterising makes the branch
*execute*; it does not make the inputs *true*. Every value in the table is a
hand transcription of believed `Clean` behaviour, and nothing on Linux checks
it. My table asserted `\\server\share\` — a string Windows never produces for
that input — so the row passed green while the form that does occur went
unguarded. Executing a branch with inputs the platform cannot produce is
coverage without verification.

**Step 3 — the counterweight.** `internal/git/clone_windows_test.go`
(`//go:build windows`) never spells out a cleaned form: it `Clean`s the input
and feeds the result straight through, so it cannot inherit a mistaken belief
about `Clean`. It does not run on Linux CI, so it does not replace the table —
the two are complementary and both files say so. `GOOS=windows go vet` keeps it
compiling on CI.

That the same mistake recurred *inside* the fix for it (a `\\?\UNC\host\share`
row added by pattern-matching, which `volumeNameLen` shows is wrong — the
`\\.\UNC` special case keys on the `.` form) is the honest finding here. It was
caught by re-deriving from the stdlib, not by anything in the pipeline. That row
is now removed rather than corrected, since the correct answer is not pinned by
the stdlib's own `volumenametests` either; guessing it again would repeat the
error. `\\?\C:` stays, because `volumenametests` *does* pin the generic branch
(`\\?\x` → `\\?\x`).

## Mutation testing

Four mutations, each confirmed to have landed on a numbered line of executable
code before running — a mutation that lands in a comment leaves the suite green
and proves nothing.

| # | Mutation | Result |
|---|---|---|
| 1 | Volume term dropped: `return cleanedPath == string(separator)` | Exactly the Windows/UNC root rows redden (`isFilesystemRoot("C:", "C:\\", "\\") = false, want true`, …). All Unix rows and every pre-existing test stay green — correct, since this mutation *is* the pre-fix code, which was right on Unix. |
| 2 | Call site disabled (`if false && isFilesystemRoot(...)`) | `TestContainedPath_RejectsRootBase` reddens. The mutation a predicate table alone cannot catch: a correct predicate nothing calls. |
| 3 | Bare-volume clause disabled | Exactly `unc share root bare volume` and `extended drive volume` redden. Pins the review fix; re-run after the row removal to confirm the narrowed table still grips. |
| 4 | `volumeName != ""` guard dropped | `empty path no volume` reddens (`isFilesystemRoot("", "", "/") = true, want false`). The **over-refusal** direction — this is what proves the fix narrows only to genuine roots instead of becoming a blanket refusal. |

All restored from pre-mutation copies; suite green with `-count=1` afterwards.

## A test was removed

`TestContainedPath_UsesIsFilesystemRoot` asserted that `containedPath` consults
the predicate, but on Linux it can only reach it through `/` — the one case
where the old and new checks agree — so it passed identically against unfixed
code while reading as a guarantee. A comment now sits in its place explaining
why no such Linux test exists, because writing it is the obvious next move and
looks like an improvement.

## Gate

`just lint`, `just arch-lint`, `just comment-lint`, `just plimsoll`,
`just lint-md`, `just coverage-check`, `just test` — all green.
`GOOS=windows go vet ./internal/git/` passes.

One comment-lint finding raised by this diff was **fixed, not suppressed**:
`[filepath.Clean]ed` is an unresolvable doc link (godoc renders the brackets
literally), reworded to "passed through [filepath.Clean]".

No `docs/` changes: `internal/git` has no published surface, no command or flag
changes, and the one in-tree caller derives its base from `os.UserHomeDir`,
which is never a volume root. Reasoning recorded in DOCS-ZFWTD6.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
