### PR TITLE
feat(mcp): hot-reload schema.yaml without a restart (TKT-NU247U)

### DIFF
--- a/docs-project/entities/guides/GUIDE-mcp-server.md
+++ b/docs-project/entities/guides/GUIDE-mcp-server.md
@@ -56,9 +56,33 @@ The server communicates over stdio using JSON-RPC. It automatically discovers th
 
 ## File Watching
 
-The server watches `entities/`, `relations/`, and `schema.yaml` for changes. When files are
-created, modified, or deleted, the graph is re-synced automatically and connected clients are
-notified via `notifications/resources/list_changed`. Changes are debounced with a 200ms window.
+The stdio server watches two things, for two different reasons. Both are debounced
+with a 200ms window.
+
+**`entities/` and `relations/`** — the store re-syncs the graph when files are created,
+modified or deleted, so an external edit (a `git pull`, another tool, your editor) is
+visible to the next read.
+
+**`schema.yaml`** — the server reloads the schema in place. A restart is not needed
+after adding an entity type, extending an enum, adding a `to:` target on a relation,
+or changing a validation rule: the next tool call sees the new schema, `create_entity`
+included.
+
+The reload rebuilds the whole metamodel-derived stack — the validator, the entity
+manager and its automations, transitions and computed properties — not just the
+schema the read tools report. Refreshing only the read surfaces would leave writes
+validating against the old schema, which is harder to diagnose than no reload at all.
+The store and the search index are reused, so a schema edit costs no reindex and
+loses none of the session's writes.
+
+If the new schema does not parse, the server logs a warning and keeps serving the
+last one that did. A save taken mid-edit is routinely unparseable and must not end
+the session.
+
+There is no `notifications/resources/list_changed` on either path. The resource SET
+(a static list plus two URI templates) never changes at runtime, and the Go SDK emits
+that notification only when the set changes. Clients re-read on demand and see current
+data, because every read goes to the store.
 
 ## Tools
 
@@ -243,9 +267,10 @@ allowlist is not built yet.
 - **Stateless.** Protocol revision `2026-07-28` removes sessions, and the
   Go SDK only reaches it in stateless mode. `GET` and `DELETE` return 405;
   only `POST` carries messages.
-- **No change notifications.** `resources/list_changed` has no stateless
-  equivalent, so there is no file watcher. Clients re-read on demand and
-  always see current data, because every read hits the store.
+- **No file watcher.** Server→client notifications need a session, so the
+  remote transport starts neither the store watcher nor the schema reload.
+  Reads always see current data (every read hits the store), but a
+  `schema.yaml` edit needs a restart here, unlike on stdio.
 - **No IdP auto-discovery yet.** RFC 9728 Protected Resource Metadata is not
   served, and the 401 carries a `WWW-Authenticate` challenge only when your
   assertion header is literally `Authorization`. Point your client at the IdP

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -50,9 +50,33 @@ The server communicates over stdio using JSON-RPC. It automatically discovers th
 
 ## File Watching
 
-The server watches `entities/`, `relations/`, and `schema.yaml` for changes. When files are
-created, modified, or deleted, the graph is re-synced automatically and connected clients are
-notified via `notifications/resources/list_changed`. Changes are debounced with a 200ms window.
+The stdio server watches two things, for two different reasons. Both are debounced
+with a 200ms window.
+
+**`entities/` and `relations/`** — the store re-syncs the graph when files are created,
+modified or deleted, so an external edit (a `git pull`, another tool, your editor) is
+visible to the next read.
+
+**`schema.yaml`** — the server reloads the schema in place. A restart is not needed
+after adding an entity type, extending an enum, adding a `to:` target on a relation,
+or changing a validation rule: the next tool call sees the new schema, `create_entity`
+included.
+
+The reload rebuilds the whole metamodel-derived stack — the validator, the entity
+manager and its automations, transitions and computed properties — not just the
+schema the read tools report. Refreshing only the read surfaces would leave writes
+validating against the old schema, which is harder to diagnose than no reload at all.
+The store and the search index are reused, so a schema edit costs no reindex and
+loses none of the session's writes.
+
+If the new schema does not parse, the server logs a warning and keeps serving the
+last one that did. A save taken mid-edit is routinely unparseable and must not end
+the session.
+
+There is no `notifications/resources/list_changed` on either path. The resource SET
+(a static list plus two URI templates) never changes at runtime, and the Go SDK emits
+that notification only when the set changes. Clients re-read on demand and see current
+data, because every read goes to the store.
 
 ## Tools
 
@@ -237,9 +261,10 @@ allowlist is not built yet.
 - **Stateless.** Protocol revision `2026-07-28` removes sessions, and the
   Go SDK only reaches it in stateless mode. `GET` and `DELETE` return 405;
   only `POST` carries messages.
-- **No change notifications.** `resources/list_changed` has no stateless
-  equivalent, so there is no file watcher. Clients re-read on demand and
-  always see current data, because every read hits the store.
+- **No file watcher.** Server→client notifications need a session, so the
+  remote transport starts neither the store watcher nor the schema reload.
+  Reads always see current data (every read hits the store), but a
+  `schema.yaml` edit needs a restart here, unlike on stdio.
 - **No IdP auto-discovery yet.** RFC 9728 Protected Resource Metadata is not
   served, and the 401 carries a `WWW-Authenticate` challenge only when your
   assertion header is literally `Authorization`. Point your client at the IdP

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -97,7 +97,12 @@ import (
 // take it to 29. They are exported because scheduler consumes them through
 // narrow capability interfaces; they do not add general Services getters.
 //
-//plimsoll:max-exported-methods=30
+// 30 → 32 (TKT-NU247U): [Services.CloseAssembly] and [Services.Base], the two
+// halves of re-assembling a base against an already-open store. Both are
+// lifecycle operations on THIS bundle rather than new getters onto its
+// contents, so they belong here and not on a narrower type.
+//
+//plimsoll:max-exported-methods=32
 type Services struct {
 	fs    storage.FS
 	paths *project.Context
@@ -158,8 +163,17 @@ type Services struct {
 	// during single-threaded wiring. Constructing here, once, preserves that.
 	fieldRedactor visibility.FieldRedactor
 
+	// base is the SharedBase this Services was assembled from. Retained so a
+	// host can build a successor base from the same Config (see
+	// [Services.Base]). Nil for a NewFromCollaborators-built Services.
+	base *SharedBase
+
 	closeOnce sync.Once
 	closeErr  error
+	// assemblyCloseOnce guards the per-assembly teardown so that a
+	// CloseAssembly followed by a Close (the reload path's final shutdown)
+	// stops the background services exactly once.
+	assemblyCloseOnce sync.Once
 }
 
 // FS returns the project filesystem.
@@ -167,6 +181,15 @@ func (s *Services) FS() storage.FS { return s.fs }
 
 // Paths returns the project context (root, metamodel path, etc.).
 func (s *Services) Paths() *project.Context { return s.paths }
+
+// Base returns the [SharedBase] this Services was assembled from, or nil when
+// it was built by [NewFromCollaborators] (which takes pre-built collaborators
+// and so has no base).
+//
+// Exposed for hosts that re-assemble: a schema hot-reload needs the base's
+// [SharedBase.Config] to build a successor base against the same project
+// inputs (TKT-NU247U).
+func (s *Services) Base() *SharedBase { return s.base }
 
 // Meta returns the loaded metamodel.
 func (s *Services) Meta() *metamodel.Metamodel { return s.meta }
@@ -1282,6 +1305,15 @@ func (b *SharedBase) Worlds() worlds.Compiled { return b.worlds }
 // Services first.
 func (b *SharedBase) Meta() *metamodel.Metamodel { return b.meta }
 
+// Config returns the validated [Config] this base was built from.
+//
+// Exposed so a host can build a SUCCESSOR base from the same inputs — which is
+// how a schema hot-reload re-reads `schema.yaml` without re-discovering the
+// project (TKT-NU247U). The returned value is a copy of a struct of handles;
+// mutating it does not affect this base, but the FS, ScriptEngine and Audit it
+// names are shared, which is exactly what makes the successor equivalent.
+func (b *SharedBase) Config() Config { return b.cfg }
+
 // Paths returns the project context this base was built from.
 func (b *SharedBase) Paths() *project.Context { return b.cfg.Paths }
 
@@ -1639,6 +1671,7 @@ func assemble(
 	background := startBackgroundServices(base, st, stateKV, versions)
 
 	return &Services{
+		base:            base,
 		gcStop:          background.gcStop,
 		mailStop:        background.mailStop,
 		mail:            background.mail,
@@ -1755,8 +1788,66 @@ func relationVersionRecorderFor(vs store.VersionService) entitymanager.RelationV
 // lives here rather than once per build-tagged jobqueue_*.go file.
 const jobQueueShutdownTimeout = 5 * time.Second
 
-// Close releases resources held by Services: store first (so any
-// in-flight observer callbacks complete), then the search backend.
+// CloseAssembly stops the resources this Services started during its own
+// [SharedBase.Assemble] — the mail worker, the data-migration GC sweep and the
+// background-job queue — and leaves the store and search backend running.
+//
+// It exists for ONE caller shape: a host that re-assembles a base against a
+// store it already owns, and must retire the superseded Services without
+// tearing down the store underneath the new one. The MCP schema hot-reload
+// (TKT-NU247U) is that caller — every Assemble starts a fresh job queue with
+// its own worker pool (on postgres, a second connection pool and a LISTEN
+// connection too), so reloading without this would leak one per schema edit.
+//
+// It is NOT a lighter Close. The store and searcher outlive this call by
+// design, so a caller that owns them must still close them separately —
+// [Services.Close] on the LAST assembled Services does that, and running both
+// is safe because each runs its teardown exactly once.
+//
+// Safe to call repeatedly and from multiple goroutines. Calling Close after
+// CloseAssembly still closes the store and search backend; the background
+// services are not stopped twice.
+func (s *Services) CloseAssembly() {
+	s.assemblyCloseOnce.Do(s.stopBackgroundServices)
+}
+
+// stopBackgroundServices stops the per-assembly background workers. Shared by
+// [Services.Close] and [Services.CloseAssembly] so the two teardown paths
+// cannot drift on WHICH services count as per-assembly — the distinction the
+// whole seam rests on.
+//
+// Mail goes first: the worker may still be delivering and its drain is
+// bounded, so stopping it before anything else gives in-flight sends their
+// best chance without risking a hung shutdown.
+func (s *Services) stopBackgroundServices() {
+	if s.mailStop != nil {
+		s.mailStop()
+		s.mailStop = nil
+	}
+	if s.gcStop != nil {
+		s.gcStop()
+		s.gcStop = nil
+	}
+	if s.jobQueue != nil {
+		// Bounded: a queue that will not drain must not wedge shutdown.
+		ctx, cancel := context.WithTimeout(context.Background(), jobQueueShutdownTimeout)
+		if err := s.jobQueue.Close(ctx); err != nil {
+			slog.Warn("appbuild: failed to close job queue", "error", err)
+		}
+		cancel()
+		s.jobQueue = nil
+	}
+}
+
+// Close releases resources held by Services: the per-assembly background
+// services first, then the store (so any in-flight observer callbacks
+// complete), then the search backend.
+//
+// The job queue is now drained BEFORE the store closes, where it used to be
+// closed after. That ordering is the safer one on its own merits — a job
+// handler may read or write the store, and draining first means a worker
+// cannot be left running against a closed one — and it is what lets
+// [Services.CloseAssembly] share this teardown.
 //
 // Safe to call repeatedly and from multiple goroutines; the close
 // sequence runs exactly once. Subsequent calls return the same nil
@@ -1764,17 +1855,10 @@ const jobQueueShutdownTimeout = 5 * time.Second
 // failures are slog.Warn'd).
 func (s *Services) Close() error {
 	s.closeOnce.Do(func() {
-		// Mail first: the worker may still be delivering, and its drain is
-		// bounded, so stopping it before the store closes gives in-flight
-		// sends their best chance without risking a hung shutdown.
-		if s.mailStop != nil {
-			s.mailStop()
-			s.mailStop = nil
-		}
-		if s.gcStop != nil {
-			s.gcStop()
-			s.gcStop = nil
-		}
+		// Shared with CloseAssembly, and guarded by its own sync.Once, so a
+		// Close following a CloseAssembly does not stop these twice.
+		s.assemblyCloseOnce.Do(s.stopBackgroundServices)
+
 		if s.store != nil {
 			if lc, ok := s.store.(store.Lifecycle); ok {
 				if err := lc.Close(); err != nil {
@@ -1785,15 +1869,6 @@ func (s *Services) Close() error {
 		if s.searchCloser != nil {
 			_ = s.searchCloser.Close()
 			s.searchCloser = nil
-		}
-		if s.jobQueue != nil {
-			// Bounded: a queue that will not drain must not wedge shutdown.
-			ctx, cancel := context.WithTimeout(context.Background(), jobQueueShutdownTimeout)
-			if err := s.jobQueue.Close(ctx); err != nil {
-				slog.Warn("appbuild: failed to close job queue", "error", err)
-			}
-			cancel()
-			s.jobQueue = nil
 		}
 	})
 	return s.closeErr

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1287,6 +1287,30 @@ type SharedBase struct {
 	aclPolicy *acl.Policy
 	meta      *metamodel.Metamodel
 	worlds    worlds.Compiled
+	// reassembly marks a base built to re-assemble against an ALREADY-OPEN
+	// store, so [assemble] skips the store-open-only steps. Set by
+	// [SharedBase.ForReassembly]; false for a base that will open its own store.
+	reassembly bool
+}
+
+// IsReassembly reports whether this base is marked to re-assemble against an
+// already-open store (see [SharedBase.ForReassembly]).
+func (b *SharedBase) IsReassembly() bool { return b.reassembly }
+
+// ForReassembly returns a copy of this base marked as re-assembling against a
+// store that is already open — the schema hot-reload case (TKT-NU247U).
+//
+// It skips the store-open-only work in [SharedBase.Assemble]: today that is
+// the postgres derived-schema reconciliation, which issues DDL and is
+// documented boot-only on `pgstore.Store.Reconcile`. Everything metamodel-
+// derived is still rebuilt, which is the point of reloading.
+//
+// Use it for EVERY assembly after the first against a given store. A base
+// used to open a store must not be marked.
+func (b *SharedBase) ForReassembly() *SharedBase {
+	next := *b
+	next.reassembly = true
+	return &next
 }
 
 // Worlds returns the compiled world scopes this base was built from.
@@ -1597,7 +1621,7 @@ func cascadeReadDeps(
 func assemble(
 	base *SharedBase, st store.Store, searcher search.Searcher,
 	visible search.VisibleSearcher, searchCloser io.Closer,
-) (*Services, error) {
+) (svc *Services, retErr error) {
 	cfg := base.cfg
 
 	visible, err := resolveVisibleSearcher(visible, searcher, st)
@@ -1643,6 +1667,16 @@ func assemble(
 	if err != nil {
 		return nil, err
 	}
+	// buildRuntimeServices STARTS the job queue (worker pool; on postgres a
+	// connection pool too), so every error path below this point must stop it.
+	// Boot could get away without this — a failed boot exits the process — but
+	// assembly is now also a RELOAD path (TKT-NU247U): a schema that loads yet
+	// fails to assemble would otherwise leak one queue per save.
+	defer func() {
+		if retErr != nil {
+			closeJobQueue(jobQueue)
+		}
+	}()
 
 	mgr, err := buildEntityManager(base, st, aliases, templater, resolvedACL,
 		autoEngine, cascadeRunner, readDeps, versions, tw, computedSet)
@@ -1662,7 +1696,19 @@ func assemble(
 	// indexes so uniqueness is enforced atomically, and publish the current
 	// unique pairs so a violation can be attributed to a property (TKT-3Q0GP1).
 	// Failures degrade to warnings — a derived-schema problem never fails boot.
-	reconcileDerivedSchemaIfSupported(context.Background(), st, base)
+	//
+	// STORE-OPEN ONLY, skipped on re-assembly. `pgstore.Store.Reconcile` is
+	// documented boot-only and says re-reconciling on a live reload "needs its
+	// own debounce/lock policy for issuing DDL off a file watcher" — that
+	// policy does not exist, so a reload must not issue DDL. Two things would
+	// go wrong if it did: CREATE/DROP INDEX on every editor autosave, and a
+	// metamodel saved mid-edit that still parses but has lost a `unique:`
+	// declaration would DROP the live index (desired-state reconciliation
+	// treats absent as delete). A `unique:` added without a restart stays
+	// enforced by the application scan; `rela db reconcile` applies it.
+	if !base.reassembly {
+		reconcileDerivedSchemaIfSupported(context.Background(), st, base)
+	}
 
 	// Evaluate the data-migration gate (adopt compatible schema-shape
 	// changes, warn on incompatible ones) and start the drift GC sweep
@@ -1804,9 +1850,13 @@ const jobQueueShutdownTimeout = 5 * time.Second
 // [Services.Close] on the LAST assembled Services does that, and running both
 // is safe because each runs its teardown exactly once.
 //
-// Safe to call repeatedly and from multiple goroutines. Calling Close after
-// CloseAssembly still closes the store and search backend; the background
-// services are not stopped twice.
+// Safe to call repeatedly, and concurrently with Close: the shared sync.Once
+// runs the teardown exactly once. Calling Close after CloseAssembly still
+// closes the store and search backend.
+//
+// It is NOT safe against a concurrent [Services.Jobs] — the teardown clears
+// the queue handle, and that field carries no lock. Retire an assembly only
+// once nothing is reaching for its background services.
 func (s *Services) CloseAssembly() {
 	s.assemblyCloseOnce.Do(s.stopBackgroundServices)
 }
@@ -1829,13 +1879,24 @@ func (s *Services) stopBackgroundServices() {
 		s.gcStop = nil
 	}
 	if s.jobQueue != nil {
-		// Bounded: a queue that will not drain must not wedge shutdown.
-		ctx, cancel := context.WithTimeout(context.Background(), jobQueueShutdownTimeout)
-		if err := s.jobQueue.Close(ctx); err != nil {
-			slog.Warn("appbuild: failed to close job queue", "error", err)
-		}
-		cancel()
+		closeJobQueue(s.jobQueue)
 		s.jobQueue = nil
+	}
+}
+
+// closeJobQueue stops q within the shutdown budget. Shared by the teardown
+// path and by assemble's error path, so a queue is never dropped un-closed.
+//
+// Nil: accepted (no-op).
+func closeJobQueue(q jobs.Queue) {
+	if q == nil {
+		return
+	}
+	// Bounded: a queue that will not drain must not wedge shutdown.
+	ctx, cancel := context.WithTimeout(context.Background(), jobQueueShutdownTimeout)
+	defer cancel()
+	if err := q.Close(ctx); err != nil {
+		slog.Warn("appbuild: failed to close job queue", "error", err)
 	}
 }
 

--- a/internal/appbuild/sharedbase_test.go
+++ b/internal/appbuild/sharedbase_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
@@ -350,5 +351,65 @@ func TestServices_BaseRoundTrips(t *testing.T) {
 	}
 	if got, want := len(next.Meta().Entities), len(base.Meta().Entities); got != want {
 		t.Errorf("successor base has %d entity types, want %d", got, want)
+	}
+}
+
+// countingCloser records how many times it was closed.
+type countingCloser struct{ n atomic.Int32 }
+
+func (c *countingCloser) Close() error { c.n.Add(1); return nil }
+
+// TestReassembly_ClosesSearchCloserExactlyOnce converts the "successor must not
+// get the searchCloser" rule from a comment into a guarantee.
+//
+// The origin assembly owns the search closer; a successor is assembled with nil
+// so the two never share it. Passing it to both would double-close — on
+// postgres that closer is the shared pgxpool.
+func TestReassembly_ClosesSearchCloserExactlyOnce(t *testing.T) {
+	base := newSharedBase(t)
+
+	st := memstore.New()
+	searcher := search.New(st, search.NewLinearSearch())
+	closer := &countingCloser{}
+
+	origin, err := base.Assemble(st, searcher, nil, closer)
+	if err != nil {
+		t.Fatalf("Assemble origin: %v", err)
+	}
+	successor, err := base.ForReassembly().Assemble(
+		origin.Store(), origin.Searcher(), origin.VisibleSearcher(), nil)
+	if err != nil {
+		t.Fatalf("Assemble successor: %v", err)
+	}
+
+	// The shutdown sequence the reload wiring runs.
+	origin.CloseAssembly()
+	successor.CloseAssembly()
+	if err := origin.Close(); err != nil {
+		t.Fatalf("Close origin: %v", err)
+	}
+
+	if got := closer.n.Load(); got != 1 {
+		t.Errorf("search closer closed %d times, want exactly 1", got)
+	}
+}
+
+// TestReassembly_SkipsStoreOpenOnlySteps pins that a re-assembly is marked as
+// such. The postgres derived-schema reconciler issues DDL and is documented
+// boot-only on pgstore.Store.Reconcile — running it off a file watcher would
+// mean CREATE/DROP INDEX on every save, and a metamodel saved mid-edit that
+// lost a `unique:` would DROP the live index.
+func TestReassembly_SkipsStoreOpenOnlySteps(t *testing.T) {
+	base := newSharedBase(t)
+
+	reassembly := base.ForReassembly()
+	if !reassembly.IsReassembly() {
+		t.Error("ForReassembly() must mark the base as re-assembling")
+	}
+	if base.IsReassembly() {
+		t.Error("ForReassembly() must not mutate the receiver — it is shared")
+	}
+	if reassembly.Meta() != base.Meta() {
+		t.Error("a re-assembly base must carry the same metamodel")
 	}
 }

--- a/internal/appbuild/sharedbase_test.go
+++ b/internal/appbuild/sharedbase_test.go
@@ -274,3 +274,81 @@ worlds:
 		}
 	})
 }
+
+// TestCloseAssembly_LeavesStoreAndSearcherUsable is the property the MCP
+// schema hot-reload rests on (TKT-NU247U).
+//
+// A reload assembles a successor against the store and searcher the previous
+// assembly opened, then retires the previous one. If that retirement closed the
+// store, the successor — and every in-flight request — would be reading a
+// closed store. CloseAssembly must stop only what its own Assemble started.
+func TestCloseAssembly_LeavesStoreAndSearcherUsable(t *testing.T) {
+	base := newSharedBase(t)
+
+	st := memstore.New()
+	searcher := search.New(st, search.NewLinearSearch())
+
+	first, err := base.Assemble(st, searcher, nil, nil)
+	if err != nil {
+		t.Fatalf("Assemble first: %v", err)
+	}
+
+	// A successor over the SAME store and searcher, exactly as a reload does.
+	second, err := base.Assemble(first.Store(), first.Searcher(), first.VisibleSearcher(), nil)
+	if err != nil {
+		t.Fatalf("Assemble successor: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+
+	first.CloseAssembly()
+
+	ctx := context.Background()
+	if err := second.Store().CreateEntity(ctx, entity.New("DOC-3", "doc")); err != nil {
+		t.Fatalf("store unusable after retiring the previous assembly: %v", err)
+	}
+	if _, err := second.Store().GetEntity(ctx, "DOC-3"); err != nil {
+		t.Fatalf("read-back failed after CloseAssembly: %v", err)
+	}
+}
+
+// TestCloseAssembly_ThenCloseIsSafe covers the shutdown sequence the reload
+// path actually runs: retire the superseded assembly, then Close the one that
+// owns the store. Both teardowns must be safe together and repeatable — a
+// double-stopped job queue or a double-closed store would surface as a panic
+// on exit, long after the reload that caused it.
+func TestCloseAssembly_ThenCloseIsSafe(t *testing.T) {
+	base := newSharedBase(t)
+	svc := assembleOver(t, base)
+
+	svc.CloseAssembly()
+	svc.CloseAssembly() // idempotent
+
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close after CloseAssembly: %v", err)
+	}
+	if err := svc.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// TestServices_BaseRoundTrips pins that an assembled Services can hand back the
+// base it came from, which is how a reload builds a successor base from the
+// same project inputs without re-discovering the project.
+func TestServices_BaseRoundTrips(t *testing.T) {
+	base := newSharedBase(t)
+	svc := assembleOver(t, base)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	if svc.Base() != base {
+		t.Fatal("Services.Base() did not return the base it was assembled from")
+	}
+
+	// The Config it carries must be enough to build an equivalent successor.
+	next, err := appbuild.NewSharedBase(svc.Base().Config())
+	if err != nil {
+		t.Fatalf("NewSharedBase from Services.Base().Config(): %v", err)
+	}
+	if got, want := len(next.Meta().Entities), len(base.Meta().Entities); got != want {
+		t.Errorf("successor base has %d entity types, want %d", got, want)
+	}
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -40,5 +40,11 @@ func (c *McpCmd) Run() error {
 	if srvErr != nil {
 		return fmt.Errorf("mcp startup: %w", srvErr)
 	}
+
+	// Pick up schema.yaml edits without a restart (TKT-NU247U). Never fails
+	// startup: a project or backend that cannot be watched just serves the
+	// schema it booted with.
+	svc.watchSchema(srv)
+
 	return srv.Serve(context.Background())
 }

--- a/internal/cli/mcp_wiring.go
+++ b/internal/cli/mcp_wiring.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
+	"path/filepath"
+	"sync"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/config"
 	relamcp "github.com/Sourcehaven-BV/rela/internal/mcp"
 	"github.com/Sourcehaven-BV/rela/internal/script"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -23,8 +28,28 @@ import (
 // the MCP wiring is not a second composition root. Only the watcher
 // adapter is MCP-specific (appbuild deliberately has no watcher story).
 type mcpServices struct {
-	svc     *appbuild.Services
+	// mu serializes reloads against each other and against Close. Reads of
+	// svc go through [mcpServices.current], which takes it briefly — the
+	// swap itself is a pointer assignment, and the MCP server publishes its
+	// own snapshot atomically, so request handling never blocks on this.
+	mu  sync.Mutex
+	svc *appbuild.Services
+	// origin is the FIRST assembled Services — the one that opened the store
+	// and the search index and therefore owns closing them. Reloads assemble
+	// successors against those same handles, so only this one may be Closed;
+	// superseded successors get CloseAssembly instead. Never reassigned.
+	origin  *appbuild.Services
 	watcher relamcp.Watcher
+	// stopSchemaWatch releases the schema.yaml subscription. Nil until
+	// [mcpServices.watchSchema] runs.
+	stopSchemaWatch func()
+}
+
+// current returns the live services bundle.
+func (s *mcpServices) current() *appbuild.Services {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.svc
 }
 
 // newMCPServices discovers the project at startDir, builds the focused
@@ -46,8 +71,99 @@ func newMCPServices(startDir string) (*mcpServices, error) {
 	}
 	return &mcpServices{
 		svc:     svc,
+		origin:  svc,
 		watcher: &mcpWatcher{store: svc.Store()},
 	}, nil
+}
+
+// reload re-reads schema.yaml and rebuilds every metamodel-derived service
+// against the store and searcher already open, returning the fresh [mcp.Deps]
+// for the caller to publish.
+//
+// Rebuilding the whole stack — not just swapping the metamodel — is required
+// for correctness. `create_entity`'s validation, enum checks and
+// relation-target checks run through the entitymanager, which holds its OWN
+// *metamodel.Metamodel, as do the compiled transitions, computed properties
+// and automations. Refreshing only the read surfaces would leave writes
+// validating against the old schema: a half-updated server is harder to
+// diagnose than one that never updated at all.
+//
+// The store and searcher are deliberately reused. They hold the entity data and
+// its index, neither of which a schema edit invalidates; reopening them would
+// mean a full search reindex on every keystroke-triggered save.
+//
+// A schema that fails to load or assemble leaves the previous services in
+// place and returns the error. The caller logs it and keeps serving — a broken
+// intermediate save while the operator is mid-edit must not take the session
+// down.
+func (s *mcpServices) reload() (relamcp.Deps, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	old := s.svc
+	base, err := appbuild.NewSharedBase(old.Base().Config(), appbuild.WithACL(acl.NopACL{}))
+	if err != nil {
+		return relamcp.Deps{}, fmt.Errorf("reload schema: %w", err)
+	}
+
+	// searchCloser is nil on purpose: the closer belongs to the ORIGIN
+	// assembly, which retains it and closes it at shutdown. Handing it to the
+	// successor too would give two bundles the same closer and close it twice.
+	next, err := base.Assemble(old.Store(), old.Searcher(), old.VisibleSearcher(), nil)
+	if err != nil {
+		return relamcp.Deps{}, fmt.Errorf("reload schema: %w", err)
+	}
+
+	// Retire the superseded assembly's background workers (job queue, mail,
+	// GC sweep) WITHOUT closing the store or searcher the new one now uses.
+	old.CloseAssembly()
+
+	s.svc = next
+	return s.deps(), nil
+}
+
+// watchSchema subscribes to schema.yaml and publishes a rebuilt dependency
+// bundle to srv on every change, so an operator editing the schema mid-session
+// sees new entity types, enum values, relation targets and validation rules
+// without restarting the server (TKT-NU247U).
+//
+// Watching is a convenience, not a startup requirement: a backend that cannot
+// watch (or a subscribe failure) is logged and the server runs with the schema
+// it booted with — exactly the pre-TKT-NU247U behavior.
+func (s *mcpServices) watchSchema(srv *relamcp.Server) {
+	sub, ok := s.current().Config().(config.Subscriber)
+	if !ok {
+		slog.Debug("mcp: config loader does not support watching; schema hot-reload disabled")
+		return
+	}
+
+	// Subscribe to the schema file that was actually discovered — a project
+	// on the legacy metamodel.yaml name must watch that file, not the
+	// canonical one it does not have.
+	name := filepath.Base(s.current().Paths().SchemaPath)
+
+	stop, err := sub.Subscribe(context.Background(), name, func() {
+		deps, err := s.reload()
+		if err != nil {
+			// Keep serving the last-good schema. A save mid-edit is
+			// routinely unparseable and must not end the session.
+			slog.Warn("mcp: schema reload failed; keeping previous schema", "error", err)
+			return
+		}
+		if err := srv.ReloadDeps(deps); err != nil {
+			slog.Warn("mcp: schema reload rejected; keeping previous schema", "error", err)
+			return
+		}
+		// The filename is not logged: it is derived from a discovered path,
+		// and the operator already knows which schema this project has. The
+		// event is what matters.
+		slog.Info("mcp: schema reloaded")
+	})
+	if err != nil {
+		slog.Warn("mcp: schema watcher not started; hot-reload disabled", "error", err)
+		return
+	}
+	s.stopSchemaWatch = stop
 }
 
 // Deps flattens the per-project services into the focused [mcp.Deps]
@@ -63,6 +179,13 @@ func newMCPServices(startDir string) (*mcpServices, error) {
 // what makes the remote transport a wiring change rather than a rewrite of
 // 34 handlers (TKT-UIR41P).
 func (s *mcpServices) Deps() relamcp.Deps {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deps()
+}
+
+// deps builds the bundle from the current services. Caller holds mu.
+func (s *mcpServices) deps() relamcp.Deps {
 	reads := s.svc.GatedReads()
 	return relamcp.Deps{
 		Store:         reads.Reader,
@@ -83,10 +206,30 @@ func (s *mcpServices) Deps() relamcp.Deps {
 // then search backend, in that order). Safe to call repeatedly — both
 // the watcher and [appbuild.Services.Close] are idempotent.
 func (s *mcpServices) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopSchemaWatch != nil {
+		s.stopSchemaWatch()
+		s.stopSchemaWatch = nil
+	}
 	if s.watcher != nil {
 		s.watcher.Stop()
 	}
-	return s.svc.Close()
+	// Two steps, because after a reload the current assembly and the one that
+	// owns the shared resources are different objects.
+	//
+	// The CURRENT assembly holds this generation's background services (job
+	// queue, mail, GC sweep) and nothing else that is exclusively its own —
+	// its store and searcher are the origin's. Stop those workers only.
+	//
+	// The ORIGIN assembly owns the store and the search closer, so it gets the
+	// full Close. When no reload has happened the two are the same object, and
+	// Close's internal sync.Once makes the pair collapse to exactly one
+	// teardown.
+	if s.svc != s.origin {
+		s.svc.CloseAssembly()
+	}
+	return s.origin.Close()
 }
 
 // --- Watcher adapter ---

--- a/internal/cli/mcp_wiring.go
+++ b/internal/cli/mcp_wiring.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -43,6 +44,12 @@ type mcpServices struct {
 	// stopSchemaWatch releases the schema.yaml subscription. Nil until
 	// [mcpServices.watchSchema] runs.
 	stopSchemaWatch func()
+	// closed is set by Close. The watcher's Stop does NOT wait for an
+	// in-flight callback, so a change event can be mid-flight when shutdown
+	// begins; without this flag that callback would assemble a whole new
+	// service generation — job queue, mail worker, GC sweep — against a store
+	// Close has already torn down, and nothing would ever stop them.
+	closed bool
 }
 
 // current returns the live services bundle.
@@ -97,10 +104,20 @@ func newMCPServices(startDir string) (*mcpServices, error) {
 // intermediate save while the operator is mid-edit must not take the session
 // down.
 func (s *mcpServices) reload() (relamcp.Deps, error) {
+	// Read the current assembly under the lock, then build the successor
+	// OUTSIDE it. Assembly re-reads the schema, compiles transitions and
+	// computed properties and starts a job queue; holding mu across all of
+	// that would make a shutdown arriving mid-reload wait for it.
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
+	if s.closed {
+		s.mu.Unlock()
+		// Shutdown won the race with a file event. Returning an error rather
+		// than assembling is the whole point: watchSchema logs and moves on.
+		return relamcp.Deps{}, errors.New("reload schema: services are closed")
+	}
 	old := s.svc
+	s.mu.Unlock()
+
 	base, err := appbuild.NewSharedBase(old.Base().Config(), appbuild.WithACL(acl.NopACL{}))
 	if err != nil {
 		return relamcp.Deps{}, fmt.Errorf("reload schema: %w", err)
@@ -109,9 +126,21 @@ func (s *mcpServices) reload() (relamcp.Deps, error) {
 	// searchCloser is nil on purpose: the closer belongs to the ORIGIN
 	// assembly, which retains it and closes it at shutdown. Handing it to the
 	// successor too would give two bundles the same closer and close it twice.
-	next, err := base.Assemble(old.Store(), old.Searcher(), old.VisibleSearcher(), nil)
+	next, err := base.ForReassembly().Assemble(old.Store(), old.Searcher(), old.VisibleSearcher(), nil)
 	if err != nil {
 		return relamcp.Deps{}, fmt.Errorf("reload schema: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Re-check: Close may have run, or another reload may have landed, while
+	// this one was assembling. Either way the successor is already obsolete
+	// and must be retired rather than published — otherwise its job queue and
+	// mail worker outlive the process's teardown.
+	if s.closed || s.svc != old {
+		next.CloseAssembly()
+		return relamcp.Deps{}, errors.New("reload schema: superseded before publish")
 	}
 
 	// Retire the superseded assembly's background workers (job queue, mail,
@@ -131,7 +160,9 @@ func (s *mcpServices) reload() (relamcp.Deps, error) {
 // watch (or a subscribe failure) is logged and the server runs with the schema
 // it booted with — exactly the pre-TKT-NU247U behavior.
 func (s *mcpServices) watchSchema(srv *relamcp.Server) {
-	sub, ok := s.current().Config().(config.Subscriber)
+	// One snapshot for both reads (CLAUDE.md: capture state once per operation).
+	svc := s.current()
+	sub, ok := svc.Config().(config.Subscriber)
 	if !ok {
 		slog.Debug("mcp: config loader does not support watching; schema hot-reload disabled")
 		return
@@ -140,7 +171,7 @@ func (s *mcpServices) watchSchema(srv *relamcp.Server) {
 	// Subscribe to the schema file that was actually discovered — a project
 	// on the legacy metamodel.yaml name must watch that file, not the
 	// canonical one it does not have.
-	name := filepath.Base(s.current().Paths().SchemaPath)
+	name := filepath.Base(svc.Paths().SchemaPath)
 
 	stop, err := sub.Subscribe(context.Background(), name, func() {
 		deps, err := s.reload()
@@ -161,6 +192,14 @@ func (s *mcpServices) watchSchema(srv *relamcp.Server) {
 	})
 	if err != nil {
 		slog.Warn("mcp: schema watcher not started; hot-reload disabled", "error", err)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		// Close ran while we were subscribing; nothing will read the handle.
+		stop()
 		return
 	}
 	s.stopSchemaWatch = stop
@@ -208,6 +247,9 @@ func (s *mcpServices) deps() relamcp.Deps {
 func (s *mcpServices) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Set before anything is torn down: a reload callback already blocked on
+	// mu must observe this and abort rather than rebuild on a dead store.
+	s.closed = true
 	if s.stopSchemaWatch != nil {
 		s.stopSchemaWatch()
 		s.stopSchemaWatch = nil

--- a/internal/cli/mcp_wiring_test.go
+++ b/internal/cli/mcp_wiring_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,8 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/appbuild/backendtest"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	relaerrors "github.com/Sourcehaven-BV/rela/internal/errors"
+	relamcp "github.com/Sourcehaven-BV/rela/internal/mcp"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
@@ -194,3 +197,163 @@ type errStartStopper struct {
 
 func (e errStartStopper) StartWatching() error { return e.err }
 func (errStartStopper) StopWatching()          {}
+
+// writeSchema overwrites the project's schema file with body.
+func writeSchema(t *testing.T, root, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "metamodel.yaml"), []byte(body), 0o644))
+}
+
+// schemaWithRisk is the seeded schema plus a second entity type, standing in
+// for an operator adding a type mid-session.
+const schemaWithRisk = `
+entities:
+  item:
+    label: Item
+    id_type: sequential
+    id_prefix: ITEM-
+    properties:
+      title:
+        type: string
+        required: true
+  risk:
+    label: Risk
+    id_type: sequential
+    id_prefix: RSK-
+    properties:
+      title:
+        type: string
+        required: true
+relations: {}
+`
+
+// TestMCPServices_ReloadPicksUpNewType is the end-to-end wiring property of
+// TKT-NU247U: editing the schema on disk and reloading yields deps whose
+// metamodel — and whose entitymanager — know the new type.
+func TestMCPServices_ReloadPicksUpNewType(t *testing.T) {
+	root := seedProject(t)
+
+	svc, err := mcpServicesForTest(t, root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	_, hadRisk := svc.Deps().Meta.GetEntityDef("risk")
+	require.False(t, hadRisk, "fixture must not already define risk")
+
+	writeSchema(t, root, schemaWithRisk)
+
+	deps, err := svc.reload()
+	require.NoError(t, err)
+
+	_, ok := deps.Meta.GetEntityDef("risk")
+	assert.True(t, ok, "reloaded metamodel should define the new type")
+
+	// The write path must move too — it holds its own metamodel, so a reload
+	// that refreshed only Deps.Meta would leave creates failing on the new type.
+	_, err = deps.EntityManager.CreateEntity(context.Background(),
+		&entity.Entity{Type: "risk", Properties: map[string]any{"title": "Supplier outage"}},
+		entity.CreateOptions{})
+	assert.NoError(t, err, "entitymanager should accept the newly declared type after reload")
+}
+
+// TestMCPServices_ReloadReusesStoreAndSearcher pins the reason reload does not
+// simply re-run Discover: the store holds the data and the searcher its index,
+// and a schema edit invalidates neither. Reopening them would mean a full
+// reindex on every save — and would drop entities written this session.
+func TestMCPServices_ReloadReusesStoreAndSearcher(t *testing.T) {
+	root := seedProject(t)
+
+	svc, err := mcpServicesForTest(t, root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	ctx := context.Background()
+	before := svc.svc.Store()
+	require.NoError(t, before.CreateEntity(ctx, &entity.Entity{
+		ID: "ITEM-1", Type: "item", Properties: map[string]any{"title": "Written before reload"},
+	}))
+
+	writeSchema(t, root, schemaWithRisk)
+	deps, err := svc.reload()
+	require.NoError(t, err)
+
+	assert.Same(t, before, svc.svc.Store(), "reload must reuse the open store, not reopen it")
+
+	// The store stays usable and keeps this session's writes.
+	got, err := svc.svc.Store().GetEntity(ctx, "ITEM-1")
+	require.NoError(t, err, "store unusable after reload")
+	assert.Equal(t, "ITEM-1", got.ID)
+
+	// And the search index is the same one, still holding the pre-reload write.
+	hits := make([]string, 0, 1)
+	for hit, hitErr := range deps.Searcher.Search(ctx, search.Query{Text: "Written"}) {
+		require.NoError(t, hitErr)
+		hits = append(hits, hit.ID)
+	}
+	assert.Contains(t, hits, "ITEM-1", "reload must not discard the search index")
+}
+
+// TestMCPServices_ReloadBadSchemaKeepsPrevious pins the fail-safe direction. A
+// watcher fires on every save, and a save taken mid-edit is routinely
+// unparseable; that must not take the session's schema down.
+func TestMCPServices_ReloadBadSchemaKeepsPrevious(t *testing.T) {
+	root := seedProject(t)
+
+	svc, err := mcpServicesForTest(t, root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	good := svc.svc
+
+	writeSchema(t, root, "entities: this-is-not-a-map\nrelations: {}\n")
+
+	_, err = svc.reload()
+	require.Error(t, err, "an unparseable schema must be reported, not adopted")
+
+	assert.Same(t, good, svc.svc, "a failed reload must leave the previous services in place")
+	_, ok := svc.Deps().Meta.GetEntityDef("item")
+	assert.True(t, ok, "previous metamodel must still be serving after a failed reload")
+}
+
+// TestMCPServices_CloseAfterReloadIsClean covers the shutdown sequence a
+// reloaded process actually runs: the current assembly and the one owning the
+// store are different objects, and both must be torn down exactly once.
+func TestMCPServices_CloseAfterReloadIsClean(t *testing.T) {
+	root := seedProject(t)
+
+	svc, err := mcpServicesForTest(t, root)
+	require.NoError(t, err)
+
+	writeSchema(t, root, schemaWithRisk)
+	_, err = svc.reload()
+	require.NoError(t, err)
+
+	require.NotSame(t, svc.origin, svc.svc, "reload should have produced a successor assembly")
+
+	require.NoError(t, svc.Close())
+	require.NoError(t, svc.Close(), "Close must stay idempotent after a reload")
+}
+
+// TestMCPServices_WatchSchemaFiresOnRealEdit drives the watcher end to end:
+// a real write to schema.yaml on disk must reach the published deps without
+// anyone calling reload() directly.
+func TestMCPServices_WatchSchemaFiresOnRealEdit(t *testing.T) {
+	root := seedProject(t)
+	svc, err := mcpServicesForTest(t, root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	srv, err := relamcp.NewServer(svc.Deps(), "test",
+		relamcp.WithPrincipal(principal.Principal{User: "t", Tool: principal.ToolMCP}))
+	require.NoError(t, err)
+
+	svc.watchSchema(srv)
+	require.NotNil(t, svc.stopSchemaWatch, "watcher should have started")
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "metamodel.yaml"), []byte(schemaWithRisk), 0o644))
+
+	assert.Eventually(t, func() bool {
+		_, ok := svc.Deps().Meta.GetEntityDef("risk")
+		return ok
+	}, 5*time.Second, 50*time.Millisecond, "watcher never picked up the schema edit")
+}

--- a/internal/cli/mcp_wiring_test.go
+++ b/internal/cli/mcp_wiring_test.go
@@ -357,3 +357,48 @@ func TestMCPServices_WatchSchemaFiresOnRealEdit(t *testing.T) {
 		return ok
 	}, 5*time.Second, 50*time.Millisecond, "watcher never picked up the schema edit")
 }
+
+// TestMCPServices_ReloadAfterCloseIsRefused pins the shutdown race.
+//
+// storage.Watcher.Stop does not wait for an in-flight OnChange, so a schema
+// event can be mid-flight when Close begins. Without the closed check, that
+// callback assembled a whole new generation — job queue, mail worker, GC sweep
+// — against a store Close had already torn down, and nothing would ever stop
+// them. On postgres that is a leaked connection pool per occurrence.
+func TestMCPServices_ReloadAfterCloseIsRefused(t *testing.T) {
+	root := seedProject(t)
+
+	svc, err := mcpServicesForTest(t, root)
+	require.NoError(t, err)
+	require.NoError(t, svc.Close())
+
+	writeSchema(t, root, schemaWithRisk)
+
+	_, err = svc.reload()
+	require.Error(t, err, "reload after Close must be refused, not serviced")
+	assert.Same(t, svc.origin, svc.svc,
+		"a refused reload must not swap in a new assembly built on a closed store")
+}
+
+// TestMCPServices_WatchSchemaAfterCloseDoesNotResurrect is the same property
+// through the public path: the watcher callback must be harmless once Close
+// has run.
+func TestMCPServices_WatchSchemaAfterCloseDoesNotResurrect(t *testing.T) {
+	root := seedProject(t)
+
+	svc, err := mcpServicesForTest(t, root)
+	require.NoError(t, err)
+
+	srv, err := relamcp.NewServer(svc.Deps(), "test",
+		relamcp.WithPrincipal(principal.Principal{User: "t", Tool: principal.ToolMCP}))
+	require.NoError(t, err)
+	svc.watchSchema(srv)
+
+	require.NoError(t, svc.Close())
+
+	// Whatever the watcher does now, it must not leave a live successor.
+	writeSchema(t, root, schemaWithRisk)
+	_, err = svc.reload()
+	require.Error(t, err)
+	assert.Same(t, svc.origin, svc.svc)
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -81,7 +81,7 @@ func (c *ValidateCmd) Run(ctx context.Context) error {
 		if discoverErr != nil {
 			return fmt.Errorf("validate scheduled mail recipients: %w", discoverErr)
 		}
-		defer mailSvc.Close() //nolint:contextcheck // Services.Close has no context-bearing variant.
+		defer mailSvc.Close()
 		if validateErr := mailSvc.ValidateScheduledMailRecipients(ctx); validateErr != nil {
 			fmt.Printf("  ✗ scheduled mail recipients: %v\n", validateErr)
 			hasErrors = true

--- a/internal/docscapture/server.go
+++ b/internal/docscapture/server.go
@@ -154,7 +154,7 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp, needSPA
 	// can't mutate the fixture; an `edit` goes through the entitymanager, which
 	// is what makes it a real, versioned write (see docs.ApplySeedWith).
 	if serr := docs.ApplySeedWith(seedCtx, svc.Store(), svc.EntityManager(), seed); serr != nil {
-		svc.Close() //nolint:contextcheck // teardown is not request-scoped; Close takes no ctx
+		svc.Close()
 		scratchCleanup()
 		_ = os.RemoveAll(tmp)
 		return nil, fmt.Errorf("seed temp project: %w", serr)
@@ -168,7 +168,7 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp, needSPA
 		svc.State(),
 	)
 	if err != nil {
-		svc.Close() //nolint:contextcheck // teardown is not request-scoped; Close takes no ctx
+		svc.Close()
 		scratchCleanup()
 		_ = os.RemoveAll(tmp)
 		return nil, fmt.Errorf("build data-entry app: %w", err)
@@ -179,7 +179,7 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp, needSPA
 	// world-scoped page, which is the thing a worlds manual most needs to show.
 	app.SetWorlds(appbuild.CompiledWorlds(svc))
 	if err := dataentry.SetWorldNeighbors(app, svc.Store(), appbuild.RelationScopes(svc)); err != nil {
-		svc.Close() //nolint:contextcheck // teardown is not request-scoped; Close takes no ctx
+		svc.Close()
 		scratchCleanup()
 		_ = os.RemoveAll(tmp)
 		return nil, fmt.Errorf("wire world neighbors: %w", err)
@@ -193,13 +193,13 @@ func standUp(ctx context.Context, projectDir string, seed []docs.SeedOp, needSPA
 	// the suggestion card would photograph an empty page and a page{} claim
 	// about it would fail for a reason that has nothing to do with worlds.
 	if err := app.SetUserState(svc.UserState()); err != nil {
-		svc.Close() //nolint:contextcheck // teardown is not request-scoped; Close takes no ctx
+		svc.Close()
 		scratchCleanup()
 		_ = os.RemoveAll(tmp)
 		return nil, fmt.Errorf("wire next-action state: %w", err)
 	}
 	if err := app.SetNextActionMatchers(appbuild.NextActionMatchers); err != nil {
-		svc.Close() //nolint:contextcheck // teardown is not request-scoped; Close takes no ctx
+		svc.Close()
 		scratchCleanup()
 		_ = os.RemoveAll(tmp)
 		return nil, fmt.Errorf("wire next-action matchers: %w", err)

--- a/internal/docscli/docscli.go
+++ b/internal/docscli/docscli.go
@@ -131,7 +131,6 @@ func (c *BuildCmd) Run(ctx context.Context, proj Project) error {
 	// EVERY path including the error path: on the postgres build the project
 	// owns a scratch schema, and a failed build must not leave one behind.
 	shared := docscapture.NewSharedProject(proj.Paths().Root)
-	//nolint:contextcheck // teardown is not request-scoped; Close takes no ctx, matching project.close
 	defer func() { _ = shared.Close() }()
 
 	// Wire a browser capturer for screenshot{} islands. If no browser is

--- a/internal/mcp/acl_test.go
+++ b/internal/mcp/acl_test.go
@@ -109,8 +109,8 @@ func gatedServer(t *testing.T) (*Server, context.Context) {
 		ProjectRoot:   t.TempDir(),
 	}
 
-	srv := &Server{deps: deps, logger: slog.New(slog.DiscardHandler)}
-	srv.handlerSet = deps.handlers()
+	srv := &Server{logger: slog.New(slog.DiscardHandler)}
+	setDeps(srv, deps)
 	return srv, principal.With(ctx, principal.Principal{User: "alice", Tool: principal.ToolMCP})
 }
 
@@ -345,7 +345,7 @@ func TestACL_Resources_AreGated(t *testing.T) {
 	t.Parallel()
 	s, ctx := gatedServer(t)
 
-	_, err := s.schemaRes.handleReadEntity(ctx, readResourceReq("rela://entity/feature/"+hiddenID))
+	_, err := group(s, selSchemaRes).handleReadEntity(ctx, readResourceReq("rela://entity/feature/"+hiddenID))
 	if err == nil {
 		t.Error("LEAK: resource read of a hidden entity succeeded")
 	} else if strings.Contains(err.Error(), hiddenTitle) {
@@ -353,7 +353,7 @@ func TestACL_Resources_AreGated(t *testing.T) {
 	}
 
 	// A readable entity still works, so the gate is not simply refusing all.
-	if _, err := s.schemaRes.handleReadEntity(ctx, readResourceReq("rela://entity/ticket/"+visibleID)); err != nil {
+	if _, err := group(s, selSchemaRes).handleReadEntity(ctx, readResourceReq("rela://entity/ticket/"+visibleID)); err != nil {
 		t.Errorf("readable entity denied through resource path: %v", err)
 	}
 }
@@ -365,11 +365,11 @@ func TestACL_Trace_HiddenRootIsNotAnOracle(t *testing.T) {
 	t.Parallel()
 	s, ctx := gatedServer(t)
 
-	hidden, err := s.trace.handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": hiddenID}))
+	hidden, err := group(s, selTrace).handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": hiddenID}))
 	if err != nil {
 		t.Fatalf("trace_from(hidden): %v", err)
 	}
-	absent, err := s.trace.handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": "NO-SUCH-ID"}))
+	absent, err := group(s, selTrace).handleTraceFrom(ctx, makeToolRequest(map[string]any{"id": "NO-SUCH-ID"}))
 	if err != nil {
 		t.Fatalf("trace_from(absent): %v", err)
 	}

--- a/internal/mcp/principal_test.go
+++ b/internal/mcp/principal_test.go
@@ -32,7 +32,7 @@ func TestNewServer_RejectsIncompleteDeps(t *testing.T) {
 	withPrincipal := WithPrincipal(principal.Principal{User: "test", Tool: principal.ToolMCP})
 
 	// makeTestServer builds a complete Deps; reuse it as the baseline.
-	complete := makeTestServer(t).deps
+	complete := makeTestServer(t).deps()
 	if _, err := NewServer(complete, "0.0.0", withPrincipal); err != nil {
 		t.Fatalf("complete Deps should construct: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestNewServer_RejectsIncompleteDeps(t *testing.T) {
 	for field, zero := range mutators {
 		t.Run(field, func(t *testing.T) {
 			t.Parallel()
-			deps := makeTestServer(t).deps
+			deps := makeTestServer(t).deps()
 			zero(&deps)
 			if _, err := NewServer(deps, "0.0.0", withPrincipal); err == nil {
 				t.Fatalf("expected error when %s is zero", field)

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -16,10 +16,10 @@ import (
 )
 
 func (s *Server) registerPrompts() {
-	s.mcp.AddPrompt(promptAnalyzeTraceability(), s.prompts.handleAnalyzeTraceabilityPrompt)
-	s.mcp.AddPrompt(promptReviewOrphans(), s.prompts.handleReviewOrphansPrompt)
-	s.mcp.AddPrompt(promptSummarizeProject(), s.prompts.handleSummarizeProjectPrompt)
-	s.mcp.AddPrompt(promptReviewEntity(), s.prompts.handleReviewEntityPrompt)
+	s.mcp.AddPrompt(promptAnalyzeTraceability(), bind(s, selPrompts, promptHandler.handleAnalyzeTraceabilityPrompt))
+	s.mcp.AddPrompt(promptReviewOrphans(), bind(s, selPrompts, promptHandler.handleReviewOrphansPrompt))
+	s.mcp.AddPrompt(promptSummarizeProject(), bind(s, selPrompts, promptHandler.handleSummarizeProjectPrompt))
+	s.mcp.AddPrompt(promptReviewEntity(), bind(s, selPrompts, promptHandler.handleReviewEntityPrompt))
 }
 
 // promptHandler serves the four registered prompts. A type of its own rather

--- a/internal/mcp/reload.go
+++ b/internal/mcp/reload.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// snapshot is the reloadable core of a [Server]: the dependency bundle and the
+// handler groups derived from it. The two MUST move together — [handlerSet] is
+// built from a [Deps] and caches its metamodel inside typeResolver,
+// schemaResourceHandler and promptHandler, so publishing them independently
+// would let a request observe new deps with handlers still bound to the old
+// metamodel.
+//
+// Published via [snapshotProvider], following the CLAUDE.md state-publish rule:
+// an atomic.Pointer for the snapshot, so readers never take a lock and never
+// observe a torn pair.
+type snapshot struct {
+	deps     Deps
+	handlers handlerSet
+}
+
+// newSnapshot derives the handler groups for d and pairs them with it.
+func newSnapshot(d Deps) *snapshot {
+	return &snapshot{deps: d, handlers: d.handlers()}
+}
+
+// snapshotProvider publishes the current [snapshot]. Readers Load lock-free;
+// the reload path Stores a freshly-derived snapshot atomically.
+//
+// Owning the pointer in its own type (rather than as a bare field on Server)
+// keeps the publish mechanics in one place, and means a Server built as a
+// literal in a test can publish a snapshot with one call rather than
+// remembering to set two fields consistently.
+type snapshotProvider struct {
+	ptr atomic.Pointer[snapshot]
+}
+
+// current returns the published snapshot. Nil only before the first publish,
+// which [NewServer] performs — a running Server always has one.
+func (p *snapshotProvider) current() *snapshot { return p.ptr.Load() }
+
+// publish installs s as the current snapshot.
+func (p *snapshotProvider) publish(s *snapshot) { p.ptr.Store(s) }
+
+// bind defers handler-group resolution to REQUEST time.
+//
+// Registration used to pass a method value (`s.trace.handleTraceFrom`) straight
+// to AddTool. A method value captures its receiver by value at the moment it is
+// formed, so every registered handler held the handler group — and through it
+// the metamodel — that existed at startup. A reloaded snapshot could never
+// reach them, and the failure would be silent: the tool keeps working, just
+// against the old schema.
+//
+// bind takes a selector for the group and the method to call on it, and
+// returns a handler that resolves the group per request. `bind(s, selTrace,
+// traceHandler.handleTraceFrom)` reads much like the old expression but
+// re-reads the snapshot on every call.
+//
+// Generic over the group and over the request/result types so one helper covers
+// tools, resources and prompts alike.
+func bind[G, Req, Res any](
+	s *Server, sel func(handlerSet) G, method func(G, context.Context, Req) (Res, error),
+) func(context.Context, Req) (Res, error) {
+	return func(ctx context.Context, req Req) (Res, error) {
+		return method(group(s, sel), ctx, req)
+	}
+}

--- a/internal/mcp/reload_test.go
+++ b/internal/mcp/reload_test.go
@@ -1,0 +1,252 @@
+package mcp
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	mcpgo "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// metaWithRisk returns the standard fixture metamodel plus a `risk` entity
+// type, standing in for the operator adding a type to schema.yaml mid-session.
+func metaWithRisk() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"requirement": {
+				Label:    "Requirement",
+				IDPrefix: "REQ",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":    {Type: "string", Required: true},
+					"status":   {Type: "string"},
+					"priority": {Type: "string"},
+				},
+			},
+			"decision": {
+				Label:    "Decision",
+				IDPrefix: "DEC",
+				Properties: map[string]metamodel.PropertyDef{
+					"title":  {Type: "string", Required: true},
+					"status": {Type: "string"},
+				},
+			},
+			"risk": {
+				Label:    "Risk",
+				IDPrefix: "RSK",
+				Properties: map[string]metamodel.PropertyDef{
+					"title": {Type: "string", Required: true},
+				},
+			},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"addresses": {Label: "addresses", From: []string{"decision"}, To: []string{"requirement"}},
+		},
+	}
+}
+
+// TestReloadDeps_NewTypeVisibleToSchemaTools is the headline behavior of
+// TKT-NU247U: a type added to schema.yaml after startup shows up without a
+// server restart.
+func TestReloadDeps_NewTypeVisibleToSchemaTools(t *testing.T) {
+	t.Parallel()
+	s, st := makeTestServerWithStore(t)
+
+	before, err := group(s, selSchemaRes).handleListEntityTypes(context.Background(), &mcpgo.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("list types before reload: %v", err)
+	}
+	if strings.Contains(getResultText(t, before), "risk") {
+		t.Fatal("fixture already has a risk type; the test would prove nothing")
+	}
+
+	next := newTestDeps(t, metaWithRisk(), st)
+	if reloadErr := s.ReloadDeps(next); reloadErr != nil {
+		t.Fatalf("ReloadDeps: %v", reloadErr)
+	}
+
+	after, err := group(s, selSchemaRes).handleListEntityTypes(context.Background(), &mcpgo.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("list types after reload: %v", err)
+	}
+	if !strings.Contains(getResultText(t, after), "risk") {
+		t.Errorf("reloaded schema does not list the new type:\n%s", getResultText(t, after))
+	}
+}
+
+// TestReloadDeps_NewTypeIsWritable pins the reason the reload rebuilds the
+// whole service stack rather than swapping Deps.Meta alone.
+//
+// create_entity validates through the entitymanager, which holds its OWN
+// metamodel. A reload that refreshed only the read surfaces would leave this
+// create failing against the old schema while get_schema happily advertised
+// the new type — a half-updated server, which is harder to diagnose than one
+// that never updated at all.
+func TestReloadDeps_NewTypeIsWritable(t *testing.T) {
+	t.Parallel()
+	s, st := makeTestServerWithStore(t)
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "tester", Tool: principal.ToolMCP})
+
+	create := makeToolRequest(map[string]any{
+		"type":       "risk",
+		"properties": map[string]any{"title": "Supplier outage"},
+	})
+
+	// The tool reports a domain failure as a result with IsError set, not as
+	// a Go error, so assert on the result.
+	before, err := s.handleCreateEntity(ctx, create)
+	if err != nil {
+		t.Fatalf("create before reload: %v", err)
+	}
+	if !before.IsError {
+		t.Fatal("creating an unknown type should fail before the reload")
+	}
+
+	if reloadErr := s.ReloadDeps(newTestDeps(t, metaWithRisk(), st)); reloadErr != nil {
+		t.Fatalf("ReloadDeps: %v", reloadErr)
+	}
+
+	result, err := s.handleCreateEntity(ctx, create)
+	if err != nil {
+		t.Fatalf("create after reload: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("write path still on the old metamodel: %s", getResultText(t, result))
+	}
+}
+
+// TestReloadDeps_ReachesRegisteredHandlers guards the trap this change was
+// built around.
+//
+// Handlers used to be registered as method values (`s.trace.handleTraceFrom`),
+// which capture the handler group — and through it the metamodel — BY VALUE at
+// registration time. A reloaded snapshot could never reach them, and the
+// failure was silent: the tool kept working, just against the old schema. This
+// asserts a handler obtained the way registerTools obtains one observes the
+// reload.
+func TestReloadDeps_ReachesRegisteredHandlers(t *testing.T) {
+	t.Parallel()
+	s, st := makeTestServerWithStore(t)
+
+	// Bound exactly as registerTools binds it, BEFORE the reload.
+	registered := bind(s, selSchemaRes, schemaResourceHandler.handleListEntityTypes)
+
+	if err := s.ReloadDeps(newTestDeps(t, metaWithRisk(), st)); err != nil {
+		t.Fatalf("ReloadDeps: %v", err)
+	}
+
+	result, err := registered(context.Background(), &mcpgo.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("registered handler: %v", err)
+	}
+	if !strings.Contains(getResultText(t, result), "risk") {
+		t.Error("a handler bound before the reload still serves the old metamodel " +
+			"— registration is capturing the snapshot by value again")
+	}
+}
+
+// TestReloadDeps_RejectsInvalidBundleAndKeepsPrevious pins the fail-safe
+// direction: a reload driven by a file watcher must never be able to leave a
+// running server without a usable metamodel.
+func TestReloadDeps_RejectsInvalidBundleAndKeepsPrevious(t *testing.T) {
+	t.Parallel()
+	s, st := makeTestServerWithStore(t)
+
+	broken := newTestDeps(t, metaWithRisk(), st)
+	broken.Meta = nil
+
+	if err := s.ReloadDeps(broken); err == nil {
+		t.Fatal("ReloadDeps accepted a Deps with no metamodel")
+	}
+
+	// The previous bundle must still be serving.
+	if s.deps().Meta == nil {
+		t.Fatal("a rejected reload cleared the published metamodel")
+	}
+	result, err := group(s, selSchemaRes).handleListEntityTypes(context.Background(), &mcpgo.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("list types after rejected reload: %v", err)
+	}
+	if !strings.Contains(getResultText(t, result), "requirement") {
+		t.Error("rejected reload disturbed the previously published schema")
+	}
+}
+
+// TestNewServer_PublishesSnapshot documents that a server is usable straight
+// out of NewServer — the snapshot pointer is never nil on a running server, so
+// the accessors need no nil check.
+func TestNewServer_PublishesSnapshot(t *testing.T) {
+	t.Parallel()
+	_, st := makeTestServerWithStore(t)
+
+	srv, err := NewServer(newTestDeps(t, metaWithRisk(), st), "0.0.0",
+		WithPrincipal(principal.Principal{User: "t", Tool: principal.ToolMCP}))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.logger = slog.New(slog.DiscardHandler)
+
+	if srv.state.current() == nil {
+		t.Fatal("NewServer left the snapshot unpublished")
+	}
+	if srv.deps().Meta == nil {
+		t.Fatal("published snapshot has no metamodel")
+	}
+}
+
+// TestReloadDeps_ConcurrentWithRequests exercises the publish/read split under
+// the race detector: reloads swap the snapshot while requests resolve it.
+//
+// The point is not the assertions — it is that `go test -race` sees a reader
+// and a writer on the same state. The snapshot is published through an
+// atomic.Pointer precisely so a request never observes a half-swapped
+// (deps, handlers) pair.
+func TestReloadDeps_ConcurrentWithRequests(t *testing.T) {
+	t.Parallel()
+	s, st := makeTestServerWithStore(t)
+
+	// Bound once, up front, the way registerTools binds a real tool.
+	listTypes := bind(s, selSchemaRes, schemaResourceHandler.handleListEntityTypes)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := range 50 {
+			meta := metaWithRisk()
+			if i%2 == 0 {
+				delete(meta.Entities, "risk")
+			}
+			if err := s.ReloadDeps(newTestDeps(t, meta, st)); err != nil {
+				t.Errorf("ReloadDeps: %v", err)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			result, err := listTypes(context.Background(), &mcpgo.CallToolRequest{})
+			if err != nil {
+				t.Errorf("list types: %v", err)
+				return
+			}
+			// Whichever snapshot won, it is a whole one: requirement is in
+			// every version of the fixture, so a torn pair would show up as a
+			// missing type or a nil-deref rather than a flaky assertion.
+			if !strings.Contains(getResultText(t, result), "requirement") {
+				t.Error("observed a snapshot without the always-present type")
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -18,7 +18,7 @@ func (s *Server) registerResources() {
 			Description: "The project's metamodel definition (entity types, relations, properties)",
 			MIMEType:    "application/json",
 		},
-		s.schemaRes.handleReadMetamodel,
+		bind(s, selSchemaRes, schemaResourceHandler.handleReadMetamodel),
 	)
 
 	// Dynamic resource template: entities
@@ -29,7 +29,7 @@ func (s *Server) registerResources() {
 			Description: "Read a specific entity with its properties, content, and relations",
 			MIMEType:    "application/json",
 		},
-		s.schemaRes.handleReadEntity,
+		bind(s, selSchemaRes, schemaResourceHandler.handleReadEntity),
 	)
 
 	// Dynamic resource template: relations
@@ -40,7 +40,7 @@ func (s *Server) registerResources() {
 			Description: "Read a specific relation between two entities",
 			MIMEType:    "application/json",
 		},
-		s.schemaRes.handleReadRelation,
+		bind(s, selSchemaRes, schemaResourceHandler.handleReadRelation),
 	)
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -211,20 +211,88 @@ type Watcher interface {
 // Server and point at the fields' methods. The remaining handlers genuinely
 // span deps — the next TKT-N0IKN9 slice.
 //
-//plimsoll:max-methods=25
+// 25 → 27 (TKT-NU247U): [Server.ReloadDeps] and the unexported deps accessor.
+// Both are the reload seam itself — ReloadDeps is the capability, and deps()
+// is what makes every handler read the CURRENT snapshot instead of one baked
+// in at construction. The six handler-group accessors that would also have
+// landed here are free functions ([group], [setDeps], [bind]) precisely to
+// keep this number from moving further; ratchet it back down with the
+// remaining handler clusters.
+//
+//plimsoll:max-methods=27
 type Server struct {
 	mcp       *mcpgo.Server
-	deps      Deps
 	logger    *slog.Logger
 	principal principal.Principal
 
-	// Extracted handler groups (TKT-YUETL7, TKT-MGNE5L) — built from deps
-	// by Deps.handlers. Embedded so the groups stay addressable as
-	// s.trace/s.export/... Identity is NOT threaded into them: every
-	// handler reads the principal from its ctx, stamped by
-	// principalMiddleware.
-	handlerSet
+	// state publishes the reloadable (Deps, handlerSet) pair. Read it per
+	// request via [Server.deps] / the s.<group>() accessors, never by
+	// caching the result across a call — a schema hot-reload (TKT-NU247U)
+	// swaps the whole snapshot between requests.
+	//
+	// Handler groups are NOT embedded fields any more. They used to be, and
+	// registerTools passed method values like `group(s, selTrace).handleTraceFrom`
+	// straight to AddTool — which binds the group BY VALUE at registration
+	// time, so a reloaded snapshot would never reach an already-registered
+	// tool. Registration now goes through closures that resolve the current
+	// snapshot per call; see registerTools.
+	state snapshotProvider
 }
+
+// setDeps derives and publishes the snapshot for d. Used by [NewServer], by
+// [Server.ReloadDeps], and by test helpers building a Server literal — one
+// call, so the deps and their handler groups cannot be set inconsistently.
+//
+// A free function rather than a method to keep Server under its plimsoll load
+// line; it is package-internal wiring, not part of the type's surface.
+func setDeps(s *Server, d Deps) { s.state.publish(newSnapshot(d)) }
+
+// deps returns the currently published dependency bundle.
+func (s *Server) deps() Deps { return s.state.current().deps }
+
+// ReloadDeps atomically republishes the server against a freshly built
+// dependency bundle, so subsequent requests observe the new metamodel and the
+// services derived from it.
+//
+// This is how `rela mcp` picks up a `schema.yaml` edit without a restart
+// (TKT-NU247U): the wiring site rebuilds the metamodel-derived service stack
+// against the SAME store and searcher, then hands the new Deps here. The
+// registered tool/resource/prompt SET is unchanged — only what the handlers
+// read through — so no capability renegotiation is involved.
+//
+// An invalid bundle is refused and the previous one stays published: a reload
+// driven by a file watcher must never be able to leave a running server
+// without a usable metamodel.
+//
+// Safe to call while requests are in flight. A request that has already
+// resolved the snapshot completes against it; the next one sees the new
+// bundle.
+func (s *Server) ReloadDeps(d Deps) error {
+	if err := d.validate(); err != nil {
+		return err
+	}
+	setDeps(s, d)
+	return nil
+}
+
+// group resolves one handler group out of the CURRENT snapshot. Callers pass a
+// selector over [handlerSet]; see [bind] for why the resolution has to happen
+// per request rather than once at registration.
+//
+// A free function rather than six accessor methods on Server: Server sits near
+// its plimsoll load line, and six one-line getters would spend that budget on
+// indirection rather than on capability.
+func group[G any](s *Server, sel func(handlerSet) G) G {
+	return sel(s.state.current().handlers)
+}
+
+// Selectors for the handler groups, used with [group] and [bind].
+func selTypes(h handlerSet) typeResolver              { return h.types }
+func selTrace(h handlerSet) traceHandler              { return h.trace }
+func selExport(h handlerSet) exportHandler            { return h.export }
+func selLua(h handlerSet) luaHandler                  { return h.lua }
+func selSchemaRes(h handlerSet) schemaResourceHandler { return h.schemaRes }
+func selPrompts(h handlerSet) promptHandler           { return h.prompts }
 
 // handlerSet is the extracted handler groups a [Server] carries.
 //
@@ -313,7 +381,6 @@ func (s *Server) principalMiddleware(next mcpgo.MethodHandler) mcpgo.MethodHandl
 // non-empty `principal.Principal{User: ..., Tool: ...}`.
 func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 	s := &Server{
-		deps:   deps,
 		logger: slog.Default().With("component", "mcp"),
 	}
 	for _, opt := range opts {
@@ -325,7 +392,7 @@ func NewServer(deps Deps, version string, opts ...Option) (*Server, error) {
 	if err := deps.validate(); err != nil {
 		return nil, err
 	}
-	s.handlerSet = deps.handlers()
+	setDeps(s, deps)
 
 	// Capabilities are inferred by the go-sdk from the features actually
 	// registered below (tools/resources/prompts each gain listChanged when
@@ -409,13 +476,13 @@ func (s *Server) Serve(ctx context.Context) error {
 	// resource list is not proactively invalidated — acceptable, and
 	// aligned with the direction of the 2026-07-28 spec, which requires an
 	// explicit subscriptions/listen opt-in for these notifications anyway.
-	if err := s.deps.Watcher.Start(func() {
+	if err := s.deps().Watcher.Start(func() {
 		s.logger.Info("graph re-synced from file changes")
 	}); err != nil {
 		s.logger.Warn("file watcher not started", "error", err)
 	}
 
-	defer s.deps.Watcher.Stop()
+	defer s.deps().Watcher.Stop()
 
 	return s.mcp.Run(ctx, &mcpgo.StdioTransport{})
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -18,9 +18,9 @@ func (s *Server) registerTools() {
 	s.mcp.AddTool(toolDeleteRelation(), s.handleDeleteRelation)
 
 	// Trace tools
-	s.mcp.AddTool(toolTraceFrom(), s.trace.handleTraceFrom)
-	s.mcp.AddTool(toolTraceTo(), s.trace.handleTraceTo)
-	s.mcp.AddTool(toolFindPath(), s.trace.handleFindPath)
+	s.mcp.AddTool(toolTraceFrom(), bind(s, selTrace, traceHandler.handleTraceFrom))
+	s.mcp.AddTool(toolTraceTo(), bind(s, selTrace, traceHandler.handleTraceTo))
+	s.mcp.AddTool(toolFindPath(), bind(s, selTrace, traceHandler.handleFindPath))
 
 	// Analysis tools
 	s.mcp.AddTool(toolAnalyzeOrphans(), s.handleAnalyzeOrphans)
@@ -32,18 +32,18 @@ func (s *Server) registerTools() {
 
 	// Schema tools (get_metamodel intentionally shares get_schema's
 	// handler — see toolGetMetamodel)
-	s.mcp.AddTool(toolGetSchema(), s.schemaRes.handleGetSchema)
-	s.mcp.AddTool(toolGetMetamodel(), s.schemaRes.handleGetSchema)
-	s.mcp.AddTool(toolListEntityTypes(), s.schemaRes.handleListEntityTypes)
-	s.mcp.AddTool(toolListRelationTypes(), s.schemaRes.handleListRelationTypes)
+	s.mcp.AddTool(toolGetSchema(), bind(s, selSchemaRes, schemaResourceHandler.handleGetSchema))
+	s.mcp.AddTool(toolGetMetamodel(), bind(s, selSchemaRes, schemaResourceHandler.handleGetSchema))
+	s.mcp.AddTool(toolListEntityTypes(), bind(s, selSchemaRes, schemaResourceHandler.handleListEntityTypes))
+	s.mcp.AddTool(toolListRelationTypes(), bind(s, selSchemaRes, schemaResourceHandler.handleListRelationTypes))
 
 	// Utility tools
-	s.mcp.AddTool(toolExport(), s.export.handleExport)
+	s.mcp.AddTool(toolExport(), bind(s, selExport, exportHandler.handleExport))
 
 	// Lua scripting tools
-	s.mcp.AddTool(toolLuaEval(), s.lua.handleLuaEval)
-	s.mcp.AddTool(toolLuaRun(), s.lua.handleLuaRun)
-	s.mcp.AddTool(toolLuaList(), s.lua.handleLuaList)
+	s.mcp.AddTool(toolLuaEval(), bind(s, selLua, luaHandler.handleLuaEval))
+	s.mcp.AddTool(toolLuaRun(), bind(s, selLua, luaHandler.handleLuaRun))
+	s.mcp.AddTool(toolLuaList(), bind(s, selLua, luaHandler.handleLuaList))
 }
 
 // --- Tool Definitions ---

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -20,12 +20,12 @@ func (s *Server) handleAnalyzeOrphans(
 	args := newToolRequest(request)
 	entityType := args.GetString("type", "")
 
-	orphanIDs, _ := s.deps.Tracer.FindOrphans(ctx)
+	orphanIDs, _ := s.deps().Tracer.FindOrphans(ctx)
 
-	st := s.deps.Store
+	st := s.deps().Store
 	resolved := ""
 	if entityType != "" {
-		resolved = s.types.resolveType(entityType)
+		resolved = group(s, selTypes).resolveType(entityType)
 	}
 
 	type orphanInfo struct {
@@ -71,7 +71,7 @@ func (s *Server) handleAnalyzeCardinality(
 ) (*mcpgo.CallToolResult, error) {
 	violations := make([]cardinalityViolation, 0) //nolint:prealloc // capacity unknown
 
-	for relName, relDef := range s.deps.Meta.Relations {
+	for relName, relDef := range s.deps().Meta.Relations {
 		violations = append(violations, s.checkCardinalityForRelation(ctx, relName, relDef)...)
 	}
 
@@ -106,7 +106,7 @@ func (s *Server) checkCardinalityBound(
 ) []cardinalityViolation {
 	var violations []cardinalityViolation
 
-	st := s.deps.Store
+	st := s.deps().Store
 	for _, entityType := range entityTypes {
 		for e, err := range st.ListEntities(ctx, store.EntityQuery{Type: entityType}) {
 			if err != nil {
@@ -163,13 +163,13 @@ func (s *Server) handleAnalyzeUnique(
 ) (*mcpgo.CallToolResult, error) {
 	violations := make([]uniqueViolation, 0)
 
-	for typeName, def := range s.deps.Meta.Entities {
+	for typeName, def := range s.deps().Meta.Entities {
 		for propName, pd := range def.PropertyDefs() {
 			if !pd.Unique || pd.List {
 				continue
 			}
 			byValue := map[string][]string{}
-			for e, err := range s.deps.Store.ListEntities(ctx, store.EntityQuery{Type: typeName}) {
+			for e, err := range s.deps().Store.ListEntities(ctx, store.EntityQuery{Type: typeName}) {
 				if err != nil {
 					break
 				}
@@ -213,8 +213,8 @@ func (s *Server) handleAnalyzeProperties(
 		Errors       []string `json:"errors"`
 	}
 
-	meta := s.deps.Meta
-	st := s.deps.Store
+	meta := s.deps().Meta
+	st := s.deps().Store
 	var allEntityErrors []entityErrors
 
 	// Validate entity properties
@@ -237,7 +237,7 @@ func (s *Server) handleAnalyzeProperties(
 	}
 
 	// Validate relation properties
-	relErrors := schema.ValidateRelationProperties(ctx, s.deps.Store, s.deps.Meta)
+	relErrors := schema.ValidateRelationProperties(ctx, s.deps().Store, s.deps().Meta)
 	allRelationErrors := make([]relationErrors, 0, len(relErrors))
 	for _, rpe := range relErrors {
 		errStrings := make([]string, len(rpe.Errors))
@@ -288,7 +288,7 @@ func (s *Server) handleAnalyzeProperties(
 func (s *Server) handleAnalyzeValidations(
 	ctx context.Context, _ *mcpgo.CallToolRequest,
 ) (*mcpgo.CallToolResult, error) {
-	rules := s.deps.Meta.Validations
+	rules := s.deps().Meta.Validations
 	if len(rules) == 0 {
 		return textResult("No custom validation rules defined in metamodel"), nil
 	}
@@ -299,7 +299,7 @@ func (s *Server) handleAnalyzeValidations(
 		Violations []string `json:"violations"`
 	}
 
-	validator := s.deps.Validator
+	validator := s.deps().Validator
 	var results []ruleResult
 	for _, rule := range rules {
 		ids, err := validator.CheckRule(ctx, rule)
@@ -336,8 +336,8 @@ func (s *Server) handleAnalyzeSchema(
 
 	dataEntry := s.loadDataEntryConfig(ctx)
 
-	counter := schema.NewStoreCounter(ctx, s.deps.Store)
-	analysis := schema.Analyze(s.deps.Meta, counter, dataEntry, threshold)
+	counter := schema.NewStoreCounter(ctx, s.deps().Store)
+	analysis := schema.Analyze(s.deps().Meta, counter, dataEntry, threshold)
 
 	if !analysis.HasIssues() {
 		return textResult("All schema types are in use"), nil
@@ -364,7 +364,7 @@ func (s *Server) handleAnalyzeSchema(
 
 // loadDataEntryConfig loads data-entry.yaml if it exists.
 func (s *Server) loadDataEntryConfig(ctx context.Context) *dataentryconfig.Config {
-	data, err := s.deps.Config.Load(ctx, dataentryconfig.ConfigFile)
+	data, err := s.deps().Config.Load(ctx, dataentryconfig.ConfigFile)
 	if err != nil {
 		return nil
 	}

--- a/internal/mcp/tools_entity.go
+++ b/internal/mcp/tools_entity.go
@@ -26,10 +26,10 @@ func (s *Server) handleListEntities(
 	limit := args.GetInt("limit", 0)
 	offset := args.GetInt("offset", 0)
 
-	st := s.deps.Store
+	st := s.deps().Store
 	q := store.EntityQuery{}
 	if entityType != "" {
-		q.Type = s.types.resolveType(entityType)
+		q.Type = group(s, selTypes).resolveType(entityType)
 	}
 
 	entities := make([]*entity.Entity, 0)
@@ -84,7 +84,7 @@ func (s *Server) handleShowEntity(
 	}
 	id = trimID(id)
 
-	st := s.deps.Store
+	st := s.deps().Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return errorResult("entity not found: " + id), nil
@@ -111,12 +111,12 @@ func (s *Server) handleSearchEntities(
 
 	q := search.Query{Text: query, Limit: limit}
 	if entityType != "" {
-		q.Types = []string{s.types.resolveType(entityType)}
+		q.Types = []string{group(s, selTypes).resolveType(entityType)}
 	}
 
-	st := s.deps.Store
+	st := s.deps().Store
 	summaries := make([]map[string]any, 0)
-	for hit, searchErr := range s.deps.Searcher.Search(ctx, q) {
+	for hit, searchErr := range s.deps().Searcher.Search(ctx, q) {
 		if searchErr != nil {
 			return errorResult(fmt.Sprintf("search failed: %v", searchErr)), nil
 		}
@@ -151,7 +151,7 @@ func (s *Server) handleCreateEntity(
 	customID := args.GetString("id", "")
 
 	// Resolve type
-	resolvedType, _, resolveErr := s.types.resolveEntityType(typeName)
+	resolvedType, _, resolveErr := group(s, selTypes).resolveEntityType(typeName)
 	if resolveErr != nil {
 		return errorResult(resolveErr.Error()), nil
 	}
@@ -160,11 +160,11 @@ func (s *Server) handleCreateEntity(
 	properties := extractProperties(request)
 
 	// Validate property names early for better error messages
-	if errResult := s.types.validatePropertyNames(resolvedType, properties); errResult != nil {
+	if errResult := group(s, selTypes).validatePropertyNames(resolvedType, properties); errResult != nil {
 		return errResult, nil
 	}
 
-	result, createErr := s.deps.EntityManager.CreateEntity(ctx,
+	result, createErr := s.deps().EntityManager.CreateEntity(ctx,
 		&entity.Entity{
 			Type:       resolvedType,
 			Properties: properties,
@@ -177,7 +177,7 @@ func (s *Server) handleCreateEntity(
 	}
 	created := result.Entity
 
-	st := s.deps.Store
+	st := s.deps().Store
 	e, _ := st.GetEntity(ctx, created.ID)
 	if e == nil {
 		// Fallback: return minimal info
@@ -202,7 +202,7 @@ func (s *Server) handleUpdateEntity(
 	}
 	id = trimID(id)
 
-	st := s.deps.Store
+	st := s.deps().Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return errorResult("entity not found: " + id), nil
@@ -216,7 +216,7 @@ func (s *Server) handleUpdateEntity(
 	}
 
 	// Validate property names early for better error messages
-	if errResult := s.types.validatePropertyNames(e.Type, properties); errResult != nil {
+	if errResult := group(s, selTypes).validatePropertyNames(e.Type, properties); errResult != nil {
 		return errResult, nil
 	}
 
@@ -243,7 +243,7 @@ func (s *Server) handleUpdateEntity(
 		patch.Content = &content
 	}
 
-	updateResult, updateErr := s.deps.EntityManager.PatchEntity(ctx, id, patch)
+	updateResult, updateErr := s.deps().EntityManager.PatchEntity(ctx, id, patch)
 	if updateErr != nil {
 		return errorResult(updateErr.Error()), nil
 	}
@@ -299,7 +299,7 @@ func (s *Server) handleDeleteEntity(
 	id = trimID(id)
 	cascade := args.GetBool("cascade", false)
 
-	st := s.deps.Store
+	st := s.deps().Store
 	e, getErr := st.GetEntity(ctx, id)
 	if getErr != nil {
 		return errorResult("entity not found: " + id), nil
@@ -314,7 +314,7 @@ func (s *Server) handleDeleteEntity(
 		}
 	}
 
-	result, delErr := s.deps.EntityManager.DeleteEntity(ctx, id, cascade)
+	result, delErr := s.deps().EntityManager.DeleteEntity(ctx, id, cascade)
 	if delErr != nil {
 		return errorResult(delErr.Error()), nil
 	}
@@ -346,10 +346,10 @@ func (s *Server) handleRenameEntity(
 	dryRun := args.GetBool("dry_run", false)
 
 	// Pause watcher during rename
-	s.deps.Watcher.Pause()
-	defer s.deps.Watcher.Resume()
+	s.deps().Watcher.Pause()
+	defer s.deps().Watcher.Resume()
 
-	result, renameErr := s.deps.EntityManager.RenameEntity(
+	result, renameErr := s.deps().EntityManager.RenameEntity(
 		ctx, oldID, newID, entity.RenameOptions{DryRun: dryRun})
 	if renameErr != nil {
 		return errorResult(renameErr.Error()), nil

--- a/internal/mcp/tools_lua_test.go
+++ b/internal/mcp/tools_lua_test.go
@@ -43,7 +43,7 @@ func TestHandleLuaEval_ReturnsScriptErrorEnvelope(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 
-	result, err := s.lua.handleLuaEval(context.Background(),
+	result, err := group(s, selLua).handleLuaEval(context.Background(),
 		luaCallToolReq(map[string]any{"code": "print('hello')\nerror('kaboom')"}))
 	if err != nil {
 		t.Fatalf("handler returned Go error: %v", err)
@@ -77,7 +77,7 @@ func TestHandleLuaEval_ReturnsScriptErrorEnvelope(t *testing.T) {
 func TestHandleLuaEval_PreservesIsErrorFlag(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, _ := s.lua.handleLuaEval(context.Background(),
+	result, _ := group(s, selLua).handleLuaEval(context.Background(),
 		luaCallToolReq(map[string]any{"code": "error('x')"}))
 	if !result.IsError {
 		t.Error("IsError flag must remain true on Lua failure for MCP clients to branch")

--- a/internal/mcp/tools_relation.go
+++ b/internal/mcp/tools_relation.go
@@ -22,7 +22,7 @@ func (s *Server) handleListRelations(
 	limit := args.GetInt("limit", 0)
 	offset := args.GetInt("offset", 0)
 
-	st := s.deps.Store
+	st := s.deps().Store
 	q := store.RelationQuery{Type: relType, From: from, To: to}
 
 	all := make([]*entity.Relation, 0)
@@ -83,7 +83,7 @@ func (s *Server) handleCreateRelation(
 		Content:    nilIfEmpty(args.GetString("content", "")),
 	}
 
-	if _, createErr := s.deps.EntityManager.CreateRelation(ctx, fromID, relType, toID, opts); createErr != nil {
+	if _, createErr := s.deps().EntityManager.CreateRelation(ctx, fromID, relType, toID, opts); createErr != nil {
 		return errorResult(createErr.Error()), nil
 	}
 
@@ -111,13 +111,13 @@ func (s *Server) handleDeleteRelation(
 	}
 	toID = trimID(toID)
 
-	st := s.deps.Store
+	st := s.deps().Store
 	if _, getErr := st.GetRelation(ctx, fromID, relType, toID); getErr != nil {
 		return errorResult(
 			fmt.Sprintf("relation not found: %s --%s--> %s", fromID, relType, toID)), nil
 	}
 
-	if delErr := s.deps.EntityManager.DeleteRelation(ctx, fromID, relType, toID); delErr != nil {
+	if delErr := s.deps().EntityManager.DeleteRelation(ctx, fromID, relType, toID); delErr != nil {
 		return errorResult(delErr.Error()), nil
 	}
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -86,11 +86,8 @@ func makeTestServerWithStore(t *testing.T) (*Server, *memstore.MemStore) {
 
 	meta, st := makeTestFixture(t)
 	deps := newTestDeps(t, meta, st)
-	srv := &Server{
-		deps:   deps,
-		logger: slog.New(slog.DiscardHandler),
-	}
-	srv.handlerSet = deps.handlers()
+	srv := &Server{logger: slog.New(slog.DiscardHandler)}
+	setDeps(srv, deps)
 	return srv, st
 }
 
@@ -305,7 +302,7 @@ func TestHandleUpdateEntity_DeletesPropertyOnNil(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, getErr := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	updated, getErr := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if getErr != nil {
 		t.Fatalf("get entity: %v", getErr)
 	}
@@ -339,7 +336,7 @@ func TestHandleUpdateEntity_DeleteAbsentPropertyIsNoOp(t *testing.T) {
 	t.Parallel()
 	// `priority` is in the metamodel but not set on REQ-001; deleting it should be a no-op.
 	s := makeTestServer(t)
-	before, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	before, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := before.Properties["priority"]; present {
 		t.Fatalf("test setup: REQ-001 should not have a priority property")
 	}
@@ -355,7 +352,7 @@ func TestHandleUpdateEntity_DeleteAbsentPropertyIsNoOp(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success on no-op delete, got error: %s", getResultText(t, result))
 	}
-	after, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	after, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := after.Properties["priority"]; present {
 		t.Errorf("priority should remain absent")
 	}
@@ -369,7 +366,7 @@ func TestHandleUpdateEntity_DeleteRequiredPropertyRejected(t *testing.T) {
 	// `title` is required; attempting to delete it must surface an actionable error
 	// rather than silently producing a now-invalid entity.
 	s := makeTestServer(t)
-	before, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	before, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	beforeTitle := before.GetString("title")
 
 	req := makeToolRequest(map[string]any{
@@ -387,7 +384,7 @@ func TestHandleUpdateEntity_DeleteRequiredPropertyRejected(t *testing.T) {
 		t.Errorf("expected 'required' in error message, got %s", getResultText(t, result))
 	}
 	// Entity must be unchanged.
-	after, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	after, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if after.GetString("title") != beforeTitle {
 		t.Errorf("entity must be unchanged after rejected delete: title was %q, now %q", beforeTitle, after.GetString("title"))
 	}
@@ -408,7 +405,7 @@ func TestHandleUpdateEntity_JSONStringPropertiesNullDeletes(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := updated.Properties["status"]; present {
 		t.Errorf("status should be removed when sent as JSON string with null")
 	}
@@ -450,7 +447,7 @@ func TestHandleUpdateEntity_MixedSetAndUnset(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if _, present := updated.Properties["status"]; present {
 		t.Errorf("status should be removed")
 	}
@@ -480,7 +477,7 @@ func TestHandleUpdateEntity_EmptyStringIsNoOp(t *testing.T) {
 		t.Errorf("expected 'no updates specified', got %s", getResultText(t, result))
 	}
 	// And the existing status is untouched.
-	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if got := updated.GetString("status"); got != "accepted" {
 		t.Errorf("status should remain 'accepted', got %q", got)
 	}
@@ -501,7 +498,7 @@ func TestHandleUpdateEntity_SetAndOverwriteStillWorks(t *testing.T) {
 	if isErrorResult(result) {
 		t.Fatalf("expected success, got error: %s", getResultText(t, result))
 	}
-	updated, _ := s.deps.Store.GetEntity(context.Background(), "REQ-001")
+	updated, _ := s.deps().Store.GetEntity(context.Background(), "REQ-001")
 	if got := updated.GetString("status"); got != "rejected" {
 		t.Errorf("expected status 'rejected', got %q", got)
 	}
@@ -766,7 +763,7 @@ func TestHandleTraceFrom(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"id": "REQ-001"})
-	result, err := s.trace.handleTraceFrom(context.Background(), req)
+	result, err := group(s, selTrace).handleTraceFrom(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -780,7 +777,7 @@ func TestHandleTraceFrom_NotFound(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"id": "NONEXISTENT"})
-	result, err := s.trace.handleTraceFrom(context.Background(), req)
+	result, err := group(s, selTrace).handleTraceFrom(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -793,7 +790,7 @@ func TestHandleTraceTo(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"id": "REQ-001"})
-	result, err := s.trace.handleTraceTo(context.Background(), req)
+	result, err := group(s, selTrace).handleTraceTo(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -807,7 +804,7 @@ func TestHandleFindPath(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"from": "DEC-001", "to": "REQ-001"})
-	result, err := s.trace.handleFindPath(context.Background(), req)
+	result, err := group(s, selTrace).handleFindPath(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -821,7 +818,7 @@ func TestHandleFindPath_NoPath(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"from": "REQ-002", "to": "REQ-003"})
-	result, err := s.trace.handleFindPath(context.Background(), req)
+	result, err := group(s, selTrace).handleFindPath(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -835,7 +832,7 @@ func TestHandleFindPath_NotFound(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
 	req := makeToolRequest(map[string]any{"from": "NONEXISTENT", "to": "REQ-001"})
-	result, err := s.trace.handleFindPath(context.Background(), req)
+	result, err := group(s, selTrace).handleFindPath(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -893,7 +890,7 @@ func TestHandleAnalyzeCardinality_WithViolation(t *testing.T) {
 	s := makeTestServer(t)
 	// Set a minimum cardinality that won't be met
 	minVal := 5
-	meta := s.deps.Meta
+	meta := s.deps().Meta
 	meta.Relations["addresses"] = metamodel.RelationDef{
 		From:        []string{"decision"},
 		To:          []string{"requirement"},
@@ -941,7 +938,7 @@ func TestHandleAnalyzeValidations_NoRules(t *testing.T) {
 func TestHandleGetMetamodel(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, err := s.schemaRes.handleGetSchema(context.Background(), &mcpgo.CallToolRequest{})
+	result, err := group(s, selSchemaRes).handleGetSchema(context.Background(), &mcpgo.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -961,7 +958,7 @@ func TestHandleGetMetamodel(t *testing.T) {
 func TestHandleListEntityTypes(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, err := s.schemaRes.handleListEntityTypes(context.Background(), &mcpgo.CallToolRequest{})
+	result, err := group(s, selSchemaRes).handleListEntityTypes(context.Background(), &mcpgo.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -978,7 +975,7 @@ func TestHandleListEntityTypes(t *testing.T) {
 func TestHandleListRelationTypes(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	result, err := s.schemaRes.handleListRelationTypes(context.Background(), &mcpgo.CallToolRequest{})
+	result, err := group(s, selSchemaRes).handleListRelationTypes(context.Background(), &mcpgo.CallToolRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -999,7 +996,7 @@ func TestHandleReadEntity(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/requirement/REQ-001"
-	contents, err := s.schemaRes.handleReadEntity(context.Background(), req)
+	contents, err := group(s, selSchemaRes).handleReadEntity(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1017,7 +1014,7 @@ func TestHandleReadEntity_TypeMismatch(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/decision/REQ-001"
-	_, err := s.schemaRes.handleReadEntity(context.Background(), req)
+	_, err := group(s, selSchemaRes).handleReadEntity(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for type mismatch")
 	}
@@ -1031,7 +1028,7 @@ func TestHandleReadEntity_NotFound(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/requirement/REQ-999"
-	_, err := s.schemaRes.handleReadEntity(context.Background(), req)
+	_, err := group(s, selSchemaRes).handleReadEntity(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for nonexistent entity")
 	}
@@ -1042,7 +1039,7 @@ func TestHandleReadEntity_InvalidURI(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://entity/onlyone"
-	_, err := s.schemaRes.handleReadEntity(context.Background(), req)
+	_, err := group(s, selSchemaRes).handleReadEntity(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for invalid URI")
 	}
@@ -1053,7 +1050,7 @@ func TestHandleReadRelation(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://relation/DEC-001/addresses/REQ-001"
-	contents, err := s.schemaRes.handleReadRelation(context.Background(), req)
+	contents, err := group(s, selSchemaRes).handleReadRelation(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1071,7 +1068,7 @@ func TestHandleReadRelation_NotFound(t *testing.T) {
 	s := makeTestServer(t)
 	req := &mcpgo.ReadResourceRequest{Params: &mcpgo.ReadResourceParams{}}
 	req.Params.URI = "rela://relation/REQ-001/nonexistent/REQ-002"
-	_, err := s.schemaRes.handleReadRelation(context.Background(), req)
+	_, err := group(s, selSchemaRes).handleReadRelation(context.Background(), req)
 	if err == nil {
 		t.Error("expected error for nonexistent relation")
 	}
@@ -1093,7 +1090,7 @@ func TestResolveType(t *testing.T) {
 		{"unknown", "unknown"}, // falls through
 	}
 	for _, tt := range tests {
-		got := s.types.resolveType(tt.input)
+		got := group(s, selTypes).resolveType(tt.input)
 		if got != tt.expected {
 			t.Errorf("resolveType(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
@@ -1103,7 +1100,7 @@ func TestResolveType(t *testing.T) {
 func TestResolveEntityType(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	resolved, def, err := s.types.resolveEntityType("requirement")
+	resolved, def, err := group(s, selTypes).resolveEntityType("requirement")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1118,7 +1115,7 @@ func TestResolveEntityType(t *testing.T) {
 func TestResolveEntityType_Unknown(t *testing.T) {
 	t.Parallel()
 	s := makeTestServer(t)
-	_, _, err := s.types.resolveEntityType("nonexistent")
+	_, _, err := group(s, selTypes).resolveEntityType("nonexistent")
 	if err == nil {
 		t.Error("expected error for unknown type")
 	}

--- a/internal/tenant/registry.go
+++ b/internal/tenant/registry.go
@@ -220,7 +220,6 @@ func (r *Registry) Acquire(ctx context.Context, orgID string) (*Lease, error) {
 		res.refs++
 		r.recency.MoveToFront(res.element)
 		r.mu.Unlock()
-		//nolint:contextcheck // teardown is not request-scoped; Services.Close takes no ctx
 		closeServices(t, svc)
 		return &Lease{Tenant: res.tenant, svc: res.svc, registry: r}, nil
 	}
@@ -233,7 +232,6 @@ func (r *Registry) Acquire(ctx context.Context, orgID string) (*Lease, error) {
 	// Eviction must NOT inherit this request's context. The tenant being closed
 	// is a different tenant from the one being served, so canceling the
 	// request must not abandon another tenant's pool half-torn-down.
-	//nolint:contextcheck // teardown is not request-scoped; Services.Close takes no ctx
 	closeAll(evicted)
 	return &Lease{Tenant: t, svc: svc, registry: r}, nil
 }

--- a/tickets/entities/docs-checklists/DOCS-ON2OGB.md
+++ b/tickets/entities/docs-checklists/DOCS-ON2OGB.md
@@ -1,0 +1,19 @@
+---
+id: DOCS-ON2OGB
+type: docs-checklist
+title: 'Docs: MCP schema hot-reload'
+status: done
+---
+
+- [x] Code docs — godoc on `Server.ReloadDeps`, `bind`, `snapshotProvider`, `Services.CloseAssembly`, `SharedBase.ForReassembly`/`Config`, `mcpServices.reload`/`watchSchema`, each stating why rather than what.
+- [x] Project docs — `docs-project/entities/guides/GUIDE-mcp-server.md` (source of the generated `docs/mcp-server.md`) "File Watching" section rewritten.
+
+Two pre-existing inaccuracies were corrected while there: it claimed
+`schema.yaml` was already watched (only `entities/` and `relations/` were), and
+it claimed changes were announced via `notifications/resources/list_changed`,
+which the go-sdk migration removed. The remote-MCP section's "no change
+notifications" bullet now states that a `schema.yaml` edit still needs a restart
+on that transport, since it starts no watcher.
+- [x] `just docs` regenerated and the generated output committed.
+- [x] ~~External docs~~ (N/A: no public API or CLI flag changed — the behavior is automatic.)
+- [x] ~~CHANGELOG~~ (N/A: repo keeps no changelog; release notes derive from commits.)

--- a/tickets/entities/implementation-checklists/IMPL-W14E24.md
+++ b/tickets/entities/implementation-checklists/IMPL-W14E24.md
@@ -1,0 +1,17 @@
+---
+id: IMPL-W14E24
+type: implementation-checklist
+title: 'Implementation: MCP schema hot-reload'
+status: done
+---
+
+- [x] `appbuild`: `Services.CloseAssembly` + shared `stopBackgroundServices`; `Services.Base()`; `SharedBase.Config()`.
+- [x] `mcp`: snapshot provider (`atomic.Pointer`), `Server.ReloadDeps`, `bind`/`group` so registered handlers resolve the current snapshot per request.
+- [x] `cli`: `mcpServices.reload` + `watchSchema`, wired from `rela mcp`.
+- [x] Tests added at all three layers, including a `-race` concurrency test.
+- [x] `just lint` clean (0 issues).
+- [x] `just arch-lint` clean.
+- [x] `just plimsoll` clean — load lines re-pinned with rationale.
+- [x] `just comment-lint` clean.
+- [x] `just coverage-check` passes.
+- [x] All build tags compile (default, postgres, memorybackend, sqlite).

--- a/tickets/entities/planning-checklists/PLAN-3VRAW4.md
+++ b/tickets/entities/planning-checklists/PLAN-3VRAW4.md
@@ -1,0 +1,13 @@
+---
+id: PLAN-3VRAW4
+type: planning-checklist
+title: 'Planning: MCP schema hot-reload'
+status: done
+---
+
+- [x] Problem understood — MCP bakes the metamodel into `mcp.Deps` and into every service `appbuild.assemble` builds; a schema edit needs a restart.
+- [x] Approach chosen — reuse `appbuild.SharedBase` + `Assemble` against the existing store/searcher, publish `mcp.Deps` via an `atomic.Pointer` snapshot.
+- [x] Alternatives considered — swapping `Deps.Meta` alone was rejected: the entitymanager holds its own metamodel, so writes would keep validating against the old schema (a half-updated server). Rebuilding the whole `Services` via `Discover` was rejected: it closes the store and forces a full search reindex.
+- [x] Risk identified — every `Assemble` starts per-assembly background services (job queue, mail worker, GC sweep) and the only teardown, `Services.Close`, also closes the shared store. Addressed with a scoped `CloseAssembly`.
+- [x] ~~Security review~~ (N/A: stdio MCP is wired `acl.NopACL` by design — the filesystem is the trust boundary; the reload changes no gate. The remote transport starts no watcher.)
+- [x] Test plan — reload visible to read tools; reload reaches the write path; a handler bound before the reload observes it; bad schema keeps last-good; store/searcher reused; close-after-reload clean; concurrent reload under `-race`.

--- a/tickets/entities/review-checklists/REV-2WIUFJ.md
+++ b/tickets/entities/review-checklists/REV-2WIUFJ.md
@@ -1,0 +1,13 @@
+---
+id: REV-2WIUFJ
+type: review-checklist
+title: 'Review: MCP schema hot-reload'
+status: done
+---
+
+- [x] Automated checks: `just lint` (0 issues), `just arch-lint`, `just plimsoll`, `just comment-lint`, `just coverage-check`, `just ci` all pass.
+- [x] Race detector clean on the touched packages.
+- [x] All four build tags compile (default, postgres, memorybackend, sqlite).
+- [x] Code review performed (cranky-code-reviewer). Findings recorded as review-response entities and addressed.
+- [x] Verification: each new test was mutation-checked — the fix was reverted and the test confirmed to fail — for the method-value binding trap, the non-atomic publish, the reload-after-close resurrection, and the searchCloser double-close.
+- [x] ~~Manual UI check~~ (N/A: stdio MCP server, no UI.)

--- a/tickets/entities/review-responses/RR-C1ALTT.md
+++ b/tickets/entities/review-responses/RR-C1ALTT.md
@@ -1,0 +1,27 @@
+---
+id: RR-C1ALTT
+type: review-response
+title: reload() after Close() resurrects services on a closed store
+finding: storage.Watcher.Stop does not await an in-flight OnChange, so a schema event mid-flight at shutdown could make reload() assemble a new service generation (job queue, mail worker, GC sweep) against a store Close had already torn down, leaking them permanently.
+severity: critical
+resolution: Added a `closed` flag set under mu at the top of Close; reload() refuses when set and re-checks after assembling, retiring the successor via CloseAssembly if superseded.
+status: addressed
+---
+
+**Finding:** `storage.Watcher.Stop` only closes `done` and the fsnotify handle —
+it does not wait for an in-flight `OnChange`, which runs synchronously after a
+200ms debounce. So a schema event can be mid-flight when `Close` begins: the
+callback blocks on `s.mu`, `Close` completes, then `reload()` proceeds and
+assembles a new generation (job queue, mail worker, GC sweep) against a
+torn-down store. Nothing would ever close them; on postgres that is a leaked
+connection pool and LISTEN connection per occurrence.
+
+**Resolution:** Added a `closed` flag on `mcpServices`, set under `mu` at the
+top of `Close` before any teardown. `reload()` returns an error when it observes
+it, and re-checks after building the successor (retiring it with `CloseAssembly`
+if shutdown or another reload landed meanwhile). `watchSchema` already
+logs-and-continues on error, so this degrades correctly.
+
+Pinned by `TestMCPServices_ReloadAfterCloseIsRefused` and
+`TestMCPServices_WatchSchemaAfterCloseDoesNotResurrect`; both were confirmed to
+fail without the guard.

--- a/tickets/entities/review-responses/RR-D8FBHT.md
+++ b/tickets/entities/review-responses/RR-D8FBHT.md
@@ -1,0 +1,9 @@
+---
+id: RR-D8FBHT
+type: review-response
+title: Reload re-ran boot-only derived-schema DDL on postgres
+finding: 'assemble calls reconcileDerivedSchemaIfSupported unconditionally, so reload re-ran it. pgstore.Store.Reconcile documents itself BOOT-ONLY and names re-reconciling on reload as a future extension needing its own debounce/lock policy for issuing DDL off a file watcher. Consequences: CREATE/DROP INDEX on every editor autosave, and a metamodel saved mid-edit that still parses but lost a `unique:` would DROP the live index, since reconciliation is desired-state and absent means delete.'
+severity: significant
+resolution: Added SharedBase.ForReassembly(), which returns a copy marked as re-assembling against an already-open store; assemble skips the store-open-only reconcile when set. The MCP reload path uses it. The version sweep is deliberately still re-run — it carries the metamodel projection and StartVersionSweep replaces the previous sweep rather than stacking one.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VFWE4C.md
+++ b/tickets/entities/review-responses/RR-VFWE4C.md
@@ -1,0 +1,9 @@
+---
+id: RR-VFWE4C
+type: review-response
+title: CloseAssembly claimed goroutine-safety it did not have; reload held the mutex across assembly
+finding: 'stopBackgroundServices nils mailStop/gcStop/jobQueue without a lock while Services.Jobs() reads jobQueue unlocked, so the documented ''safe from multiple goroutines'' invited a racy use. Separately, reload() held s.mu across the whole Assemble (disk I/O, Lua compilation, on postgres a network round-trip), blocking Deps() and Close(). Two minor consistency issues: watchSchema took the mutex twice for two related reads, and stopSchemaWatch was assigned outside it.'
+severity: minor
+resolution: Narrowed the CloseAssembly doc to what actually holds (safe repeatedly and against Close; not against a concurrent Jobs()). reload() now builds the successor outside the lock and takes it only for the swap, re-checking for supersession. watchSchema captures one snapshot and assigns stopSchemaWatch under the mutex.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YMRGY2.md
+++ b/tickets/entities/review-responses/RR-YMRGY2.md
@@ -1,0 +1,9 @@
+---
+id: RR-YMRGY2
+type: review-response
+title: assemble leaks a started job queue on later error paths
+finding: buildRuntimeServices STARTS the job queue, but a later failure in assemble (e.g. buildEntityManager) returned without closing it. Boot-only this was harmless since a failed boot exits the process; making assembly a reload path turns it into one leaked queue per bad schema save — on postgres, a connection pool each time.
+severity: critical
+resolution: Named the return values and added a deferred closeJobQueue on the error path; factored closeJobQueue so the teardown path and the error path share one bounded close.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-NU247U.md
+++ b/tickets/entities/tickets/TKT-NU247U.md
@@ -1,0 +1,58 @@
+---
+id: TKT-NU247U
+type: ticket
+title: MCP server hot-reloads schema.yaml on change
+kind: enhancement
+priority: medium
+effort: m
+status: in-progress
+---
+
+## Problem
+
+The MCP server loads `schema.yaml` once at startup. The metamodel is baked into
+`mcp.Deps.Meta` **and** deep into every derived service built by
+`appbuild.assemble` — validator, entitymanager (automations, transitions,
+computed, templater), affordances, field redactor.
+
+So editing `schema.yaml` during an MCP session requires a manual server restart
+before a new entity type, enum value, relation target or validation rule takes
+effect. Iterative modelling in an agent session is interrupted by a restart
+cycle on every schema edit.
+
+Upstream: sourcehaven-bv/rela#644.
+
+## Why reloading only `Deps.Meta` is not enough
+
+`create_entity` validation, enum checks and relation-target checks all run
+through `EntityManager`, which holds its own `*metamodel.Metamodel`. Swapping
+only `Deps.Meta` would refresh the read surfaces (`get_schema`, resources,
+prompts) while leaving writes validating against the stale schema — the exact
+symptom the issue reports, only harder to diagnose because part of the surface
+would appear to update.
+
+## Approach
+
+`appbuild.SharedBase` already splits the tenant-independent half (config,
+options, acl.yaml, metamodel) from the per-store half. `NewSharedBase` re-reads
+`schema.yaml`; `SharedBase.Assemble(store, searcher, visible, closer)` rebuilds
+everything metamodel-derived against an **existing** store — no store close, no
+search reindex.
+
+The obstacle: each `Assemble` also starts per-assembly background services (job
+queue with its worker pool, mail outbox worker, data-migration GC sweep, and on
+postgres a version sweep), and the only teardown — `Services.Close` — *also*
+closes the shared store and search closer. Re-assembling per schema change would
+leak a job queue per edit.
+
+So this ticket adds a narrowly-scoped teardown that stops the per-assembly
+background services while leaving the shared store/searcher untouched, and the
+MCP wiring drives it from a `schema.yaml` watcher.
+
+## Constraints
+
+- A parse error must retain the last-good metamodel and log clearly — never
+leave the server without a schema.
+- Readers observe either the pre- or post-reload snapshot, never a torn one
+(`atomic.Pointer`, per the CLAUDE.md state-publish rule).
+- The reload must not close or reindex the store.

--- a/tickets/entities/tickets/TKT-NU247U.md
+++ b/tickets/entities/tickets/TKT-NU247U.md
@@ -5,7 +5,7 @@ title: MCP server hot-reloads schema.yaml on change
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: done
 ---
 
 ## Problem

--- a/tickets/relations/TKT-NU247U--affects--mcp-api.md
+++ b/tickets/relations/TKT-NU247U--affects--mcp-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: affects
+to: mcp-api
+---

--- a/tickets/relations/TKT-NU247U--has-docs--DOCS-ON2OGB.md
+++ b/tickets/relations/TKT-NU247U--has-docs--DOCS-ON2OGB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-docs
+to: DOCS-ON2OGB
+---

--- a/tickets/relations/TKT-NU247U--has-implementation--IMPL-W14E24.md
+++ b/tickets/relations/TKT-NU247U--has-implementation--IMPL-W14E24.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-implementation
+to: IMPL-W14E24
+---

--- a/tickets/relations/TKT-NU247U--has-planning--PLAN-3VRAW4.md
+++ b/tickets/relations/TKT-NU247U--has-planning--PLAN-3VRAW4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-planning
+to: PLAN-3VRAW4
+---

--- a/tickets/relations/TKT-NU247U--has-review--REV-2WIUFJ.md
+++ b/tickets/relations/TKT-NU247U--has-review--REV-2WIUFJ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-review
+to: REV-2WIUFJ
+---

--- a/tickets/relations/TKT-NU247U--has-review-response--RR-C1ALTT.md
+++ b/tickets/relations/TKT-NU247U--has-review-response--RR-C1ALTT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-review-response
+to: RR-C1ALTT
+---

--- a/tickets/relations/TKT-NU247U--has-review-response--RR-D8FBHT.md
+++ b/tickets/relations/TKT-NU247U--has-review-response--RR-D8FBHT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-review-response
+to: RR-D8FBHT
+---

--- a/tickets/relations/TKT-NU247U--has-review-response--RR-VFWE4C.md
+++ b/tickets/relations/TKT-NU247U--has-review-response--RR-VFWE4C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-review-response
+to: RR-VFWE4C
+---

--- a/tickets/relations/TKT-NU247U--has-review-response--RR-YMRGY2.md
+++ b/tickets/relations/TKT-NU247U--has-review-response--RR-YMRGY2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: has-review-response
+to: RR-YMRGY2
+---

--- a/tickets/relations/TKT-NU247U--implements--FEAT-019.md
+++ b/tickets/relations/TKT-NU247U--implements--FEAT-019.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NU247U
+relation: implements
+to: FEAT-019
+---


### PR DESCRIPTION
Closes #644.

The MCP server loaded `schema.yaml` once at startup, so every schema edit during a session — a new entity type, an extended enum, a new `to:` on a relation, a changed validation rule — needed a manual restart before it took effect. Iterative modelling in an agent session was interrupted by a restart cycle on each change.

`rela mcp` now watches the schema file and reloads in place.

## Why the whole stack is rebuilt, not just the metamodel

The tempting fix is to swap `mcp.Deps.Meta`. That is wrong: `create_entity`'s validation, enum checks and relation-target checks run through the entitymanager, which holds its **own** `*metamodel.Metamodel`, as do the compiled transitions, computed properties and automations. Refreshing only the read surfaces would leave `get_schema` advertising a type that `create_entity` then rejects — a half-updated server, harder to diagnose than one that never updated. `TestMCPServices_ReloadPicksUpNewType` fails with `unknown entity type` if you try it that way.

So the reload rebuilds everything metamodel-derived via `appbuild.SharedBase` + `Assemble`, against the **same** store and searcher. A schema edit costs no reindex and loses none of the session's writes.

## Changes

**`internal/mcp`** — `Deps` and its `handlerSet` are published together as a snapshot behind an `atomic.Pointer`; `Server.ReloadDeps` republishes.

Handlers were registered as method values (`s.trace.handleTraceFrom`), which capture the receiver **by value** at registration. A reloaded snapshot could never have reached them, and the failure would have been silent — the tool keeps working, just against the old schema. Registration now goes through `bind(s, selTrace, traceHandler.handleTraceFrom)`, which resolves the snapshot per request. `TestReloadDeps_ReachesRegisteredHandlers` pins it.

**`internal/appbuild`** — `Services.CloseAssembly()` stops only the per-assembly background services (job queue, mail worker, GC sweep) and leaves the store and searcher running, so a superseded assembly can be retired without tearing down what its successor is using. Every `Assemble` starts a job queue with a worker pool (on postgres, a connection pool and a LISTEN connection), so without this a reload would leak one per schema edit.

Also `Services.Base()`, `SharedBase.Config()` and `SharedBase.ForReassembly()`.

**`internal/cli`** — `mcpServices.reload()` and `watchSchema`, wired from `rela mcp`.

## Fail-safe behavior

A schema that does not parse leaves the previous services in place and logs a warning. A save taken mid-edit is routinely unparseable and must not end the session.

## Review findings addressed

A code-review pass found four issues in the wiring, all fixed in the second commit — the common thread being code written under a build-once assumption meeting a new repeat-invocation lifetime:

- **Reload after `Close` resurrected services on a closed store.** `storage.Watcher.Stop` does not await an in-flight `OnChange`, so a change event mid-flight at shutdown assembled a whole new generation against a torn-down store, with nothing left to stop it. Now guarded by a `closed` flag, with a re-check after assembly.
- **`assemble` leaked a started job queue on its error paths.** Harmless when assembly only happened at boot (a failed boot exits); with reload it became one leaked queue per bad schema save. Now closed via a deferred handler.
- **Reload re-ran boot-only DDL on postgres.** `pgstore.Store.Reconcile` documents itself boot-only and names reload re-reconciliation as a future extension needing its own debounce/lock policy for issuing DDL off a file watcher. Left as-is it meant `CREATE`/`DROP INDEX` on every autosave — and a metamodel saved mid-edit that still parses but has lost a `unique:` would have **dropped** the live index, since reconciliation is desired-state. `ForReassembly()` skips it. The version sweep is deliberately still re-run: it carries the metamodel projection, and `StartVersionSweep` replaces the previous sweep rather than stacking one.
- **`CloseAssembly` claimed thread-safety it did not have**, and `reload()` held the mutex across the whole assembly. Doc narrowed to what holds; the successor is now built outside the lock.

## Testing

Tests at all three layers. Each was mutation-checked — the fix reverted, the test confirmed to fail — for the method-value binding trap, the non-atomic publish (caught by `-race`), the reload-after-close resurrection, and the `searchCloser` double-close.

Includes an end-to-end test driving a real file edit through the watcher, and a concurrency test running reloads against in-flight requests under `-race`.

`just ci` passes; all four build tags compile.

## Docs

`GUIDE-mcp-server.md`'s "File Watching" section is rewritten. Two pre-existing inaccuracies are corrected while there: it claimed `schema.yaml` was already watched (only `entities/` and `relations/` were), and that changes were announced via `notifications/resources/list_changed`, which the go-sdk migration removed.

