### PR TITLE
fix(acl): refuse verb keys under role_relations, document the all-verbs gate

### DIFF
--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -22,28 +22,62 @@ restriction on who can create one. **If you use groups in
 `assignments`, you must gate writes to the membership relation**, or
 any user who can create such a relation can grant themselves any role.
 
-The simplest hardening is to require a `member-of:create` permission
+The simplest hardening is to require a `delegate-membership` permission
 on the relation and grant it only to administrative roles:
 
 ```yaml
 role_relations:
   member-of:
-    requires_permission: member-of:create
+    requires_permission: delegate-membership
 
 roles:
   admin:
-    permissions: [member-of:create]
+    permissions: [delegate-membership]
     create: ["*"]
     update: ["*"]
     delete: ["*"]
     read: ["*"]
 ```
 
-With that in place, only principals who hold `member-of:create`
+With that in place, only principals who hold `delegate-membership`
 (directly or via inherited role) can add someone to a group.
 Operators of single-user instances who don't use groups can ignore
 this; the moment you add an `assignments` mapping for a group, this
 is mandatory.
+
+### The gate covers every verb
+
+`requires_permission:` takes one permission name, and it gates **all**
+write verbs on the relation — create, update and delete alike. There is
+no `create:`/`update:`/`delete:` form here, and that is deliberate: the
+escalation this gate stops is a *create*
+(`alice --member-of--> admins`), so a policy gating only some verbs
+would read as hardened while stopping nothing. Removing a conferred
+edge is an availability attack in its own right, so `delete` is not
+safely left open either. Naming the permission after a verb
+(`member-of:create`) is therefore misleading — prefer
+`delegate-membership`, which says what holding it lets you do.
+
+Writing a verb key under `role_relations:` is refused at load rather
+than ignored, so a policy that reaches for one fails loudly instead of
+booting un-gated:
+
+```console
+$ rela acl audit
+appbuild: load acl.yaml: acl: parse /srv/rela/acl.yaml: role_relations:
+"create" is not supported — `requires_permission:` gates ALL write verbs
+on a role-conferring relation, by design. Per-verb permissions are
+`relation_grants:`, which is refused on a type that confers a role
+```
+
+The policy fails to load at all, so this stops the server rather than
+only the linter — which is the point: an un-gated membership relation
+should not boot.
+
+Per-verb relation permissions do exist — as `relation_grants:`, covered
+in [GUIDE-acl-overview]. They apply only to relation types that do
+**not** confer a role; naming a gated `role_relations:` type there is
+refused, so the two can never disagree about one relation.
 
 If you point `membership_relation:` at a domain-specific relation
 (e.g. `heeft_rol` in a Dutch-language ISMS), the same hardening
@@ -54,7 +88,7 @@ the relation you actually configured:
 membership_relation: heeft_rol
 role_relations:
   heeft_rol:
-    requires_permission: member-of:create
+    requires_permission: delegate-membership
 ```
 
 The `rela acl audit` linter (below) flags an un-gated membership

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -16,28 +16,62 @@ restriction on who can create one. **If you use groups in
 `assignments`, you must gate writes to the membership relation**, or
 any user who can create such a relation can grant themselves any role.
 
-The simplest hardening is to require a `member-of:create` permission
+The simplest hardening is to require a `delegate-membership` permission
 on the relation and grant it only to administrative roles:
 
 ```yaml
 role_relations:
   member-of:
-    requires_permission: member-of:create
+    requires_permission: delegate-membership
 
 roles:
   admin:
-    permissions: [member-of:create]
+    permissions: [delegate-membership]
     create: ["*"]
     update: ["*"]
     delete: ["*"]
     read: ["*"]
 ```
 
-With that in place, only principals who hold `member-of:create`
+With that in place, only principals who hold `delegate-membership`
 (directly or via inherited role) can add someone to a group.
 Operators of single-user instances who don't use groups can ignore
 this; the moment you add an `assignments` mapping for a group, this
 is mandatory.
+
+### The gate covers every verb
+
+`requires_permission:` takes one permission name, and it gates **all**
+write verbs on the relation — create, update and delete alike. There is
+no `create:`/`update:`/`delete:` form here, and that is deliberate: the
+escalation this gate stops is a *create*
+(`alice --member-of--> admins`), so a policy gating only some verbs
+would read as hardened while stopping nothing. Removing a conferred
+edge is an availability attack in its own right, so `delete` is not
+safely left open either. Naming the permission after a verb
+(`member-of:create`) is therefore misleading — prefer
+`delegate-membership`, which says what holding it lets you do.
+
+Writing a verb key under `role_relations:` is refused at load rather
+than ignored, so a policy that reaches for one fails loudly instead of
+booting un-gated:
+
+```console
+$ rela acl audit
+appbuild: load acl.yaml: acl: parse /srv/rela/acl.yaml: role_relations:
+"create" is not supported — `requires_permission:` gates ALL write verbs
+on a role-conferring relation, by design. Per-verb permissions are
+`relation_grants:`, which is refused on a type that confers a role
+```
+
+The policy fails to load at all, so this stops the server rather than
+only the linter — which is the point: an un-gated membership relation
+should not boot.
+
+Per-verb relation permissions do exist — as `relation_grants:`, covered
+in [GUIDE-acl-overview]. They apply only to relation types that do
+**not** confer a role; naming a gated `role_relations:` type there is
+refused, so the two can never disagree about one relation.
 
 If you point `membership_relation:` at a domain-specific relation
 (e.g. `heeft_rol` in a Dutch-language ISMS), the same hardening
@@ -48,7 +82,7 @@ the relation you actually configured:
 membership_relation: heeft_rol
 role_relations:
   heeft_rol:
-    requires_permission: member-of:create
+    requires_permission: delegate-membership
 ```
 
 The `rela acl audit` linter (below) flags an un-gated membership

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -667,9 +667,55 @@ func roleHasAffordanceGrants(role RoleDef) bool {
 // `docs/server-security.md` for the full hardening pattern. The UC1 example
 // policy in features_test.go is intentionally minimal and would be
 // wide-open if copy-pasted into a deployment.
+// # The gate is all-verbs, deliberately
+//
+// [RoleRelationDef.RequiresPermission] is a single permission covering
+// every write verb on the type — there is no per-verb form, and one is
+// not an oversight. The escalation this gate exists to stop is a
+// CREATE (`alice --member-of--> admins`), so a policy that gated only
+// some verbs would read as hardened while stopping nothing; and
+// revoking a conferred edge is an availability attack, so `delete` is
+// not safely un-gated either. Per-verb create/update/delete
+// permissions exist for relation types that do NOT confer roles — see
+// [RelationWriteGrant] (`relation_grants:`), which is refused on any
+// type carrying this gate precisely so the two cannot disagree.
 type RoleRelationDef struct {
 	Confers            string `yaml:"confers"`
 	RequiresPermission string `yaml:"requires_permission"`
+}
+
+// UnmarshalYAML rejects unknown keys rather than silently dropping them.
+// This struct's fields are a closed set, and yaml.v3 ignores anything it
+// cannot map — so `create: add-member` under a `role_relations:` entry
+// would load clean and leave the relation UNGATED, which fails open on
+// the one gate whose whole job is tamper-resistance.
+//
+// The write-verb keys get their own message: an operator reaching for
+// them has a coherent intent (per-verb relation permissions), it is just
+// spelled `relation_grants:` and only applies to relation types that do
+// not confer a role. "unknown key" would read as a typo and hide that.
+func (d *RoleRelationDef) UnmarshalYAML(unmarshal func(any) error) error {
+	var raw map[string]string
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	for _, k := range slices.Sorted(maps.Keys(raw)) {
+		switch k {
+		case "confers", "requires_permission":
+		case "create", "update", "delete", "read":
+			return fmt.Errorf(
+				"role_relations: %q is not supported — `requires_permission:` gates ALL "+
+					"write verbs on a role-conferring relation, by design. Per-verb "+
+					"permissions are `relation_grants:`, which is refused on a type that "+
+					"confers a role", k)
+		default:
+			return fmt.Errorf(
+				"role_relations: unknown key %q (want confers, requires_permission)", k)
+		}
+	}
+	d.Confers = raw["confers"]
+	d.RequiresPermission = raw["requires_permission"]
+	return nil
 }
 
 // knownPolicyKeys is the allowlist used for unknown-key warnings.

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
@@ -405,6 +406,63 @@ func TestLoadPolicy_BlankRoleRelationsKey_Rejected(t *testing.T) {
 				t.Fatalf("LoadPolicy: expected error on blank role_relations key; got nil")
 			}
 		})
+	}
+}
+
+// A write-verb key under a `role_relations:` entry is refused at load rather
+// than silently dropped. yaml.v3 ignores unmappable keys, so before this guard
+// `create: add-member` loaded clean and left the relation UNGATED — a fail-open
+// on the one gate whose job is tamper-resistance. The verb keys get a message
+// naming `relation_grants:`, since an operator reaching for them has a coherent
+// intent that is simply spelled elsewhere.
+func TestLoadPolicy_RoleRelationsVerbKey_Rejected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{"create", "role_relations:\n  member-of:\n    create: add-member\n", "relation_grants"},
+		{"update", "role_relations:\n  member-of:\n    update: edit-member\n", "relation_grants"},
+		{"delete", "role_relations:\n  member-of:\n    delete: rm-member\n", "relation_grants"},
+		{"read", "role_relations:\n  member-of:\n    read: see-member\n", "relation_grants"},
+		{
+			"unknown key",
+			"role_relations:\n  member-of:\n    confer: editor\n",
+			"unknown key",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := writeTempPolicy(t, tc.yaml)
+			_, err := acl.LoadPolicy(path)
+			if err == nil {
+				t.Fatalf("LoadPolicy: expected error on role_relations %s key; got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("LoadPolicy error = %q, want it to mention %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// The supported keys still load, so the strict unmarshaller did not narrow the
+// real surface: both fields must survive a round-trip.
+func TestLoadPolicy_RoleRelationsSupportedKeys(t *testing.T) {
+	t.Parallel()
+	path := writeTempPolicy(t,
+		"role_relations:\n  member-of:\n    confers: editor\n    requires_permission: delegate-membership\n")
+	p, err := acl.LoadPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	got := p.RoleRelations["member-of"]
+	if got.Confers != "editor" {
+		t.Errorf("Confers = %q, want %q", got.Confers, "editor")
+	}
+	if got.RequiresPermission != "delegate-membership" {
+		t.Errorf("RequiresPermission = %q, want %q", got.RequiresPermission, "delegate-membership")
 	}
 }
 

--- a/tickets/entities/automated-measures/AM-acl-config-structs-reject-unknown-keys.md
+++ b/tickets/entities/automated-measures/AM-acl-config-structs-reject-unknown-keys.md
@@ -1,0 +1,34 @@
+---
+id: AM-acl-config-structs-reject-unknown-keys
+type: automated-measure
+title: Config structs under acl.yaml reject unknown keys at load
+description: 'Table tests asserting that a nested acl.yaml config struct fails the policy load on an unrecognized key rather than dropping it. Covers RoleRelationDef (the four write verbs get a message naming relation_grants:, anything else "unknown key") alongside the pre-existing RelationWriteGrant coverage. yaml.v3 ignores unmappable keys by default, so without a strict UnmarshalYAML a typo in a security-relevant block loads clean and enforces nothing.'
+kind: test
+location: internal/acl (TestLoadPolicy_RoleRelationsVerbKey_Rejected, TestLoadPolicy_RoleRelationsSupportedKeys)
+status: proposed
+---
+
+Guards the why5 of the verb-key fail-open: the project had no stated invariant
+that security-relevant config fails closed on unrecognized input. Strictness was
+applied per-struct as each was written, so `RelationWriteGrant` — the block that
+*widens* access — got the strict parser, while `RoleRelationDef` — the block
+that *restricts* it — got the lenient one. That is precisely backwards.
+
+The direction of the failure is what matters, and it is why a lenient parser is
+not a neutral default here. A dropped key in `relation_grants:` removes an
+alternative satisfier: the write falls back to the source-type verb grant and is
+*more* likely to be denied. A dropped key in `role_relations:` removes the
+delegate-X gate entirely, and every consumer reads the resulting empty
+`RequiresPermission` as "this relation was never gated" — so the failure is
+invisible to `aclaudit` A2 and to the boot warning as well.
+
+Two assertions, both needed. The rejection test alone would pass against a
+parser that refuses everything; the round-trip test
+(`TestLoadPolicy_RoleRelationsSupportedKeys`) pins that `confers` and
+`requires_permission` still load, so the guard cannot be satisfied by
+over-tightening.
+
+The rule this generalizes to, for the next struct added under `acl.yaml`: a
+strict unmarshaller is the default, and the question to ask before accepting a
+lenient one is which direction a dropped key fails. Leniency is only acceptable
+where it fails closed.

--- a/tickets/entities/bugs/BUG-BRZX6O.md
+++ b/tickets/entities/bugs/BUG-BRZX6O.md
@@ -1,0 +1,88 @@
+---
+id: BUG-BRZX6O
+type: bug
+title: role_relations silently drops write-verb keys so a role-conferring relation loads ungated
+description: 'RoleRelationDef had no UnmarshalYAML, and yaml.v3 ignores keys it cannot map. An operator writing `role_relations: {member-of: {create: add-member}}` — reaching for per-verb permissions by analogy with relation_grants: — got a policy that loaded clean with requires_permission empty, i.e. the membership relation completely ungated. The one gate whose job is tamper-resistance failed open on a plausible typo.'
+priority: medium
+effort: s
+why1: A verb key under a role_relations entry is dropped at parse time, so the delegate-X gate silently does not exist and the relation is writable by anyone holding the source-type verb grant.
+why2: RoleRelationDef is a plain two-field struct with no UnmarshalYAML; yaml.v3's default behaviour is to ignore unmappable keys rather than error.
+why3: The adjacent RelationWriteGrant DOES have a strict UnmarshalYAML rejecting unknown keys (and gives `read:` its own message). The stricter treatment landed on the block that widens access, not on the block that restricts it.
+why4: Strictness was applied per-struct as each was written, driven by whichever failure the author had in mind at the time, rather than derived from a rule about which config surfaces must fail loudly.
+why5: 'The project has no stated invariant that security-relevant config fails closed on unrecognized input. Absent one, ''unknown key'' is judged by how confusing it is to the operator rather than by which direction the failure goes — so the struct where a dropped key means LESS enforcement is exactly the one that got the lenient parser.'
+status: done
+prevention: 'Two things. (1) RoleRelationDef now has a strict UnmarshalYAML rejecting unknown keys, with the write verbs getting a message naming relation_grants: — the mistake is refused at load rather than discouraged in prose, and because it fails in appbuild policy load it blocks every entry point, not just the linter. (2) The docs stated the gate is all-verbs and why, and the guide example permission was renamed member-of:create -> delegate-membership: the old name read exactly like a per-verb key and was the most likely thing to suggest the broken config in the first place. The general lesson recorded here: when adding a config struct to acl.yaml, the default must be a strict unmarshaller, and the question to ask is which direction a dropped key fails — leniency is only acceptable where it fails closed.'
+---
+
+## Symptom
+
+A policy reaching for per-verb permissions on a role-conferring relation —
+by analogy with the `relation_grants:` block, which genuinely has them —
+loads without complaint:
+
+```yaml
+# acl.yaml
+role_relations:
+  member-of:
+    create: add-member
+```
+
+`create:` is not a field on `RoleRelationDef`, so yaml.v3 drops it.
+`RequiresPermission` stays `""`, which every consumer reads as "this
+relation is not gated". The membership relation is now writable by anyone
+holding the source-type verb grant — the self-promotion escalation
+(`alice --member-of--> admins`) that the gate exists to prevent.
+
+The operator has config that reads as hardened and enforces nothing, and
+nothing anywhere reports it: `RequiresPermission != ""` is the boolean
+`aclaudit` A2 and the boot warning both key on, so from their point of
+view this policy simply never configured a gate.
+
+## Why it was plausible to write
+
+`relation_grants:` — the top-level block — really does take
+`create:`/`update:`/`delete:`, with a `permission:` shorthand covering all
+three. So per-verb keys are a real part of the ACL vocabulary; they just
+live on the block for relations that do *not* confer a role.
+
+The security guide's own worked example made this worse by naming the
+permission `member-of:create`. That is a flat opaque string gating all
+verbs, but it reads like a per-verb key, and it invites the reader to
+assume a matching `member-of:delete` exists.
+
+## Fix
+
+`RoleRelationDef.UnmarshalYAML` rejects unknown keys, mirroring the
+existing `RelationWriteGrant` unmarshaller. The four write verbs get a
+dedicated message, since an operator reaching for them has a coherent
+intent that is simply spelled elsewhere:
+
+```console
+$ rela acl audit
+appbuild: load acl.yaml: acl: parse /srv/rela/acl.yaml: role_relations:
+"create" is not supported — `requires_permission:` gates ALL write verbs
+on a role-conferring relation, by design. Per-verb permissions are
+`relation_grants:`, which is refused on a type that confers a role
+```
+
+The failure is at policy load in `appbuild`, so it stops every entry
+point rather than only the linter — an un-gated membership relation
+should not boot.
+
+## Why the gate stays flat
+
+Worth recording, since the obvious "fix" is to add the per-verb form
+rather than refuse it:
+
+- The escalation the gate stops is a **create**. A policy gating only
+  some verbs would read as hardened while stopping nothing.
+- Removing a conferred edge is an availability attack, so `delete` is not
+  safely left open either.
+- `RequiresPermission != ""` is consumed as a boolean "is this gated" by
+  `EffectiveMembershipRelation`, `aclaudit` A2/A6/A7 and the boot
+  warning. Making it per-verb turns each into "gated for which verbs",
+  and each is a site where a wrong answer fails open.
+
+Per-verb CUD already exists for the non-role-conferring case, and
+`relation_grants:` is refused on any type carrying this gate, so the two
+can never disagree about one relation.

--- a/tickets/entities/review-checklists/REV-R53YNE.md
+++ b/tickets/entities/review-checklists/REV-R53YNE.md
@@ -1,0 +1,96 @@
+---
+id: REV-R53YNE
+type: review-checklist
+title: 'Review: role_relations verb-key fail-open'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just check`)
+- [x] Lint clean (included in `just check`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just check` exit 0. `just arch-lint` → no warnings. `just comment-lint` → no
+unresolvable doc links across 11650 comments. `just coverage-check` → package
+floor (50%) and total (65%) both satisfied; total 78.6%. `just docs-check`
+passes on the committed tree (it diffs the working tree, so it must be run
+after committing the regenerated `docs/`).
+
+## Code Review
+
+- [x] ~~Run `/code-review` command (invokes cranky-code-reviewer agent)~~
+(N/A: not run. This change is one strict unmarshaller mirroring an existing
+one in the same file plus documentation prose; it adds no evaluation path and
+alters no decision logic. Recorded here rather than silently skipped.)
+- [x] ~~All critical review-responses addressed~~ (N/A: no review run, none
+raised)
+- [x] ~~All significant review-responses addressed~~ (N/A: no review run, none
+raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none
+
+Self-review: the diff touches `internal/acl/policy.go` (one struct's godoc plus
+a new `UnmarshalYAML`), `internal/acl/policy_test.go` (two new tests), the
+`GUIDE-acl-security` source entity, and the regenerated `docs/acl-security.md`.
+No unrelated changes.
+
+The security model is deliberately untouched. No evaluation path, ceiling, or
+`aclaudit` check changed, so `RequiresPermission != ""` remains the boolean
+"is this gated" that A2/A6/A7, `EffectiveMembershipRelation` and the boot
+warning all key on — which is exactly why the fix refuses the per-verb form
+rather than implementing it.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented below
+
+**Acceptance Status:**
+
+1. *A write-verb key under `role_relations:` is refused at load* — **PASS**.
+`TestLoadPolicy_RoleRelationsVerbKey_Rejected` covers `create`/`update`/
+`delete`/`read` (each asserted to mention `relation_grants`) plus a typo'd
+`confer:` asserting "unknown key". Verified end-to-end against the built
+binary on a scratch project: `rela acl audit` and `rela list` both refuse,
+proving the failure is at `appbuild` policy load and therefore blocks every
+entry point, not just the linter.
+
+2. *The supported keys still load* — **PASS**.
+`TestLoadPolicy_RoleRelationsSupportedKeys` round-trips `confers` and
+`requires_permission`, so the strict unmarshaller did not narrow the real
+surface.
+
+3. *No existing config breaks* — **PASS**. No `acl.yaml` in the repo uses
+`role_relations` at all (`prototypes/data-entry/project/acl.yaml` is the only
+policy file). The new error can only fire on config that was already
+silently broken, since a dropped verb key never had an effect.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix, not
+an enhancement)
+- [x] User-facing documentation updated — this bug was *half* a documentation
+defect, so the docs are part of the fix rather than a follow-up: the
+`GUIDE-acl-security` guide gained a "The gate covers every verb" section
+explaining why the gate is flat, and its example permission was renamed
+`member-of:create` → `delegate-membership` because the old name read exactly
+like a per-verb key and was the most likely source of the broken config.
+`docs/acl-security.md` regenerated with `just docs`.
+- [x] ~~Docs-checklist marked as done~~ (N/A: no docs-checklist needed)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI

--- a/tickets/relations/BUG-BRZX6O--adds-measure--AM-acl-config-structs-reject-unknown-keys.md
+++ b/tickets/relations/BUG-BRZX6O--adds-measure--AM-acl-config-structs-reject-unknown-keys.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BRZX6O
+relation: adds-measure
+to: AM-acl-config-structs-reject-unknown-keys
+---

--- a/tickets/relations/BUG-BRZX6O--affects--authorization.md
+++ b/tickets/relations/BUG-BRZX6O--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BRZX6O
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-BRZX6O--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-BRZX6O--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BRZX6O
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/BUG-BRZX6O--has-review--REV-R53YNE.md
+++ b/tickets/relations/BUG-BRZX6O--has-review--REV-R53YNE.md
@@ -1,0 +1,5 @@
+---
+from: BUG-BRZX6O
+relation: has-review
+to: REV-R53YNE
+---


### PR DESCRIPTION
## Why

`role_relations.<rel>.requires_permission` is a single flat permission that gates **all** write verbs on a role-conferring relation. That flatness is correct — the escalation it stops (`alice --member-of--> admins`) is a *create*, so a partially-gated policy would read as hardened while stopping nothing — but nothing in the code or docs said so, and two things actively invited the wrong conclusion:

1. **`RoleRelationDef` had no strict unmarshaller.** yaml.v3 silently drops keys it cannot map, so:

   ```yaml
   role_relations:
     member-of:
       create: add-member      # silently dropped — relation is now UNGATED
   ```

   loaded clean and left the membership relation open. That is a fail-open on the one gate whose entire job is tamper-resistance. `RelationWriteGrant` one struct over already guards against exactly this; `role_relations` did not.

2. **The security guide's worked example named the permission `member-of:create`** — which reads exactly like a per-verb key, making `member-of:delete` look like it should also work. It doesn't.

Per-verb CUD permissions *do* exist, as top-level `relation_grants:`, but no `role_relations` documentation pointed forward to them.

## What changed

- **`RoleRelationDef.UnmarshalYAML`** (`internal/acl/policy.go`) rejects unknown keys. `create`/`update`/`delete`/`read` get their own message naming `relation_grants:`, since an operator reaching for them has a coherent intent that is simply spelled elsewhere. Mirrors the existing `RelationWriteGrant` unmarshaller.
- **Godoc** on `RoleRelationDef` explains why the gate is all-verbs (create is the escalation; delete is an availability attack, so neither is safely split).
- **`docs-project/entities/guides/GUIDE-acl-security.md`** gains a "The gate covers every verb" section, and the example permission is renamed `member-of:create` → `delegate-membership` (matching what the godoc already used). `docs/acl-security.md` regenerated via `just docs`.

Verified against the built binary — the failure is at policy load in `appbuild`, so it blocks every entry point rather than only the linter:

```console
$ rela acl audit
appbuild: load acl.yaml: acl: parse /tmp/acltest/acl.yaml: role_relations: "create" is not supported — `requires_permission:` gates ALL write verbs on a role-conferring relation, by design. Per-verb permissions are `relation_grants:`, which is refused on a type that confers a role
```

## Compatibility

The new error only fires on config that was **already broken** — a dropped verb key never had an effect. No `acl.yaml` in the repo uses `role_relations` at all (checked `prototypes/data-entry/project/acl.yaml`), and the security model is unchanged: no evaluation path, ceiling, or `aclaudit` check was touched, so `RequiresPermission != ""` remains the boolean "is this gated" that A2/A6/A7 and the boot warning rely on.

## Tests

`TestLoadPolicy_RoleRelationsVerbKey_Rejected` (table-driven over the four verb keys plus a typo'd `confer:`) and `TestLoadPolicy_RoleRelationsSupportedKeys` (round-trips both real fields, so the strict unmarshaller did not narrow the real surface).

Local: `just check`, `just arch-lint`, `just comment-lint`, `just docs-check`, `just coverage-check` all pass.

https://claude.ai/code/session_019QbeaMhbmDKnYpzdaJzZJt