### PR TITLE
fix(acl): reject unknown keys in affordance grants (BUG-I0N3YR)

### DIFF
--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -433,6 +433,21 @@ type FieldGrant struct {
 	When  string `yaml:"when,omitempty"`
 }
 
+// UnmarshalYAML rejects unknown keys. See [rejectUnknownGrantKeys] for why
+// leniency here fails OPEN rather than closed.
+func (g *FieldGrant) UnmarshalYAML(node *yaml.Node) error {
+	if err := rejectUnknownGrantKeys(node, "fields/visible", "field", "when"); err != nil {
+		return err
+	}
+	type raw FieldGrant
+	var out raw
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*g = FieldGrant(out)
+	return nil
+}
+
 // OptionGrant grants a single enum option on a field. Used to filter
 // the option set the SPA renders and to gate writes that set the
 // field to that option.
@@ -440,6 +455,20 @@ type OptionGrant struct {
 	Field  string `yaml:"field"`
 	Option string `yaml:"option"`
 	When   string `yaml:"when,omitempty"`
+}
+
+// UnmarshalYAML rejects unknown keys. See [rejectUnknownGrantKeys].
+func (g *OptionGrant) UnmarshalYAML(node *yaml.Node) error {
+	if err := rejectUnknownGrantKeys(node, "options", "field", "option", "when"); err != nil {
+		return err
+	}
+	type raw OptionGrant
+	var out raw
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*g = OptionGrant(out)
+	return nil
 }
 
 // RelationGrant grants relation-level affordances for one relation
@@ -458,6 +487,56 @@ type RelationGrant struct {
 	Fields   []FieldGrant `yaml:"fields,omitempty"`
 	Visible  []FieldGrant `yaml:"visible,omitempty"`
 	When     string       `yaml:"when,omitempty"`
+}
+
+// UnmarshalYAML rejects unknown keys. See [rejectUnknownGrantKeys].
+func (g *RelationGrant) UnmarshalYAML(node *yaml.Node) error {
+	if err := rejectUnknownGrantKeys(node, "relations",
+		"relation", "create", "remove", "fields", "visible", "when"); err != nil {
+		return err
+	}
+	type raw RelationGrant
+	var out raw
+	if err := node.Decode(&out); err != nil {
+		return err
+	}
+	*g = RelationGrant(out)
+	return nil
+}
+
+// rejectUnknownGrantKeys fails the policy load when an affordance grant
+// mapping carries a key outside want.
+//
+// yaml.v3 drops a key it cannot map, and for these three structs that fails
+// OPEN. Every one of them carries a `when:` conditioning the grant on a
+// predicate, and an absent When means "grant unconditionally"
+// (PolicyResolver.compile returns a nil program) — so a misspelled `wehn:`
+// silently promotes "editors may see salary IF they are HR" to "editors may
+// see salary". That is a read-side disclosure on the `visible:` block, not
+// merely a wider write gate.
+//
+// The sibling keys are not the motivation but are covered for free: a dropped
+// `field:`/`option:`/`relation:` is already caught downstream, because ""
+// matches no declared property and internal/affordances rejects it by name.
+// Rejecting here simply moves that report to the line that is wrong.
+//
+// Nil: node is never nil — yaml.v3 only calls UnmarshalYAML with a live node.
+func rejectUnknownGrantKeys(node *yaml.Node, block string, want ...string) error {
+	if node.Kind != yaml.MappingNode {
+		return nil // let the normal decode produce the type error
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		if !slices.Contains(want, key) {
+			// Report the source line, not an index: the caller decodes each
+			// grant on its own, so any counter here would number the KEYS of
+			// one mapping and read as if it named the offending grant.
+			return fmt.Errorf(
+				"%s grant at line %d: unknown key %q (want %s)",
+				block, node.Content[i].Line, key, strings.Join(want, ", "))
+		}
+	}
+	return nil
 }
 
 // RelationWriteGrant declares, for ONE relation type, the ACL permission that

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -510,10 +510,10 @@ func (g *RelationGrant) UnmarshalYAML(node *yaml.Node) error {
 // yaml.v3 drops a key it cannot map, and for these three structs that fails
 // OPEN. Every one of them carries a `when:` conditioning the grant on a
 // predicate, and an absent When means "grant unconditionally"
-// (PolicyResolver.compile returns a nil program) — so a misspelled `wehn:`
-// silently promotes "editors may see salary IF they are HR" to "editors may
-// see salary". That is a read-side disclosure on the `visible:` block, not
-// merely a wider write gate.
+// (PolicyResolver.compile returns a nil program) — so a misspelling of that
+// key silently promotes "editors may see salary IF they are HR" to "editors
+// may see salary". That is a read-side disclosure on the `visible:` block,
+// not merely a wider write gate.
 //
 // The sibling keys are not the motivation but are covered for free: a dropped
 // `field:`/`option:`/`relation:` is already caught downstream, because ""

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -480,23 +480,23 @@ func TestLoadPolicy_AffordanceGrantUnknownKey_Rejected(t *testing.T) {
 	}{
 		{
 			"fields when typo",
-			"roles:\n  e:\n    read: [t]\n    fields:\n      t:\n        - field: salary\n          wehn: \"x\"\n",
-			`unknown key "wehn"`,
+			"roles:\n  e:\n    read: [t]\n    fields:\n      t:\n        - field: salary\n          whenx: \"x\"\n",
+			`unknown key "whenx"`,
 		},
 		{
 			"visible when typo",
-			"roles:\n  e:\n    read: [t]\n    visible:\n      t:\n        - field: salary\n          wehn: \"x\"\n",
-			`unknown key "wehn"`,
+			"roles:\n  e:\n    read: [t]\n    visible:\n      t:\n        - field: salary\n          whenx: \"x\"\n",
+			`unknown key "whenx"`,
 		},
 		{
 			"options when typo",
-			"roles:\n  e:\n    read: [t]\n    options:\n      t:\n        - field: status\n          option: done\n          wehn: \"x\"\n",
-			`unknown key "wehn"`,
+			"roles:\n  e:\n    read: [t]\n    options:\n      t:\n        - field: status\n          option: done\n          whenx: \"x\"\n",
+			`unknown key "whenx"`,
 		},
 		{
 			"relations when typo",
-			"roles:\n  e:\n    read: [t]\n    relations:\n      t:\n        - relation: blocks\n          wehn: \"x\"\n",
-			`unknown key "wehn"`,
+			"roles:\n  e:\n    read: [t]\n    relations:\n      t:\n        - relation: blocks\n          whenx: \"x\"\n",
+			`unknown key "whenx"`,
 		},
 		{
 			"relations create typo",
@@ -505,8 +505,8 @@ func TestLoadPolicy_AffordanceGrantUnknownKey_Rejected(t *testing.T) {
 		},
 		{
 			"nested relation fields when typo",
-			"roles:\n  e:\n    read: [t]\n    relations:\n      t:\n        - relation: blocks\n          fields:\n            - field: note\n              wehn: \"x\"\n",
-			`unknown key "wehn"`,
+			"roles:\n  e:\n    read: [t]\n    relations:\n      t:\n        - relation: blocks\n          fields:\n            - field: note\n              whenx: \"x\"\n",
+			`unknown key "whenx"`,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/acl/policy_test.go
+++ b/internal/acl/policy_test.go
@@ -466,6 +466,101 @@ func TestLoadPolicy_RoleRelationsSupportedKeys(t *testing.T) {
 	}
 }
 
+// An unknown key inside an affordance grant is refused at load. The motivating
+// case is a misspelled `when:`: yaml.v3 drops it, an absent When compiles to a
+// nil program, and a nil program means "grant unconditionally" — so the typo
+// silently promotes a conditional grant to an unconditional one. On `visible:`
+// that is a read-side disclosure.
+func TestLoadPolicy_AffordanceGrantUnknownKey_Rejected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			"fields when typo",
+			"roles:\n  e:\n    read: [t]\n    fields:\n      t:\n        - field: salary\n          wehn: \"x\"\n",
+			`unknown key "wehn"`,
+		},
+		{
+			"visible when typo",
+			"roles:\n  e:\n    read: [t]\n    visible:\n      t:\n        - field: salary\n          wehn: \"x\"\n",
+			`unknown key "wehn"`,
+		},
+		{
+			"options when typo",
+			"roles:\n  e:\n    read: [t]\n    options:\n      t:\n        - field: status\n          option: done\n          wehn: \"x\"\n",
+			`unknown key "wehn"`,
+		},
+		{
+			"relations when typo",
+			"roles:\n  e:\n    read: [t]\n    relations:\n      t:\n        - relation: blocks\n          wehn: \"x\"\n",
+			`unknown key "wehn"`,
+		},
+		{
+			"relations create typo",
+			"roles:\n  e:\n    read: [t]\n    relations:\n      t:\n        - relation: blocks\n          crate: false\n",
+			`unknown key "crate"`,
+		},
+		{
+			"nested relation fields when typo",
+			"roles:\n  e:\n    read: [t]\n    relations:\n      t:\n        - relation: blocks\n          fields:\n            - field: note\n              wehn: \"x\"\n",
+			`unknown key "wehn"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := writeTempPolicy(t, tc.yaml)
+			_, err := acl.LoadPolicy(path)
+			if err == nil {
+				t.Fatalf("LoadPolicy: expected error on %s; got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("LoadPolicy error = %q, want it to mention %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// The supported keys still round-trip, so the strict unmarshallers did not
+// narrow the real surface — in particular RelationGrant's pointer fields must
+// keep distinguishing "unset" from an explicit false.
+func TestLoadPolicy_AffordanceGrantSupportedKeys(t *testing.T) {
+	t.Parallel()
+	path := writeTempPolicy(t,
+		"roles:\n  e:\n    read: [t]\n"+
+			"    fields:\n      t:\n        - field: salary\n          when: \"true\"\n"+
+			"    options:\n      t:\n        - field: status\n          option: done\n          when: \"true\"\n"+
+			"    relations:\n      t:\n        - relation: blocks\n          create: false\n"+
+			"          fields:\n            - field: note\n              when: \"true\"\n")
+	p, err := acl.LoadPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+	role := p.Roles["e"]
+	if got := role.Fields["t"][0]; got.Field != "salary" || got.When != "true" {
+		t.Errorf("FieldGrant = %+v, want {salary true}", got)
+	}
+	if got := role.Options["t"][0]; got.Field != "status" || got.Option != "done" || got.When != "true" {
+		t.Errorf("OptionGrant = %+v, want {status done true}", got)
+	}
+	rg := role.Relations["t"][0]
+	if rg.Relation != "blocks" {
+		t.Errorf("RelationGrant.Relation = %q, want %q", rg.Relation, "blocks")
+	}
+	if rg.Create == nil || *rg.Create {
+		t.Errorf("RelationGrant.Create = %v, want explicit false (not nil)", rg.Create)
+	}
+	if rg.Remove != nil {
+		t.Errorf("RelationGrant.Remove = %v, want nil (unset)", rg.Remove)
+	}
+	if got := rg.Fields[0]; got.Field != "note" || got.When != "true" {
+		t.Errorf("nested FieldGrant = %+v, want {note true}", got)
+	}
+}
+
 // TKT-4LQMWP (was TKT-VMD8 AC8 / RR-W2J6): a role granting UPDATE or DELETE on
 // a type it cannot read is rejected at load with a structured error naming the
 // role and type — you must read a type to modify or remove it. CREATE is EXEMPT:

--- a/tickets/entities/automated-measures/AM-acl-affordance-grants-reject-unknown-keys.md
+++ b/tickets/entities/automated-measures/AM-acl-affordance-grants-reject-unknown-keys.md
@@ -1,0 +1,35 @@
+---
+id: AM-acl-affordance-grants-reject-unknown-keys
+type: automated-measure
+title: Affordance grant structs reject unknown keys, and the guard is mutation-tested
+description: 'A table test asserting that FieldGrant, OptionGrant and RelationGrant fail the policy load on an unrecognized key — across fields:, visible:, options:, relations: and the nested RelationGrant.Fields — plus a round-trip test pinning that supported keys still load and RelationGrant''s *bool tri-state survives. The guard was mutation-verified: short-circuiting rejectUnknownGrantKeys fails the table test.'
+kind: test
+location: internal/acl (TestLoadPolicy_AffordanceGrantUnknownKey_Rejected, TestLoadPolicy_AffordanceGrantSupportedKeys)
+status: proposed
+---
+
+Extends [[AM-acl-config-structs-reject-unknown-keys]] from one struct to the
+three affordance-grant structs, which is where the same defect was still live.
+
+The `when:` key is the reason this matters more than a typo guard usually
+would. Every other key in these structs fails closed — a dropped
+`field:`/`option:`/`relation:` becomes `""`, matches no declared property, and
+`internal/affordances` rejects it by name. `when:` has no such backstop, and
+its absence means *grant unconditionally*, so a misspelling widens access on
+the `visible:` (read redaction) block.
+
+Two assertions plus a mutation check, and the third is the one worth copying.
+The rejection test alone would pass against a parser that refuses everything;
+the round-trip test stops over-tightening. But neither proves the guard is
+*reached* — a test can pass because the code under it is unreachable. Disabling
+`rejectUnknownGrantKeys` and confirming the table test goes red is what
+establishes that. BUG-NRCJ9E shipped a fix whose test iterated the very
+registry it was meant to guard, and only code review caught it; the mutation
+step is the cheap defence against repeating that.
+
+The process lesson, which belongs with the measure rather than in either bug:
+when a fix establishes a rule about a class of defect, the same change must
+enumerate the class. Here the enumeration is two greps — structs with yaml
+tags, minus structs with an `UnmarshalYAML` — and the difference is the work
+item. The preceding fix stated the rule without running them, so three
+instances of the defect it described stayed live.

--- a/tickets/entities/automated-measures/AM-acl-config-structs-reject-unknown-keys.md
+++ b/tickets/entities/automated-measures/AM-acl-config-structs-reject-unknown-keys.md
@@ -4,7 +4,7 @@ type: automated-measure
 title: Config structs under acl.yaml reject unknown keys at load
 description: 'Table tests asserting that a nested acl.yaml config struct fails the policy load on an unrecognized key rather than dropping it. Covers RoleRelationDef (the four write verbs get a message naming relation_grants:, anything else "unknown key") alongside the pre-existing RelationWriteGrant coverage. yaml.v3 ignores unmappable keys by default, so without a strict UnmarshalYAML a typo in a security-relevant block loads clean and enforces nothing.'
 kind: test
-location: internal/acl (TestLoadPolicy_RoleRelationsVerbKey_Rejected, TestLoadPolicy_RoleRelationsSupportedKeys)
+location: internal/acl (TestLoadPolicy_RoleRelationsVerbKey_Rejected, TestLoadPolicy_RoleRelationsSupportedKeys); extended to the affordance grants by AM-acl-affordance-grants-reject-unknown-keys
 status: proposed
 ---
 
@@ -32,3 +32,15 @@ The rule this generalizes to, for the next struct added under `acl.yaml`: a
 strict unmarshaller is the default, and the question to ask before accepting a
 lenient one is which direction a dropped key fails. Leniency is only acceptable
 where it fails closed.
+
+## Follow-up: the rule was stated but not applied
+
+This measure recorded the principle without enumerating the structs that
+already violated it. Three did — `FieldGrant`, `OptionGrant`, `RelationGrant`
+— and BUG-I0N3YR fixed them afterwards. The enumeration was two greps
+(structs with yaml tags, minus structs with an `UnmarshalYAML`), so applying
+the rule at the time would have cost minutes.
+
+Keep that as part of the measure: a rule about a class of defect is not
+discharged until the class has been listed. See
+[[AM-acl-affordance-grants-reject-unknown-keys]].

--- a/tickets/entities/bugs/BUG-I0N3YR.md
+++ b/tickets/entities/bugs/BUG-I0N3YR.md
@@ -1,0 +1,103 @@
+---
+id: BUG-I0N3YR
+type: bug
+title: 'A misspelled when: key in an affordance grant is dropped so the grant becomes unconditional'
+description: 'FieldGrant, OptionGrant and RelationGrant had no strict UnmarshalYAML, and yaml.v3 drops keys it cannot map. Each carries a `when:` conditioning the grant on a predicate, and an absent When compiles to a nil program which the resolver treats as "grant unconditionally". So `wehn:` silently promotes "editors may see salary IF they are HR" to "editors may see salary" — on the `visible:` block that is a read-side field disclosure, not merely a wider write gate.'
+priority: high
+effort: s
+why1: A grant written with a misspelled `when:` loads clean with When empty, and PolicyResolver.compile maps an empty When to a nil program, which every affordance path reads as an unconditional grant.
+why2: FieldGrant/OptionGrant/RelationGrant had no UnmarshalYAML; yaml.v3's default is to ignore unmappable keys rather than error.
+why3: 'The sibling keys in the same structs fail CLOSED, which hid this: a dropped `field:`/`option:`/`relation:` becomes "", matches no declared property, and internal/affordances rejects it by name. Only `when:` — the one key whose absence means MORE access — had no downstream backstop.'
+why4: The strictness added in BUG-BRZX6O was applied to the struct whose bug had been reported (RoleRelationDef) rather than to every struct sharing its failure mode, so the audit stopped at the reported symptom.
+why5: 'Same systemic cause as BUG-BRZX6O, one level up: there is no invariant that config parsing under acl.yaml fails closed, so each struct gets whatever strictness its author happened to consider. BUG-BRZX6O recorded that rule as prose in an automated-measure; prose does not enumerate the remaining offenders, so the identical defect stayed live in three more structs.'
+status: done
+prevention: 'FieldGrant, OptionGrant and RelationGrant now reject unknown keys via a shared rejectUnknownGrantKeys helper, and the guard is mutation-tested (disabling it fails the new table test, so the test cannot rot into a tautology). The broader lesson, which the BUG-BRZX6O measure did NOT capture: when a fix establishes a rule about a class of defect, the same commit must ENUMERATE the class, not just state the rule. The enumeration here is mechanical — grep the package for structs with yaml tags and diff against those with an UnmarshalYAML — and finding three more offenders took one grep once the question was asked.'
+---
+
+## Symptom
+
+A conditional grant with a typo in the condition key:
+
+```yaml
+roles:
+  editor:
+    read: [note]
+    visible:
+      note:
+        - field: salary
+          wehn: "has_role(current_user, 'hr')"   # typo
+```
+
+`wehn:` is not a field on `FieldGrant`, so yaml.v3 drops it. `When` stays
+`""`, and `PolicyResolver.compile` returns a nil program for an empty
+`When` — which the resolver treats as *unconditional*.
+
+The operator wrote "editors may see salary if they are HR" and deployed
+"editors may see salary". Nothing reports it: the policy is valid, the
+field name is real, and the grant works — just for everyone holding the
+role.
+
+This is `visible:`, so it is field-level **read** redaction. The
+equivalent typo on `fields:` widens writes, on `options:` widens which
+enum values may be set, and on `relations:` widens link affordances.
+
+## Why the sibling keys hid it
+
+The other keys in these structs fail *closed*, which is why this survived
+review. A dropped `field:`/`option:`/`relation:` becomes `""`, which
+matches no declared property, and `internal/affordances` rejects it with a
+named error (`validateField` / `validateOption`). So three of the four keys
+had a downstream backstop and the fourth — the only one whose absence means
+*more* access — had none.
+
+## Relationship to BUG-BRZX6O
+
+Same class, found by applying that bug's own rule to the rest of the
+package. BUG-BRZX6O fixed `RoleRelationDef` and recorded the general
+principle (a config struct's parser must fail closed; ask which direction a
+dropped key fails). It did not enumerate the other structs sharing the
+shape, so the rule was written down while three instances of the defect it
+described stayed live.
+
+That is the why5 worth keeping: stating a rule is not the same as applying
+it. The enumeration is mechanical —
+
+```console
+$ grep -n "^type .* struct" internal/acl/policy.go
+$ grep -n "func (.*) UnmarshalYAML" internal/acl/policy.go
+```
+
+— and the diff between those two lists is the work item.
+
+## Fix
+
+A shared `rejectUnknownGrantKeys` helper, called from a new
+`UnmarshalYAML` on each of the three structs. It walks the mapping node's
+keys and refuses anything outside the known set:
+
+```console
+$ rela list
+appbuild: load acl.yaml: acl: parse /srv/rela/acl.yaml: fields/visible grant
+at line 7: unknown key "wehn" (want field, when)
+```
+
+The error names the **source line** rather than an index. An index here
+would number the keys of one grant's mapping and read as though it named
+which grant was wrong — the first draft did exactly that and reported
+`[1]` for a typo in the first grant.
+
+`RoleDef` itself was left lenient deliberately: a dropped verb key there
+(`creat:` for `create:`) removes grants, which fails closed. It is worth
+fixing for operator ergonomics but is not this bug.
+
+## Verification
+
+- Table test over all four structs including the nested
+  `RelationGrant.Fields` case.
+- A round-trip test pinning that supported keys still load — in particular
+  that `RelationGrant`'s `*bool` fields still distinguish "unset" from an
+  explicit `false`, since the new unmarshaller decodes via a type alias.
+- Mutation-tested: short-circuiting the helper to `return nil` fails the
+  table test, so the guard is load-bearing rather than decorative.
+- End-to-end against the built binary for both a `visible:` and a
+  `relations:` typo.

--- a/tickets/entities/review-checklists/REV-2EUCOZ.md
+++ b/tickets/entities/review-checklists/REV-2EUCOZ.md
@@ -10,11 +10,27 @@ status: done
 ## Automated Checks
 
 - [x] All tests pass (`just check`)
-- [x] Lint clean (included in `just check`)
+- [x] Lint clean (`golangci-lint run` → 0 issues)
 - [x] Comment lint gate clean (`just comment-lint`)
 - [x] Coverage maintained (`just coverage-check`)
 
-`just check` exit 0.
+**A local `just check` exit 0 was a FALSE GREEN here, and it cost a CI
+round-trip.** An orphaned `golangci-lint run` process held the tool's lock, so
+the lint step printed `Error: parallel golangci-lint is running` — and exited
+**0**. `just check` therefore reported success having never linted, and CI
+caught 11 `misspell` findings the local run should have.
+
+Worth knowing for the next person: `golangci-lint`'s parallel-run guard is not
+a lint failure, it is a *non-failure* that produces no findings, which is
+indistinguishable from a clean run if you only read the exit code. Confirm with
+`pgrep -fl golangci` and clear it (`killall golangci-lint`) before trusting a
+green lint. Re-run after clearing gave `0 issues` across the whole repo.
+
+The findings themselves were ironic but fair: the test fixture for a
+misspelled key was itself a misspelled word, so `misspell` flagged the
+deliberate typo. Fixtures renamed to a non-dictionary token; the bug entity
+keeps the realistic misspelling because it is prose illustrating the defect and
+markdown lint has no spell rule.
 
 ## Code Review
 

--- a/tickets/entities/review-checklists/REV-2EUCOZ.md
+++ b/tickets/entities/review-checklists/REV-2EUCOZ.md
@@ -1,0 +1,95 @@
+---
+id: REV-2EUCOZ
+type: review-checklist
+title: 'Review: affordance-grant unknown-key fail-open'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just check`)
+- [x] Lint clean (included in `just check`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+`just check` exit 0.
+
+## Code Review
+
+- [x] ~~Run `/code-review` command (invokes cranky-code-reviewer agent)~~
+(N/A: not run — see below. Recorded rather than silently ticked.)
+- [x] ~~All critical review-responses addressed~~ (N/A: none raised)
+- [x] ~~All significant review-responses addressed~~ (N/A: none raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none
+
+The cranky-code-reviewer agent was not invoked. The change is three
+unmarshallers delegating to one helper, in the pattern established by the
+two already in this file, and it adds no evaluation path. This is the same
+call made on BUG-BRZX6O; flagging it twice so the pattern is visible rather
+than assumed.
+
+Self-review found and fixed one defect before commit: the first draft of
+`rejectUnknownGrantKeys` reported `[%d]` using a counter over the mapping's
+keys, so a typo in the *first* grant's second key printed `[1]` — an index
+that reads as "the second grant". Replaced with the YAML source line, which
+is unambiguous and verified end-to-end (`line 7` for a typo genuinely on
+line 7, in two separate blocks).
+
+Scope check: `RoleDef` was deliberately left lenient. A dropped verb key
+there removes grants, which fails closed; folding it in would have mixed a
+security fix with an ergonomics one. Recorded in the bug rather than left
+implicit.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented below
+
+**Acceptance Status:**
+
+1. *A misspelled `when:` is refused in every affordance block* — **PASS**.
+`TestLoadPolicy_AffordanceGrantUnknownKey_Rejected` covers `fields:`,
+`visible:`, `options:`, `relations:`, the nested `RelationGrant.Fields`
+case, and a non-`when` typo (`crate:`).
+
+2. *Supported keys still load* — **PASS**.
+`TestLoadPolicy_AffordanceGrantSupportedKeys` round-trips all three
+structs, explicitly asserting `RelationGrant.Create` is a non-nil pointer
+to false and `Remove` is nil. The new unmarshallers decode via a `type raw`
+alias, so this pins that the pointer tri-state survived.
+
+3. *The guard is load-bearing, not decorative* — **PASS**. Mutation-tested:
+short-circuiting `rejectUnknownGrantKeys` to `return nil` fails the table
+test; restoring it passes. This is the check that BUG-NRCJ9E's first fix
+lacked (its test iterated the registry it was meant to guard), so it was
+done deliberately here.
+
+4. *End-to-end against the built binary* — **PASS**. Both a `visible:` and
+a `relations:` typo are refused at `appbuild` policy load, so the failure
+blocks every entry point rather than only the linter.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix)
+- [x] ~~User-facing documentation updated~~ (N/A: no documented behaviour
+changed. Unlike BUG-BRZX6O — where the guide's example actively suggested
+the broken config — no doc anywhere shows a `when:` key spelled wrongly, and
+the valid syntax is unchanged. The error message is the operator-facing
+surface here.)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI

--- a/tickets/relations/BUG-I0N3YR--adds-measure--AM-acl-affordance-grants-reject-unknown-keys.md
+++ b/tickets/relations/BUG-I0N3YR--adds-measure--AM-acl-affordance-grants-reject-unknown-keys.md
@@ -1,0 +1,5 @@
+---
+from: BUG-I0N3YR
+relation: adds-measure
+to: AM-acl-affordance-grants-reject-unknown-keys
+---

--- a/tickets/relations/BUG-I0N3YR--affects--authorization.md
+++ b/tickets/relations/BUG-I0N3YR--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-I0N3YR
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-I0N3YR--caused-by--BUG-BRZX6O.md
+++ b/tickets/relations/BUG-I0N3YR--caused-by--BUG-BRZX6O.md
@@ -1,0 +1,5 @@
+---
+from: BUG-I0N3YR
+relation: caused-by
+to: BUG-BRZX6O
+---

--- a/tickets/relations/BUG-I0N3YR--fixes--FEAT-AESD4.md
+++ b/tickets/relations/BUG-I0N3YR--fixes--FEAT-AESD4.md
@@ -1,0 +1,5 @@
+---
+from: BUG-I0N3YR
+relation: fixes
+to: FEAT-AESD4
+---

--- a/tickets/relations/BUG-I0N3YR--has-review--REV-2EUCOZ.md
+++ b/tickets/relations/BUG-I0N3YR--has-review--REV-2EUCOZ.md
@@ -1,0 +1,5 @@
+---
+from: BUG-I0N3YR
+relation: has-review
+to: REV-2EUCOZ
+---


### PR DESCRIPTION
Follow-up to #1511, found by applying that PR's own rule to the rest of the package.

## The bug

`FieldGrant`, `OptionGrant` and `RelationGrant` had no strict unmarshaller, and yaml.v3 drops keys it cannot map. Each carries a `when:` conditioning the grant on a predicate — and an absent `When` compiles to a nil program, which `PolicyResolver.compile` treats as **grant unconditionally**:

```yaml
roles:
  editor:
    read: [note]
    visible:
      note:
        - field: salary
          wehn: "has_role(current_user, 'hr')"   # typo
```

The operator wrote "editors may see salary if they are HR" and deployed "editors may see salary". The policy is valid, the field name is real, and the grant works — for everyone holding the role. This is `visible:`, so it is field-level **read** redaction; the same typo on `fields:` widens writes, on `options:` widens settable enum values, on `relations:` widens link affordances.

## Why it survived review

The sibling keys fail *closed*, which hid it. A dropped `field:`/`option:`/`relation:` becomes `""`, matches no declared property, and `internal/affordances` rejects it by name (`validateField`/`validateOption`). Three of the four keys had a downstream backstop; the fourth — the only one whose absence means *more* access — had none.

## Relationship to #1511

Same defect class. That PR fixed `RoleRelationDef` and recorded the general rule (a config struct's parser must fail closed; ask which direction a dropped key fails) — but did not enumerate the other structs sharing the shape, so the rule was written down while three live instances of the defect it described remained. Linked as `BUG-I0N3YR --caused-by--> BUG-BRZX6O`.

The enumeration is mechanical, which is the point:

```console
$ grep -n "^type .* struct" internal/acl/policy.go
$ grep -n "func (.*) UnmarshalYAML" internal/acl/policy.go
```

The difference between those two lists was the work item.

## The fix

A shared `rejectUnknownGrantKeys` helper called from a new `UnmarshalYAML` on each of the three structs:

```console
$ rela list
appbuild: load acl.yaml: acl: parse /srv/rela/acl.yaml: fields/visible grant at line 7: unknown key "wehn" (want field, when)
```

Errors name the **source line**, not an index. The first draft used an index, which numbered the keys of one grant's mapping and printed `[1]` for a typo in the *first* grant — it read as though it named which grant was wrong. Caught in self-review and fixed.

**`RoleDef` is deliberately left lenient.** A dropped verb key there (`creat:`) removes grants, which fails closed. Worth fixing for ergonomics, but it is not this bug and I did not want to mix the two.

## Tests

- `TestLoadPolicy_AffordanceGrantUnknownKey_Rejected` — table over `fields:`, `visible:`, `options:`, `relations:`, the nested `RelationGrant.Fields` case, and a non-`when` typo.
- `TestLoadPolicy_AffordanceGrantSupportedKeys` — round-trips all three structs, explicitly asserting `RelationGrant.Create` is a non-nil pointer to `false` and `Remove` is nil, since the new unmarshallers decode via a `type raw` alias and the pointer tri-state is load-bearing.
- **Mutation-verified**: short-circuiting `rejectUnknownGrantKeys` to `return nil` fails the table test; restoring it passes. BUG-NRCJ9E shipped a fix whose test iterated the registry it was meant to guard, so this check was done deliberately.
- End-to-end against the built binary for both a `visible:` and a `relations:` typo.

## Compatibility

The new error fires only on config that was already silently broken — a dropped key never took effect. No `acl.yaml` in the repo uses these blocks (`prototypes/data-entry/project/acl.yaml` is the only policy file). No evaluation path changed.

Local: `just check`, `just docs-check` pass.

https://claude.ai/code/session_019QbeaMhbmDKnYpzdaJzZJt