### PR TITLE
feat(dataentry): drop unsafe-inline from the app CSP (TKT-JO125X)

### DIFF
--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -4605,6 +4605,42 @@ The app and its files are served from `/api/v1/_apps/<id>/`, so reference
 sibling assets with **relative** URLs (`<script src="app.js">`, `<img
 src="logo.png">`).
 
+### Scripts and styles must be separate files
+
+An app's Content-Security-Policy does **not** allow `unsafe-inline`, so these
+are blocked and will silently do nothing:
+
+```html
+<style>body { margin: 0 }</style>          <!-- blocked -->
+<script>console.log('hi')</script>         <!-- blocked -->
+<div style="margin: 1rem">…</div>          <!-- blocked -->
+<button onclick="save()">Save</button>     <!-- blocked -->
+```
+
+Put them in sibling files and use classes instead:
+
+```html
+<link rel="stylesheet" href="app.css" />
+<script src="app.js"></script>
+```
+
+```js
+// in app.js
+document.getElementById('save').addEventListener('click', save)
+```
+
+`rela apps new` scaffolds exactly this layout, so a generated app works without
+changes. A blocked resource shows as a CSP violation in the browser console —
+if a style or handler seems to be ignored, check there first.
+
+**Why.** An app already runs with `allow-scripts`, so this is not what stops an
+app doing what it wants; the data boundary is the path-scoped CSP plus
+`connect-src 'none'` plus the bridge. Barring inline code protects an app from
+*its own* bugs: if your app builds DOM from entity data with `innerHTML`, a
+`<script>` or `onerror=` smuggled in through that data is blocked rather than
+executed. Escape your own output regardless — the CSP is the second line, not
+the first.
+
 **Publish / unpublish.** A folder with an `index.html` is live. To take an app
 offline without deleting it, rename the folder (e.g. `ticket-counter` →
 `_ticket-counter`, which fails the id rule) or remove its `index.html`.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -4599,6 +4599,42 @@ The app and its files are served from `/api/v1/_apps/<id>/`, so reference
 sibling assets with **relative** URLs (`<script src="app.js">`, `<img
 src="logo.png">`).
 
+### Scripts and styles must be separate files
+
+An app's Content-Security-Policy does **not** allow `unsafe-inline`, so these
+are blocked and will silently do nothing:
+
+```html
+<style>body { margin: 0 }</style>          <!-- blocked -->
+<script>console.log('hi')</script>         <!-- blocked -->
+<div style="margin: 1rem">…</div>          <!-- blocked -->
+<button onclick="save()">Save</button>     <!-- blocked -->
+```
+
+Put them in sibling files and use classes instead:
+
+```html
+<link rel="stylesheet" href="app.css" />
+<script src="app.js"></script>
+```
+
+```js
+// in app.js
+document.getElementById('save').addEventListener('click', save)
+```
+
+`rela apps new` scaffolds exactly this layout, so a generated app works without
+changes. A blocked resource shows as a CSP violation in the browser console —
+if a style or handler seems to be ignored, check there first.
+
+**Why.** An app already runs with `allow-scripts`, so this is not what stops an
+app doing what it wants; the data boundary is the path-scoped CSP plus
+`connect-src 'none'` plus the bridge. Barring inline code protects an app from
+*its own* bugs: if your app builds DOM from entity data with `innerHTML`, a
+`<script>` or `onerror=` smuggled in through that data is blocked rather than
+executed. Escape your own output regardless — the CSP is the second line, not
+the first.
+
 **Publish / unpublish.** A folder with an `index.html` is live. To take an app
 offline without deleting it, rename the folder (e.g. `ticket-counter` →
 `_ticket-counter`, which fails the id rule) or remove its `index.html`.

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -393,6 +393,10 @@ function createTestProject(): string {
     path.join(tmpDir, "apps", "e2e-demo", "index.html"),
     E2E_DEMO_APP_HTML,
   );
+  fs.writeFileSync(
+    path.join(tmpDir, "apps", "e2e-demo", "app.js"),
+    E2E_DEMO_APP_JS,
+  );
   for (const [rel, content] of Object.entries(SEED_ENTITIES)) {
     fs.writeFileSync(path.join(tmpDir, rel), content);
   }
@@ -1470,55 +1474,61 @@ const E2E_DEMO_APP_HTML = `<!doctype html>
          the path-scoped CSP (connect-src 'none' + scoped img-src) must block it.
          Result lands in [data-testid=csp-probe]: 'blocked' if the boundary holds. -->
     <div data-testid="csp-probe">pending</div>
-    <script>
-      var cspEl = document.querySelector('[data-testid=csp-probe]');
-      (function probeCSP() {
-        // 1) connect-src 'none' must reject a direct fetch to the API.
-        fetch('/api/v1/features/FEAT-001')
-          .then(function () { cspEl.textContent = 'LEAK: fetch reached /api/'; })
-          .catch(function () {
-            // 2) img-src is path-scoped to the app, so an /api/ image must fail.
-            var img = new Image();
-            img.onload = function () { cspEl.textContent = 'LEAK: img loaded /api/'; };
-            img.onerror = function () { cspEl.textContent = 'blocked'; };
-            img.src = '/api/v1/features/FEAT-001';
-          });
-      })();
-      function ready(fn) {
-        var done = false;
-        function go() { if (!done) { done = true; fn(); } }
-        window.addEventListener('rela:ready', go, { once: true });
-        setTimeout(go, 1000);
-      }
-      var statusEl = document.querySelector('[data-testid=status]');
-      var countEl = document.querySelector('[data-testid=feature-count]');
-      var linkResultEl = document.querySelector('[data-testid=link-result]');
-
-      ready(async function () {
-        try {
-          var res = await window.rela.list({ type: 'feature', params: { per_page: 200 } });
-          var n = (res && res.data ? res.data.length : 0);
-          countEl.textContent = String(n);
-          statusEl.textContent = 'loaded';
-        } catch (e) {
-          statusEl.textContent = 'error: ' + (e && e.message ? e.message : e);
-        }
-      });
-
-      document.querySelector('[data-testid=link-btn]').addEventListener('click', async function () {
-        linkResultEl.textContent = 'linking';
-        try {
-          await window.rela.relationCreate({
-            type: 'feature', id: 'FEAT-001', relation: 'blocks', targetId: 'FEAT-002',
-          });
-          linkResultEl.textContent = 'linked';
-        } catch (e) {
-          linkResultEl.textContent = 'error: ' + (e && e.message ? e.message : e);
-        }
-      });
-    </script>
+    <script src="app.js"></script>
   </body>
 </html>`;
+
+/** The e2e demo app's script, served as a sibling file.
+ *
+ *  A separate file, not an inline <script>: the app CSP carries no
+ *  'unsafe-inline' (TKT-JO125X), so an inline block would be blocked and this
+ *  app would do nothing — every apps.spec.ts assertion would fail on a blank
+ *  page rather than on the behaviour under test. */
+const E2E_DEMO_APP_JS = `var cspEl = document.querySelector('[data-testid=csp-probe]');
+(function probeCSP() {
+  // 1) connect-src 'none' must reject a direct fetch to the API.
+  fetch('/api/v1/features/FEAT-001')
+    .then(function () { cspEl.textContent = 'LEAK: fetch reached /api/'; })
+    .catch(function () {
+      // 2) img-src is path-scoped to the app, so an /api/ image must fail.
+      var img = new Image();
+      img.onload = function () { cspEl.textContent = 'LEAK: img loaded /api/'; };
+      img.onerror = function () { cspEl.textContent = 'blocked'; };
+      img.src = '/api/v1/features/FEAT-001';
+    });
+})();
+function ready(fn) {
+  var done = false;
+  function go() { if (!done) { done = true; fn(); } }
+  window.addEventListener('rela:ready', go, { once: true });
+  setTimeout(go, 1000);
+}
+var statusEl = document.querySelector('[data-testid=status]');
+var countEl = document.querySelector('[data-testid=feature-count]');
+var linkResultEl = document.querySelector('[data-testid=link-result]');
+
+ready(async function () {
+  try {
+    var res = await window.rela.list({ type: 'feature', params: { per_page: 200 } });
+    var n = (res && res.data ? res.data.length : 0);
+    countEl.textContent = String(n);
+    statusEl.textContent = 'loaded';
+  } catch (e) {
+    statusEl.textContent = 'error: ' + (e && e.message ? e.message : e);
+  }
+});
+
+document.querySelector('[data-testid=link-btn]').addEventListener('click', async function () {
+  linkResultEl.textContent = 'linking';
+  try {
+    await window.rela.relationCreate({
+      type: 'feature', id: 'FEAT-001', relation: 'blocks', targetId: 'FEAT-002',
+    });
+    linkResultEl.textContent = 'linked';
+  } catch (e) {
+    linkResultEl.textContent = 'error: ' + (e && e.message ? e.message : e);
+  }
+});`;
 
 /** Document script rendered by rela-server when visiting
  *  /entity/feature/FEAT-001?doc=feature-overview. Emits a single link to

--- a/frontend/src/app-editor/relaEditor.ts
+++ b/frontend/src/app-editor/relaEditor.ts
@@ -17,19 +17,11 @@
 // what lets the editor be swapped later without touching plugins.
 
 import EasyMDE from 'easymde'
-// CSS is imported with ?inline so Vite returns it as a STRING (not an emitted
-// sibling file), letting the build stay a single self-contained IIFE. The
-// strings are injected into <head> once, on first element mount.
-import easymdeCSS from 'easymde/dist/easymde.min.css?inline'
-import fontAwesomeCSS from 'font-awesome/css/font-awesome.min.css?inline'
-// Font-face override: points FA's glyph webfont at the app-relative reserved
-// path (_rela-editor.woff2), permitted by the app CSP's `font-src <base>`.
-// Injected AFTER fontAwesomeCSS so it wins.
-import fontOverrideCSS from './relaEditorFont.css?inline'
-// Theme override: re-skins EasyMDE's hardcoded light chrome with rela tokens so
-// the editor follows the host light/dark theme. Injected LAST so it wins over
-// EasyMDE's own CSS.
-import themeCSS from './relaEditorTheme.css?inline'
+// The editor's CSS is NOT imported here. It is concatenated at build time by
+// the emitEditorCSS plugin (vite.editor.config.ts) into a sibling
+// rela-editor.css, which rela serves at the app-relative reserved path
+// _rela-editor.css. This module only links it — see ensureStylesInjected for
+// why an inline <style> is not an option.
 import { attachBacktickAutocomplete, type BacktickController } from './relaBacktick'
 
 // The bridge SDK (_rela.js) exposes window.rela. The backtick autocomplete only
@@ -42,16 +34,31 @@ interface RelaBridge {
 
 const TAG = 'rela-editor'
 const STYLE_ID = 'rela-editor-styles'
+// The app CSP has no 'unsafe-inline', so an injected <style> element would be
+// blocked and the editor would render unstyled. rela serves the same CSS as a
+// file at the app's own path; a <link> is a resource load, which the
+// path-scoped style-src permits. Relative on purpose: it resolves against the
+// app base (/api/v1/_apps/<id>/), like _rela.js and the FA font.
+const STYLE_HREF = '_rela-editor.css'
 
-// Inject the editor's stylesheets into the document head exactly once,
-// regardless of how many <rela-editor> elements mount. Order matters: FA base,
-// then the font-face override, then EasyMDE's own CSS.
+// Link the editor's stylesheet into the document head exactly once, regardless
+// of how many <rela-editor> elements mount.
+//
+// A <link> rather than a <style> with inlined text: the app CSP carries no
+// 'unsafe-inline', so an injected <style> element is blocked outright — the
+// element lands in the DOM, its .sheet stays null, and the editor renders with
+// no styling at all. That failure is silent apart from a console violation,
+// which is why the served stylesheet is the only supported path.
+//
+// Order is preserved inside the served file: FA base, font-face override,
+// EasyMDE, then the theme (which must win).
 function ensureStylesInjected(): void {
   if (document.getElementById(STYLE_ID)) return
-  const style = document.createElement('style')
-  style.id = STYLE_ID
-  style.textContent = [fontAwesomeCSS, fontOverrideCSS, easymdeCSS, themeCSS].join('\n')
-  document.head.appendChild(style)
+  const link = document.createElement('link')
+  link.id = STYLE_ID
+  link.rel = 'stylesheet'
+  link.href = STYLE_HREF
+  document.head.appendChild(link)
 }
 
 class RelaEditorElement extends HTMLElement {

--- a/frontend/vite.editor.config.ts
+++ b/frontend/vite.editor.config.ts
@@ -78,8 +78,59 @@ function emitEditorFont(): Plugin {
   }
 }
 
+// emitEditorCSS concatenates the editor's stylesheets into a single
+// rela-editor.css asset, which rela serves at the app-relative reserved path
+// _rela-editor.css.
+//
+// The CSS is a separate file rather than a string inlined into the IIFE because
+// the app CSP has no 'unsafe-inline': a <style> element injected at runtime is
+// blocked outright (element in the DOM, .sheet null, editor completely
+// unstyled), whereas a <link> is an ordinary resource load the path-scoped
+// style-src permits.
+//
+// Order is load-bearing and must match the old concatenation: FA base, then the
+// font-face override (points FA's glyph font at _rela-editor.woff2), then
+// EasyMDE's own CSS, then the rela theme LAST so it wins.
+function emitEditorCSS(): Plugin {
+  return {
+    name: 'emit-editor-css',
+    async generateBundle() {
+      const { createRequire } = await import('node:module')
+      const require = createRequire(import.meta.url)
+      const { readFile } = await import('node:fs/promises')
+
+      const resolvePkg = (spec: string, what: string): string => {
+        try {
+          return require.resolve(spec)
+        } catch {
+          throw new Error(`emit-editor-css: could not resolve ${what} (${spec}) — is the dependency installed?`)
+        }
+      }
+
+      const parts = await Promise.all([
+        readFile(resolvePkg('font-awesome/css/font-awesome.min.css', 'Font Awesome CSS'), 'utf8'),
+        readFile(fileURLToPath(new URL('./src/app-editor/relaEditorFont.css', import.meta.url)), 'utf8'),
+        readFile(resolvePkg('easymde/dist/easymde.min.css', 'EasyMDE CSS'), 'utf8'),
+        readFile(fileURLToPath(new URL('./src/app-editor/relaEditorTheme.css', import.meta.url)), 'utf8'),
+      ])
+
+      // The bundled FA CSS ships @font-face rules pointing at paths that do not
+      // exist under the app base; stripFontAwesomeFontFace drops them from the
+      // JS build, and relaEditorFont.css re-adds the one we serve. Apply the
+      // same strip here so the emitted file agrees with the bundle.
+      const fa = parts[0].replace(/@font-face\s*\{[^}]*\}/g, '')
+
+      this.emitFile({
+        type: 'asset',
+        fileName: 'rela-editor.css',
+        source: [fa, parts[1], parts[2], parts[3]].join('\n'),
+      })
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [stripFontAwesomeFontFace(), emitEditorFont()],
+  plugins: [stripFontAwesomeFontFace(), emitEditorFont(), emitEditorCSS()],
   // No public/ asset copying — this is a standalone lib build, not the SPA.
   publicDir: false,
   define: {

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -31,11 +31,15 @@ func (c *AppsNewCmd) Run() error {
 
 	out.WriteSuccess("Created app %q", result.ID)
 	out.WriteMessage("  %s", result.IndexAbs)
+	out.WriteMessage("  %s", result.CSSAbs)
+	out.WriteMessage("  %s", result.JSAbs)
 	out.WriteMessage("")
 	out.WriteMessage("Next steps:")
-	out.WriteMessage("  - Edit %s", result.IndexAbs)
+	out.WriteMessage("  - Edit %s and %s", result.JSAbs, result.CSSAbs)
 	out.WriteMessage("  - Run the data-entry server and open /app/%s", result.ID)
 	out.WriteMessage("  - The app calls rela.list/get/create/... via window.rela; see the")
 	out.WriteMessage("    Custom apps section of the data-entry guide for the full bridge API.")
+	out.WriteMessage("  - Keep styles and code in these files: the app CSP blocks inline")
+	out.WriteMessage("    <script>/<style> and style=\"\" attributes.")
 	return nil
 }

--- a/internal/dataentry/apps.go
+++ b/internal/dataentry/apps.go
@@ -50,6 +50,12 @@ const appCSSEntry = "_rela.css"
 // that use the editor pay its bundle. Reserved (underscore-prefixed).
 const appEditorEntry = "_rela-editor.js"
 
+// appEditorCSSEntry is the reserved per-app path that serves the <rela-editor>
+// stylesheet. A file, not an inline <style>: the app CSP has no
+// 'unsafe-inline', so a runtime-injected style element would be blocked and the
+// editor would render unstyled.
+const appEditorCSSEntry = "_rela-editor.css"
+
 // appEditorFontEntry is the reserved per-app path that serves the Font Awesome
 // glyph webfont the editor's toolbar uses. The bundle's @font-face points here
 // (a same-base URL), so the app CSP's `font-src <base>` permits it without

--- a/internal/dataentry/apps_editor.go
+++ b/internal/dataentry/apps_editor.go
@@ -11,8 +11,8 @@ import (
 // The <rela-editor> Custom Element bundle and its glyph webfont, built by the
 // standalone editor build (frontend/vite.editor.config.ts) into
 // frontend → ../internal/dataentry/app_editor_dist and embedded here. Served at
-// the reserved per-app paths _rela-editor.js / _rela-editor.woff2 (see apps.go
-// and apps_handler.go). TKT-5F9V56.
+// the reserved per-app paths _rela-editor.js / _rela-editor.css /
+// _rela-editor.woff2 (see apps.go and apps_handler.go). TKT-5F9V56.
 //
 // Like the SPA bundle (static/v2), these are BUILD ARTIFACTS — gitignored and
 // produced by `npm run build` (frontend/package.json runs the editor build too).
@@ -50,6 +50,11 @@ var (
 	// appEditorFontSource returns the toolbar glyph webfont served at
 	// /api/v1/_apps/<id>/_rela-editor.woff2.
 	appEditorFontSource = func() []byte { return appEditorAsset("rela-editor.woff2") }
+	// appEditorCSSSource returns the editor stylesheet served at
+	// /api/v1/_apps/<id>/_rela-editor.css. Served as a FILE rather than inlined
+	// into the bundle: the app CSP has no 'unsafe-inline', so a <style> element
+	// injected at runtime is blocked and the editor renders unstyled.
+	appEditorCSSSource = func() []byte { return appEditorAsset("rela-editor.css") }
 )
 
 // ETags for the editor assets, computed lazily from the current bytes so a
@@ -60,6 +65,7 @@ var (
 // unversioned URL). Empty when the asset isn't built.
 func appEditorJSETag() string   { return weakETagFor(appEditorSource()) }
 func appEditorFontETag() string { return weakETagFor(appEditorFontSource()) }
+func appEditorCSSETag() string  { return weakETagFor(appEditorCSSSource()) }
 
 func weakETagFor(b []byte) string {
 	if len(b) == 0 {

--- a/internal/dataentry/apps_handler.go
+++ b/internal/dataentry/apps_handler.go
@@ -31,11 +31,23 @@ import (
 //     are not a cross-origin channel.)
 //   - form-action 'none' + the iframe sandbox (no allow-top-navigation) block
 //     form-POST and navigation exfiltration.
+//   - script-src/style-src carry NO 'unsafe-inline', so an app's scripts and
+//     styles must be separate files. This is not part of the data boundary —
+//     an app already runs with allow-scripts and could execute anything it
+//     ships. It is defense in depth AGAINST THE APP'S OWN BUGS: if an app
+//     builds DOM from entity data with innerHTML, a <script> smuggled through
+//     that data is blocked here rather than executed. `rela apps new`
+//     scaffolds separate app.css/app.js so a generated app works under this
+//     unchanged (TKT-JO125X); an app author who inlines gets a CSP violation
+//     in the console, not silent breakage of the host.
+//
+// Note this also blocks style="" attributes, which would need 'unsafe-hashes'
+// to permit. Apps use classes instead.
 func appCSP(base string) string {
 	return strings.Join([]string{
 		"default-src 'none'",
-		"script-src " + base + " 'unsafe-inline'",
-		"style-src " + base + " 'unsafe-inline'",
+		"script-src " + base,
+		"style-src " + base,
 		"img-src " + base + " data: blob:",
 		"font-src " + base,
 		"connect-src 'none'",
@@ -141,6 +153,10 @@ func (a *App) handleV1App(w http.ResponseWriter, r *http.Request) {
 		// iframe (re)load. appContentTypes[".js"] is the single source for the
 		// content-type so it can't drift.
 		serveCachedAsset(w, r, appContentTypes[".js"], appEditorJSETag(), appEditorSource())
+		return
+	}
+	if entry == appEditorCSSEntry {
+		serveCachedAsset(w, r, appContentTypes[".css"], appEditorCSSETag(), appEditorCSSSource())
 		return
 	}
 	if entry == appEditorFontEntry {

--- a/internal/dataentry/apps_test.go
+++ b/internal/dataentry/apps_test.go
@@ -54,6 +54,28 @@ func TestAppCSP_PathScopedNoEgress(t *testing.T) {
 			t.Errorf("%s must use an absolute scheme://host source, got %q", dir, seg)
 		}
 	}
+	// No 'unsafe-inline' on script-src/style-src: an app's code and styles are
+	// separate files, so a <script> or an onerror= smuggled in through the
+	// app's own innerHTML bug is blocked rather than executed (TKT-JO125X,
+	// issue #1025). `rela apps new` scaffolds app.js/app.css for this reason;
+	// re-adding 'unsafe-inline' here silently removes the protection, hence
+	// the assertion rather than a comment.
+	for _, dir := range []string{"script-src", "style-src"} {
+		idx := strings.Index(csp, dir+" ")
+		if idx < 0 {
+			continue // missing-directive is already reported above
+		}
+		seg := csp[idx:]
+		if end := strings.Index(seg, ";"); end >= 0 {
+			seg = seg[:end]
+		}
+		if strings.Contains(seg, "unsafe-inline") {
+			t.Errorf("%s must not allow 'unsafe-inline': %q", dir, seg)
+		}
+		if strings.Contains(seg, "unsafe-eval") {
+			t.Errorf("%s must not allow 'unsafe-eval': %q", dir, seg)
+		}
+	}
 	// Exfil channels closed.
 	for _, want := range []string{"form-action 'none'", "base-uri 'none'", "frame-ancestors 'self'"} {
 		if !strings.Contains(csp, want) {
@@ -564,9 +586,37 @@ func TestHandleV1App(t *testing.T) {
 		}
 	})
 
+	t.Run("serves the reserved _rela-editor.css stylesheet", func(t *testing.T) {
+		withTestEditorAssets(t)
+		w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo/_rela-editor.css")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		if w.Body.Len() == 0 {
+			t.Error("editor stylesheet is empty")
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "text/css; charset=utf-8" {
+			t.Errorf("stylesheet Content-Type = %q, want text/css; charset=utf-8", ct)
+		}
+		// This endpoint exists BECAUSE style-src carries no 'unsafe-inline':
+		// the bundle links this file instead of injecting a <style>, which the
+		// browser would block (element present, .sheet null, editor unstyled —
+		// verified in-browser, TKT-JO125X). A same-path <link> is an ordinary
+		// resource load that style-src <base> already permits, so this needs no
+		// CSP widening — unlike the font, it is not cross-origin (a stylesheet
+		// link from the app document is same-origin with the app's own path).
+		csp := w.Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, "style-src ") || !strings.Contains(csp, "/api/v1/_apps/demo/") {
+			t.Errorf("style-src must path-scope the app (covers _rela-editor.css): %q", csp)
+		}
+		if strings.Contains(csp, "unsafe-inline") {
+			t.Errorf("style-src must not regain 'unsafe-inline': %q", csp)
+		}
+	})
+
 	t.Run("editor assets carry an ETag and 304 on If-None-Match", func(t *testing.T) {
 		withTestEditorAssets(t)
-		for _, entry := range []string{"_rela-editor.js", "_rela-editor.woff2"} {
+		for _, entry := range []string{"_rela-editor.js", "_rela-editor.css", "_rela-editor.woff2"} {
 			w := doRequest(t, app, http.MethodGet, "/api/v1/_apps/demo/"+entry)
 			etag := w.Header().Get("ETag")
 			if etag == "" {
@@ -687,12 +737,17 @@ func editorBundleBuilt() bool { return len(appEditorSource()) > 0 }
 func withTestEditorAssets(t *testing.T) {
 	t.Helper()
 	const fakeJS = `(function(){customElements.define('rela-editor',class extends HTMLElement{});` +
-		`/* @font-face url(` + appEditorFontEntry + `) */})();`
+		`var h='` + appEditorCSSEntry + `';})();`
+	const fakeCSS = `.CodeMirror{font-family:monospace}` +
+		`@font-face{font-family:FontAwesome;src:url(` + appEditorFontEntry + `)}`
 	fakeFont := []byte("wOF2-test-font-bytes")
-	origJS, origFont := appEditorSource, appEditorFontSource
+	origJS, origFont, origCSS := appEditorSource, appEditorFontSource, appEditorCSSSource
 	appEditorSource = func() []byte { return []byte(fakeJS) }
 	appEditorFontSource = func() []byte { return fakeFont }
-	t.Cleanup(func() { appEditorSource, appEditorFontSource = origJS, origFont })
+	appEditorCSSSource = func() []byte { return []byte(fakeCSS) }
+	t.Cleanup(func() {
+		appEditorSource, appEditorFontSource, appEditorCSSSource = origJS, origFont, origCSS
+	})
 }
 
 // TestAppEditorBundleEmbedded verifies the editor bundle + font, WHEN BUILT,
@@ -706,8 +761,20 @@ func TestAppEditorBundleEmbedded(t *testing.T) {
 	if !strings.Contains(string(js), "rela-editor") {
 		t.Error("editor bundle does not define the rela-editor custom element")
 	}
-	if !strings.Contains(string(js), appEditorFontEntry) {
-		t.Errorf("editor bundle must reference the reserved font path %q (its @font-face)", appEditorFontEntry)
+	// The bundle LINKS its stylesheet rather than inlining it: an injected
+	// <style> is blocked by the app CSP (no 'unsafe-inline') and the editor
+	// renders unstyled. Assert the reference so a build that reverts to
+	// inlining fails here rather than silently shipping a broken editor.
+	if !strings.Contains(string(js), appEditorCSSEntry) {
+		t.Errorf("editor bundle must reference the reserved stylesheet path %q", appEditorCSSEntry)
+	}
+	css := appEditorCSSSource()
+	if len(css) == 0 {
+		t.Fatal("editor stylesheet not embedded")
+	}
+	// The @font-face moved into the stylesheet along with the rest of the CSS.
+	if !strings.Contains(string(css), appEditorFontEntry) {
+		t.Errorf("editor stylesheet must reference the reserved font path %q (its @font-face)", appEditorFontEntry)
 	}
 	if len(appEditorFontSource()) == 0 {
 		t.Fatal("editor woff2 font not embedded")

--- a/internal/projectsetup/app.go
+++ b/internal/projectsetup/app.go
@@ -14,11 +14,18 @@ type ScaffoldAppResult struct {
 	ID       string
 	Dir      string // absolute apps/<id> directory
 	IndexAbs string // absolute index.html path
+	CSSAbs   string // absolute app.css path
+	JSAbs    string // absolute app.js path
 }
 
-// ScaffoldApp creates a starter custom-app folder apps/<id>/ with an index.html
-// wired up to the bridge SDK (_rela.js) and the optional theme stylesheet
-// (_rela.css). startDir is where project discovery begins (empty = cwd).
+// ScaffoldApp creates a starter custom-app folder apps/<id>/ wired up to the
+// bridge SDK (_rela.js) and the optional theme stylesheet (_rela.css).
+// startDir is where project discovery begins (empty = cwd).
+//
+// It writes THREE files — index.html, app.css, app.js — rather than one
+// self-contained page. The app CSP has no 'unsafe-inline', so an inline
+// <style> or <script> in a scaffolded app would be silently dead on arrival
+// (see dataentry.appCSP). Separate files are what actually runs.
 func ScaffoldApp(startDir, id string) (*ScaffoldAppResult, error) {
 	fs := storage.NewSafeFS(storage.NewOsFS())
 	return ScaffoldAppWithFS(startDir, id, fs)
@@ -36,7 +43,9 @@ func ScaffoldAppWithFS(startDir, id string, fs storage.FS) (*ScaffoldAppResult, 
 	}
 
 	appDir := filepath.Join(ctx.Root, project.AppsDir, id)
-	indexPath := filepath.Join(appDir, "index.html")
+	indexPath := filepath.Join(appDir, appIndexName)
+	cssPath := filepath.Join(appDir, appCSSName)
+	jsPath := filepath.Join(appDir, appJSName)
 
 	if _, err := fs.Stat(indexPath); err == nil {
 		return nil, fmt.Errorf("app %q already exists (%s)", id, indexPath)
@@ -45,16 +54,44 @@ func ScaffoldAppWithFS(startDir, id string, fs storage.FS) (*ScaffoldAppResult, 
 	if err := fs.MkdirAll(appDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create app directory: %w", err)
 	}
-	if err := fs.WriteFile(indexPath, []byte(starterAppHTML(id)), 0o644); err != nil {
-		return nil, fmt.Errorf("write index.html: %w", err)
+	// index.html last: it is what appExists() keys on, so writing it only after
+	// its two assets are on disk means a half-written scaffold is not yet a
+	// live app.
+	for _, f := range []struct {
+		path string
+		body string
+	}{
+		{cssPath, starterAppCSS()},
+		{jsPath, starterAppJS()},
+		{indexPath, starterAppHTML(id)},
+	} {
+		if err := fs.WriteFile(f.path, []byte(f.body), 0o644); err != nil {
+			return nil, fmt.Errorf("write %s: %w", filepath.Base(f.path), err)
+		}
 	}
 
-	return &ScaffoldAppResult{ID: id, Dir: appDir, IndexAbs: indexPath}, nil
+	return &ScaffoldAppResult{
+		ID: id, Dir: appDir, IndexAbs: indexPath, CSSAbs: cssPath, JSAbs: jsPath,
+	}, nil
 }
 
-// starterAppHTML returns a minimal, working app: it links the bridge SDK and the
-// optional rela theme, reads through the bridge on load, and renders a result.
-// Authors edit from here.
+// appIndexName, appCSSName and appJSName are the scaffold's three files. The
+// asset names are ordinary (no underscore prefix): rela reserves the "_" prefix
+// for endpoints it serves from the binary (_rela.js, _rela.css), and an app may
+// not shadow those.
+const (
+	appIndexName = "index.html"
+	appCSSName   = "app.css"
+	appJSName    = "app.js"
+)
+
+// starterAppHTML returns a minimal, working app: it links the bridge SDK, the
+// optional rela theme, and the app's own stylesheet and script. Authors edit
+// from here.
+//
+// Deliberately free of inline <style>/<script> and style="" attributes — the
+// app CSP has no 'unsafe-inline', so inline code would not run. Keep it that
+// way when editing this template.
 func starterAppHTML(id string) string {
 	return `<!doctype html>
 <html lang="en">
@@ -72,40 +109,60 @@ func starterAppHTML(id string) string {
     <!-- Optional: rela's theme tokens + base controls (.btn/.input/.card).
          Dark mode follows the host automatically. Remove for full control. -->
     <link rel="stylesheet" href="_rela.css" />
-    <style>
-      body {
-        font-family: inherit;
-        margin: 0;
-        padding: 1.5rem;
-        color: var(--text-color);
-        background: var(--bg-color);
-      }
-      h1 { font-size: 1.25rem; margin: 0 0 1rem; }
-      .muted { color: var(--muted-text); }
-    </style>
+    <!-- This app's own styles and code. Separate files, not inline: the app
+         CSP has no 'unsafe-inline', so an inline <style> or <script> here
+         would be blocked and silently do nothing. -->
+    <link rel="stylesheet" href="` + appCSSName + `" />
   </head>
   <body>
     <h1>` + id + `</h1>
     <div id="out" class="muted">Loading…</div>
 
-    <script>
-      // window.rela is ready after the one-time 'rela:ready' event. Calls made
-      // earlier are queued, so this is just to avoid a flash of empty content.
-      window.addEventListener('rela:ready', async () => {
-        const out = document.getElementById('out');
-        try {
-          // Replace 'ticket' with one of your entity types. See the available
-          // bridge methods (rela.list/get/search/create/update/...) in the
-          // data-entry guide.
-          const res = await rela.list({ type: 'ticket', params: { per_page: 50 } });
-          out.classList.remove('muted');
-          out.textContent = (res.data ? res.data.length : 0) + ' entities loaded.';
-        } catch (e) {
-          out.textContent = 'Error: ' + (e && e.message ? e.message : e);
-        }
-      });
-    </script>
+    <script src="` + appJSName + `"></script>
   </body>
 </html>
+`
+}
+
+// starterAppCSS is the scaffold's stylesheet. It uses rela's theme tokens so
+// the app follows the host's light/dark mode without extra work.
+func starterAppCSS() string {
+	return `body {
+  font-family: inherit;
+  margin: 0;
+  padding: 1.5rem;
+  color: var(--text-color);
+  background: var(--bg-color);
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin: 0 0 1rem;
+}
+
+.muted {
+  color: var(--muted-text);
+}
+`
+}
+
+// starterAppJS is the scaffold's script: it waits for the bridge, reads through
+// it, and renders the result.
+func starterAppJS() string {
+	return `// window.rela is ready after the one-time 'rela:ready' event. Calls made
+// earlier are queued, so this is just to avoid a flash of empty content.
+window.addEventListener('rela:ready', async () => {
+  const out = document.getElementById('out');
+  try {
+    // Replace 'ticket' with one of your entity types. See the available
+    // bridge methods (rela.list/get/search/create/update/...) in the
+    // data-entry guide.
+    const res = await rela.list({ type: 'ticket', params: { per_page: 50 } });
+    out.classList.remove('muted');
+    out.textContent = (res.data ? res.data.length : 0) + ' entities loaded.';
+  } catch (e) {
+    out.textContent = 'Error: ' + (e && e.message ? e.message : e);
+  }
+});
 `
 }

--- a/internal/projectsetup/app_test.go
+++ b/internal/projectsetup/app_test.go
@@ -2,6 +2,7 @@ package projectsetup_test
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -47,11 +48,72 @@ func TestScaffoldApp_CreatesWiredUpApp(t *testing.T) {
 		`<script src="_rela.js">`,                    // bridge SDK wired
 		`href="_rela.css"`,                           // theme opt-in
 		`name="rela-app:label"`,                      // metadata stub
-		`rela.list(`,                                 // a working bridge call
-		`window.addEventListener('rela:ready'`,
+		`href="app.css"`,                             // own styles, as a file
+		`<script src="app.js">`,                      // own code, as a file
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("starter index.html missing %q", want)
+		}
+	}
+
+	// The two asset files exist and carry the behavior that used to be inline.
+	css, err := fs.ReadFile(res.CSSAbs)
+	if err != nil {
+		t.Fatalf("app.css not written: %v", err)
+	}
+	if !strings.Contains(string(css), "var(--text-color)") {
+		t.Error("starter app.css should use rela's theme tokens")
+	}
+	js, err := fs.ReadFile(res.JSAbs)
+	if err != nil {
+		t.Fatalf("app.js not written: %v", err)
+	}
+	for _, want := range []string{`rela.list(`, `window.addEventListener('rela:ready'`} {
+		if !strings.Contains(string(js), want) {
+			t.Errorf("starter app.js missing %q", want)
+		}
+	}
+}
+
+// TestScaffoldApp_NoInlineCodeOrStyles is the guard that keeps `rela apps new`
+// working out of the box. The app CSP carries no 'unsafe-inline'
+// (dataentry.appCSP), so an inline <script>, <style> or style="" attribute in
+// the scaffold would be BLOCKED — the generated app would render unstyled and
+// do nothing, before the author writes a line of their own code. Nothing else
+// fails in that case: the files are written, the server serves them, and the
+// breakage only shows as a console violation in a browser.
+var htmlCommentRe = regexp.MustCompile(`(?s)<!--.*?-->`)
+
+func TestScaffoldApp_NoInlineCodeOrStyles(t *testing.T) {
+	fs, root := newProjectFS(t)
+
+	res, err := projectsetup.ScaffoldAppWithFS(root, "inline-check", fs)
+	if err != nil {
+		t.Fatalf("ScaffoldApp: %v", err)
+	}
+	html, err := fs.ReadFile(res.IndexAbs)
+	if err != nil {
+		t.Fatalf("read index.html: %v", err)
+	}
+	body := string(html)
+
+	// An opening <style>/<script> tag with no src= is an inline block. Strip
+	// HTML comments first: the template deliberately EXPLAINS this rule in a
+	// comment that names both tags, and a raw substring check would match that
+	// prose and fail on the very text telling authors to avoid inlining.
+	markup := htmlCommentRe.ReplaceAllString(body, "")
+	for _, bad := range []string{"<style", "<script>"} {
+		if strings.Contains(markup, bad) {
+			t.Errorf("scaffolded index.html must not contain an inline %s block: the app CSP blocks it", bad)
+		}
+	}
+	if strings.Contains(body, `style="`) {
+		t.Error(`scaffolded index.html must not use style="" attributes: blocked without 'unsafe-hashes'; use a class in app.css`)
+	}
+	// on*= inline event handlers are blocked by script-src-attr for the same reason.
+	for _, bad := range []string{"onclick=", "onload=", "onerror="} {
+		if strings.Contains(body, bad) {
+			t.Errorf("scaffolded index.html must not use an inline %s handler: the app CSP blocks it", bad)
 		}
 	}
 }

--- a/tickets/apps/ticket-counter/app.css
+++ b/tickets/apps/ticket-counter/app.css
@@ -1,0 +1,48 @@
+/* App-specific layout, using the rela tokens for colors so it matches the
+   host theme in both light and dark. */
+html,
+body {
+  height: 100%;
+}
+body {
+  font-family: inherit;
+  margin: 0;
+  padding: 1.5rem;
+  color: var(--text-color);
+  background: var(--bg-color);
+  box-sizing: border-box;
+}
+h1 {
+  font-size: 1.25rem;
+  margin: 0 0 1rem;
+}
+table {
+  border-collapse: collapse;
+  min-width: 16rem;
+}
+th,
+td {
+  text-align: left;
+  padding: 0.35rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+td.count {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.muted {
+  color: var(--muted-text);
+}
+.err {
+  color: var(--error-color);
+}
+/* Layout for the table and the refresh button. These were style="" attributes;
+   the app CSP has no 'unsafe-inline', which covers style attributes too
+   (they would need 'unsafe-hashes'), so they live here as classes instead. */
+.counts-table {
+  padding: 0.5rem 1rem;
+}
+
+.refresh-button {
+  margin-top: 1rem;
+}

--- a/tickets/apps/ticket-counter/app.js
+++ b/tickets/apps/ticket-counter/app.js
@@ -1,0 +1,57 @@
+// The host hands the SDK its bridge port a moment after load and signals
+// it with the one-time 'rela:ready' event. The SDK queues calls made
+// before the port arrives, so we could call straight away — but waiting
+// avoids a flash of an empty table if the handshake is slow.
+let started = false;
+function whenReady(fn) {
+  if (started) return;
+  started = true;
+  fn();
+}
+window.addEventListener('rela:ready', () => whenReady(load), { once: true });
+// Safety net: if the event already fired (or fires very fast), start anyway.
+setTimeout(() => whenReady(load), 500);
+
+const statusEl = document.getElementById('status');
+const tableEl = document.getElementById('table');
+const rowsEl = document.getElementById('rows');
+const refreshBtn = document.getElementById('refresh');
+
+async function load() {
+  statusEl.textContent = 'Loading tickets…';
+  try {
+    // Page through tickets and tally status. A real app would request a
+    // server-side aggregate; this keeps the demo dependency-free.
+    const res = await window.rela.list({ type: 'ticket', params: { per_page: 200 } });
+    const items = (res && res.data) || [];
+    const counts = {};
+    for (const t of items) {
+      const s = (t.properties && t.properties.status) || 'unknown';
+      counts[s] = (counts[s] || 0) + 1;
+    }
+    rowsEl.replaceChildren();
+    Object.keys(counts)
+      .sort()
+      .forEach((s) => {
+        // Build cells with textContent (auto-escaping) rather than
+        // innerHTML string concatenation — status values come from the
+        // entity store and must never be treated as HTML.
+        const tr = document.createElement('tr');
+        const label = document.createElement('td');
+        label.textContent = s;
+        const count = document.createElement('td');
+        count.className = 'count';
+        count.textContent = String(counts[s]);
+        tr.append(label, count);
+        rowsEl.appendChild(tr);
+      });
+    statusEl.textContent = items.length + ' tickets';
+    tableEl.hidden = false;
+    refreshBtn.hidden = false;
+  } catch (e) {
+    statusEl.className = 'err';
+    statusEl.textContent = 'Error: ' + (e && e.message ? e.message : e);
+  }
+}
+
+refreshBtn.addEventListener('click', load);

--- a/tickets/apps/ticket-counter/index.html
+++ b/tickets/apps/ticket-counter/index.html
@@ -15,116 +15,21 @@
     <!-- Opt into rela's theme tokens + base controls (.btn/.input/.card).
          Dark mode follows the host automatically (the SDK toggles .dark). -->
     <link rel="stylesheet" href="_rela.css" />
-    <style>
-      /* App-specific layout, using the rela tokens for colors so it matches the
-         host theme in both light and dark. */
-      html,
-      body {
-        height: 100%;
-      }
-      body {
-        font-family: inherit;
-        margin: 0;
-        padding: 1.5rem;
-        color: var(--text-color);
-        background: var(--bg-color);
-        box-sizing: border-box;
-      }
-      h1 {
-        font-size: 1.25rem;
-        margin: 0 0 1rem;
-      }
-      table {
-        border-collapse: collapse;
-        min-width: 16rem;
-      }
-      th,
-      td {
-        text-align: left;
-        padding: 0.35rem 0.75rem;
-        border-bottom: 1px solid var(--border-color);
-      }
-      td.count {
-        text-align: right;
-        font-variant-numeric: tabular-nums;
-      }
-      .muted {
-        color: var(--muted-text);
-      }
-      .err {
-        color: var(--error-color);
-      }
-    </style>
+    <!-- This app's own styles. A separate file, not an inline <style>:
+         the app CSP has no 'unsafe-inline', so inline CSS is blocked. -->
+    <link rel="stylesheet" href="app.css" />
   </head>
   <body>
     <h1>Tickets by status</h1>
     <div id="status" class="muted">Connecting…</div>
-    <table id="table" class="card" hidden style="padding: 0.5rem 1rem;">
+    <table id="table" class="card counts-table" hidden>
       <thead>
         <tr><th>Status</th><th>Count</th></tr>
       </thead>
       <tbody id="rows"></tbody>
     </table>
-    <button id="refresh" class="btn" hidden style="margin-top: 1rem;">Refresh</button>
+    <button id="refresh" class="btn refresh-button" hidden>Refresh</button>
 
-    <script>
-      // The host hands the SDK its bridge port a moment after load and signals
-      // it with the one-time 'rela:ready' event. The SDK queues calls made
-      // before the port arrives, so we could call straight away — but waiting
-      // avoids a flash of an empty table if the handshake is slow.
-      let started = false;
-      function whenReady(fn) {
-        if (started) return;
-        started = true;
-        fn();
-      }
-      window.addEventListener('rela:ready', () => whenReady(load), { once: true });
-      // Safety net: if the event already fired (or fires very fast), start anyway.
-      setTimeout(() => whenReady(load), 500);
-
-      const statusEl = document.getElementById('status');
-      const tableEl = document.getElementById('table');
-      const rowsEl = document.getElementById('rows');
-      const refreshBtn = document.getElementById('refresh');
-
-      async function load() {
-        statusEl.textContent = 'Loading tickets…';
-        try {
-          // Page through tickets and tally status. A real app would request a
-          // server-side aggregate; this keeps the demo dependency-free.
-          const res = await window.rela.list({ type: 'ticket', params: { per_page: 200 } });
-          const items = (res && res.data) || [];
-          const counts = {};
-          for (const t of items) {
-            const s = (t.properties && t.properties.status) || 'unknown';
-            counts[s] = (counts[s] || 0) + 1;
-          }
-          rowsEl.replaceChildren();
-          Object.keys(counts)
-            .sort()
-            .forEach((s) => {
-              // Build cells with textContent (auto-escaping) rather than
-              // innerHTML string concatenation — status values come from the
-              // entity store and must never be treated as HTML.
-              const tr = document.createElement('tr');
-              const label = document.createElement('td');
-              label.textContent = s;
-              const count = document.createElement('td');
-              count.className = 'count';
-              count.textContent = String(counts[s]);
-              tr.append(label, count);
-              rowsEl.appendChild(tr);
-            });
-          statusEl.textContent = items.length + ' tickets';
-          tableEl.hidden = false;
-          refreshBtn.hidden = false;
-        } catch (e) {
-          statusEl.className = 'err';
-          statusEl.textContent = 'Error: ' + (e && e.message ? e.message : e);
-        }
-      }
-
-      refreshBtn.addEventListener('click', load);
-    </script>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/tickets/entities/docs-checklists/DOCS-LD8RGZ.md
+++ b/tickets/entities/docs-checklists/DOCS-LD8RGZ.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-LD8RGZ
+type: docs-checklist
+title: 'Docs: app CSP requires external scripts and styles'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — `appCSP`'s doc says what the missing `unsafe-inline` protects against and what it does NOT (it is not the data boundary); the scaffold template carries a comment telling anyone editing it why inlining is not an option
+- [x] Function/type docs if public API — `ScaffoldApp` documents why it writes three files
+
+## Project Documentation
+
+- [x] ~~README updated (if applicable)~~ (README does not cover custom apps)
+- [x] ~~CLAUDE.md updated (if new patterns)~~ (no new pattern; tightens an existing header)
+- [x] Help text accurate (if CLI changes) — `rela apps new` now lists all three files and notes that the CSP blocks inline code
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (repo has no CHANGELOG.md)
+- [x] API docs updated (if applicable) — the data-entry guide's Custom apps section gains "Scripts and styles must be separate files": what is blocked (inline `<style>`/`<script>`, `style=""`, `on*=`), what to write instead, and why. Edited in `docs-project/` and regenerated with `just docs`.

--- a/tickets/entities/implementation-checklists/IMPL-2GEFB2.md
+++ b/tickets/entities/implementation-checklists/IMPL-2GEFB2.md
@@ -1,0 +1,144 @@
+---
+id: IMPL-2GEFB2
+type: implementation-checklist
+title: 'Implementation: App CSP: drop unsafe-inline and split the scaffold into external files'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Unit tests alone cannot support the claim here — "the browser accepts this
+policy and the app still works" is not observable from the header string. So
+every acceptance criterion was checked by building the binaries, serving a real
+project, and driving headless Chrome.
+
+**AC1 — a scaffolded app works out of the box.** `rela apps new mydash` wrote
+index.html + app.css + app.js. Served under the strict CSP (`script-src <base>;
+style-src <base>`, no `unsafe-inline`):
+
+| Observation | Value |
+| --- | --- |
+| `app.css` applied | h1 `17.5px` (1.25rem), body padding `21px` (1.5rem) |
+| `.muted` colour resolved | `rgb(102, 102, 102)` |
+| `_rela.js` + `app.js` loaded | `typeof window.rela === "object"` |
+| scripts / stylesheets | `["_rela.js","app.js"]` / `["_rela.css","app.css"]` |
+| violations during load | none |
+
+**AC2 — reference app renders identically.** The two former `style=""`
+attributes are now classes; computed values match what the inline attributes set
+(root font-size is 14px):
+
+| Element | Was | Now |
+| --- | --- | --- |
+| `#table` padding | `0.5rem 1rem` | `7px 14px` via `.counts-table` |
+| `#refresh` margin-top | `1rem` | `14px` via `.refresh-button` |
+
+`app.js` also *ran*: `#status` moved from "Connecting…" to "Loading tickets…",
+which only happens inside `load()`.
+
+**AC4 — the protection is real.** Injected both XSS shapes into a served app:
+
+```js
+d.innerHTML = '<img src=x onerror="window.__xss=1">';   // the innerHTML vector
+s.textContent = 'window.__xss2 = 1;';                    // injected <script>
+```
+
+Result: `{inlineEventHandlerRan: false, injectedScriptRan: false, violations:
+["script-src-elem <- inline", "script-src-attr <- inline"]}`.
+
+**Control — the test discriminates.** The same injection against a binary built
+from the CURRENT CSP: `{inlineScriptRan: true, violations: []}`. So the new
+policy is what blocks it, not something else.
+
+**AC5** — `app.js` → `200 text/javascript; charset=utf-8`, `app.css` → `200
+text/css; charset=utf-8` over HTTP.
+
+**Mutation testing** (both applied to real code, line-checked):
+
+| Mutation | Result |
+| --- | --- |
+| Inline `<style>` put back in the scaffold template (app.go:116) | `TestScaffoldApp_NoInlineCodeOrStyles` reddens |
+| `'unsafe-inline'` restored in `appCSP` (apps_handler.go:49-50) | `TestAppCSP_PathScopedNoEgress` reddens on both directives |
+
+## Two real breakages the browser found (and static reading did not)
+
+Both would have shipped as silent, visual-only failures. Neither was visible in
+the diff, in any unit test, or in the CSP header string.
+
+**1. The `<rela-editor>` bundle rendered completely unstyled.** `_rela-editor.js`
+calls `ensureStylesInjected()`, which built a `<style>` element holding 44KB of
+concatenated CSS (Font Awesome + EasyMDE + theme) and appended it to
+`document.head`. Under the strict CSP that element is BLOCKED: it lands in the
+DOM, but `style.sheet === null` and nothing applies. Observed
+`.CodeMirror` inheriting the app's sans-serif instead of monospace, and the
+toolbar glyphs gone.
+
+Fixed by emitting the CSS as a build artifact (`emitEditorCSS` plugin in
+`vite.editor.config.ts`) served at a new reserved endpoint `_rela-editor.css`,
+with the bundle injecting a `<link>` instead. A `<link>` is a resource load that
+the path-scoped `style-src <base>` already permits — no CSP widening. Same shape
+as the existing `_rela-editor.woff2` endpoint.
+
+After the fix, in-browser: `{violations: [], styleTag: "LINK",
+styleSheetApplied: true, styleRuleCount: 919, cmFontFamily: "monospace"}`, and
+12 Font Awesome elements resolving to family `FontAwesome` with real glyph
+content.
+
+Note this also shrank the JS bundle 382KB → 337KB, since the CSS is no longer a
+string literal inside it.
+
+**2. The e2e demo app would have stopped running.** `E2E_DEMO_APP_HTML` in
+`e2e/tests/fixtures.ts` carried the CSP probe and the bridge calls in an inline
+`<script>`. Blocked under the new policy, so every assertion in `apps.spec.ts`
+would have failed against a blank page rather than the behaviour under test.
+Split into a sibling `app.js` written alongside `index.html`.
+
+## Test-filter mistake worth recording
+
+I first ran the new endpoint's mutation with `-run "TestApp"` and read the
+resulting `ok` as "the mutation did not break anything". The subtests live under
+`TestHandleV1App`, which that pattern does not match — they never ran. Re-run
+with the right filter, the mutation reddens exactly the two new subtests
+(404 on the endpoint; missing ETag). A passing filter that selects nothing looks
+identical to a passing test.
+
+One test-authoring bug worth recording: the inline guard first matched the raw
+strings `<style>`/`<script>` and failed on the template's own *comment*
+explaining the rule. Fixed by stripping HTML comments before matching — the
+comment is worth keeping, since it is what tells an author editing the template
+why inlining is not an option.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-1XW722.md
+++ b/tickets/entities/planning-checklists/PLAN-1XW722.md
@@ -1,0 +1,214 @@
+---
+id: PLAN-1XW722
+type: planning-checklist
+title: 'Planning: App CSP: drop unsafe-inline and split the scaffold into external files'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `appCSP()` drops `'unsafe-inline'` from script-src/style-src; the `rela apps
+new` scaffold splits into index.html + app.css + app.js; the reference app
+`tickets/apps/ticket-counter/` splits the same way (including its two `style=""`
+attributes); app-authoring docs state the rule; tests pin both halves.
+
+OUT: nonce or hash-based CSP (needs per-request HTML rewriting — see
+"Alternatives"); `unsafe-hashes` for `style=""` attributes; the SPA's own CSP;
+every other CSP directive (`connect-src 'none'`, path-scoping, `form-action`,
+`frame-ancestors`) is unchanged.
+
+**Acceptance Criteria:**
+
+1. AC1 A freshly scaffolded app loads and runs under the strict CSP with no
+violations → `rela apps new`, serve, load in a real browser.
+2. AC2 The reference app renders identically → compare computed styles for the
+two former `style=""` attributes.
+3. AC3 `appCSP()` contains no `'unsafe-inline'` → assertion in
+`TestAppCSP_PathScopedNoEgress`.
+4. AC4 An inline `<script>` / `onerror=` in an app is blocked → inject both in
+a browser under the served CSP.
+5. AC5 External `.css`/`.js` serve with correct content types → existing
+`appContentTypes` map; verified over HTTP.
+6. AC6 Docs tell app authors to use external files and classes.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — the design question was settled empirically (see below)
+rather than by survey.
+
+**Existing Solutions:**
+
+- `TKT-VEJ39W` specifies the current header and marks which parts are
+load-bearing: path-scoping every resource directive, `connect-src 'none'`,
+`form-action 'none'` + sandbox. `unsafe-inline` is NOT among them — it was there
+to let single-file apps work, not as part of the boundary.
+- `appContentTypes` (`internal/dataentry/apps.go:206`) already maps `.js`/`.css`
+to fixed content types, with a comment noting a correct type is load-bearing
+under nosniff. So external assets were always a supported shape; nothing new is
+needed to serve them.
+- The reference app already avoids `innerHTML` in favour of `textContent`, with
+a comment saying why. This change makes the CSP back that discipline up.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+Drop `'unsafe-inline'` from the two directives, and make the scaffold emit the
+layout that works under the result:
+
+```go
+"script-src " + base,
+"style-src " + base,
+```
+
+`ScaffoldAppWithFS` writes three files instead of one. index.html is written
+LAST, because `appExists()` keys on it — writing it after its assets means a
+half-written scaffold is not yet a live app.
+
+**Alternatives rejected:**
+
+- *Nonce-based CSP.* Real protection, but apps are static operator files
+streamed verbatim by `openAppEntry`; a nonce must be a per-response attribute on
+every inline tag, so this turns static file serving into an HTML
+parse-and-rewrite pipeline — a new security-relevant component, for a Low
+finding. It also only covers `<script>`/`<style>` elements; `style=""`
+attributes would still need `unsafe-hashes`.
+- *Per-app opt-in (`<meta name="rela-app:strict-csp">`).* Backwards compatible,
+but two CSP paths to reason about and test, and the apps that most need the
+protection are the least likely to set the flag.
+- *Leave it and document.* This was my recommendation while the scaffold was
+the blocker. Once the scaffold is fixed, the argument for keeping
+`unsafe-inline` is gone: the cost was compatibility, and there is no in-repo app
+or generated app that needs it.
+
+**Files to modify:**
+
+- `internal/dataentry/apps_handler.go` — the CSP + its doc comment
+- `internal/dataentry/apps_test.go` — assert no `unsafe-inline`
+- `internal/projectsetup/app.go` — three-file scaffold
+- `internal/projectsetup/app_test.go` — updated + inline-free guard
+- `internal/cli/apps.go` — report the new files, mention the rule
+- `tickets/apps/ticket-counter/{index.html,app.css,app.js}` — split
+- `docs-project/entities/guides/GUIDE-data-entry.md` — the authoring rule
+(regenerate `docs/` with `just docs`)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+No new input. The CSP is emitted from `appBaseURL`, which already refuses a Host
+header containing characters that could inject CSP tokens.
+
+**Security-Sensitive Operations:**
+
+The header IS the operation. Removing a source expression only narrows what the
+app may load, so the failure direction is "a legitimate app resource is
+blocked", not "something unsafe is permitted" — which is why the acceptance work
+is mostly about proving apps still WORK.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+Unit: `TestAppCSP_PathScopedNoEgress` gains an `unsafe-inline`/`unsafe-eval`
+assertion (AC3). `TestScaffoldApp_NoInlineCodeOrStyles` fails if the scaffold
+ever reintroduces an inline block, a `style=""`, or an `on*=` handler (AC1's
+regression half).
+
+Browser (headless Chrome, real served CSP) — a unit test cannot show that a
+browser accepts the policy, which is the actual claim:
+- scaffolded app: external css/js applied, `window.rela` present (AC1)
+- reference app: computed padding/margin match the old inline values (AC2)
+- injected `<script>` and `onerror=` both blocked (AC4)
+- control on the OLD CSP: the same injection RUNS — so the test discriminates
+
+**Edge Cases:**
+
+- `style=""` attributes — blocked (need `unsafe-hashes`), so the reference app's
+two were moved to classes. Documented for authors.
+- `on*=` inline handlers — blocked by `script-src-attr`; verified.
+- Asset names must not start with `_`: the handler reserves that prefix for
+binary-served endpoints, so `app.css`/`app.js` (no underscore) are correct.
+- A half-written scaffold: index.html is written last so the folder is not a
+live app until its assets exist.
+- Existing third-party apps that inline WILL break. Accepted — see Risks.
+
+**Negative Tests:**
+
+Inline code fails VISIBLY: a CSP violation in the browser console naming the
+directive. It does not fail the request or break the host, so the docs point
+authors at the console.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- *An existing app that inlines stops working.* The real cost of this change.
+Mitigated: the only in-repo app is the reference one (split here), the scaffold
+is fixed, the failure is a clear console violation rather than silence, and the
+docs say what to do. Explicitly accepted rather than softened with a per-app
+opt-out, which would leave the protection off exactly where it matters.
+- *The strict CSP breaks something not covered by the two apps I tested.*
+Mitigated by testing in a real browser rather than asserting on the header
+string, and by leaving every other directive untouched.
+
+**Effort:** s
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+<!-- Which docs need updating? Check all that apply:
+- [x] docs/metamodel.md - New metamodel features
+- [x] docs/cli-reference.md - New/changed commands
+- [x] docs/data-entry.md - UI changes
+- [x] CLAUDE.md - New patterns or conventions
+- [x] README.md - Project-level changes
+- [x] N/A - Internal change, no user-facing docs needed
+-->
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** N/A — the design risk here was "does a real browser
+accept this", which was settled by building it and loading it before writing the
+ticket, rather than by review.

--- a/tickets/entities/review-checklists/REV-Q1ERIB.md
+++ b/tickets/entities/review-checklists/REV-Q1ERIB.md
@@ -1,0 +1,117 @@
+---
+id: REV-Q1ERIB
+type: review-checklist
+title: 'Review: App CSP: drop unsafe-inline and split the scaffold into external files'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** None created — the two findings that mattered were found
+by in-browser verification during implementation and fixed in the same branch
+(the editor stylesheet and the e2e fixture; both written up in IMPL-2GEFB2).
+
+The review question that produced them was: *what else injects inline style or
+script into an app document at runtime?* That is not answerable from the diff —
+the editor bundle is a build artifact, and the e2e app HTML is a TypeScript
+string constant. Both were found by loading a real page and by grepping for
+inline markup in generated sources.
+
+Repo-wide sweep for anything else now blocked, all clear:
+
+- app HTML files: only `tickets/apps/ticket-counter/` (split here) and the e2e
+fixture (split here). `mockups/` and the SPA's own `index.html` are not served
+under the app CSP.
+- Go sources emitting app HTML: only the scaffold template, which is now
+inline-free and has a test to keep it that way.
+- docs examples an author would copy: none inline.
+- code/tests/e2e depending on `'unsafe-inline'`: none. The remaining mentions
+are historical ticket entities (TKT-VEJ39W, TKT-3DBK6I) that correctly record
+what was true when written.
+- `.style.cssText` in the editor bundle (10 occurrences): CSSOM property
+writes, NOT inline style attributes — unaffected by `style-src`. Verified in
+browser, not just reasoned about.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+All PASS, each verified in a real browser rather than against the header string.
+Full evidence tables in IMPL-2GEFB2.
+
+- AC1 scaffolded app works out of the box — PASS (external css/js applied,
+`window.rela` present, zero violations)
+- AC2 reference app renders identically — PASS (`7px 14px` / `14px` match the
+old inline values at the theme's 14px root)
+- AC3 `appCSP()` has no `unsafe-inline` — PASS (asserted; mutation reddens it)
+- AC4 inline `<script>` and `onerror=` blocked — PASS (both, with a control
+proving the OLD CSP lets them run)
+- AC5 external `.css`/`.js` serve correctly — PASS
+- AC6 docs state the rule — PASS
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/tickets/TKT-JO125X.md
+++ b/tickets/entities/tickets/TKT-JO125X.md
@@ -1,0 +1,62 @@
+---
+id: TKT-JO125X
+type: ticket
+title: 'App CSP: drop unsafe-inline and split the scaffold into external files'
+kind: enhancement
+priority: low
+status: done
+---
+
+## Problem
+
+`appCSP()` sets `script-src` and `style-src` to include `'unsafe-inline'`, which
+disables a defense-in-depth layer against XSS *inside* an app: if an app injects
+untrusted data into the DOM (e.g. via `innerHTML`), a strict CSP would still
+block the resulting `<script>` tags. With `unsafe-inline` that injection runs.
+
+Reported as [#1025](https://github.com/sourcehaven-bv/rela/issues/1025) from the
+IB review of #1012. Severity: Low. Grounds: POLICY-015 §3 (OWASP A03).
+
+This is not a weakening of the main boundary — an app already runs with
+`allow-scripts`. The actual data boundary is path-scoping + `connect-src 'none'`
++ the bridge, and none of that changes here.
+
+## Why this was previously parked
+
+`unsafe-inline` was deliberate (TKT-VEJ39W), and the blocker was that rela's own
+scaffold emits inline markup: `rela apps new` writes an `index.html` with an
+inline `<style>` and `<script>`. A strict CSP would break the app rela generates
+for you before you write a line of your own code.
+
+The decision: **the scaffold should work out of the box**, so fix the scaffold.
+
+## Verified empirically before implementing
+
+Built a server with the strict CSP and loaded a split-file app in a real browser
+(headless Chrome):
+
+- external `app.css` applied (h1 17.5px, body padding 21px)
+- external `_rela.js` loaded (`window.rela` defined)
+- injected inline `<script>` did NOT run; violation `script-src-elem <- inline`
+- injected inline `<style>` did NOT apply; violation `style-src-elem <- inline`
+
+Control on the CURRENT CSP: the same injected inline script DOES run, with zero
+violations. So the change delivers exactly the protection the issue asks for.
+
+## Approach
+
+1. Scaffold writes three files: `index.html`, `app.css`, `app.js` — no inline.
+2. Reference app `tickets/apps/ticket-counter/` split the same way, including
+its two inline `style=` attributes (pure layout, moved to classes).
+3. `appCSP()` drops `'unsafe-inline'` from `script-src` and `style-src`.
+4. Docs state the rule so app authors know why, and that `style=` attributes
+would need `unsafe-hashes` (i.e. use classes instead).
+
+## Acceptance criteria
+
+- AC1 A scaffolded app loads and runs under the strict CSP with no violations.
+- AC2 The reference app renders identically to before.
+- AC3 `appCSP()` contains no `'unsafe-inline'`; a test pins it.
+- AC4 An inline `<script>` in an app is blocked (regression guard).
+- AC5 External `.css`/`.js` still serve with correct content types.
+- AC6 Docs tell app authors to use external files and classes.

--- a/tickets/relations/TKT-JO125X--affects--authorization.md
+++ b/tickets/relations/TKT-JO125X--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JO125X
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-JO125X--has-docs--DOCS-LD8RGZ.md
+++ b/tickets/relations/TKT-JO125X--has-docs--DOCS-LD8RGZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JO125X
+relation: has-docs
+to: DOCS-LD8RGZ
+---

--- a/tickets/relations/TKT-JO125X--has-implementation--IMPL-2GEFB2.md
+++ b/tickets/relations/TKT-JO125X--has-implementation--IMPL-2GEFB2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JO125X
+relation: has-implementation
+to: IMPL-2GEFB2
+---

--- a/tickets/relations/TKT-JO125X--has-planning--PLAN-1XW722.md
+++ b/tickets/relations/TKT-JO125X--has-planning--PLAN-1XW722.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JO125X
+relation: has-planning
+to: PLAN-1XW722
+---

--- a/tickets/relations/TKT-JO125X--has-review--REV-Q1ERIB.md
+++ b/tickets/relations/TKT-JO125X--has-review--REV-Q1ERIB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JO125X
+relation: has-review
+to: REV-Q1ERIB
+---

--- a/tickets/relations/TKT-JO125X--implements--FEAT-BFDB9Q.md
+++ b/tickets/relations/TKT-JO125X--implements--FEAT-BFDB9Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-JO125X
+relation: implements
+to: FEAT-BFDB9Q
+---


### PR DESCRIPTION
Fixes #1025 (TKT-JO125X). IB-review finding on #1012.

## The problem

`appCSP()` allowed `'unsafe-inline'` on `script-src` and `style-src`. That is
not the data boundary — an app already runs with `allow-scripts` and could
execute anything it ships — but it disabled a defense-in-depth layer against the
app's **own** bugs: if an app builds DOM from entity data with `innerHTML`, a
`<script>` or `onerror=` smuggled through that data executed.

## Why this was parked, and what changed

`unsafe-inline` was deliberate (TKT-VEJ39W). The blocker was that rela's own
scaffold emitted a single `index.html` with an inline `<style>` and `<script>`,
so a strict CSP would break the app rela generates for you before you write a
line of your own code.

The call: **the scaffold should work out of the box**, so fix the scaffold.

- `rela apps new` now writes `index.html` + `app.css` + `app.js`.
- The reference app `tickets/apps/ticket-counter/` is split the same way. Its
  two `style=""` attributes became classes — `style-src` blocks those too
  without `unsafe-hashes`.
- `appCSP()` drops `'unsafe-inline'`.

## Two breakages only a browser found

Neither is visible in the diff, in a unit test, or in the header string. Both
would have shipped as silent visual failures.

**The `<rela-editor>` bundle rendered completely unstyled.** It built a
`<style>` element holding 44KB of concatenated CSS (Font Awesome + EasyMDE +
theme) and appended it to `document.head`. Under the strict CSP that element is
blocked: it lands in the DOM, `style.sheet` stays `null`, nothing applies.
`.CodeMirror` inherited the app's sans-serif instead of monospace and the
toolbar glyphs vanished.

Fixed by emitting the CSS as a build artifact (`emitEditorCSS` in
`vite.editor.config.ts`) served at a new reserved `_rela-editor.css` endpoint,
with the bundle injecting a `<link>`. A `<link>` is a resource load that the
path-scoped `style-src <base>` already permits, so no CSP widening — the same
shape as the existing `_rela-editor.woff2` endpoint. The JS bundle drops
382KB → 337KB as a side effect, since the CSS is no longer a string literal
inside it.

**The e2e demo app would have stopped running.** `E2E_DEMO_APP_HTML` carried the
CSP probe and bridge calls in an inline `<script>`, so every assertion in
`apps.spec.ts` would have failed against a blank page rather than the behaviour
under test. Split into a sibling `app.js`.

## Verification

Headless Chrome against a real server, because "the browser accepts this policy
and the app still works" is not observable from the header:

| Check | Result |
|---|---|
| Scaffolded app under strict CSP | external css/js applied (h1 `17.5px`, padding `21px`), `window.rela` present, **zero violations** |
| Reference app | `.counts-table` → `7px 14px`, `.refresh-button` → `14px` — matching the old inline values at the theme's 14px root; `app.js` ran (status advanced to "Loading tickets…") |
| Editor after the fix | `styleTag: "LINK"`, `styleSheetApplied: true`, `919` rules, `.CodeMirror` → `monospace`, 12 FA elements resolving to family `FontAwesome` with real glyph content |
| XSS payloads | injected `<script>` and `onerror=` **both blocked** — `script-src-elem`, `script-src-attr` |
| **Control on the OLD CSP** | the same injection **runs**, zero violations — so the new policy is what blocks it |

Mutations, each confirmed on a numbered line of executable code:

| Mutation | Result |
|---|---|
| Inline `<style>` back in the scaffold template | `TestScaffoldApp_NoInlineCodeOrStyles` reddens |
| `'unsafe-inline'` restored in `appCSP` | `TestAppCSP_PathScopedNoEgress` reddens on both directives |
| `_rela-editor.css` endpoint removed | 404 + missing ETag on the two new subtests |

Worth flagging: I first ran that third mutation with `-run "TestApp"` and read
the resulting `ok` as "nothing broke". The subtests live under
`TestHandleV1App`, which that pattern does not match — they never ran. A filter
that selects nothing looks exactly like a passing test.

## Compatibility

A third-party app that inlines will break, visibly, with a CSP violation naming
the directive. Accepted rather than softened with a per-app opt-out, which would
leave the protection off precisely where it matters. The only in-repo apps are
the reference one and the e2e fixture, both split here; the scaffold generates
the working shape; the docs say what to do.

https://claude.ai/code/session_01Rz1pkAMNfQnhtQWPzvsvtg
