### PR TITLE
fix(security): make path validation a type, sanitize mermaid SVG

### DIFF
--- a/e2e/pages/entity.page.ts
+++ b/e2e/pages/entity.page.ts
@@ -333,6 +333,55 @@ export class EntityPage extends BasePage {
     return this.page.locator('.cb-stats');
   }
 
+  // --- mermaid body-content helpers ---
+
+  /** Rendered mermaid diagrams inside the content body. */
+  get mermaidDiagrams(): Locator {
+    return this.contentBody.locator('.mermaid-diagram');
+  }
+
+  /** Wait for the first mermaid diagram to finish rendering. Rendering is
+   *  async (mermaid measures text in the live DOM before emitting SVG), so a
+   *  bare count() races it. */
+  async waitForMermaidDiagram() {
+    await expect(this.mermaidDiagrams.first()).toBeVisible({ timeout: 15_000 });
+  }
+
+  /** Text of every node label in the first diagram. Flowchart labels are
+   *  XHTML inside <foreignObject>; sequence labels are SVG <text>. */
+  async mermaidLabelTexts(): Promise<string[]> {
+    return this.mermaidDiagrams.first().locator('foreignObject, text').allTextContents();
+  }
+
+  /** Number of mermaid `.nodeLabel` wrappers inside the first diagram's
+   *  labels. Zero means the label MARKUP was stripped even if text survived. */
+  async mermaidLabelElementCount(): Promise<number> {
+    return this.mermaidDiagrams.first().locator('foreignObject .nodeLabel').count();
+  }
+
+  /** Number of <br> elements inside the first diagram's labels — a
+   *  multi-line node label that survived sanitization keeps its line break. */
+  async mermaidLabelLineBreakCount(): Promise<number> {
+    return this.mermaidDiagrams.first().locator('foreignObject br').count();
+  }
+
+  /** Names of every on* attribute anywhere inside the first diagram. */
+  async mermaidEventHandlerAttributes(): Promise<string[]> {
+    return this.mermaidDiagrams.first().evaluate((root) =>
+      Array.from(root.querySelectorAll('*')).flatMap((el) =>
+        Array.from(el.attributes)
+          .map((a) => a.name)
+          .filter((n) => /^on/i.test(n)),
+      ),
+    );
+  }
+
+  /** Embedded-media elements inside the first diagram. A label is text; any
+   *  of these came from a hostile label and must have been stripped. */
+  async mermaidEmbeddedMediaCount(): Promise<number> {
+    return this.mermaidDiagrams.first().locator('img, iframe, object, embed, video, audio').count();
+  }
+
   async hasCheckboxStats(): Promise<boolean> {
     return this.checkboxStats.isVisible().catch(() => false);
   }

--- a/e2e/tests/mermaid.spec.ts
+++ b/e2e/tests/mermaid.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from './fixtures';
+import { EntityPage } from '../pages';
+
+/**
+ * Mermaid diagrams in entity body content, rendered in a REAL browser through
+ * the real mermaid library and the real sanitizer.
+ *
+ * The unit tests in frontend/src/utils/markdown.test.ts mock mermaid.render()
+ * — necessary for the attack cases, since strict mermaid never emits a
+ * <script> — so this is the one place that checks what mermaid ACTUALLY emits
+ * survives sanitization. Flowchart labels are XHTML inside <foreignObject>, and
+ * every single-pass DOMPurify configuration silently discards them while the
+ * shapes still render: the diagram looks fine and reads as empty boxes. jsdom
+ * cannot run mermaid at all (no layout engine — getBBox), so this cannot be a
+ * unit test.
+ */
+test.describe('Mermaid diagrams in entity content', () => {
+  let featureId: string | null = null;
+
+  test.beforeEach(async ({ api }) => {
+    const feature = await api.createEntity('features', {
+      properties: {
+        title: 'Mermaid Render Feature',
+        description: 'Renders a flowchart from body content',
+        status: 'draft',
+        priority: 'high',
+      },
+      content: [
+        '```mermaid',
+        'graph TD',
+        '  A["Line1<br/>Line2"] --> B[Done]',
+        '  B --> C["<img src=x onerror=alert(1)>"]',
+        '```',
+      ].join('\n'),
+    });
+    featureId = feature.id;
+  });
+
+  test.afterEach(async ({ api }) => {
+    if (featureId) {
+      await api.deleteEntity('features', featureId).catch(() => {});
+      featureId = null;
+    }
+  });
+
+  test('renders flowchart labels with their markup intact', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('feature', featureId!);
+    await entity.waitForMermaidDiagram();
+
+    const labels = (await entity.mermaidLabelTexts()).join('\n');
+    expect(labels).toContain('Line1');
+    expect(labels).toContain('Line2');
+    expect(labels).toContain('Done');
+
+    // The label SUBTREE must survive, not just its text: text alone also
+    // survives the broken configurations. The .nodeLabel wrapper is mermaid's
+    // styling hook; the <br> is what keeps a multi-line node from collapsing
+    // into one run-together word.
+    expect(await entity.mermaidLabelElementCount()).toBeGreaterThan(0);
+    expect(await entity.mermaidLabelLineBreakCount()).toBeGreaterThan(0);
+  });
+
+  test('strips executable content from a hostile label', async ({ appPage }) => {
+    const entity = new EntityPage(appPage);
+    await entity.navigateToEntity('feature', featureId!);
+    await entity.waitForMermaidDiagram();
+
+    expect(await entity.mermaidEventHandlerAttributes()).toEqual([]);
+    // Strict mermaid strips the handler but still emits the <img>; the
+    // sanitizer must remove the element itself.
+    expect(await entity.mermaidEmbeddedMediaCount()).toBe(0);
+  });
+});

--- a/frontend/src/utils/markdown.test.ts
+++ b/frontend/src/utils/markdown.test.ts
@@ -518,6 +518,9 @@ describe('markdown', () => {
     // Diagram source is user-authored markdown, so a future
     // `securityLevel: 'loose'` (what you need for clickable nodes) must not be
     // one line away from stored XSS.
+    //
+    // Fixtures are shaped like real mermaid 11 output: flowchart/state labels
+    // are XHTML inside <foreignObject>, sequence labels are SVG <text>.
     describe('sanitizes mermaid SVG output', () => {
       const NS = 'xmlns="http://www.w3.org/2000/svg"'
       const XH = 'xmlns="http://www.w3.org/1999/xhtml"'
@@ -525,6 +528,11 @@ describe('markdown', () => {
       // inside this module's source would end the enclosing <script> block in
       // any tooling that parses the file as HTML.
       const CLOSE_SCRIPT = '</' + 'script>'
+      // What mermaid actually emits for `A["Line1<br/>Line2"]`.
+      const realLabel =
+        `<foreignObject width="40" height="20"><div ${XH} style="display: table-cell; white-space: nowrap;">` +
+        `<span class="nodeLabel"><p>Line1<br/>Line2</p></span></div></foreignObject>`
+      const label = (inner: string) => `<foreignObject><div ${XH}>${inner}</div></foreignObject>`
 
       async function render(svg: string): Promise<Element> {
         const container = document.createElement('div')
@@ -548,103 +556,130 @@ describe('markdown', () => {
             .filter((n) => /^on/i.test(n)),
         )
       }
+      function hrefs(el: Element): string[] {
+        return Array.from(el.querySelectorAll('*'))
+          .map((e) => e.getAttribute('href') ?? e.getAttribute('xlink:href'))
+          .filter((h): h is string => !!h)
+      }
 
-      it('strips event handlers on SVG elements', async () => {
-        const d = await render(`<svg ${NS}><text onclick="alert(1)">label</text></svg>`)
-        expect(eventHandlers(d)).toEqual([])
-        expect(d.textContent).toContain('label')
+      describe('strips from the SVG skeleton', () => {
+        it('event handlers', async () => {
+          const d = await render(`<svg ${NS}><text onclick="alert(1)">label</text></svg>`)
+          expect(eventHandlers(d)).toEqual([])
+          expect(d.textContent).toContain('label')
+        })
+        it('script elements', async () => {
+          const d = await render(`<svg ${NS}><script>alert(1)${CLOSE_SCRIPT}<text>label</text></svg>`)
+          expect(d.querySelector('script')).toBeNull()
+        })
+        it('javascript: URLs', async () => {
+          const d = await render(`<svg ${NS}><a href="javascript:alert(1)"><text>x</text></a></svg>`)
+          expect(hrefs(d).some((h) => /javascript:/i.test(h))).toBe(false)
+        })
       })
 
-      it('strips script elements', async () => {
+      // The label subtree is sanitized in a SEPARATE pass under the HTML
+      // profile, so it needs its own coverage — a clean SVG pass proves nothing
+      // about it. Each case keeps a benign sibling to show the label itself
+      // survives while the payload does not.
+      describe('strips from inside a foreignObject label', () => {
+        it('img with an onerror handler — and the img itself', async () => {
+          const d = await render(`<svg ${NS}>${label('<img src="x" onerror="alert(1)"/><span>L</span>')}</svg>`)
+          expect(eventHandlers(d)).toEqual([])
+          // Handler-stripped is not enough: strict mermaid already does that
+          // and still emits the element, which fetches an attacker-chosen URL.
+          expect(d.querySelector('img')).toBeNull()
+          expect(d.textContent).toContain('L')
+        })
+        it('script elements', async () => {
+          const d = await render(`<svg ${NS}>${label(`<script>alert(1)${CLOSE_SCRIPT}<span>L</span>`)}</svg>`)
+          expect(d.querySelector('script')).toBeNull()
+          expect(d.textContent).toContain('L')
+        })
+        it('javascript: links', async () => {
+          const d = await render(`<svg ${NS}>${label('<a href="javascript:alert(1)">L</a>')}</svg>`)
+          expect(hrefs(d).some((h) => /javascript:/i.test(h))).toBe(false)
+          expect(d.textContent).toContain('L')
+        })
+        it('handlers on the label wrapper itself', async () => {
+          const d = await render(`<svg ${NS}><foreignObject><div ${XH} onclick="alert(1)">L</div></foreignObject></svg>`)
+          expect(eventHandlers(d)).toEqual([])
+        })
+        it('iframes and other embedded media', async () => {
+          const d = await render(`<svg ${NS}>${label('<iframe src="javascript:alert(1)"></iframe>L')}</svg>`)
+          expect(d.querySelector('iframe')).toBeNull()
+        })
+      })
+
+      // The pairing marker is an internal attribute allowed through the SVG
+      // pass. Input that carries it must not be able to claim a label — that
+      // would write attacker-chosen HTML into an element of the attacker's
+      // choosing — and it must never reach the document.
+      it('ignores a spoofed pairing attribute and leaves none behind', async () => {
         const d = await render(
-          `<svg ${NS}><script>alert(1)${CLOSE_SCRIPT}<text>label</text></svg>`,
+          `<svg ${NS}><rect data-rela-label-slot="0"/><g id="real">${label('Real')}</g></svg>`,
         )
-        expect(d.querySelector('script')).toBeNull()
+        expect(d.querySelector('rect')!.textContent).toBe('')
+        expect(d.querySelector('#real')!.textContent).toBe('Real')
+        expect(d.querySelector('[data-rela-label-slot]')).toBeNull()
       })
 
-      it('strips javascript: URLs', async () => {
-        const d = await render(`<svg ${NS}><a href="javascript:alert(1)"><text>x</text></a></svg>`)
-        const hrefs = Array.from(d.querySelectorAll('*'))
-          .map((e) => e.getAttribute('href'))
-          .filter(Boolean)
-        expect(hrefs.some((h) => /javascript:/i.test(h!))).toBe(false)
-      })
-
-      // The label subtree is sanitized separately, in the HTML namespace, so
-      // it needs its own coverage — a guard on the SVG half would not cover it.
-      it('strips scripts and handlers inside a foreignObject label', async () => {
-        const d = await render(
-          `<svg ${NS}><foreignObject><div ${XH}>` +
-            `<img src="x" onerror="alert(1)"/><script>alert(2)${CLOSE_SCRIPT}` +
-            `</div></foreignObject></svg>`,
-        )
-        expect(eventHandlers(d)).toEqual([])
-        expect(d.querySelector('script')).toBeNull()
-        // Handler-stripped is not enough: strict mermaid already does that and
-        // still emits the element, which fetches an attacker-chosen URL.
-        expect(d.querySelector('img')).toBeNull()
-      })
-
-      it('produces an empty diagram rather than throwing on malformed SVG', async () => {
+      it('yields an empty diagram, not the literal text, on non-SVG input', async () => {
         const d = await render('not xml <<<')
-        expect(d.querySelector('script')).toBeNull()
-        expect(eventHandlers(d)).toEqual([])
+        expect(d.querySelector('svg')).toBeNull()
+        expect(d.textContent).toBe('')
       })
 
-      // The counterpart to the cases above: the sanitizer must not be so
-      // strict that it silently eats the diagram. Flowchart and state-diagram
-      // labels are XHTML inside <foreignObject>, which a single
-      // DOMPurify.sanitize() over the whole SVG string discards in every
-      // configuration — shapes and arrows still render, the labels just vanish.
-      // Sequence diagrams use SVG <text> and are unaffected, so checking one
-      // diagram type would hide this.
-      it('preserves foreignObject label text and SVG shape markup', async () => {
-        const d = await render(
-          `<svg ${NS} viewBox="0 0 100 50"><g class="node">` +
-            `<rect width="40" height="20"></rect>` +
-            `<foreignObject width="40" height="20">` +
-            `<div ${XH}><span class="nodeLabel">Start</span></div>` +
-            `</foreignObject></g>` +
-            `<path class="edge" d="M0,0 L10,10"></path></svg>`,
-        )
-        expect(d.querySelector('svg')).toBeTruthy()
-        expect(d.querySelector('rect')).toBeTruthy()
-        expect(d.querySelector('path')).toBeTruthy()
-        expect(d.querySelector('foreignObject')).toBeTruthy()
-        expect(d.textContent).toContain('Start')
-      })
+      // The counterpart to everything above: the sanitizer must not be so
+      // strict that it silently eats the diagram. A single DOMPurify call over
+      // the whole SVG cannot keep the XHTML inside <foreignObject> in ANY
+      // configuration (see the sanitizer's doc comment) — and shapes still
+      // render, so that failure ships as boxes with no or run-together text.
+      // These assert STRUCTURE, not just textContent: text alone survives the
+      // broken configurations too.
+      describe('preserves what mermaid actually emits', () => {
+        it('flowchart label markup: wrapper, .nodeLabel, <p>, <br>, style', async () => {
+          const d = await render(`<svg ${NS} viewBox="0 0 100 50"><g class="node"><rect width="40" height="20"></rect>${realLabel}</g><path class="edge" d="M0,0 L10,10"></path></svg>`)
+          expect(d.querySelector('svg')).toBeTruthy()
+          expect(d.querySelector('rect')).toBeTruthy()
+          expect(d.querySelector('path')).toBeTruthy()
+          const fo = d.querySelector('foreignObject')!
+          expect(fo).toBeTruthy()
+          expect(fo.children.length).toBeGreaterThan(0)
+          expect(fo.querySelector('.nodeLabel')).toBeTruthy()
+          expect(fo.querySelector('p')).toBeTruthy()
+          // The one that bites: a multi-line node must not collapse into one word.
+          expect(fo.querySelector('br')).toBeTruthy()
+          expect(fo.querySelector('div')!.getAttribute('style')).toContain('table-cell')
+          expect(fo.textContent).toContain('Line1')
+          expect(fo.textContent).toContain('Line2')
+        })
 
-      // Labels are paired to their shape by an explicit marker attribute, not
-      // by document order, because the SVG pass may drop an element. With
-      // positional pairing a single dropped node shifts every later label onto
-      // the wrong shape — a silent data-integrity bug in the rendered diagram.
-      it('keeps each label with its own shape', async () => {
-        const fo = (label: string) =>
-          `<foreignObject><div ${XH}><span>${label}</span></div></foreignObject>`
-        const d = await render(
-          `<svg ${NS}><g id="one"><rect/>${fo('First')}</g>` +
-            `<g id="two"><rect/>${fo('Second')}</g></svg>`,
-        )
-        const groups = Array.from(d.querySelectorAll('g'))
-        expect(groups).toHaveLength(2)
-        expect(groups[0].textContent).toContain('First')
-        expect(groups[0].textContent).not.toContain('Second')
-        expect(groups[1].textContent).toContain('Second')
-      })
+        it('sequence-diagram SVG <text> labels', async () => {
+          const d = await render(`<svg ${NS}><text>Alice</text><line x1="0" y1="0" x2="9" y2="9"/></svg>`)
+          expect(d.textContent).toContain('Alice')
+          expect(d.querySelector('line')).toBeTruthy()
+        })
 
-      // The marker is an implementation detail of the two-pass sanitize and
-      // must not survive into the document.
-      it('removes its internal pairing attribute', async () => {
-        const d = await render(
-          `<svg ${NS}><foreignObject><div ${XH}><span>Start</span></div></foreignObject></svg>`,
-        )
-        expect(d.innerHTML).not.toContain('data-rela-label-slot')
-      })
+        // Labels are paired to their shape by an explicit marker, not by
+        // position; positional pairing shifts every later label onto the wrong
+        // shape the moment sanitization drops a node.
+        it('each label with its own shape', async () => {
+          const d = await render(
+            `<svg ${NS}><g id="one"><rect/>${label('<span>First</span>')}</g>` +
+              `<g id="two"><rect/>${label('<span>Second</span>')}</g></svg>`,
+          )
+          expect(d.querySelector('#one')!.textContent).toBe('First')
+          expect(d.querySelector('#two')!.textContent).toBe('Second')
+        })
 
-      it('preserves SVG <text> labels used by sequence diagrams', async () => {
-        const d = await render(`<svg ${NS}><text>Alice</text><line x1="0" y1="0" x2="9" y2="9"/></svg>`)
-        expect(d.textContent).toContain('Alice')
-        expect(d.querySelector('line')).toBeTruthy()
+        // A label is one render's state only: the module-level lift buffer must
+        // not carry entries across calls.
+        it('does not leak labels between renders', async () => {
+          await render(`<svg ${NS}>${label('Stale')}</svg>`)
+          const d = await render(`<svg ${NS}>${label('Fresh')}</svg>`)
+          expect(d.textContent).toBe('Fresh')
+        })
       })
     })
   })

--- a/frontend/src/utils/markdown.test.ts
+++ b/frontend/src/utils/markdown.test.ts
@@ -510,6 +510,143 @@ describe('markdown', () => {
       expect(container.querySelector('.mermaid-diagram')).toBeTruthy()
       expect(container.querySelector('pre.mermaid')).toBeNull()
     })
+
+    // Mermaid runs with securityLevel: 'strict', so it escapes labels itself.
+    // These tests mock render() to return what a RELAXED or BROKEN mermaid
+    // would emit, because that is the failure this sanitizer exists to catch:
+    // the defence must be ours, not a setting inside a third-party call.
+    // Diagram source is user-authored markdown, so a future
+    // `securityLevel: 'loose'` (what you need for clickable nodes) must not be
+    // one line away from stored XSS.
+    describe('sanitizes mermaid SVG output', () => {
+      const NS = 'xmlns="http://www.w3.org/2000/svg"'
+      const XH = 'xmlns="http://www.w3.org/1999/xhtml"'
+      // Assembled rather than written literally: a literal closing script tag
+      // inside this module's source would end the enclosing <script> block in
+      // any tooling that parses the file as HTML.
+      const CLOSE_SCRIPT = '</' + 'script>'
+
+      async function render(svg: string): Promise<Element> {
+        const container = document.createElement('div')
+        container.innerHTML = '<pre><code class="language-mermaid">graph TD\nA-->B</code></pre>'
+        const mermaid = await import('mermaid')
+        vi.spyOn(mermaid.default, 'render').mockResolvedValue({
+          svg,
+          diagramType: 'flowchart',
+          bindFunctions: vi.fn(),
+        })
+        await renderMermaidDiagrams(container)
+        const diagram = container.querySelector('.mermaid-diagram')
+        expect(diagram).toBeTruthy()
+        return diagram!
+      }
+
+      function eventHandlers(el: Element): string[] {
+        return Array.from(el.querySelectorAll('*')).flatMap((e) =>
+          Array.from(e.attributes)
+            .map((a) => a.name)
+            .filter((n) => /^on/i.test(n)),
+        )
+      }
+
+      it('strips event handlers on SVG elements', async () => {
+        const d = await render(`<svg ${NS}><text onclick="alert(1)">label</text></svg>`)
+        expect(eventHandlers(d)).toEqual([])
+        expect(d.textContent).toContain('label')
+      })
+
+      it('strips script elements', async () => {
+        const d = await render(
+          `<svg ${NS}><script>alert(1)${CLOSE_SCRIPT}<text>label</text></svg>`,
+        )
+        expect(d.querySelector('script')).toBeNull()
+      })
+
+      it('strips javascript: URLs', async () => {
+        const d = await render(`<svg ${NS}><a href="javascript:alert(1)"><text>x</text></a></svg>`)
+        const hrefs = Array.from(d.querySelectorAll('*'))
+          .map((e) => e.getAttribute('href'))
+          .filter(Boolean)
+        expect(hrefs.some((h) => /javascript:/i.test(h!))).toBe(false)
+      })
+
+      // The label subtree is sanitized separately, in the HTML namespace, so
+      // it needs its own coverage — a guard on the SVG half would not cover it.
+      it('strips scripts and handlers inside a foreignObject label', async () => {
+        const d = await render(
+          `<svg ${NS}><foreignObject><div ${XH}>` +
+            `<img src="x" onerror="alert(1)"/><script>alert(2)${CLOSE_SCRIPT}` +
+            `</div></foreignObject></svg>`,
+        )
+        expect(eventHandlers(d)).toEqual([])
+        expect(d.querySelector('script')).toBeNull()
+        // Handler-stripped is not enough: strict mermaid already does that and
+        // still emits the element, which fetches an attacker-chosen URL.
+        expect(d.querySelector('img')).toBeNull()
+      })
+
+      it('produces an empty diagram rather than throwing on malformed SVG', async () => {
+        const d = await render('not xml <<<')
+        expect(d.querySelector('script')).toBeNull()
+        expect(eventHandlers(d)).toEqual([])
+      })
+
+      // The counterpart to the cases above: the sanitizer must not be so
+      // strict that it silently eats the diagram. Flowchart and state-diagram
+      // labels are XHTML inside <foreignObject>, which a single
+      // DOMPurify.sanitize() over the whole SVG string discards in every
+      // configuration — shapes and arrows still render, the labels just vanish.
+      // Sequence diagrams use SVG <text> and are unaffected, so checking one
+      // diagram type would hide this.
+      it('preserves foreignObject label text and SVG shape markup', async () => {
+        const d = await render(
+          `<svg ${NS} viewBox="0 0 100 50"><g class="node">` +
+            `<rect width="40" height="20"></rect>` +
+            `<foreignObject width="40" height="20">` +
+            `<div ${XH}><span class="nodeLabel">Start</span></div>` +
+            `</foreignObject></g>` +
+            `<path class="edge" d="M0,0 L10,10"></path></svg>`,
+        )
+        expect(d.querySelector('svg')).toBeTruthy()
+        expect(d.querySelector('rect')).toBeTruthy()
+        expect(d.querySelector('path')).toBeTruthy()
+        expect(d.querySelector('foreignObject')).toBeTruthy()
+        expect(d.textContent).toContain('Start')
+      })
+
+      // Labels are paired to their shape by an explicit marker attribute, not
+      // by document order, because the SVG pass may drop an element. With
+      // positional pairing a single dropped node shifts every later label onto
+      // the wrong shape — a silent data-integrity bug in the rendered diagram.
+      it('keeps each label with its own shape', async () => {
+        const fo = (label: string) =>
+          `<foreignObject><div ${XH}><span>${label}</span></div></foreignObject>`
+        const d = await render(
+          `<svg ${NS}><g id="one"><rect/>${fo('First')}</g>` +
+            `<g id="two"><rect/>${fo('Second')}</g></svg>`,
+        )
+        const groups = Array.from(d.querySelectorAll('g'))
+        expect(groups).toHaveLength(2)
+        expect(groups[0].textContent).toContain('First')
+        expect(groups[0].textContent).not.toContain('Second')
+        expect(groups[1].textContent).toContain('Second')
+      })
+
+      // The marker is an implementation detail of the two-pass sanitize and
+      // must not survive into the document.
+      it('removes its internal pairing attribute', async () => {
+        const d = await render(
+          `<svg ${NS}><foreignObject><div ${XH}><span>Start</span></div></foreignObject></svg>`,
+        )
+        expect(d.innerHTML).not.toContain('data-rela-label-slot')
+      })
+
+      it('preserves SVG <text> labels used by sequence diagrams', async () => {
+        const d = await render(`<svg ${NS}><text>Alice</text><line x1="0" y1="0" x2="9" y2="9"/></svg>`)
+        expect(d.textContent).toContain('Alice')
+        expect(d.querySelector('line')).toBeTruthy()
+      })
+    })
   })
 
   describe('encodePlantUMLHex', () => {

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -185,9 +185,38 @@ function inaccessibleTooltipFor(reason: string | undefined): string {
 // would silently mis-align the (n/m) widget with which line a click toggles.
 export { checkboxStats as getCheckboxStats } from './checkboxToggle'
 
-// Marker attribute used to pair a label subtree with its foreignObject across
-// the SVG sanitization pass. Removed again before the element is inserted.
+// Sanitizer instance dedicated to mermaid output. It carries the label-lifting
+// hook below, which must not run for renderMarkdown's ordinary HTML, so it
+// cannot share the default DOMPurify instance.
+const mermaidPurifier = DOMPurify(window)
+
+// Marker pairing a lifted label with its foreignObject across the SVG pass.
+// The hook strips it from EVERY element on entry, so input cannot spoof a
+// slot and have someone else's label written into an element of its choosing;
+// it is removed again before the element reaches the document.
 const LABEL_SLOT_ATTR = 'data-rela-label-slot'
+
+// Labels lifted out during the current sanitizeMermaidSVG call. Module-level
+// because a DOMPurify hook has no other channel back to its caller; sanitize()
+// is synchronous, so a call only ever observes its own entries.
+let liftedLabels: string[] = []
+
+mermaidPurifier.addHook('uponSanitizeElement', (node, data) => {
+  if (node.nodeType !== Node.ELEMENT_NODE) return
+  const el = node as Element
+  el.removeAttribute(LABEL_SLOT_ATTR)
+  if (data.tagName !== 'foreignobject') return
+  el.setAttribute(LABEL_SLOT_ATTR, String(liftedLabels.length))
+  liftedLabels.push(el.innerHTML)
+  el.textContent = ''
+})
+
+// Element types that never belong in a diagram label. A label is formatted
+// text, so dropping embedded media costs nothing legitimate and closes the one
+// thing strict mermaid still lets through from a hostile label: the event
+// handler is stripped but the element survives, which is enough for a request
+// to an attacker-chosen URL when the diagram is viewed.
+const LABEL_FORBID_TAGS = ['img', 'picture', 'source', 'video', 'audio', 'iframe', 'object', 'embed']
 
 /**
  * Sanitize a mermaid-produced SVG and return it as a detached element.
@@ -195,80 +224,70 @@ const LABEL_SLOT_ATTR = 'data-rela-label-slot'
  * Mermaid runs with `securityLevel: 'strict'`, so it already escapes diagram
  * labels. This is defence in depth, and it is not theoretical: with a hostile
  * label, strict mermaid emits no event-handler attributes but DOES emit a live
- * `<img>` element built from the label text. Sanitizing removes that. It also
- * means a future `securityLevel: 'loose'` — a one-line change, and the setting
- * you need for clickable nodes — cannot silently turn user-authored diagram
- * source into stored XSS.
+ * `<img>` element built from the label text. It also means a future
+ * `securityLevel: 'loose'` — a one-line change, and the setting you need for
+ * clickable nodes — cannot silently turn user-authored diagram source into
+ * stored XSS.
  *
- * ## Why this is not a one-line DOMPurify.sanitize(svg)
+ * ## Why this is two passes and not one `DOMPurify.sanitize(svg)`
  *
- * Mermaid renders flowchart and state-diagram labels as XHTML `<div>`/`<span>`
- * inside an SVG `<foreignObject>`. Handing that whole string to DOMPurify
- * discards the label content in EVERY configuration — SVG profile, SVG+HTML
- * profile, bare defaults, `ADD_TAGS: ['foreignObject']`, `NAMESPACE`,
- * `PARSER_MEDIA_TYPE: 'image/svg+xml'`, and `IN_PLACE` on an already-parsed
- * node were all measured in a real browser and all produced empty labels.
- * The document is parsed in the SVG namespace, where the XHTML children of
- * `foreignObject` are not valid content and are dropped.
+ * Mermaid renders flowchart and state-diagram labels as XHTML
+ * (`<div><span class="nodeLabel"><p>…<br>…</p></span></div>`) inside an SVG
+ * `<foreignObject>`. DOMPurify 3.4 cannot retain that subtree in a single
+ * call, in any configuration — measured, not assumed:
  *
- * The failure is silent and easy to ship: diagrams still render, with correct
- * shapes and arrows and no labels inside them. Sequence diagrams are NOT
- * affected (they use SVG `<text>`), so spot-checking one diagram type hides it.
+ *  - With the SVG profile alone the HTML elements are not allowed, so they are
+ *    unwrapped: only their text survives. `Line1<br>Line2` becomes
+ *    `Line1Line2`, the `.nodeLabel` styling hook is gone, and bare text is not
+ *    valid `foreignObject` content, so it may not paint at all.
+ *  - Allowing them (the `html` profile, or `ADD_TAGS`) is WORSE: DOMPurify's
+ *    namespace check runs after the allowed-tags check and force-removes an
+ *    allowed HTML element under an SVG parent, children and all. The label
+ *    vanishes entirely.
  *
- * So each part is sanitized in the namespace it actually belongs to: the SVG
- * skeleton under the SVG profile, and each `foreignObject` label subtree
- * separately under the HTML profile. Both halves are still sanitized — the
- * split is about parsing context, not about exempting anything.
+ * Either way shapes and arrows still render, so the diagram looks fine and
+ * reads as empty or run-together boxes. Sequence diagrams use SVG `<text>` and
+ * are NOT affected, so checking one diagram type hides it.
  *
- * Returns an element rather than a string because re-serializing and
- * re-parsing the result would reintroduce the same namespace loss.
+ * So the label subtrees are lifted out by a hook DURING the SVG pass (the raw
+ * string is only ever handed to DOMPurify — there is no pre-parse, which is
+ * what a previous version did and what turned the untrusted text into DOM
+ * before any sanitizer saw it), then each label is sanitized on its own under
+ * the HTML profile and written back into its emptied `foreignObject`. Setting
+ * `innerHTML` on a foreignObject parses in the XHTML namespace, exactly as
+ * mermaid itself does. Both halves are sanitized; the split is about parsing
+ * context, not exemption.
+ *
+ * Input whose sanitized root is not an `<svg>` (a parse failure, or text that
+ * was never a diagram) yields an empty host rather than rendering the literal
+ * string on the page.
  */
 function sanitizeMermaidSVG(svg: string): HTMLElement {
   const host = document.createElement('div')
   host.className = 'mermaid-diagram'
 
-  // Parse as SVG so foreignObject's XHTML children land in the right
-  // namespace and survive to be sanitized below.
-  const parsed = new DOMParser().parseFromString(svg, 'image/svg+xml')
-  const root = parsed.documentElement
-  // A parse error yields an <parsererror> document rather than throwing.
-  if (!root || root.nodeName === 'parsererror' || parsed.querySelector('parsererror')) {
-    return host
-  }
-
-  // Lift each label out, sanitize it as HTML, and put it back. Done before
-  // the SVG pass so the SVG sanitizer never sees the XHTML subtrees.
-  //
-  // Each emptied foreignObject is tagged with its index rather than paired by
-  // document order afterwards: the SVG pass is free to drop an element, and
-  // positional pairing would then reattach every remaining label to the wrong
-  // node — labels silently swapped between diagram shapes.
-  const labels: string[] = []
-  for (const fo of Array.from(root.querySelectorAll('foreignObject'))) {
-    fo.setAttribute(LABEL_SLOT_ATTR, String(labels.length))
-    labels.push(fo.innerHTML)
-    fo.textContent = ''
-  }
-
-  const cleanSvg = DOMPurify.sanitize(root.outerHTML, {
+  liftedLabels = []
+  const fragment = mermaidPurifier.sanitize(svg, {
     USE_PROFILES: { svg: true, svgFilters: true },
     ADD_TAGS: ['foreignObject'],
     ADD_ATTR: [LABEL_SLOT_ATTR],
+    RETURN_DOM_FRAGMENT: true,
   })
-  host.innerHTML = cleanSvg
+  const labels = liftedLabels
+  liftedLabels = []
+
+  const root = fragment.firstElementChild
+  if (!root || root.nodeName.toLowerCase() !== 'svg') return host
+  host.appendChild(fragment)
 
   for (const slot of Array.from(host.querySelectorAll(`[${LABEL_SLOT_ATTR}]`))) {
     const i = Number(slot.getAttribute(LABEL_SLOT_ATTR))
     slot.removeAttribute(LABEL_SLOT_ATTR)
+    if (slot.nodeName.toLowerCase() !== 'foreignobject') continue
     if (!Number.isInteger(i) || i < 0 || i >= labels.length) continue
-    // A diagram label is formatted text, never embedded media. Dropping
-    // <img> and friends costs nothing legitimate and closes the one thing
-    // strict mermaid still lets through from a hostile label: the handler
-    // is stripped but the element itself survives, which is enough for a
-    // request to an attacker-chosen URL when the diagram is viewed.
     slot.innerHTML = DOMPurify.sanitize(labels[i], {
       USE_PROFILES: { html: true },
-      FORBID_TAGS: ['img', 'picture', 'source', 'video', 'audio', 'iframe', 'object', 'embed'],
+      FORBID_TAGS: LABEL_FORBID_TAGS,
     })
   }
   return host

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -185,6 +185,95 @@ function inaccessibleTooltipFor(reason: string | undefined): string {
 // would silently mis-align the (n/m) widget with which line a click toggles.
 export { checkboxStats as getCheckboxStats } from './checkboxToggle'
 
+// Marker attribute used to pair a label subtree with its foreignObject across
+// the SVG sanitization pass. Removed again before the element is inserted.
+const LABEL_SLOT_ATTR = 'data-rela-label-slot'
+
+/**
+ * Sanitize a mermaid-produced SVG and return it as a detached element.
+ *
+ * Mermaid runs with `securityLevel: 'strict'`, so it already escapes diagram
+ * labels. This is defence in depth, and it is not theoretical: with a hostile
+ * label, strict mermaid emits no event-handler attributes but DOES emit a live
+ * `<img>` element built from the label text. Sanitizing removes that. It also
+ * means a future `securityLevel: 'loose'` — a one-line change, and the setting
+ * you need for clickable nodes — cannot silently turn user-authored diagram
+ * source into stored XSS.
+ *
+ * ## Why this is not a one-line DOMPurify.sanitize(svg)
+ *
+ * Mermaid renders flowchart and state-diagram labels as XHTML `<div>`/`<span>`
+ * inside an SVG `<foreignObject>`. Handing that whole string to DOMPurify
+ * discards the label content in EVERY configuration — SVG profile, SVG+HTML
+ * profile, bare defaults, `ADD_TAGS: ['foreignObject']`, `NAMESPACE`,
+ * `PARSER_MEDIA_TYPE: 'image/svg+xml'`, and `IN_PLACE` on an already-parsed
+ * node were all measured in a real browser and all produced empty labels.
+ * The document is parsed in the SVG namespace, where the XHTML children of
+ * `foreignObject` are not valid content and are dropped.
+ *
+ * The failure is silent and easy to ship: diagrams still render, with correct
+ * shapes and arrows and no labels inside them. Sequence diagrams are NOT
+ * affected (they use SVG `<text>`), so spot-checking one diagram type hides it.
+ *
+ * So each part is sanitized in the namespace it actually belongs to: the SVG
+ * skeleton under the SVG profile, and each `foreignObject` label subtree
+ * separately under the HTML profile. Both halves are still sanitized — the
+ * split is about parsing context, not about exempting anything.
+ *
+ * Returns an element rather than a string because re-serializing and
+ * re-parsing the result would reintroduce the same namespace loss.
+ */
+function sanitizeMermaidSVG(svg: string): HTMLElement {
+  const host = document.createElement('div')
+  host.className = 'mermaid-diagram'
+
+  // Parse as SVG so foreignObject's XHTML children land in the right
+  // namespace and survive to be sanitized below.
+  const parsed = new DOMParser().parseFromString(svg, 'image/svg+xml')
+  const root = parsed.documentElement
+  // A parse error yields an <parsererror> document rather than throwing.
+  if (!root || root.nodeName === 'parsererror' || parsed.querySelector('parsererror')) {
+    return host
+  }
+
+  // Lift each label out, sanitize it as HTML, and put it back. Done before
+  // the SVG pass so the SVG sanitizer never sees the XHTML subtrees.
+  //
+  // Each emptied foreignObject is tagged with its index rather than paired by
+  // document order afterwards: the SVG pass is free to drop an element, and
+  // positional pairing would then reattach every remaining label to the wrong
+  // node — labels silently swapped between diagram shapes.
+  const labels: string[] = []
+  for (const fo of Array.from(root.querySelectorAll('foreignObject'))) {
+    fo.setAttribute(LABEL_SLOT_ATTR, String(labels.length))
+    labels.push(fo.innerHTML)
+    fo.textContent = ''
+  }
+
+  const cleanSvg = DOMPurify.sanitize(root.outerHTML, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    ADD_TAGS: ['foreignObject'],
+    ADD_ATTR: [LABEL_SLOT_ATTR],
+  })
+  host.innerHTML = cleanSvg
+
+  for (const slot of Array.from(host.querySelectorAll(`[${LABEL_SLOT_ATTR}]`))) {
+    const i = Number(slot.getAttribute(LABEL_SLOT_ATTR))
+    slot.removeAttribute(LABEL_SLOT_ATTR)
+    if (!Number.isInteger(i) || i < 0 || i >= labels.length) continue
+    // A diagram label is formatted text, never embedded media. Dropping
+    // <img> and friends costs nothing legitimate and closes the one thing
+    // strict mermaid still lets through from a hostile label: the handler
+    // is stripped but the element itself survives, which is enough for a
+    // request to an attacker-chosen URL when the diagram is viewed.
+    slot.innerHTML = DOMPurify.sanitize(labels[i], {
+      USE_PROFILES: { html: true },
+      FORBID_TAGS: ['img', 'picture', 'source', 'video', 'audio', 'iframe', 'object', 'embed'],
+    })
+  }
+  return host
+}
+
 /**
  * Render markdown and then process mermaid diagrams.
  * Call this when the content is mounted in the DOM.
@@ -221,10 +310,7 @@ export async function renderMermaidDiagrams(container: HTMLElement): Promise<voi
     const id = `mermaid-${++mermaidCounter}`
     try {
       const { svg } = await mermaid.render(id, source)
-      const div = document.createElement('div')
-      div.className = 'mermaid-diagram'
-      div.innerHTML = svg
-      pre.replaceWith(div)
+      pre.replaceWith(sanitizeMermaidSVG(svg))
     } catch (err) {
       console.error('Mermaid render error:', err)
       // Leave the block as-is on error.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Sourcehaven-BV/rela
 
-go 1.26
+go 1.26.0
 
 toolchain go1.26.6
 
@@ -170,7 +170,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=

--- a/internal/cli/rename.go
+++ b/internal/cli/rename.go
@@ -89,7 +89,10 @@ func resolveRenameEntity(svc *writeServices, oldType, newType, renamePlural stri
 		newPlural = newType + "s"
 	}
 	paths := svc.Paths
-	oldTemplatePath := paths.EntityTemplatePath(resolvedOld)
+	oldTemplatePath, err := paths.EntityTemplatePath(resolvedOld)
+	if err != nil {
+		return nil, err
+	}
 	_, statErr := svc.FS.Stat(oldTemplatePath)
 	entityCount, _ := svc.Store.CountEntities(context.Background(), store.EntityQuery{Type: resolvedOld})
 

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/Sourcehaven-BV/rela/internal/errors"
@@ -255,63 +256,100 @@ func SchemaFileAt(dir string, fs storage.FS) (path string, isLegacy, found bool)
 }
 
 // EntityTemplatePath returns the file path for an entity type template.
-// If variant is non-empty, returns the path for that variant (e.g., type--variant.md).
-func (c *Context) EntityTemplatePath(entityType string) string {
-	return filepath.Join(c.EntityTemplatesDir, entityType+".md")
+// The type name is checked by validateTemplateName first — see there for why
+// that is a blocklist and what it rejects.
+func (c *Context) EntityTemplatePath(entityType string) (string, error) {
+	if err := validateTemplateName("entity type", entityType); err != nil {
+		return "", err
+	}
+	return filepath.Join(c.EntityTemplatesDir, entityType+".md"), nil
 }
 
 // EntityTemplateVariantPath returns the file path for an entity template
 // variant. Variant templates use the naming convention: <type>--<variant>.md
 //
-// Both segments are checked against an identifier allowlist first: this
-// function joins them into a path handed to a raw storage.FS, which performs
-// no validation of its own. Its callers reach it from
+// Both segments are validated first: this function joins them into a path
+// handed to a raw storage.FS, which performs no validation of its own, and a
+// segment here is not reliably operator-authored — callers reach it from
 // entitymanager.CreateOptions.Variant, and automation interpolates
-// {{new.kind}} — an API-settable entity property — into the template name, so
-// a segment here is not reliably operator-authored.
+// {{new.kind}} (an API-settable entity property) into the template name.
 //
-// internal/automation applies the same allowlist before its own use
-// (isValidTemplateName). That check remains the one that produces a good
-// error message for a bad automation; this one exists so the invariant is
-// local to the join rather than owned by a single caller in another package.
-// A future caller that forgets gets an error, not a traversal.
+// The two halves are validated differently on purpose. The TYPE gets the same
+// blocklist as EntityTemplatePath, because type names are metamodel names.
+// The VARIANT gets an identifier allowlist that matches
+// automation.isValidTemplateName character for character, so an automation
+// that passes its own check cannot fail here; that check stays where it is
+// because it produces the better error for a bad automation. This one exists
+// so the invariant is local to the join rather than owned by a single caller
+// in another package — a future caller that forgets gets an error, not a
+// traversal.
 func (c *Context) EntityTemplateVariantPath(entityType, variant string) (string, error) {
-	if err := validateTemplateSegment("entity type", entityType); err != nil {
+	if variant == "" {
+		return c.EntityTemplatePath(entityType)
+	}
+	if err := validateTemplateName("entity type", entityType); err != nil {
 		return "", err
 	}
-	if variant == "" {
-		return c.EntityTemplatePath(entityType), nil
-	}
-	if err := validateTemplateSegment("template variant", variant); err != nil {
+	if err := validateTemplateVariant(variant); err != nil {
 		return "", err
 	}
 	return filepath.Join(c.EntityTemplatesDir, entityType+"--"+variant+".md"), nil
 }
 
-// validateTemplateSegment rejects anything but identifier characters.
-// Allowlist rather than blocklist, for the reason RootedFS.resolve gives:
-// enumerating the dangerous forms (separators, "..", NUL, drive letters,
-// Windows reserved names) is a list you can be wrong about, and being wrong
-// fails open.
-func validateTemplateSegment(what, seg string) error {
-	if seg == "" {
+// RelationTemplatePath returns the file path for a relation type template.
+// The type name is checked by validateTemplateName first.
+func (c *Context) RelationTemplatePath(relationType string) (string, error) {
+	if err := validateTemplateName("relation type", relationType); err != nil {
+		return "", err
+	}
+	return filepath.Join(c.RelationTemplatesDir, relationType+".md"), nil
+}
+
+// validateTemplateName rejects a type name that cannot serve as a single path
+// segment under the templates directory.
+//
+// It is a BLOCKLIST, deliberately, mirroring metamodel.ValidateSchemaName
+// (which this package cannot import): shipped metamodels legitimately use
+// dashes, dots, internal spaces and non-ASCII letters in type names, and an
+// allowlist would reject existing valid schemas — and, because the default
+// template is resolved through here too, would break templates for such a
+// type entirely. What is rejected is exactly what could leave the directory
+// or produce a different file than the name says: empty, the "." and ".."
+// segments, both separator kinds, NUL and other control characters, and
+// leading/trailing whitespace (a likely typo, and the metamodel rejects it
+// too).
+func validateTemplateName(what, name string) error {
+	if name == "" {
 		return fmt.Errorf("project: %s must not be empty", what)
 	}
-	for _, ch := range seg {
+	if name == "." || name == ".." {
+		return fmt.Errorf("project: %s %q is not a valid name", what, name)
+	}
+	if strings.TrimSpace(name) != name {
+		return fmt.Errorf("project: %s %q must not have leading or trailing whitespace", what, name)
+	}
+	for _, ch := range name {
+		if ch == '/' || ch == '\\' || ch < 0x20 || ch == 0x7f {
+			return fmt.Errorf("project: %s %q contains a path separator or control character", what, name)
+		}
+	}
+	return nil
+}
+
+// validateTemplateVariant is the identifier allowlist for a template variant:
+// alphanumeric, hyphen and underscore only. Kept identical to
+// automation.isValidTemplateName — widen both or neither.
+func validateTemplateVariant(variant string) error {
+	for _, ch := range variant {
 		switch {
 		case ch >= 'a' && ch <= 'z',
 			ch >= 'A' && ch <= 'Z',
 			ch >= '0' && ch <= '9',
 			ch == '-', ch == '_':
 		default:
-			return fmt.Errorf("project: %s %q contains invalid characters "+
-				"(only alphanumeric, hyphen, underscore allowed)", what, seg)
+			return fmt.Errorf("project: template variant %q contains invalid characters "+
+				"(only alphanumeric, hyphen, underscore allowed)", variant)
 		}
 	}
 	return nil
-}
-
-// RelationTemplatePath returns the file path for a relation type template
-func (c *Context) RelationTemplatePath(relationType string) string {
-	return filepath.Join(c.RelationTemplatesDir, relationType+".md")
 }

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -260,13 +260,55 @@ func (c *Context) EntityTemplatePath(entityType string) string {
 	return filepath.Join(c.EntityTemplatesDir, entityType+".md")
 }
 
-// EntityTemplateVariantPath returns the file path for an entity template variant.
-// Variant templates use the naming convention: <type>--<variant>.md
-func (c *Context) EntityTemplateVariantPath(entityType, variant string) string {
-	if variant == "" {
-		return c.EntityTemplatePath(entityType)
+// EntityTemplateVariantPath returns the file path for an entity template
+// variant. Variant templates use the naming convention: <type>--<variant>.md
+//
+// Both segments are checked against an identifier allowlist first: this
+// function joins them into a path handed to a raw storage.FS, which performs
+// no validation of its own. Its callers reach it from
+// entitymanager.CreateOptions.Variant, and automation interpolates
+// {{new.kind}} — an API-settable entity property — into the template name, so
+// a segment here is not reliably operator-authored.
+//
+// internal/automation applies the same allowlist before its own use
+// (isValidTemplateName). That check remains the one that produces a good
+// error message for a bad automation; this one exists so the invariant is
+// local to the join rather than owned by a single caller in another package.
+// A future caller that forgets gets an error, not a traversal.
+func (c *Context) EntityTemplateVariantPath(entityType, variant string) (string, error) {
+	if err := validateTemplateSegment("entity type", entityType); err != nil {
+		return "", err
 	}
-	return filepath.Join(c.EntityTemplatesDir, entityType+"--"+variant+".md")
+	if variant == "" {
+		return c.EntityTemplatePath(entityType), nil
+	}
+	if err := validateTemplateSegment("template variant", variant); err != nil {
+		return "", err
+	}
+	return filepath.Join(c.EntityTemplatesDir, entityType+"--"+variant+".md"), nil
+}
+
+// validateTemplateSegment rejects anything but identifier characters.
+// Allowlist rather than blocklist, for the reason RootedFS.resolve gives:
+// enumerating the dangerous forms (separators, "..", NUL, drive letters,
+// Windows reserved names) is a list you can be wrong about, and being wrong
+// fails open.
+func validateTemplateSegment(what, seg string) error {
+	if seg == "" {
+		return fmt.Errorf("project: %s must not be empty", what)
+	}
+	for _, ch := range seg {
+		switch {
+		case ch >= 'a' && ch <= 'z',
+			ch >= 'A' && ch <= 'Z',
+			ch >= '0' && ch <= '9',
+			ch == '-', ch == '_':
+		default:
+			return fmt.Errorf("project: %s %q contains invalid characters "+
+				"(only alphanumeric, hyphen, underscore allowed)", what, seg)
+		}
+	}
+	return nil
 }
 
 // RelationTemplatePath returns the file path for a relation type template

--- a/internal/project/context_test.go
+++ b/internal/project/context_test.go
@@ -262,6 +262,70 @@ func TestContextEntityTemplatePath(t *testing.T) {
 	}
 }
 
+func TestContextEntityTemplateVariantPath(t *testing.T) {
+	ctx := newContext("/test")
+	dir := "/test/" + TemplatesDir + "/" + EntityTemplatesDir
+
+	t.Run("empty variant falls back to the type template", func(t *testing.T) {
+		got, err := ctx.EntityTemplateVariantPath("requirement", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := dir + "/requirement.md"; got != want {
+			t.Errorf("expected %s, got %s", want, got)
+		}
+	})
+
+	t.Run("variant", func(t *testing.T) {
+		got, err := ctx.EntityTemplateVariantPath("requirement", "detailed")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := dir + "/requirement--detailed.md"; got != want {
+			t.Errorf("expected %s, got %s", want, got)
+		}
+	})
+}
+
+// TestContextEntityTemplateVariantPath_RejectsTraversal pins the local guard.
+// The variant reaches here from automation's {{new.kind}} interpolation, which
+// carries an API-settable entity property, and the joined path goes to a raw
+// storage.FS that validates nothing. internal/automation applies the same
+// allowlist, but a caller that skipped it must not get a traversal.
+func TestContextEntityTemplateVariantPath_RejectsTraversal(t *testing.T) {
+	ctx := newContext("/test")
+	bad := []string{
+		"../../../../etc/passwd",
+		"..",
+		"a/b",
+		"a\\b",
+		"a\x00b",
+		"a b",
+		"a.b", // a dot would let a variant pick up an extension
+	}
+	for _, seg := range bad {
+		t.Run("variant="+seg, func(t *testing.T) {
+			if _, err := ctx.EntityTemplateVariantPath("requirement", seg); err == nil {
+				t.Errorf("EntityTemplateVariantPath(requirement, %q) = nil error, want rejection", seg)
+			}
+		})
+		t.Run("type="+seg, func(t *testing.T) {
+			if _, err := ctx.EntityTemplateVariantPath(seg, "detailed"); err == nil {
+				t.Errorf("EntityTemplateVariantPath(%q, detailed) = nil error, want rejection", seg)
+			}
+		})
+	}
+
+	// An empty ENTITY TYPE is a bug in the caller and is rejected; an empty
+	// VARIANT is the documented "no variant" case and must keep working.
+	if _, err := ctx.EntityTemplateVariantPath("", "detailed"); err == nil {
+		t.Error("empty entity type = nil error, want rejection")
+	}
+	if _, err := ctx.EntityTemplateVariantPath("requirement", ""); err != nil {
+		t.Errorf("empty variant should fall back to the type template, got %v", err)
+	}
+}
+
 func TestContextRelationTemplatePath(t *testing.T) {
 	ctx := newContext("/test")
 

--- a/internal/project/context_test.go
+++ b/internal/project/context_test.go
@@ -255,7 +255,10 @@ func TestContextExists(t *testing.T) {
 func TestContextEntityTemplatePath(t *testing.T) {
 	ctx := newContext("/test")
 
-	got := ctx.EntityTemplatePath("requirement")
+	got, err := ctx.EntityTemplatePath("requirement")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "/test/" + TemplatesDir + "/" + EntityTemplatesDir + "/requirement.md"
 	if got != want {
 		t.Errorf("expected %s, got %s", want, got)
@@ -287,49 +290,83 @@ func TestContextEntityTemplateVariantPath(t *testing.T) {
 	})
 }
 
-// TestContextEntityTemplateVariantPath_RejectsTraversal pins the local guard.
-// The variant reaches here from automation's {{new.kind}} interpolation, which
-// carries an API-settable entity property, and the joined path goes to a raw
-// storage.FS that validates nothing. internal/automation applies the same
-// allowlist, but a caller that skipped it must not get a traversal.
-func TestContextEntityTemplateVariantPath_RejectsTraversal(t *testing.T) {
+// TestContextTemplatePaths_TypeNameBlocklist pins the local guard on TYPE
+// names and, just as importantly, what it does NOT reject. Type names are
+// metamodel names, and metamodel.ValidateSchemaName documents that shipped
+// schemas legitimately use dashes, dots, internal spaces and non-ASCII — an
+// allowlist here would break templates (including the DEFAULT template) for
+// such a type. Only what could leave the directory is refused.
+func TestContextTemplatePaths_TypeNameBlocklist(t *testing.T) {
 	ctx := newContext("/test")
-	bad := []string{
-		"../../../../etc/passwd",
-		"..",
-		"a/b",
-		"a\\b",
-		"a\x00b",
-		"a b",
-		"a.b", // a dot would let a variant pick up an extension
-	}
-	for _, seg := range bad {
-		t.Run("variant="+seg, func(t *testing.T) {
-			if _, err := ctx.EntityTemplateVariantPath("requirement", seg); err == nil {
-				t.Errorf("EntityTemplateVariantPath(requirement, %q) = nil error, want rejection", seg)
-			}
-		})
-		t.Run("type="+seg, func(t *testing.T) {
-			if _, err := ctx.EntityTemplateVariantPath(seg, "detailed"); err == nil {
-				t.Errorf("EntityTemplateVariantPath(%q, detailed) = nil error, want rejection", seg)
-			}
-		})
-	}
+	accepted := []string{"requirement", "review-response", "some property", "v1.2", "café", "user_story"}
+	rejected := []string{"", ".", "..", "../etc", "a/b", "a\\b", "a\x00b", " lead", "trail ", "tab\tbed"}
 
-	// An empty ENTITY TYPE is a bug in the caller and is rejected; an empty
-	// VARIANT is the documented "no variant" case and must keep working.
-	if _, err := ctx.EntityTemplateVariantPath("", "detailed"); err == nil {
-		t.Error("empty entity type = nil error, want rejection")
+	for _, name := range accepted {
+		t.Run("accept/"+name, func(t *testing.T) {
+			if _, err := ctx.EntityTemplatePath(name); err != nil {
+				t.Errorf("EntityTemplatePath(%q): %v (a valid metamodel name must be accepted)", name, err)
+			}
+			if _, err := ctx.EntityTemplateVariantPath(name, "detailed"); err != nil {
+				t.Errorf("EntityTemplateVariantPath(%q, detailed): %v", name, err)
+			}
+			if _, err := ctx.RelationTemplatePath(name); err != nil {
+				t.Errorf("RelationTemplatePath(%q): %v", name, err)
+			}
+		})
 	}
-	if _, err := ctx.EntityTemplateVariantPath("requirement", ""); err != nil {
-		t.Errorf("empty variant should fall back to the type template, got %v", err)
+	for _, name := range rejected {
+		t.Run("reject/"+name, func(t *testing.T) {
+			if _, err := ctx.EntityTemplatePath(name); err == nil {
+				t.Errorf("EntityTemplatePath(%q) = nil error, want rejection", name)
+			}
+			if _, err := ctx.EntityTemplateVariantPath(name, "detailed"); err == nil {
+				t.Errorf("EntityTemplateVariantPath(%q, detailed) = nil error, want rejection", name)
+			}
+			if _, err := ctx.EntityTemplateVariantPath(name, ""); err == nil {
+				t.Errorf("EntityTemplateVariantPath(%q, \"\") = nil error, want rejection", name)
+			}
+			if _, err := ctx.RelationTemplatePath(name); err == nil {
+				t.Errorf("RelationTemplatePath(%q) = nil error, want rejection", name)
+			}
+		})
+	}
+}
+
+// TestContextEntityTemplateVariantPath_VariantAllowlist pins the VARIANT half,
+// which is an identifier allowlist kept identical to
+// automation.isValidTemplateName. The variant reaches here from automation's
+// {{new.kind}} interpolation — an API-settable entity property — and the
+// joined path goes to a raw storage.FS that validates nothing.
+func TestContextEntityTemplateVariantPath_VariantAllowlist(t *testing.T) {
+	ctx := newContext("/test")
+	for _, v := range []string{"detailed", "bug-report", "v2_draft", "A1"} {
+		if _, err := ctx.EntityTemplateVariantPath("requirement", v); err != nil {
+			t.Errorf("variant %q: %v, want accepted", v, err)
+		}
+	}
+	for _, v := range []string{"../../../../etc/passwd", "..", "a/b", "a\\b", "a\x00b", "a b", "a.b", "café"} {
+		if _, err := ctx.EntityTemplateVariantPath("requirement", v); err == nil {
+			t.Errorf("variant %q = nil error, want rejection", v)
+		}
+	}
+	// Empty variant is the documented "no variant" case and falls back to the
+	// type template.
+	got, err := ctx.EntityTemplateVariantPath("requirement", "")
+	if err != nil {
+		t.Fatalf("empty variant: %v", err)
+	}
+	if want := "/test/" + TemplatesDir + "/" + EntityTemplatesDir + "/requirement.md"; got != want {
+		t.Errorf("empty variant = %s, want %s", got, want)
 	}
 }
 
 func TestContextRelationTemplatePath(t *testing.T) {
 	ctx := newContext("/test")
 
-	got := ctx.RelationTemplatePath("satisfies")
+	got, err := ctx.RelationTemplatePath("satisfies")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "/test/" + TemplatesDir + "/" + RelationTemplatesDir + "/satisfies.md"
 	if got != want {
 		t.Errorf("expected %s, got %s", want, got)

--- a/internal/renametype/renametype.go
+++ b/internal/renametype/renametype.go
@@ -98,9 +98,15 @@ func (s *Service) Rename(oldType, newType, newPlural string) (int, error) {
 			count, err)
 	}
 
-	oldTemplatePath := paths.EntityTemplatePath(oldType)
+	oldTemplatePath, err := paths.EntityTemplatePath(oldType)
+	if err != nil {
+		return count, fmt.Errorf("resolve template path for %s (entity files already renamed): %w", oldType, err)
+	}
+	newTemplatePath, err := paths.EntityTemplatePath(newType)
+	if err != nil {
+		return count, fmt.Errorf("resolve template path for %s (entity files already renamed): %w", newType, err)
+	}
 	if _, err := fs.Stat(oldTemplatePath); err == nil {
-		newTemplatePath := paths.EntityTemplatePath(newType)
 		if err := fs.MkdirAll(paths.EntityTemplatesDir, 0o755); err != nil {
 			return count, fmt.Errorf("create template dir %s (entity files already renamed): %w",
 				paths.EntityTemplatesDir, err)

--- a/internal/storage/rooted.go
+++ b/internal/storage/rooted.go
@@ -158,7 +158,7 @@ func (r *RootedFS) contain(joined string) (ValidatedPath, error) {
 	// is then the one that passed the prefix check above. The shape matters:
 	// a combined `clean != root && !HasPrefix` condition lets the success path
 	// be reached without the prefix check ever running, which is both a
-	// weaker argument and one a static analyser correctly refuses to accept.
+	// weaker argument and one a static analyzer correctly refuses to accept.
 	if clean == r.root {
 		return r.rootPath(), nil
 	}

--- a/internal/storage/rooted.go
+++ b/internal/storage/rooted.go
@@ -119,6 +119,15 @@ func (r *RootedFS) resolve(key string) (ValidatedPath, error) {
 			return ValidatedPath{}, fmt.Errorf("storage: Windows reserved name %q not allowed in key", seg)
 		}
 	}
+	// filepath.IsLocal is the standard library's own answer to the question
+	// the rules above ask — not empty, not absolute, cannot escape via "..",
+	// not a Windows reserved name — so for every key they accept it is true by
+	// construction. It is kept as an independent second opinion that does not
+	// share a bug with the hand-written rules, and it is the check a static
+	// analyser recognises as a barrier on the key itself.
+	if !filepath.IsLocal(key) {
+		return ValidatedPath{}, errors.New("storage: key must be a local relative path")
+	}
 	return r.contain(filepath.Join(r.root, key))
 }
 
@@ -139,10 +148,21 @@ func (r *RootedFS) contain(joined string) (ValidatedPath, error) {
 	// case a container or a test tmpdir at the filesystem root actually hits:
 	// "//entities" matches nothing and every path looks like an escape.
 	prefix := strings.TrimSuffix(r.root, string(filepath.Separator)) + string(filepath.Separator)
-	if clean != r.root && !strings.HasPrefix(clean, prefix) {
-		return ValidatedPath{}, fmt.Errorf("storage: resolved path %q escapes root %q", clean, r.root)
+	if strings.HasPrefix(clean, prefix) {
+		return ValidatedPath{p: clean}, nil
 	}
-	return ValidatedPath{p: clean}, nil
+	// The root itself. resolve can never produce it (a non-empty key always
+	// joins to something below the root); only parent() can, for a top-level
+	// file. Hand back the root we already hold rather than the derived string
+	// — same value, but the only path-derived value this function ever returns
+	// is then the one that passed the prefix check above. The shape matters:
+	// a combined `clean != root && !HasPrefix` condition lets the success path
+	// be reached without the prefix check ever running, which is both a
+	// weaker argument and one a static analyser correctly refuses to accept.
+	if clean == r.root {
+		return r.rootPath(), nil
+	}
+	return ValidatedPath{}, fmt.Errorf("storage: resolved path %q escapes root %q", clean, r.root)
 }
 
 // rootPath is the root itself as a ValidatedPath. NewRootedFS made it

--- a/internal/storage/rooted.go
+++ b/internal/storage/rooted.go
@@ -119,7 +119,30 @@ func (r *RootedFS) resolve(key string) (ValidatedPath, error) {
 			return ValidatedPath{}, fmt.Errorf("storage: Windows reserved name %q not allowed in key", seg)
 		}
 	}
-	return ValidatedPath{p: filepath.Join(r.root, key)}, nil
+	return r.contain(filepath.Join(r.root, key))
+}
+
+// contain is the final barrier: it cleans the joined path and verifies the
+// result is still the root or strictly beneath it, and it is the ONLY place
+// (besides rootPath, which uses the root itself) that mints a ValidatedPath.
+//
+// The segment checks above already reject every traversal form, so this
+// should be unreachable — that is the point. It converts "the rules above are
+// exhaustive" from a claim into a checked postcondition, so a future edit that
+// loosens one of them fails closed here instead of escaping the root. It is
+// also what makes the containment legible to static analysis, which cannot
+// infer it from the string-level rules.
+func (r *RootedFS) contain(joined string) (ValidatedPath, error) {
+	clean := filepath.Clean(joined)
+	// Compare against the root with exactly one trailing separator. Building
+	// the prefix as root+sep breaks when the root IS the separator ("/"), the
+	// case a container or a test tmpdir at the filesystem root actually hits:
+	// "//entities" matches nothing and every path looks like an escape.
+	prefix := strings.TrimSuffix(r.root, string(filepath.Separator)) + string(filepath.Separator)
+	if clean != r.root && !strings.HasPrefix(clean, prefix) {
+		return ValidatedPath{}, fmt.Errorf("storage: resolved path %q escapes root %q", clean, r.root)
+	}
+	return ValidatedPath{p: clean}, nil
 }
 
 // rootPath is the root itself as a ValidatedPath. NewRootedFS made it
@@ -129,12 +152,21 @@ func (r *RootedFS) rootPath() ValidatedPath {
 	return ValidatedPath{p: r.root}
 }
 
-// parent returns the directory containing v. A validated path's parent
-// is still under the root (resolve rejects every key that could escape
-// it), so the result stays a ValidatedPath — this is the one derivation
-// that preserves the invariant.
+// parent returns the directory containing v, which is still inside the root
+// (v is contained, and a contained path's parent is the root or below it).
+// It goes through contain anyway rather than minting a ValidatedPath
+// directly: keeping construction to a single checked chokepoint is what makes
+// the invariant hold by inspection.
+//
+// A parent that somehow escaped would be a bug in contain, so this returns
+// the root rather than a path outside it — MkdirAll on the root is a harmless
+// no-op, whereas propagating an out-of-root directory is not.
 func (r *RootedFS) parent(v ValidatedPath) ValidatedPath {
-	return ValidatedPath{p: filepath.Dir(v.p)}
+	p, err := r.contain(filepath.Dir(v.p))
+	if err != nil {
+		return r.rootPath()
+	}
+	return p
 }
 
 // ReadFile reads the file at key.

--- a/internal/storage/rooted.go
+++ b/internal/storage/rooted.go
@@ -124,7 +124,7 @@ func (r *RootedFS) resolve(key string) (ValidatedPath, error) {
 	// not a Windows reserved name — so for every key they accept it is true by
 	// construction. It is kept as an independent second opinion that does not
 	// share a bug with the hand-written rules, and it is the check a static
-	// analyser recognises as a barrier on the key itself.
+	// analyzer recognizes as a barrier on the key itself.
 	if !filepath.IsLocal(key) {
 		return ValidatedPath{}, errors.New("storage: key must be a local relative path")
 	}

--- a/internal/storage/rooted.go
+++ b/internal/storage/rooted.go
@@ -22,6 +22,12 @@ import (
 // decorators (SafeFS, MemFS) and for the wiring layer that constructs
 // RootedFS.
 //
+// Internally the same claim is carried by [ValidatedPath]: resolve
+// returns one, and RootedFS reaches the wrapped FS only through
+// validatedFS, whose methods take a ValidatedPath. So there is no
+// path — not even an accidental one inside this type — from an
+// unvalidated key to an os call.
+//
 // Getwd is intentionally omitted — it does not fit the keyed-access
 // model.
 //
@@ -40,7 +46,8 @@ import (
 // RootedFS is stateless after construction (root and fs are immutable)
 // and inherits the concurrency semantics of the underlying FS.
 type RootedFS struct {
-	fs   FS
+	vfs  validatedFS
+	fs   FS // retained only for SupportsStreaming's backend sniff
 	root string
 }
 
@@ -57,7 +64,7 @@ func NewRootedFS(fs FS, root string) (*RootedFS, error) {
 	if err != nil {
 		return nil, fmt.Errorf("storage: resolve RootedFS root: %w", err)
 	}
-	return &RootedFS{fs: fs, root: filepath.Clean(abs)}, nil
+	return &RootedFS{vfs: validatedFS{fs: fs}, fs: fs, root: filepath.Clean(abs)}, nil
 }
 
 // windowsReserved lists Windows reserved device names (case-insensitive,
@@ -82,37 +89,52 @@ var windowsReserved = map[string]bool{
 //   - reject Windows reserved device names (CON, NUL, COM1–9, etc.)
 //
 // Valid keys produce filepath.Join(root, key).
-func (r *RootedFS) resolve(key string) (string, error) {
+func (r *RootedFS) resolve(key string) (ValidatedPath, error) {
 	if key == "" {
-		return "", errors.New("storage: key must not be empty")
+		return ValidatedPath{}, errors.New("storage: key must not be empty")
 	}
 	for _, c := range key {
 		if c < 0x20 || c == 0x7f {
-			return "", errors.New("storage: control character (including NUL) not allowed in key")
+			return ValidatedPath{}, errors.New("storage: control character (including NUL) not allowed in key")
 		}
 	}
 	if strings.ContainsRune(key, '\\') {
-		return "", errors.New("storage: backslash not allowed in key (use forward slash)")
+		return ValidatedPath{}, errors.New("storage: backslash not allowed in key (use forward slash)")
 	}
 	if strings.ContainsRune(key, ':') {
-		return "", errors.New("storage: colon not allowed in key (blocks Windows drive letters and ADS)")
+		return ValidatedPath{}, errors.New("storage: colon not allowed in key (blocks Windows drive letters and ADS)")
 	}
 	if strings.HasPrefix(key, "/") {
-		return "", errors.New("storage: key must be relative")
+		return ValidatedPath{}, errors.New("storage: key must be relative")
 	}
 	for seg := range strings.SplitSeq(key, "/") {
 		if seg == "" || seg == "." || seg == ".." {
-			return "", errors.New("storage: traversal or empty segment not allowed in key")
+			return ValidatedPath{}, errors.New("storage: traversal or empty segment not allowed in key")
 		}
 		stem := strings.ToLower(seg)
 		if i := strings.Index(stem, "."); i >= 0 {
 			stem = stem[:i]
 		}
 		if windowsReserved[stem] {
-			return "", fmt.Errorf("storage: Windows reserved name %q not allowed in key", seg)
+			return ValidatedPath{}, fmt.Errorf("storage: Windows reserved name %q not allowed in key", seg)
 		}
 	}
-	return filepath.Join(r.root, key), nil
+	return ValidatedPath{p: filepath.Join(r.root, key)}, nil
+}
+
+// rootPath is the root itself as a ValidatedPath. NewRootedFS made it
+// absolute and cleaned it, so it satisfies the invariant by
+// construction — it is not derived from a caller-supplied key at all.
+func (r *RootedFS) rootPath() ValidatedPath {
+	return ValidatedPath{p: r.root}
+}
+
+// parent returns the directory containing v. A validated path's parent
+// is still under the root (resolve rejects every key that could escape
+// it), so the result stays a ValidatedPath — this is the one derivation
+// that preserves the invariant.
+func (r *RootedFS) parent(v ValidatedPath) ValidatedPath {
+	return ValidatedPath{p: filepath.Dir(v.p)}
 }
 
 // ReadFile reads the file at key.
@@ -121,7 +143,7 @@ func (r *RootedFS) ReadFile(key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.fs.ReadFile(full)
+	return r.vfs.ReadFile(full)
 }
 
 // WriteFile writes data to key, creating parent directories if needed.
@@ -132,10 +154,10 @@ func (r *RootedFS) WriteFile(key string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	if err := r.fs.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+	if err := r.vfs.MkdirAll(r.parent(full), 0o755); err != nil {
 		return err
 	}
-	return r.fs.WriteFile(full, data, perm)
+	return r.vfs.WriteFile(full, data, perm)
 }
 
 // OpenForWrite opens key for streaming writes, creating parent
@@ -152,10 +174,10 @@ func (r *RootedFS) OpenForWrite(key string, perm os.FileMode) (io.WriteCloser, e
 	if err != nil {
 		return nil, err
 	}
-	if err := r.fs.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+	if err := r.vfs.MkdirAll(r.parent(full), 0o755); err != nil {
 		return nil, err
 	}
-	return os.OpenFile(full, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	return r.vfs.OpenForWrite(full, perm)
 }
 
 // AbsPath resolves key to its absolute filesystem path. Used by
@@ -168,7 +190,11 @@ func (r *RootedFS) OpenForWrite(key string, perm os.FileMode) (io.WriteCloser, e
 // raw FS methods to bypass validation. If you need that, you're
 // probably looking for OpenForWrite.
 func (r *RootedFS) AbsPath(key string) (string, error) {
-	return r.resolve(key)
+	full, err := r.resolve(key)
+	if err != nil {
+		return "", err
+	}
+	return full.String(), nil
 }
 
 // SupportsStreaming reports whether OpenForWrite can be used against
@@ -196,7 +222,7 @@ func (r *RootedFS) Remove(key string) error {
 	if err != nil {
 		return err
 	}
-	return r.fs.Remove(full)
+	return r.vfs.Remove(full)
 }
 
 // Rename renames oldKey to newKey. Both keys are validated.
@@ -209,7 +235,7 @@ func (r *RootedFS) Rename(oldKey, newKey string) error {
 	if err != nil {
 		return err
 	}
-	return r.fs.Rename(oldFull, newFull)
+	return r.vfs.Rename(oldFull, newFull)
 }
 
 // Stat returns file info for key.
@@ -218,7 +244,7 @@ func (r *RootedFS) Stat(key string) (os.FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.fs.Stat(full)
+	return r.vfs.Stat(full)
 }
 
 // MkdirAll creates the directory at key and any missing parents.
@@ -227,7 +253,7 @@ func (r *RootedFS) MkdirAll(key string, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	return r.fs.MkdirAll(full, perm)
+	return r.vfs.MkdirAll(full, perm)
 }
 
 // ReadDir reads the directory entries at key.
@@ -236,7 +262,7 @@ func (r *RootedFS) ReadDir(key string) ([]os.DirEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.fs.ReadDir(full)
+	return r.vfs.ReadDir(full)
 }
 
 // Open opens the file at key for reading.
@@ -245,7 +271,7 @@ func (r *RootedFS) Open(key string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return r.fs.Open(full)
+	return r.vfs.Open(full)
 }
 
 // Walk walks the subtree rooted at key. The callback receives keys
@@ -255,7 +281,7 @@ func (r *RootedFS) Walk(key string, fn fs.WalkDirFunc) error {
 	if err != nil {
 		return err
 	}
-	return r.fs.Walk(full, r.relativize(fn))
+	return r.vfs.Walk(full, r.relativize(fn))
 }
 
 // WalkAll walks the entire rooted tree.
@@ -266,7 +292,7 @@ func (r *RootedFS) Walk(key string, fn fs.WalkDirFunc) error {
 // entry do so via ReadDir("<first subkey>") or similar, not by feeding
 // "." back in.
 func (r *RootedFS) WalkAll(fn fs.WalkDirFunc) error {
-	return r.fs.Walk(r.root, r.relativize(fn))
+	return r.vfs.Walk(r.rootPath(), r.relativize(fn))
 }
 
 // relativize wraps a WalkDirFunc so it receives root-relative

--- a/internal/storage/rooted_test.go
+++ b/internal/storage/rooted_test.go
@@ -79,8 +79,8 @@ func TestRootedFS_Resolve_Accepts(t *testing.T) {
 				t.Fatalf("expected ok for %q, got %v", k, err)
 			}
 			want := filepath.Join(rfs.root, k)
-			if full != want {
-				t.Fatalf("resolve(%q) = %q, want %q", k, full, want)
+			if full.String() != want {
+				t.Fatalf("resolve(%q) = %q, want %q", k, full.String(), want)
 			}
 		})
 	}
@@ -132,7 +132,7 @@ func TestRootedFS_ResolvedPath_StaysInsideRoot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("resolve(%q): %v", k, err)
 		}
-		rel, err := filepath.Rel(rfs.root, full)
+		rel, err := filepath.Rel(rfs.root, full.String())
 		if err != nil {
 			t.Fatalf("rel: %v", err)
 		}
@@ -468,18 +468,18 @@ func FuzzResolve(f *testing.F) {
 		if err != nil {
 			return // rejection is fine — we only assert on acceptances
 		}
-		rel, relErr := filepath.Rel(rfs.root, full)
+		rel, relErr := filepath.Rel(rfs.root, full.String())
 		if relErr != nil {
-			t.Fatalf("filepath.Rel(%q, %q): %v", rfs.root, full, relErr)
+			t.Fatalf("filepath.Rel(%q, %q): %v", rfs.root, full.String(), relErr)
 		}
 		// rel must not be ".." and must not step up out of root.
 		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			t.Fatalf("resolved %q escapes root: rel=%q full=%q", key, rel, full)
+			t.Fatalf("resolved %q escapes root: rel=%q full=%q", key, rel, full.String())
 		}
 		// full must be root itself or a path inside root.
 		sep := string(filepath.Separator)
-		if full != rfs.root && !strings.HasPrefix(full, rfs.root+sep) {
-			t.Fatalf("resolved %q not prefixed by root: full=%q root=%q", key, full, rfs.root)
+		if full.String() != rfs.root && !strings.HasPrefix(full.String(), rfs.root+sep) {
+			t.Fatalf("resolved %q not prefixed by root: full=%q root=%q", key, full.String(), rfs.root)
 		}
 	})
 }

--- a/internal/storage/validated.go
+++ b/internal/storage/validated.go
@@ -39,7 +39,7 @@ func (v ValidatedPath) String() string { return v.p }
 // with an unvalidated path.
 //
 // The adapter is deliberately thin — it exists for the type barrier,
-// not for behaviour. Path values are unwrapped exactly here and nowhere
+// not for behavior. Path values are unwrapped exactly here and nowhere
 // else, which keeps the number of places that turn a validated path
 // back into a bare string down to one reviewable file.
 type validatedFS struct {

--- a/internal/storage/validated.go
+++ b/internal/storage/validated.go
@@ -1,0 +1,93 @@
+package storage
+
+import (
+	"io"
+	"io/fs"
+	"os"
+)
+
+// ValidatedPath is an absolute filesystem path that has passed
+// RootedFS.resolve: the key it was built from contained no traversal
+// syntax (no "..", no absolute prefix, no backslash, colon, control
+// character, empty segment or Windows reserved name), and the path is
+// the join of that key onto a RootedFS root.
+//
+// The single string field is unexported and there is no exported
+// constructor, so no package outside storage can produce one. A
+// function taking a ValidatedPath therefore has a compile-time
+// guarantee that the path passed validation — the barrier that was
+// previously only a documented convention (see the RootedFS type doc)
+// is now carried by the type system.
+//
+// This is what validatedFS exists to consume. It is also what makes
+// the "path injection" shape legible to static analysis: the taint
+// path from a caller-supplied key to os.WriteFile now runs through a
+// constructor that only the validator can call.
+//
+// Nil: never returned — the zero ValidatedPath is an empty path, which
+// every os call rejects.
+type ValidatedPath struct {
+	p string
+}
+
+// String returns the absolute filesystem path.
+func (v ValidatedPath) String() string { return v.p }
+
+// validatedFS adapts a raw [FS] to ValidatedPath-keyed methods. It is
+// the only thing RootedFS calls: every RootedFS method resolves its key
+// to a ValidatedPath first, so the raw FS underneath is never reachable
+// with an unvalidated path.
+//
+// The adapter is deliberately thin — it exists for the type barrier,
+// not for behaviour. Path values are unwrapped exactly here and nowhere
+// else, which keeps the number of places that turn a validated path
+// back into a bare string down to one reviewable file.
+type validatedFS struct {
+	fs FS
+}
+
+func (v validatedFS) ReadFile(path ValidatedPath) ([]byte, error) {
+	return v.fs.ReadFile(path.p)
+}
+
+func (v validatedFS) WriteFile(path ValidatedPath, data []byte, perm os.FileMode) error {
+	return v.fs.WriteFile(path.p, data, perm)
+}
+
+func (v validatedFS) Remove(path ValidatedPath) error {
+	return v.fs.Remove(path.p)
+}
+
+func (v validatedFS) Rename(oldPath, newPath ValidatedPath) error {
+	return v.fs.Rename(oldPath.p, newPath.p)
+}
+
+func (v validatedFS) Stat(path ValidatedPath) (os.FileInfo, error) {
+	return v.fs.Stat(path.p)
+}
+
+func (v validatedFS) MkdirAll(path ValidatedPath, perm os.FileMode) error {
+	return v.fs.MkdirAll(path.p, perm)
+}
+
+func (v validatedFS) ReadDir(path ValidatedPath) ([]os.DirEntry, error) {
+	return v.fs.ReadDir(path.p)
+}
+
+func (v validatedFS) Walk(root ValidatedPath, fn fs.WalkDirFunc) error {
+	return v.fs.Walk(root.p, fn)
+}
+
+func (v validatedFS) Open(path ValidatedPath) (io.ReadCloser, error) {
+	return v.fs.Open(path.p)
+}
+
+// OpenForWrite opens path for streaming writes. Unlike the other
+// methods this bypasses the wrapped FS and calls os.OpenFile directly:
+// the FS interface has no streaming-write method, and adding one is a
+// larger design change. The bypass is guarded by
+// [RootedFS.SupportsStreaming], which returns true only for an
+// OsFS-backed stack — a MemFS-backed RootedFS never reaches here.
+func (v validatedFS) OpenForWrite(path ValidatedPath, perm os.FileMode) (io.WriteCloser, error) {
+	return os.OpenFile(path.p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+}

--- a/internal/storage/validated_test.go
+++ b/internal/storage/validated_test.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestValidatedPath_ZeroValueIsEmpty(t *testing.T) {
+	var v ValidatedPath
+	if v.String() != "" {
+		t.Fatalf("zero ValidatedPath = %q, want empty", v.String())
+	}
+}
+
+func TestValidatedFS_UnwrapsToUnderlyingFS(t *testing.T) {
+	dir := t.TempDir()
+	rfs, err := NewRootedFS(NewOsFS(), dir)
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	full, err := rfs.resolve("a/b.txt")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := rfs.vfs.MkdirAll(rfs.parent(full), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := rfs.vfs.WriteFile(full, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "a", "b.txt"))
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+	if string(got) != "hi" {
+		t.Fatalf("content = %q, want %q", got, "hi")
+	}
+}
+
+// TestParent_StaysInsideRoot pins the claim in parent's doc comment: the
+// directory of a validated path is itself under the root, so widening the
+// invariant to it is sound. A key like "a/b.txt" must not have "." or the
+// root's own parent as its parent.
+func TestParent_StaysInsideRoot(t *testing.T) {
+	dir := t.TempDir()
+	rfs, err := NewRootedFS(NewOsFS(), dir)
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	for _, key := range []string{"a.txt", "a/b.txt", "a/b/c/d.txt"} {
+		t.Run(key, func(t *testing.T) {
+			full, err := rfs.resolve(key)
+			if err != nil {
+				t.Fatalf("resolve(%q): %v", key, err)
+			}
+			p := rfs.parent(full).String()
+			if p != rfs.root && !strings.HasPrefix(p, rfs.root+string(filepath.Separator)) {
+				t.Fatalf("parent(%q) = %q, outside root %q", key, p, rfs.root)
+			}
+		})
+	}
+}
+
+// rawFSCall matches a call on RootedFS's retained raw FS handle — the one
+// field that still holds an unvalidated-path interface.
+var rawFSCall = regexp.MustCompile(`r\.fs\.[A-Z]`)
+
+// directOSCall matches a direct os/filepath filesystem call. These belong in
+// validated.go (which unwraps ValidatedPath deliberately) and nowhere else in
+// the rooted path.
+var directOSCall = regexp.MustCompile(`\bos\.(ReadFile|WriteFile|OpenFile|Open|Remove|RemoveAll|Rename|Mkdir|MkdirAll|ReadDir|Stat|Lstat)\(`)
+
+// TestRootedFS_ReachesFSOnlyThroughValidatedFS is a guard test in the style of
+// internal/acl's ceilingguard_test: it scans rooted.go's source for the two
+// shapes that would bypass the ValidatedPath barrier.
+//
+// The barrier is a type, but Go cannot express "this struct field may only be
+// read by that method". RootedFS keeps a raw `fs FS` for SupportsStreaming's
+// backend sniff, and a future edit could reach an I/O method on it with a bare
+// string — reintroducing exactly the taint path this change closed. Likewise a
+// direct os.* call would skip validatedFS entirely, which is what
+// OpenForWrite used to do.
+//
+// Both are cheap to write by accident and invisible in review, so they are
+// checked mechanically rather than left to prose.
+func TestRootedFS_ReachesFSOnlyThroughValidatedFS(t *testing.T) {
+	src, err := os.ReadFile("rooted.go")
+	if err != nil {
+		t.Fatalf("read rooted.go: %v", err)
+	}
+	for i, line := range strings.Split(string(src), "\n") {
+		code, _, _ := strings.Cut(line, "//")
+		if m := rawFSCall.FindString(code); m != "" {
+			t.Errorf("rooted.go:%d calls the raw FS directly (%q); go through r.vfs so the path carries ValidatedPath: %s",
+				i+1, m, strings.TrimSpace(line))
+		}
+		if m := directOSCall.FindString(code); m != "" {
+			t.Errorf("rooted.go:%d calls %s directly, bypassing validatedFS; put the unwrap in validated.go: %s",
+				i+1, m, strings.TrimSpace(line))
+		}
+	}
+}

--- a/internal/storage/validated_test.go
+++ b/internal/storage/validated_test.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 )
@@ -25,11 +27,11 @@ func TestValidatedFS_UnwrapsToUnderlyingFS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if err := rfs.vfs.MkdirAll(rfs.parent(full), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
+	if mkErr := rfs.vfs.MkdirAll(rfs.parent(full), 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
 	}
-	if err := rfs.vfs.WriteFile(full, []byte("hi"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
+	if wErr := rfs.vfs.WriteFile(full, []byte("hi"), 0o644); wErr != nil {
+		t.Fatalf("WriteFile: %v", wErr)
 	}
 	got, err := os.ReadFile(filepath.Join(dir, "a", "b.txt"))
 	if err != nil {
@@ -64,42 +66,113 @@ func TestParent_StaysInsideRoot(t *testing.T) {
 	}
 }
 
-// rawFSCall matches a call on RootedFS's retained raw FS handle — the one
-// field that still holds an unvalidated-path interface.
-var rawFSCall = regexp.MustCompile(`r\.fs\.[A-Z]`)
-
-// directOSCall matches a direct os/filepath filesystem call. These belong in
-// validated.go (which unwraps ValidatedPath deliberately) and nowhere else in
-// the rooted path.
-var directOSCall = regexp.MustCompile(`\bos\.(ReadFile|WriteFile|OpenFile|Open|Remove|RemoveAll|Rename|Mkdir|MkdirAll|ReadDir|Stat|Lstat)\(`)
-
-// TestRootedFS_ReachesFSOnlyThroughValidatedFS is a guard test in the style of
-// internal/acl's ceilingguard_test: it scans rooted.go's source for the two
-// shapes that would bypass the ValidatedPath barrier.
-//
-// The barrier is a type, but Go cannot express "this struct field may only be
-// read by that method". RootedFS keeps a raw `fs FS` for SupportsStreaming's
-// backend sniff, and a future edit could reach an I/O method on it with a bare
-// string — reintroducing exactly the taint path this change closed. Likewise a
-// direct os.* call would skip validatedFS entirely, which is what
-// OpenForWrite used to do.
-//
-// Both are cheap to write by accident and invisible in review, so they are
-// checked mechanically rather than left to prose.
-func TestRootedFS_ReachesFSOnlyThroughValidatedFS(t *testing.T) {
-	src, err := os.ReadFile("rooted.go")
-	if err != nil {
-		t.Fatalf("read rooted.go: %v", err)
+// TestContain_RootIsFilesystemRoot pins the "/" case. Building the prefix as
+// root+separator yields "//", which no path has, so every key under a root of
+// "/" reads as an escape — a container or a tmpdir at the filesystem root hits
+// this, and the failure is a blanket refusal rather than anything subtle.
+func TestContain_RootIsFilesystemRoot(t *testing.T) {
+	rfs := &RootedFS{root: string(filepath.Separator)}
+	for _, key := range []string{"entities", "entities/tickets/a.md"} {
+		t.Run(key, func(t *testing.T) {
+			got, err := rfs.contain(filepath.Join(rfs.root, key))
+			if err != nil {
+				t.Fatalf("contain(%q) under root %q: %v", key, rfs.root, err)
+			}
+			if want := filepath.Join(rfs.root, key); got.String() != want {
+				t.Fatalf("contain = %q, want %q", got.String(), want)
+			}
+		})
 	}
-	for i, line := range strings.Split(string(src), "\n") {
-		code, _, _ := strings.Cut(line, "//")
-		if m := rawFSCall.FindString(code); m != "" {
-			t.Errorf("rooted.go:%d calls the raw FS directly (%q); go through r.vfs so the path carries ValidatedPath: %s",
-				i+1, m, strings.TrimSpace(line))
+}
+
+// TestContain_RejectsEscape pins the postcondition itself: contain is the last
+// barrier, so it must refuse a path outside the root even though resolve's
+// segment rules should already have made that impossible.
+func TestContain_RejectsEscape(t *testing.T) {
+	dir := t.TempDir()
+	rfs, err := NewRootedFS(NewOsFS(), dir)
+	if err != nil {
+		t.Fatalf("NewRootedFS: %v", err)
+	}
+	for _, p := range []string{
+		filepath.Join(dir, "..", "outside.md"),
+		filepath.Dir(dir),
+		dir + "-sibling/x.md", // prefix-of-root without a separator boundary
+	} {
+		t.Run(p, func(t *testing.T) {
+			if _, err := rfs.contain(p); err == nil {
+				t.Errorf("contain(%q) = nil error, want rejection (root %q)", p, dir)
+			}
+		})
+	}
+}
+
+// TestParent_FallsBackToRootOnEscape drives parent's defensive branch. It is
+// unreachable through resolve (a contained path's parent is contained), so the
+// only way to make contain fail is a hand-built RootedFS whose root does not
+// contain the path. The fallback must be the root itself, never the escaping
+// directory.
+func TestParent_FallsBackToRootOnEscape(t *testing.T) {
+	sep := string(filepath.Separator)
+	rfs := &RootedFS{root: filepath.Join(sep, "a")}
+	got := rfs.parent(ValidatedPath{p: filepath.Join(sep, "b", "c")})
+	if got.String() != rfs.root {
+		t.Fatalf("parent of out-of-root path = %q, want the root %q", got.String(), rfs.root)
+	}
+}
+
+// rootedGoExemptFuncs are the rooted.go functions allowed to read the raw
+// `fs` field. Exemption list, not inclusion list, so a new method fails closed.
+var rootedGoExemptFuncs = map[string]string{
+	"SupportsStreaming": "type-sniffs the backend chain; performs no I/O",
+}
+
+// TestRootedGo_NoRawFSOrDirectOSAccess is a guard test in the style of
+// internal/acl's ceilingguard_test. It parses rooted.go and fails on either
+// shape that bypasses the ValidatedPath barrier:
+//
+//   - any read of the raw `fs` field outside the exempt functions — Go cannot
+//     say "this field may only be read by that method", and a local alias
+//     (`raw := r.fs; raw.ReadFile(bareString)`) is zero validation;
+//   - any direct os.* call — validated.go is the one place a ValidatedPath is
+//     unwrapped, and it exists so that this file never has to.
+//
+// It walks the AST rather than matching source text: a regex over `r.fs.X`
+// is defeated by exactly that alias, which SupportsStreaming already uses,
+// and a guard that passes against the regression it names is worse than none.
+//
+// Scope is rooted.go only, by design. safefs.go and osfs.go ARE the raw layer
+// beneath the barrier and are expected to call os.* directly.
+func TestRootedGo_NoRawFSOrDirectOSAccess(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "rooted.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse rooted.go: %v", err)
+	}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
 		}
-		if m := directOSCall.FindString(code); m != "" {
-			t.Errorf("rooted.go:%d calls %s directly, bypassing validatedFS; put the unwrap in validated.go: %s",
-				i+1, m, strings.TrimSpace(line))
+		if _, exempt := rootedGoExemptFuncs[fn.Name.Name]; exempt {
+			continue
 		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.SelectorExpr:
+				if x.Sel.Name == "fs" {
+					t.Errorf("%s: %s reads the raw FS field; go through r.vfs so the path carries ValidatedPath",
+						fset.Position(x.Pos()), fn.Name.Name)
+				}
+			case *ast.CallExpr:
+				if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+					if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "os" {
+						t.Errorf("%s: %s calls os.%s directly, bypassing validatedFS; put the unwrap in validated.go",
+							fset.Position(x.Pos()), fn.Name.Name, sel.Sel.Name)
+					}
+				}
+			}
+			return true
+		})
 	}
 }

--- a/internal/templating/fstemplater.go
+++ b/internal/templating/fstemplater.go
@@ -25,7 +25,10 @@ func NewFSTemplater(fs storage.FS, paths *project.Context) *FSTemplater {
 }
 
 func (t *FSTemplater) EntityTemplate(_ context.Context, entityType, variant string) (*Template, error) {
-	path := t.paths.EntityTemplateVariantPath(entityType, variant)
+	path, err := t.paths.EntityTemplateVariantPath(entityType, variant)
+	if err != nil {
+		return nil, err
+	}
 	doc, err := loadEntityTemplateDoc(t.fs, path)
 	if err != nil {
 		return nil, err
@@ -55,7 +58,10 @@ func (t *FSTemplater) RelationTemplate(_ context.Context, relationType string) (
 func (t *FSTemplater) GenerateEntity(
 	_ context.Context, meta *metamodel.Metamodel, entityType, variant string, force bool,
 ) (bool, error) {
-	path := t.paths.EntityTemplateVariantPath(entityType, variant)
+	path, err := t.paths.EntityTemplateVariantPath(entityType, variant)
+	if err != nil {
+		return false, err
+	}
 	return generateEntityTemplate(t.fs, path, meta, entityType, force)
 }
 

--- a/internal/templating/fstemplater.go
+++ b/internal/templating/fstemplater.go
@@ -44,7 +44,10 @@ func (t *FSTemplater) EntityTemplates(_ context.Context, entityType string) ([]*
 }
 
 func (t *FSTemplater) RelationTemplate(_ context.Context, relationType string) (*Template, error) {
-	path := t.paths.RelationTemplatePath(relationType)
+	path, err := t.paths.RelationTemplatePath(relationType)
+	if err != nil {
+		return nil, err
+	}
 	doc, err := loadRelationTemplateDoc(t.fs, path)
 	if err != nil {
 		return nil, err
@@ -68,7 +71,10 @@ func (t *FSTemplater) GenerateEntity(
 func (t *FSTemplater) GenerateRelation(
 	_ context.Context, meta *metamodel.Metamodel, relationType string, force bool,
 ) (bool, error) {
-	path := t.paths.RelationTemplatePath(relationType)
+	path, err := t.paths.RelationTemplatePath(relationType)
+	if err != nil {
+		return false, err
+	}
 	return generateRelationTemplate(t.fs, path, meta, relationType, force)
 }
 

--- a/tickets/entities/implementation-checklists/IMPL-ZWA3HE.md
+++ b/tickets/entities/implementation-checklists/IMPL-ZWA3HE.md
@@ -1,0 +1,75 @@
+---
+id: IMPL-ZWA3HE
+type: implementation-checklist
+title: 'Implementation: Clear the 4 open go/path-injection and 1 js/xss-through-dom CodeQL alerts'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] ~~Integration tests written (test full flow, not just units)~~ (N/A:
+no new flow — this hardens existing paths. The existing store conformance
+suite, fsstore tests and the frontend suite already exercise the full flow and
+all pass unchanged.)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Mermaid rendering was verified against REAL mermaid in a REAL browser, not just
+in the test environment — the whole risk here is a sanitizer that silently
+strips diagram labels, which unit tests with mocked SVG cannot catch on their
+own.
+
+- Rendered flowchart, sequence and `stateDiagram-v2` through actual
+  `mermaid.render()` with `securityLevel: 'strict'` in Chrome, then compared
+  raw vs sanitized output. Confirmed mermaid puts flowchart and state labels in
+  `<foreignObject>` (sequence uses SVG `<text>`), and that the naive
+  `USE_PROFILES: {svg: true}` fix drops `Start` / `Choice` / `Done` / `Still` /
+  `Moving` while leaving shapes and arrows — i.e. it ships as empty boxes.
+- Confirmed the shipped config preserves every label and still strips
+  handlers, `<script>`, `javascript:` URLs and embedded media.
+- Confirmed with a hostile label (`<img src=x onerror=...>`) that strict
+  mermaid emits no event handler but DOES emit a live `<img>`; the sanitizer
+  removes it.
+- Both documented load-bearing config choices (`ADD_TAGS: ['foreignObject']`,
+  and omitting the `html` profile) were mutation-tested: each mutation fails 3
+  tests. The Go guard test was mutation-tested the same way.
+
+Note: happy-dom disagrees with real browsers on DOMPurify output. This test
+file already opts into jsdom for that reason (BUG-SQSV6V), so the new tests run
+on the accurate DOM.
+
+Go side: full `go test ./...`, `just arch-lint`, `just plimsoll`,
+`golangci-lint run ./...`, `just comment-lint` all pass. The root-is-`/`
+containment case was found by an actual fsstore test failure, not by
+inspection, and is now pinned by `TestContain_RootIsFilesystemRoot`.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-9P5W7O.md
+++ b/tickets/entities/planning-checklists/PLAN-9P5W7O.md
@@ -1,0 +1,244 @@
+---
+id: PLAN-9P5W7O
+type: planning-checklist
+title: 'Planning: Clear the 4 open go/path-injection and 1 js/xss-through-dom CodeQL alerts'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+> Filled in retrospectively: this was a scoped lint-clearing task worked from a
+> written brief, so the planning below records the decisions actually taken
+> rather than predicting them.
+
+**Scope:**
+
+IN: the 5 open CodeQL alerts — 4 `go/path-injection` (`internal/storage`) and 1
+`js/xss-through-dom` (`frontend/src/utils/markdown.ts`).
+
+OUT (deliberate, per the brief):
+- No change to `.github/workflows/codeql.yml`. Narrowing the analyser to
+  silence findings is the failure mode this work exists to avoid.
+- No change to `internal/storage`'s symlink posture. `RootedFS` documents
+  symlink resolution as out of scope ("the threat model is caller-supplied key
+  contains traversal syntax, not attacker has write access to the root"). If
+  that is wrong it is its own ticket, not a drive-by change here.
+- No streaming method on the `FS` interface. `OpenForWrite`'s direct
+  `os.OpenFile` is deliberate and guarded by `SupportsStreaming()`; routing it
+  through `r.fs` is a larger design change.
+
+**Acceptance Criteria:**
+
+1. Alerts 29/31/32/33 no longer reachable — the taint path from a
+   caller-supplied key to an `os.*` call runs through a barrier the analyser
+   recognises. Test: `TestRootedFS_ReachesFSOnlyThroughValidatedFS` fails if
+   any raw-FS or direct-`os` call reappears in `rooted.go`.
+2. Alert 20 fixed by owning the escaping rather than relying on mermaid's.
+   Test: hostile-SVG cases assert no surviving handler/script/`javascript:`.
+3. **Diagrams still render with labels.** Test:
+   `preserves foreignObject label text and SVG shape markup`, plus a real
+   browser check against real mermaid.
+4. Nothing dismissed rather than fixed.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: scoped lint-clearing task
+worked from a written brief that already surveyed the options.)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A: both
+fixes are local to this codebase's own types.)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — small, well-specified change.
+
+**Existing Solutions:**
+
+- **Prior art in-tree:** FEAT-ZPGGK already describes exactly this ("a single
+  `resolve(key)` method is the path-validation barrier, visible to CodeQL"),
+  and TKT-TX53E anticipated CodeQL query-set expansion over the same code. This
+  ticket implements the barrier half of that feature.
+- **Guard-test pattern:** `internal/acl/ceilingguard_test.go` scans its own
+  package for a bypass shape and fails on it, using an exemption list so new
+  files fail closed. `TestRootedFS_ReachesFSOnlyThroughValidatedFS` follows it.
+- **DOMPurify** is already a dependency (used by `renderMarkdown`), so no new
+  library was needed for the frontend half.
+- **No suppression precedent:** `grep -rn 'codeql' --include='*.go'` returns
+  nothing, so annotating the alerts away would have set a new precedent. The
+  brief also rates suppression below the type change.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+*Go.* `resolve()` returns a `ValidatedPath` (unexported field, no exported
+constructor) rather than a `string`, and `RootedFS` reaches the wrapped `FS`
+only through a `validatedFS` adapter whose methods take one. A single
+`contain()` chokepoint mints every `ValidatedPath`, cleaning the joined path
+and verifying it is still under the root — turning "the segment rules are
+exhaustive" into a checked postcondition rather than a claim.
+
+*Frontend.* Sanitize mermaid's SVG through DOMPurify before insertion, with
+`ADD_TAGS: ['foreignObject']` and the SVG profile only.
+
+**Alternatives rejected:**
+
+- *Suppression comments* (`// codeql[go/path-injection]`): the brief's own
+  fallback. Rejected — buys silence, not safety, and there is no precedent.
+- *Making `OsFS` validate*: wrong layer. `OsFS` is deliberately an unguarded
+  `os.*` wrapper; containment belongs in `RootedFS`.
+- *A pre-parse with `DOMParser.parseFromString(svg, 'image/svg+xml')`*: tried
+  first, and it is what discards labels — the XHTML children of
+  `foreignObject` are invalid in the SVG namespace. Do not reintroduce.
+- *Dropping to `textContent`*: the SVG must be parsed as markup to render.
+
+**Files to modify:**
+
+- `internal/storage/validated.go` (new), `rooted.go`, `validated_test.go`
+  (new), `rooted_test.go`
+- `internal/project/context.go`, `context_test.go`,
+  `internal/templating/fstemplater.go`
+- `frontend/src/utils/markdown.ts`, `markdown.test.ts`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **HTTP URL path** (`handleV1DynamicRoutes`, `api_v1.go:139`) — the single
+  taint source CodeQL reports for all four Go alerts. Becomes an entity ID,
+  then an fsstore key. Validated by `entity.ValidateID` and again by
+  `RootedFS.resolve`; invalid input is rejected with an error, never joined.
+- **Entity template variant** — reaches `EntityTemplateVariantPath` from
+  `entitymanager.CreateOptions.Variant`, and automation interpolates
+  `{{new.kind}}` (an API-settable entity property) into it. Allowlist
+  (alphanumeric/hyphen/underscore); invalid input returns an error.
+- **Diagram source** — user-authored markdown body content, rendered by
+  mermaid then sanitized.
+
+Allowlist throughout, deliberately: enumerating the dangerous forms
+(separators, `..`, NUL, drive letters, Windows reserved names) is a list you can
+be wrong about, and being wrong fails open.
+
+**Security-Sensitive Operations:**
+
+- File read/write/delete under a project root (`RootedFS` → `os.*`). Protected
+  by `resolve()`'s segment rules plus the `contain()` postcondition.
+- `os.OpenFile` in `OpenForWrite` — deliberate, guarded by
+  `SupportsStreaming()`, now takes a `ValidatedPath`.
+- HTML insertion of third-party-rendered SVG into the DOM.
+
+Errors name the offending key or path but no file contents; a resolve failure
+is an argument error, not an oracle over the filesystem.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+- AC1 → `TestRootedFS_ReachesFSOnlyThroughValidatedFS` (source scan),
+  `TestValidatedFS_UnwrapsToUnderlyingFS`, existing `storetest` conformance.
+- AC2 → the hostile-SVG cases (handler, script, `javascript:`, media in a
+  label).
+- AC3 → `preserves foreignObject label text and SVG shape markup`,
+  `preserves SVG <text> labels used by sequence diagrams`,
+  `keeps each label with its own shape`, plus a real-browser check against
+  real mermaid rendering flowchart / sequence / `stateDiagram-v2`.
+- AC4 → `gh api .../code-scanning/alerts?state=open` shows the alerts as
+  `fixed`, not `dismissed`.
+
+**Edge Cases:**
+
+- **Root is `/`** — `root + separator` is `//`, which no path matches, so every
+  key reads as an escape. Found by a real fsstore test failure, not by
+  inspection. Pinned by `TestContain_RootIsFilesystemRoot`.
+- **Sibling-prefix path** (`/root-sibling/x` against root `/root`) — must be
+  rejected; a naive `HasPrefix` without the separator boundary accepts it.
+- **Empty variant** — the documented "no variant" case, must keep working;
+  empty entity type is a caller bug and must be rejected.
+- **Malformed SVG** — must yield an empty diagram, not a throw.
+- **Sequence vs flowchart diagrams** — different label mechanisms (`<text>` vs
+  `<foreignObject>`), so both must be covered; testing one hides the bug.
+
+**Negative Tests:**
+
+`TestContain_RejectsEscape`, `TestRootedFS_Resolve_Rejects`,
+`TestContextEntityTemplateVariantPath_RejectsTraversal` (traversal, separators,
+NUL, spaces, dots), and the four hostile-SVG cases. All fail with an error
+return; none panic or silently pass through.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **The sanitizer silently breaks diagrams.** The main risk, and it
+  materialised: the obvious fix strips every flowchart and state label while
+  leaving shapes, so it looks fine. Mitigated by verifying against real mermaid
+  in a real browser, covering all three diagram types, and mutation-testing
+  both load-bearing config choices.
+- **`ValidatedPath` ripples too far for one PR.** Mitigated by keeping
+  `AbsPath`'s `string` return (its one consumer compares paths, never does
+  I/O), so the change stops at the `storage` package boundary.
+- **The type change looks like a fix without being one.** Mitigated by
+  auditing every raw-`storage.FS` caller first, and by `contain()` being a real
+  runtime postcondition rather than only a compile-time cast.
+- **happy-dom vs jsdom disagree on DOMPurify**, so tests can pass against
+  behaviour real browsers do not have. Mitigated: this file already opts into
+  jsdom (BUG-SQSV6V).
+
+Effort: m.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] ~~User-facing docs identified~~ (N/A: internal hardening — no CLI, API,
+metamodel or UI surface changes. Rationale lives in the code's doc comments,
+which is where the next person editing the sanitizer will look.)
+- [x] ~~Docs-checklist will be created when entering implementation~~ (N/A:
+`chore` kind, not an enhancement or docs ticket.)
+
+**Documentation Impact:**
+<!-- Which docs need updating? Check all that apply:
+- [ ] docs/metamodel.md - New metamodel features
+- [ ] docs/cli-reference.md - New/changed commands
+- [ ] docs/data-entry.md - UI changes
+- [ ] CLAUDE.md - New patterns or conventions
+- [ ] README.md - Project-level changes
+- [x] N/A - Internal change, no user-facing docs needed
+-->
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: the
+approach was specified in a written brief that had already weighed the type
+change against suppression. The one design decision taken *against* the brief —
+the frontend sanitizer config — was settled by measurement rather than review.)
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** None — see above. CodeQL itself acted as the review
+on the first push: it flagged the moved sink and the pre-parse step, and both
+were fixed rather than suppressed.

--- a/tickets/entities/review-checklists/REV-QVZSGG.md
+++ b/tickets/entities/review-checklists/REV-QVZSGG.md
@@ -1,0 +1,86 @@
+---
+id: REV-QVZSGG
+type: review-checklist
+title: 'Review: Clear the 4 open go/path-injection and 1 js/xss-through-dom CodeQL alerts'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`) — enforced in CI's Test job (go-test-coverage), which passed on the first push; the local recipe currently fails on a doubled module path in the tool itself, unrelated to this change. Touched packages: storage 85%, project 95%, templating 84%, all above floor.
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** see the `has-review-response` relations on TKT-R8QEV3 (9: 2 critical, 4 significant, 3 minor; all addressed except the AbsPath one, wont-fix with reason). The two criticals were real: the first frontend sanitizer flattened every flowchart label, and the first guard test passed against the bypass it named.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 (Go barrier legible + guarded): PASS — CodeQL's Analyze (go) passed on the first push; the moved-sink alert it raised is closed by `contain()`; go/ast guard mutation-verified.
+- AC2 (own the escaping): PASS — SVG-side and label-side hostile cases, unit + real-browser e2e.
+- AC3 (diagrams still render WITH labels): PASS — structural unit tests + `e2e/tests/mermaid.spec.ts` against real mermaid (`.nodeLabel` and `<br>` survive).
+- AC4 (nothing dismissed): PASS — no dismissals; final alert state to be confirmed via the API after merge.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: chore, internal hardening)
+- [x] ~~User-facing documentation updated~~ (N/A: no user-facing surface changed)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI (PR opened before this checklist existed — the ticket gate itself was the first CI failure; CI is monitored to green from here)
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-1RUR2G.md
+++ b/tickets/entities/review-responses/RR-1RUR2G.md
@@ -1,0 +1,9 @@
+---
+id: RR-1RUR2G
+type: review-response
+title: No test exercised real mermaid output
+finding: Every mermaid test mocks render() so nothing checked that what mermaid actually emits survives sanitization.
+severity: significant
+resolution: 'Real mermaid cannot run under jsdom (getBBox) so added e2e/tests/mermaid.spec.ts: real browser and real mermaid; asserts label markup survives and hostile-label img / handlers are stripped. Passes.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3G42ND.md
+++ b/tickets/entities/review-responses/RR-3G42ND.md
@@ -1,0 +1,9 @@
+---
+id: RR-3G42ND
+type: review-response
+title: AbsPath downgrades ValidatedPath to string by convention
+finding: The one deliberate string escape. Its single caller only compares paths and never does I/O.
+severity: minor
+reason: Exporting ValidatedPath accessors is worse. The caller (fsstore layout) is verified I/O-free and the doc comment already forbids passing it back into raw FS methods. Left as documented.
+status: wont-fix
+---

--- a/tickets/entities/review-responses/RR-A1CUO8.md
+++ b/tickets/entities/review-responses/RR-A1CUO8.md
@@ -1,0 +1,9 @@
+---
+id: RR-A1CUO8
+type: review-response
+title: Entity-type allowlist contradicts metamodel.ValidateSchemaName
+finding: validateTemplateSegment allowlisted [A-Za-z0-9_-] for the entity TYPE but the metamodel deliberately uses a blocklist because shipped schemas use dashes / dots / spaces / non-ASCII. The check also ran before the empty-variant return so default templates broke for such types.
+severity: significant
+resolution: Type names now use validateTemplateName — a blocklist mirroring ValidateSchemaName (empty; . and ..; separators; control chars; edge whitespace). The variant keeps the identifier allowlist identical to automation.isValidTemplateName. Tests pin accepted names such as review-response / some property / v1.2 / café.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CN6K2D.md
+++ b/tickets/entities/review-responses/RR-CN6K2D.md
@@ -1,0 +1,9 @@
+---
+id: RR-CN6K2D
+type: review-response
+title: Mermaid sanitizer flattens foreignObject label markup
+finding: 'Single-pass DOMPurify with the SVG profile unwraps the XHTML inside foreignObject so only text survives: br multi-line labels collapse to one word; the .nodeLabel styling hook is lost; bare text is not valid foreignObject content. Allowing the HTML tags is worse — DOMPurify 3.4 force-removes an allowed HTML element under an SVG parent.'
+severity: critical
+resolution: 'Two-pass: an uponSanitizeElement hook on a dedicated DOMPurify instance lifts each label during the SVG pass; each label is then sanitized under the HTML profile and written back. Structural unit tests assert .nodeLabel / p / br / style survive; e2e/tests/mermaid.spec.ts renders real mermaid in a real browser and checks the same.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-HHJDVK.md
+++ b/tickets/entities/review-responses/RR-HHJDVK.md
@@ -1,0 +1,9 @@
+---
+id: RR-HHJDVK
+type: review-response
+title: parent() fallback branch untested
+finding: The contain-failure branch is unreachable via resolve and had no test.
+severity: minor
+resolution: TestParent_FallsBackToRootOnEscape drives it with a hand-built RootedFS whose root does not contain the path.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ODGGH3.md
+++ b/tickets/entities/review-responses/RR-ODGGH3.md
@@ -1,0 +1,9 @@
+---
+id: RR-ODGGH3
+type: review-response
+title: Guard test passes against an aliased raw-FS bypass
+finding: TestRootedFS_ReachesFSOnlyThroughValidatedFS matched the literal r.fs.X with a regex. raw := r.fs followed by raw.ReadFile(bareString) — zero validation — passed it.
+severity: critical
+resolution: 'Rewritten over go/ast as TestRootedGo_NoRawFSOrDirectOSAccess: any SelectorExpr reading the fs field outside an exemption list and any os.* call fails. Mutation-verified against the exact alias; scope (rooted.go only) documented.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QX7IGD.md
+++ b/tickets/entities/review-responses/RR-QX7IGD.md
@@ -1,0 +1,9 @@
+---
+id: RR-QX7IGD
+type: review-response
+title: Non-SVG sanitizer input rendered as literal text
+finding: RETURN_DOM_FRAGMENT on garbage yields a text node that was appended to the page.
+severity: minor
+resolution: A fragment whose first element is not <svg> yields an empty host; test asserts textContent is empty.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SHEMBL.md
+++ b/tickets/entities/review-responses/RR-SHEMBL.md
@@ -1,0 +1,9 @@
+---
+id: RR-SHEMBL
+type: review-response
+title: EntityTemplatePath left unguarded next to the guarded variant path
+finding: The rationale for guarding EntityTemplateVariantPath applies verbatim to EntityTemplatePath (3 raw-FS callers) and RelationTemplatePath.
+severity: significant
+resolution: Both now validate and return (string; error). Callers in renametype / cli rename / templating updated.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YK5XFA.md
+++ b/tickets/entities/review-responses/RR-YK5XFA.md
@@ -1,0 +1,9 @@
+---
+id: RR-YK5XFA
+type: review-response
+title: Frontend regression tests only asserted textContent
+finding: Text survives the broken configurations too so the preserves tests could not distinguish preserved labels from flattened ones.
+severity: significant
+resolution: 'Tests assert structure (foreignObject.children>0 / .nodeLabel / p / br / style) and label-side sanitization separately. Mutation-verified: no-restore fails 7 tests; unsanitized-restore fails 5.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-R8QEV3.md
+++ b/tickets/entities/tickets/TKT-R8QEV3.md
@@ -1,0 +1,62 @@
+---
+id: TKT-R8QEV3
+type: ticket
+title: Clear the 4 open go/path-injection and 1 js/xss-through-dom CodeQL alerts
+kind: chore
+priority: medium
+effort: m
+status: done
+---
+
+## Description
+
+Five CodeQL alerts sat open on `develop` since April–June 2026: four
+`go/path-injection` (`internal/storage/osfs.go`, `internal/storage/rooted.go`)
+and one `js/xss-through-dom` (`frontend/src/utils/markdown.ts`). All four Go
+alerts share a single taint source — the data-entry HTTP URL path in
+`handleV1DynamicRoutes`.
+
+They made the aggregate CodeQL check red on unrelated PRs, so they were worth
+clearing on their own branch rather than folded into feature work.
+
+### Were they real?
+
+Mostly no, and that was verified rather than assumed. An audit of every
+production holder of a raw `storage.FS`, and every direct `os.*` filesystem
+call, found no reachable traversal: attachments, entity IDs, Lua, and the
+data-entry handlers are each already gated. CodeQL flagged them because
+`RootedFS.resolve` was a string-level validator returning a `string`, which the
+analyser does not recognise as a barrier, and `mermaid.render()` is an opaque
+third-party call.
+
+One latent issue *was* found — see below.
+
+### Changes
+
+- `internal/storage`: `resolve()` returns a `ValidatedPath` (unexported field,
+no exported constructor) instead of a `string`, and `RootedFS` reaches the
+wrapped `FS` only through `validatedFS`. The documented "keys were validated"
+convention becomes a compile-time property. A `contain()` chokepoint is the
+single place a `ValidatedPath` is minted, turning "the segment rules are
+exhaustive" into a checked postcondition.
+- `internal/project`: `EntityTemplateVariantPath` now validates its own
+segments. It joins into a raw `storage.FS` and automation interpolates
+`{{new.kind}}` (an API-settable property) into the variant, so its only guard
+living in `internal/automation` was one forgetful caller from a traversal. Not
+exploitable today; the invariant is now local to the join.
+- `frontend`: mermaid SVG is sanitized through DOMPurify before insertion.
+
+### Notes for the next person
+
+The obvious frontend fix is wrong. `DOMPurify.sanitize(svg, {USE_PROFILES: {svg:
+true}})` strips `<foreignObject>`, which is where mermaid puts every flowchart
+and state-diagram label — shapes and arrows still render, so it ships as empty
+boxes. Sequence diagrams use SVG `<text>` and are unaffected, so checking one
+diagram type hides it. `ADD_TAGS: ['foreignObject']` and omitting the `html`
+profile are both load-bearing, and both are mutation-verified by tests.
+
+Guard tests: `TestRootedFS_ReachesFSOnlyThroughValidatedFS` scans `rooted.go`
+for raw-FS and direct-`os` calls (the style of `internal/acl`'s
+`ceilingguard_test.go`), and `TestContain_*` pins the containment postcondition,
+including the root-is-`/` case that a container or a tmpdir at the filesystem
+root actually hits.

--- a/tickets/relations/TKT-R8QEV3--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-R8QEV3--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-R8QEV3--affects--store-backends.md
+++ b/tickets/relations/TKT-R8QEV3--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-R8QEV3--has-implementation--IMPL-ZWA3HE.md
+++ b/tickets/relations/TKT-R8QEV3--has-implementation--IMPL-ZWA3HE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-implementation
+to: IMPL-ZWA3HE
+---

--- a/tickets/relations/TKT-R8QEV3--has-planning--PLAN-9P5W7O.md
+++ b/tickets/relations/TKT-R8QEV3--has-planning--PLAN-9P5W7O.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-planning
+to: PLAN-9P5W7O
+---

--- a/tickets/relations/TKT-R8QEV3--has-review--REV-QVZSGG.md
+++ b/tickets/relations/TKT-R8QEV3--has-review--REV-QVZSGG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review
+to: REV-QVZSGG
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-1RUR2G.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-1RUR2G.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-1RUR2G
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-3G42ND.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-3G42ND.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-3G42ND
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-A1CUO8.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-A1CUO8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-A1CUO8
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-CN6K2D.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-CN6K2D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-CN6K2D
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-HHJDVK.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-HHJDVK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-HHJDVK
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-ODGGH3.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-ODGGH3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-ODGGH3
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-QX7IGD.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-QX7IGD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-QX7IGD
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-SHEMBL.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-SHEMBL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-SHEMBL
+---

--- a/tickets/relations/TKT-R8QEV3--has-review-response--RR-YK5XFA.md
+++ b/tickets/relations/TKT-R8QEV3--has-review-response--RR-YK5XFA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: has-review-response
+to: RR-YK5XFA
+---

--- a/tickets/relations/TKT-R8QEV3--implements--FEAT-ZPGGK.md
+++ b/tickets/relations/TKT-R8QEV3--implements--FEAT-ZPGGK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R8QEV3
+relation: implements
+to: FEAT-ZPGGK
+---


### PR DESCRIPTION
Clears the 5 open CodeQL alerts (4 `go/path-injection`, 1 `js/xss-through-dom`).
All four Go alerts share one taint source: the dataentry HTTP URL path
(`internal/dataentry/api_v1.go:139`). Ticket: **TKT-R8QEV3** (implements FEAT-ZPGGK).

Standalone security PR — not folded into a feature branch, so it can be
reviewed on its own.

| # | Rule | Location |
|---|---|---|
| 33 | `go/path-injection` | `internal/storage/rooted.go` (`OpenForWrite`) |
| 32, 31 | `go/path-injection` | `internal/storage/osfs.go` (`WriteFile`) |
| 29 | `go/path-injection` | `internal/storage/osfs.go` (`ReadDir`) |
| 20 | `js/xss-through-dom` | `frontend/src/utils/markdown.ts` |

## Are these real bugs?

Mostly no — but the premise was verified rather than assumed. An audit of every
raw `storage.FS` holder and direct `os.*` call in production code found **no
genuine traversal**: attachments, entity IDs (`entity.ValidateID` *and*
`RootedFS.resolve`), Lua (`filepath.IsLocal`, `os.OpenRoot`) and the dataentry
handlers are each gated. One latent issue was found and fixed — see *project*.

## storage: the barrier is now a type, with a checked postcondition

`resolve()` returns `ValidatedPath` (unexported field, no exported constructor)
instead of `string`, and `RootedFS` reaches the wrapped `FS` only through
`validatedFS`, whose methods take one. The single place a `ValidatedPath` is
minted is `contain()`: `filepath.Clean` + a root-containment check. The segment
rules should make that unreachable — which is the point: "the rules are
exhaustive" becomes a checked postcondition instead of a claim, and it is the
barrier the analyser can see. (The first push moved the sink into `validated.go`
without this; CodeQL correctly re-flagged it.) Found on the way: `root + sep`
breaks when the root is `/` — pinned by `TestContain_RootIsFilesystemRoot`.

`OpenForWrite`'s direct `os.OpenFile` is **deliberate and already guarded** by
`SupportsStreaming()`; it moved into the adapter rather than being "cleaned up".

`RootedFS` keeps a raw `fs FS` for `SupportsStreaming`'s type sniff, and Go
can't express "this field may only be read by that method", so
`TestRootedGo_NoRawFSOrDirectOSAccess` walks `rooted.go`'s AST and fails on any
read of that field outside an exemption list, or any `os.*` call. It is AST
rather than regex because a regex over `r.fs.X` is defeated by exactly the alias
`SupportsStreaming` uses (`raw := r.fs`) — the first version of this test passed
against that; the review caught it. Mutation-verified. Scope is `rooted.go`
only: `safefs.go`/`osfs.go` are the intentional raw layer beneath the barrier.

## project: one real finding

`EntityTemplateVariantPath` joined both segments into a path for a raw
`storage.FS` and validated nothing; its only guard lives in
`internal/automation`, which interpolates `{{new.kind}}` — an API-settable
entity property — into the template name. Not exploitable today, but one
forgetful caller from a traversal.

Now validated locally, and `EntityTemplatePath`/`RelationTemplatePath` with it
(same argument, same raw-FS callers). Two rules on purpose: **type names get a
blocklist** (empty, `.`/`..`, separators, control chars, edge whitespace)
mirroring `metamodel.ValidateSchemaName`, which documents that shipped schemas
legitimately use dashes, dots, spaces and non-ASCII — an allowlist would have
broken templates for such types, including the default one (review finding).
The **variant keeps an identifier allowlist** identical to
`automation.isValidTemplateName`. Every schema and template in the repo passes.

## frontend: the obvious one-liner breaks the product

`DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } })` **destroys every
flowchart and state-diagram label.** Mermaid renders them as XHTML
(`<div><span class="nodeLabel"><p>…<br>…</p></span></div>`) inside
`<foreignObject>`, and DOMPurify 3.4 cannot retain that in a single call in
*any* configuration — measured: with the SVG profile the HTML elements are
unwrapped (only text survives: `Line1<br>Line2` → `Line1Line2`, `.nodeLabel`
gone, bare text not valid `foreignObject` content); *allowing* them is worse,
because the namespace check runs after the allowed-tags check and
force-removes an allowed HTML element under an SVG parent, children and all.
Shapes and arrows still render, so it ships as empty boxes; sequence diagrams
(SVG `<text>`) are unaffected, so checking one type hides it.

So it is two passes: a hook on a dedicated DOMPurify instance lifts each label
*during* the SVG pass (the raw string is only ever handed to DOMPurify — no
`DOMParser` pre-parse, which is what CodeQL flagged on the first push and what
turned untrusted text into DOM before any sanitizer saw it), then each label is
sanitized under the HTML profile and written back into its emptied
`foreignObject`. Both halves are sanitized; the split is parsing context, not
exemption. Labels pair to shapes by a marker the hook strips from every input
element first, so input can't spoof a slot. Embedded media is forbidden in
labels: strict mermaid strips a hostile label's handler but still emits the
`<img>`, which is enough for a request to an attacker-chosen URL on view.

Defence in depth (mermaid runs `securityLevel: 'strict'`) — but `'loose'` is
one line and the setting clickable nodes need; it must not be one line from
stored XSS.

**Verification:** unit tests assert *structure* (`.nodeLabel`, `<p>`, `<br>`,
`style`), not just text — text also survives the broken configs; mutation-tested
(no-restore fails 7, unsanitized-restore fails 5). Real mermaid can't run under
jsdom (`getBBox`), so **`e2e/tests/mermaid.spec.ts`** renders a real flowchart
with a multi-line and a hostile label in Chromium and asserts the same. Passes.

## Verification

Go suite, `arch-lint`, `plimsoll`, `golangci-lint run ./...`, `comment-lint`
pass. 2146 frontend tests, typecheck, lint clean. Coverage floors met (CI's
Test job). Code review findings (9) recorded as review-responses on
TKT-R8QEV3 — 8 addressed, 1 wont-fix with reason.

**Reviewer check:** confirm the alert *count* drops rather than that the check
merely turns green — the first push was green on all three Analyze jobs while
adding two new alerts.

```
gh api "repos/sourcehaven-bv/rela/code-scanning/alerts?state=open" \
  | jq -r '.[] | "\(.number) \(.rule.id) \(.most_recent_instance.location.path)"'
```

Nothing dismissed; all five should reach `fixed` on merge.

## Out of scope (per the brief)

- No change to `.github/workflows/codeql.yml`.
- No change to `internal/storage`'s symlink posture (documented as out of scope
  on `RootedFS`).

https://claude.ai/code/session_01GVAxHgoy2StqDiKyzdZwu1