### PR TITLE
fix(fsstore): install the self-echo recorder in New, fan out post-write observers (BUG-S24X52)

### DIFF
--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,4 +162,97 @@ func TestFSFactoryOpenStoreReturnsIndependentStores(t *testing.T) {
 	defer s2.Close()
 
 	assert.NotSame(t, s1, s2, "each OpenStore call returns a fresh store")
+}
+
+// storeWatcher is the watcher capability the production wiring
+// (dataentry, mcp) type-asserts on the opened store. Declared here at
+// the consumer, like those sites do.
+type storeWatcher interface {
+	StartWatching() error
+	StopWatching()
+}
+
+// TestFSFactoryWatcherSuppressesSelfEcho pins the production wiring
+// of the fsstore self-echo LRU (BUG-S24X52). It opens the store the
+// way appbuild does — FSFactory over SafeFS(OsFS) on a real
+// directory — starts the fsnotify watcher, and performs one write
+// through the store followed by one genuinely external write that
+// bypasses SafeFS. Exactly two events must surface: the store's own
+// synchronous Created, and the external Created. If the post-write
+// observer is not installed by construction, the watcher re-parses
+// the self-write and a spurious Updated for POL-1 appears before the
+// external event.
+//
+// The assertion waits on a POSITIVE signal (the external file's
+// Created event) rather than a wall-clock silence: fsnotify delivers
+// events for one directory tree in order and POL-1 was written first,
+// so by the time POL-2's event has been reconciled, POL-1's has too.
+func TestFSFactoryWatcherSuppressesSelfEcho(t *testing.T) {
+	root := t.TempDir()
+	fs := storage.NewSafeFS(storage.NewOsFS())
+	paths := &project.Context{
+		Root:         root,
+		EntitiesDir:  filepath.Join(root, "entities"),
+		RelationsDir: filepath.Join(root, "relations"),
+		CacheDir:     filepath.Join(root, ".rela"),
+	}
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"policy": {Plural: "policies"},
+		},
+	}
+	// The directories must exist before the watcher starts — including
+	// the per-type leaf: the watcher adds new subdirectories on their
+	// Create event, and a file written into a directory created a
+	// moment earlier can slip through unobserved. That would make this
+	// test pass because the self-write was never SEEN, not because it
+	// was suppressed.
+	require.NoError(t, os.MkdirAll(filepath.Join(paths.EntitiesDir, "policies"), 0o755))
+	require.NoError(t, os.MkdirAll(paths.RelationsDir, 0o755))
+
+	rec := &recordingObserver{}
+	factory := &app.FSFactory{FS: fs, Paths: paths}
+	factory.AddObserver(rec)
+	s, err := factory.OpenStore(meta)
+	require.NoError(t, err)
+	defer s.Close()
+
+	w, ok := s.(storeWatcher)
+	require.True(t, ok, "fsstore must expose StartWatching/StopWatching")
+	require.NoError(t, w.StartWatching())
+	defer w.StopWatching()
+
+	events, cancel := s.Subscribe(16)
+	defer cancel()
+
+	ctx := context.Background()
+	require.NoError(t, s.CreateEntity(ctx, &entity.Entity{ID: "POL-1", Type: "policy"}))
+
+	// An external edit: bypass SafeFS entirely, as a user or another
+	// process would.
+	external := filepath.Join(paths.EntitiesDir, "policies", "POL-2.md")
+	require.NoError(t, os.WriteFile(external, []byte("---\nid: POL-2\ntype: policy\n---\n"), 0o644))
+
+	var got []store.Event
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev := <-events:
+			got = append(got, ev)
+		case <-deadline:
+			t.Fatalf("timed out waiting for the external create of POL-2; events so far: %+v", got)
+		}
+		if len(got) > 0 && got[len(got)-1].EntityID == "POL-2" {
+			break
+		}
+	}
+
+	want := []store.Event{
+		{Op: store.EventEntityCreated, EntityType: "policy", EntityID: "POL-1"},
+		{Op: store.EventEntityCreated, EntityType: "policy", EntityID: "POL-2"},
+	}
+	assert.Equal(t, want, got,
+		"the store's own write must not be re-delivered by the watcher as an Updated")
+	assert.Equal(t, []string{"POL-1", "POL-2"}, rec.putIDs(),
+		"observers must see each entity exactly once")
 }

--- a/internal/storage/memfs.go
+++ b/internal/storage/memfs.go
@@ -16,16 +16,16 @@ import (
 // It is safe for concurrent use.
 // Primarily intended for testing.
 //
-// MemFS supports an OnPostWrite observer (like SafeFS) so tests that
+// MemFS supports OnPostWrite observers (like SafeFS) so tests that
 // need to exercise the watcher's self-echo LRU can install a hook
 // without building a SafeFS(OsFS) stack. The hook fires synchronously
 // from WriteFile with the bytes that were stored.
 type MemFS struct {
-	mu       sync.RWMutex
-	files    map[string]*memFile  // path → file contents
-	dirs     map[string]time.Time // directory path → mtime
-	cwd      string               // current working directory for Getwd
-	observer WriteObserver
+	mu    sync.RWMutex
+	files map[string]*memFile  // path → file contents
+	dirs  map[string]time.Time // directory path → mtime
+	cwd   string               // current working directory for Getwd
+	hook  postWriteHook
 }
 
 type memFile struct {
@@ -65,33 +65,30 @@ func (m *MemFS) ReadFile(path string) ([]byte, error) {
 	return data, nil
 }
 
-// OnPostWrite installs a write observer. Mirrors SafeFS.OnPostWrite
-// so tests that need self-echo hashing wired into fsstore can install
-// a hook on a MemFS-based store without a SafeFS(OsFS) stack.
-func (m *MemFS) OnPostWrite(obs WriteObserver) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.observer = obs
+// OnPostWrite installs a write observer and returns its remover.
+// Mirrors SafeFS.OnPostWrite so tests that need self-echo hashing
+// wired into fsstore can install a hook on a MemFS-based store
+// without a SafeFS(OsFS) stack.
+func (m *MemFS) OnPostWrite(obs WriteObserver) (remove func()) {
+	return m.hook.add(obs)
 }
 
 // WriteFileExternal writes data without firing the post-write
-// observer. Used by tests to simulate an edit made by another process
+// observers. Used by tests to simulate an edit made by another process
 // (e.g. a user touching a file on disk) — in production such an edit
 // would never flow through SafeFS.WriteFile, so it shouldn't register
-// with the observer either.
+// with the observers either.
 func (m *MemFS) WriteFileExternal(path string, data []byte, perm os.FileMode) error {
-	m.mu.Lock()
-	obs := m.observer
-	m.observer = nil
-	m.mu.Unlock()
-	err := m.WriteFile(path, data, perm)
-	m.mu.Lock()
-	m.observer = obs
-	m.mu.Unlock()
-	return err
+	return m.writeFile(path, data, perm, false)
 }
 
 func (m *MemFS) WriteFile(path string, data []byte, perm os.FileMode) error {
+	return m.writeFile(path, data, perm, true)
+}
+
+// writeFile stores data at path; notify selects whether the post-write
+// observers fire (WriteFile) or not (WriteFileExternal).
+func (m *MemFS) writeFile(path string, data []byte, perm os.FileMode, notify bool) error {
 	m.mu.Lock()
 	path = cleanPath(path)
 
@@ -116,10 +113,9 @@ func (m *MemFS) WriteFile(path string, data []byte, perm os.FileMode) error {
 	if !existed {
 		m.touchDir(dir, now)
 	}
-	obs := m.observer
 	m.mu.Unlock()
-	if obs != nil {
-		obs(path, stored)
+	if notify {
+		m.hook.fire(path, stored)
 	}
 	return nil
 }

--- a/internal/storage/memfs_test.go
+++ b/internal/storage/memfs_test.go
@@ -231,7 +231,7 @@ func TestMemFS_OnPostWriteFiresWithOnDiskBytes(t *testing.T) {
 		path string
 		data []byte
 	}
-	m.OnPostWrite(func(p string, d []byte) {
+	remove := m.OnPostWrite(func(p string, d []byte) {
 		cp := make([]byte, len(d))
 		copy(cp, d)
 		calls = append(calls, struct {
@@ -250,13 +250,13 @@ func TestMemFS_OnPostWriteFiresWithOnDiskBytes(t *testing.T) {
 		t.Errorf("observer got %q, want %q", calls[0].data, "observed")
 	}
 
-	// Replace with nil clears the observer.
-	m.OnPostWrite(nil)
+	// The returned remover uninstalls the observer.
+	remove()
 	if err := m.WriteFile("/obs2.txt", []byte("ignored"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if len(calls) != 1 {
-		t.Errorf("cleared observer fired: calls = %d", len(calls))
+		t.Errorf("removed observer fired: calls = %d", len(calls))
 	}
 }
 

--- a/internal/storage/postwrite.go
+++ b/internal/storage/postwrite.go
@@ -1,0 +1,64 @@
+package storage
+
+import "sync"
+
+// WriteObserver is invoked after a successful durable WriteFile,
+// with the exact bytes that landed on disk after the atomic rename.
+// See SafeFS.OnPostWrite.
+type WriteObserver func(path string, data []byte)
+
+// postWriteHook is the observer registry shared by SafeFS and MemFS.
+// Any number of observers may be installed; each fires once per
+// successful write, in installation order, and is removed only
+// through the handle its installation returned. A registry rather
+// than a single slot because two stores may legitimately share one FS
+// (rela-desktop project switches, a future multi-project host over the
+// fs build); with one slot the second store's install silently evicted
+// the first's self-echo recorder (BUG-S24X52).
+type postWriteHook struct {
+	mu   sync.RWMutex
+	next int
+	obs  []postWriteEntry
+}
+
+type postWriteEntry struct {
+	id int
+	fn WriteObserver
+}
+
+// add installs fn and returns its removal function. A nil fn is a
+// no-op whose removal does nothing. Removal is idempotent.
+func (h *postWriteHook) add(fn WriteObserver) (remove func()) {
+	if fn == nil {
+		return func() {}
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	id := h.next
+	h.next++
+	h.obs = append(h.obs, postWriteEntry{id: id, fn: fn})
+	return func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		for i, e := range h.obs {
+			if e.id == id {
+				h.obs = append(h.obs[:i:i], h.obs[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// fire invokes every installed observer with (path, data), outside
+// the registry lock so an observer may install or remove observers.
+func (h *postWriteHook) fire(path string, data []byte) {
+	h.mu.RLock()
+	snapshot := make([]WriteObserver, 0, len(h.obs))
+	for _, e := range h.obs {
+		snapshot = append(snapshot, e.fn)
+	}
+	h.mu.RUnlock()
+	for _, fn := range snapshot {
+		fn(path, data)
+	}
+}

--- a/internal/storage/safefs.go
+++ b/internal/storage/safefs.go
@@ -3,13 +3,7 @@ package storage
 import (
 	"os"
 	"path/filepath"
-	"sync"
 )
-
-// WriteObserver is invoked after a successful durable WriteFile,
-// with the exact bytes that landed on disk after the atomic rename.
-// See SafeFS.OnPostWrite.
-type WriteObserver func(path string, data []byte)
 
 // SafeFS wraps an FS and overrides WriteFile with atomic write semantics.
 // It writes to a temporary file, fsyncs it, then renames over the target path.
@@ -21,17 +15,16 @@ type WriteObserver func(path string, data []byte)
 //
 // # Post-write observation
 //
-// SafeFS exposes a single observer hook via OnPostWrite. The hook
-// fires exactly once per successful durable write, with the bytes
-// that sit on disk after the atomic rename. Failed writes (the temp
-// file was created but the rename failed) do NOT fire the hook.
+// SafeFS exposes an observer hook via OnPostWrite. Each installed
+// observer fires exactly once per successful durable write, with the
+// bytes that sit on disk after the atomic rename. Failed writes (the
+// temp file was created but the rename failed) do NOT fire the hook.
 // The fsstore watcher uses this hook to hash self-writes so it can
 // skip its own fsnotify echoes.
 type SafeFS struct {
 	FS
 
-	mu       sync.RWMutex
-	observer WriteObserver
+	hook postWriteHook
 }
 
 // NewSafeFS creates a SafeFS that wraps the given filesystem.
@@ -39,13 +32,12 @@ func NewSafeFS(fs FS) *SafeFS {
 	return &SafeFS{FS: fs}
 }
 
-// OnPostWrite installs obs as the post-write observer. Only one
-// observer is supported; a second call replaces the first. Passing
-// nil clears the observer.
-func (s *SafeFS) OnPostWrite(obs WriteObserver) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.observer = obs
+// OnPostWrite installs obs as a post-write observer and returns the
+// function that uninstalls exactly that observer. Any number of
+// observers may be installed; they fire in installation order. A nil
+// obs installs nothing and returns a no-op remover.
+func (s *SafeFS) OnPostWrite(obs WriteObserver) (remove func()) {
+	return s.hook.add(obs)
 }
 
 // WriteFile writes data to path atomically:
@@ -53,7 +45,7 @@ func (s *SafeFS) OnPostWrite(obs WriteObserver) {
 //  2. Fsyncs the temp file
 //  3. Renames temp file to final path (atomic on POSIX)
 //  4. Fsyncs the parent directory
-//  5. Fires the post-write observer with (path, data)
+//  5. Fires the post-write observers with (path, data)
 //
 // Steps 1-4 are performed even when no observer is installed. Step 5
 // is skipped if the rename fails — a failed write leaves no durable
@@ -101,13 +93,8 @@ func (s *SafeFS) WriteFile(path string, data []byte, perm os.FileMode) error {
 	// Fsync parent directory to persist the rename
 	syncDir(dir)
 
-	// Notify observer. Only fires on successful durable write.
-	s.mu.RLock()
-	obs := s.observer
-	s.mu.RUnlock()
-	if obs != nil {
-		obs(path, data)
-	}
+	// Notify observers. Only fires on successful durable write.
+	s.hook.fire(path, data)
 
 	return nil
 }

--- a/internal/storage/safefs_test.go
+++ b/internal/storage/safefs_test.go
@@ -228,31 +228,42 @@ func TestSafeFS_OnPostWrite_NoObserverIsFineByDefault(t *testing.T) {
 	}
 }
 
-func TestSafeFS_OnPostWrite_ReplacesPreviousObserver(t *testing.T) {
+func TestSafeFS_OnPostWrite_FanOutAndRemove(t *testing.T) {
 	dir := t.TempDir()
 	sfs := NewSafeFS(NewOsFS())
 
 	var aCalls, bCalls int
-	sfs.OnPostWrite(func(_ string, _ []byte) { aCalls++ })
+	removeA := sfs.OnPostWrite(func(_ string, _ []byte) { aCalls++ })
 	sfs.OnPostWrite(func(_ string, _ []byte) { bCalls++ })
 
-	path := filepath.Join(dir, "replaced.txt")
+	path := filepath.Join(dir, "fanout.txt")
 	if err := sfs.WriteFile(path, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if aCalls != 0 {
-		t.Errorf("replaced observer still fired: aCalls = %d", aCalls)
-	}
-	if bCalls != 1 {
-		t.Errorf("current observer fired %d times, want 1", bCalls)
+	if aCalls != 1 || bCalls != 1 {
+		t.Errorf("both observers must fire once: a=%d b=%d", aCalls, bCalls)
 	}
 
-	// nil clears the observer.
-	sfs.OnPostWrite(nil)
+	// Removing one observer leaves the other installed; a second
+	// removal is a harmless no-op.
+	removeA()
+	removeA()
 	if err := sfs.WriteFile(path, []byte("y"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if bCalls != 1 {
-		t.Errorf("cleared observer still fired: bCalls = %d", bCalls)
+	if aCalls != 1 {
+		t.Errorf("removed observer still fired: aCalls = %d", aCalls)
+	}
+	if bCalls != 2 {
+		t.Errorf("remaining observer fired %d times, want 2", bCalls)
+	}
+
+	// nil installs nothing and its remover does nothing.
+	sfs.OnPostWrite(nil)()
+	if err := sfs.WriteFile(path, []byte("z"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if bCalls != 3 {
+		t.Errorf("nil install disturbed the registry: bCalls = %d", bCalls)
 	}
 }

--- a/internal/store/fsstore/fsstore.go
+++ b/internal/store/fsstore/fsstore.go
@@ -44,7 +44,16 @@ const recentHashCapacity = 4096
 // Rooted is the primary write/read surface — every data I/O flows
 // through it, so path validation sits in one auditable place.
 // FS remains for raw operations that legitimately need absolute
-// paths (watcher self-echo reads from fsnotify events).
+// paths (watcher self-echo reads from fsnotify events). It is expected
+// to be the bottom-most FS — the one whose WriteFile puts bytes on disk
+// (SafeFS in production, MemFS in tests) — because [New] installs the
+// store's self-echo recorder on it through the postWriteObservable
+// capability. Not enforced by the type system (a decorator that swallows
+// OnPostWrite would look identical); the runtime consequence of an FS
+// without the capability is that the store still opens (the CLI never
+// watches) but [FSStore.StartWatching] returns
+// [ErrWatchNeedsObservableFS] rather than deliver every self-write back
+// as an external edit (BUG-S24X52).
 //
 // EntitiesKey/RelationsKey/AttachmentsKey/CacheKey are root-relative
 // forward-slash keys (e.g. "entities", ".rela"), not absolute paths.
@@ -156,8 +165,12 @@ type attachMeta struct {
 // key-resolution and markdown-codec groups off FSStore, so the
 // content-states surface above sits on a smaller base.
 //
+// (92 → 92 / 36 → 35, BUG-S24X52: exported RecordWrite deleted — New
+// installs the unexported recordSelfWrite on the FS directly, so no
+// external caller needs an entry point.)
+//
 //plimsoll:max-methods=92
-//plimsoll:max-exported-methods=36
+//plimsoll:max-exported-methods=35
 type FSStore struct {
 	// rooted is the validated-key I/O surface. Every read, write,
 	// directory op, and remove that operates on files under the
@@ -214,21 +227,33 @@ type FSStore struct {
 	// echoes tracks the hash of bytes most recently written by
 	// this store so the external-change watcher can distinguish
 	// its own writes (self-echoes) from genuine external edits.
-	// Fed by SafeFS.OnPostWrite with the bytes that landed on disk.
+	// Fed by the FS's post-write observer (installed in New) with
+	// the bytes that landed on disk.
 	echoes *echoTracker
+	// echoWiringErr is nil when New installed the self-echo recorder
+	// on the FS, else the error StartWatching returns: a watcher
+	// without echo suppression is a bug, not a degraded mode
+	// (BUG-S24X52). Immutable after New — read without mu.
+	echoWiringErr error
+	// unwireEchoes uninstalls the recorder; Close calls it so a
+	// closed store stops feeding its LRU from a shared FS.
+	// Nil: accepted — set only when wiring succeeded.
+	unwireEchoes func()
+}
+
+// postWriteObservable is the capability fsstore needs from its FS to
+// learn the bytes that actually landed on disk: SafeFS in production,
+// MemFS in tests. Declared here, at the consumer, and discovered by
+// type assertion in [New] so the wiring lives with the type that owns
+// the echo tracker — the previous home (app.FSFactory) lost it in a
+// refactor and nothing noticed (BUG-S24X52). The returned remover is
+// what lets Close uninstall exactly this store's recorder.
+type postWriteObservable interface {
+	OnPostWrite(storage.WriteObserver) (remove func())
 }
 
 // compile-time interface check
 var _ store.Store = (*FSStore)(nil)
-
-// RecordWrite is the post-write observer entry point. Typically
-// wired via SafeFS.OnPostWrite(store.RecordWrite). The watcher
-// uses the recorded hash to suppress self-echoes.
-//
-// Signature matches storage.WriteObserver.
-func (s *FSStore) RecordWrite(path string, content []byte) {
-	s.echoes.Recorded(path, content)
-}
 
 // New creates a new filesystem-backed store. It scans the entities and
 // relations directories to build the in-memory index, and loads or rebuilds
@@ -286,7 +311,33 @@ func New(cfg Config) (*FSStore, error) {
 	}
 	s.loadAttachmentsIndex()
 
+	// Self-echo recording is installed here, not by the caller: the
+	// watcher's correctness depends on it, and a construction site
+	// that forgets is indistinguishable from one that works until the
+	// watcher runs. Installed LAST so a failed open leaves nothing on
+	// the caller's FS. An FS without the capability is tolerated at
+	// open (CLI paths never watch) and refused at StartWatching.
+	if obs, ok := cfg.FS.(postWriteObservable); ok {
+		s.unwireEchoes = obs.OnPostWrite(s.recordSelfWrite)
+	} else {
+		s.echoWiringErr = ErrWatchNeedsObservableFS
+	}
+
 	return s, nil
+}
+
+// recordSelfWrite is the post-write observer New installs. It records
+// only writes under this store's own entities/relations directories:
+// the FS may be shared by several stores (rela-desktop project
+// switches, a multi-project host), and a hash recorded for another
+// store's file would be a wasted LRU slot at best and, for two stores
+// over ONE root, would suppress the other store's genuine write as an
+// echo. Two live stores over one root is unsupported regardless —
+// their indexes diverge — but the recorder must not make it quieter.
+func (s *FSStore) recordSelfWrite(path string, data []byte) {
+	if s.isEntityPath(path) || s.isRelationPath(path) {
+		s.echoes.Recorded(path, data)
+	}
 }
 
 // loadAttachmentsIndex walks the attachments directory and populates

--- a/internal/store/fsstore/watcher.go
+++ b/internal/store/fsstore/watcher.go
@@ -47,9 +47,14 @@ func (s *FSStore) emit(ev store.Event) {
 	}
 }
 
-// Close shuts down the store, persists the index, and closes all subscriber channels.
+// Close shuts down the store, persists the index, closes all subscriber
+// channels, and uninstalls the self-echo recorder from the FS so a
+// store that outlives this one on the same FS is the only one fed.
 func (s *FSStore) Close() error {
 	s.StopWatching()
+	if s.unwireEchoes != nil {
+		s.unwireEchoes()
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -65,15 +70,29 @@ func (s *FSStore) Close() error {
 
 // --- external-change watcher ---
 
+// ErrWatchNeedsObservableFS is returned by StartWatching when the
+// store's FS offered no post-write observer at New (see Config.FS).
+// Without one the watcher cannot tell its own writes from external
+// edits and would re-deliver every store write as an Updated event,
+// so it refuses to start rather than run degraded (BUG-S24X52).
+var ErrWatchNeedsObservableFS = errors.New(
+	"fsstore: StartWatching requires an FS with a post-write observer (SafeFS or MemFS); " +
+		"wrap the FS with storage.NewSafeFS at the entry point")
+
 // StartWatching begins watching the entities and relations directories for
 // external file changes (edits made outside the store API). Detected
 // changes are reconciled into the in-memory index and re-emitted as
-// store.Events. Self-writes are suppressed via the echoTracker.
+// store.Events. Self-writes are suppressed via the echoTracker, which
+// New feeds from the FS's post-write observer; an FS without one makes
+// this return [ErrWatchNeedsObservableFS].
 //
 // Calling StartWatching more than once is a no-op after the first call.
 //
 // coverage-ignore-func: requires real filesystem events via fsnotify
 func (s *FSStore) StartWatching() error {
+	if s.echoWiringErr != nil {
+		return s.echoWiringErr
+	}
 	s.mu.Lock()
 	if s.extWatcher != nil {
 		s.mu.Unlock()

--- a/internal/store/fsstore/watcher_internal_test.go
+++ b/internal/store/fsstore/watcher_internal_test.go
@@ -29,10 +29,9 @@ func newTestStore(t *testing.T) (*FSStore, *storage.MemFS) {
 		},
 	})
 	require.NoError(t, err)
-	// Mirror production wiring: subscribe the store's RecordWrite to
-	// the filesystem's post-write hook so the watcher's self-echo
-	// LRU sees the bytes that actually landed.
-	fs.OnPostWrite(s.RecordWrite)
+	// New installs the self-echo recorder on the MemFS itself
+	// (BUG-S24X52) — no manual OnPostWrite here, so these tests
+	// exercise the same wiring production gets.
 	return s, fs
 }
 
@@ -239,4 +238,98 @@ func TestHasPathPrefix(t *testing.T) {
 		assert.Equalf(t, c.want, hasPathPrefix(c.path, c.dir),
 			"hasPathPrefix(%q, %q)", c.path, c.dir)
 	}
+}
+
+// TestNewInstallsSelfEchoRecorder pins that New itself wires the
+// echo tracker to the FS's post-write observer (BUG-S24X52): a write
+// made through the store, replayed to the reconciler as if fsnotify
+// had reported it, is recognized as a self-echo and produces no
+// second event. newTestStore deliberately does NOT call OnPostWrite.
+func TestNewInstallsSelfEchoRecorder(t *testing.T) {
+	s, fs := newTestStore(t)
+	ch, cancel := s.Subscribe(16)
+	defer cancel()
+
+	require.NoError(t, s.CreateEntity(context.Background(), &entity.Entity{
+		ID: "REQ-1", Type: "requirement",
+		Properties: map[string]any{"title": "one"},
+	}))
+	require.Len(t, drainEvents(ch), 1, "the store's own Created event")
+
+	path := "/entities/requirements/REQ-1.md"
+	_, err := fs.ReadFile(path)
+	require.NoError(t, err, "the write must have landed on the FS")
+
+	s.handleExternalEvents([]storage.ChangeEvent{{Path: path, Op: storage.OpModify}})
+	assert.Empty(t, drainEvents(ch), "a self-write replayed by the watcher must be suppressed")
+	require.NoError(t, s.echoWiringErr)
+}
+
+// TestTwoStoresOnOneFSKeepTheirOwnEchoes pins the fan-out contract
+// (BUG-S24X52 review C1): opening a second store on the same FS must
+// not evict the first store's recorder, and each store records only
+// writes under its own root.
+func TestTwoStoresOnOneFSKeepTheirOwnEchoes(t *testing.T) {
+	fs := storage.NewMemFS()
+	open := func(root string) *FSStore {
+		t.Helper()
+		require.NoError(t, fs.MkdirAll(root, 0o755))
+		rooted, err := storage.NewRootedFS(fs, root)
+		require.NoError(t, err)
+		s, err := New(Config{
+			FS: fs, Rooted: rooted,
+			EntitiesKey: "entities", RelationsKey: "relations", CacheKey: ".rela",
+			Schemas: map[string]store.EntityTypeSchema{"requirement": {Plural: "requirements"}},
+		})
+		require.NoError(t, err)
+		return s
+	}
+	s1 := open("/a")
+	s2 := open("/b")
+	defer s2.Close()
+
+	ch1, cancel1 := s1.Subscribe(16)
+	defer cancel1()
+	require.NoError(t, s1.CreateEntity(context.Background(), &entity.Entity{ID: "REQ-1", Type: "requirement"}))
+	require.Len(t, drainEvents(ch1), 1)
+
+	p1 := "/a/entities/requirements/REQ-1.md"
+	data, err := fs.ReadFile(p1)
+	require.NoError(t, err)
+	assert.True(t, s1.echoes.IsEcho(p1, data), "s1 must still be recording after s2 opened")
+	assert.False(t, s2.echoes.IsEcho(p1, data), "s2 must not record a write under s1's root")
+
+	s1.handleExternalEvents([]storage.ChangeEvent{{Path: p1, Op: storage.OpModify}})
+	assert.Empty(t, drainEvents(ch1), "s1's own write replayed must be suppressed even with s2 alive")
+
+	// Close uninstalls: a later write at s1's path is no longer recorded.
+	require.NoError(t, s1.Close())
+	require.NoError(t, fs.WriteFile(p1, []byte("---\nid: REQ-1\ntype: requirement\n---\nlater\n"), 0o644))
+	assert.False(t, s1.echoes.IsEcho(p1, []byte("---\nid: REQ-1\ntype: requirement\n---\nlater\n")),
+		"a closed store must not keep recording")
+}
+
+// opaqueFS hides MemFS's OnPostWrite so the store sees an FS that
+// cannot be observed — the shape a bare OsFS has.
+type opaqueFS struct{ storage.FS }
+
+func TestStartWatchingRefusesUnobservableFS(t *testing.T) {
+	fs := opaqueFS{storage.NewMemFS()}
+	rooted, err := storage.NewRootedFS(fs, "/")
+	require.NoError(t, err)
+	s, err := New(Config{
+		FS:           fs,
+		Rooted:       rooted,
+		EntitiesKey:  "entities",
+		RelationsKey: "relations",
+		CacheKey:     ".rela",
+		Schemas: map[string]store.EntityTypeSchema{
+			"requirement": {Plural: "requirements"},
+		},
+	})
+	require.NoError(t, err, "opening without an observable FS is allowed (CLI paths never watch)")
+	require.ErrorIs(t, s.echoWiringErr, ErrWatchNeedsObservableFS)
+
+	err = s.StartWatching()
+	require.ErrorIs(t, err, ErrWatchNeedsObservableFS)
 }

--- a/tickets/entities/automated-measures/AM-fsstore-self-write-single-event-via-factory.md
+++ b/tickets/entities/automated-measures/AM-fsstore-self-write-single-event-via-factory.md
@@ -1,0 +1,9 @@
+---
+id: AM-fsstore-self-write-single-event-via-factory
+type: automated-measure
+title: A write through the production FSFactory path with the watcher running delivers exactly one store event
+description: Constructs the fsstore via app.FSFactory.OpenStore (not a hand-built fsstore.Config), starts the watcher, writes an entity, and asserts one Subscribe event and one observer EntityPut. Fails if the SafeFS.OnPostWrite echo observer is not installed by production wiring.
+kind: test
+location: internal/app/factory_test.go TestFSFactoryWatcherSuppressesSelfEcho; internal/store/fsstore/watcher_internal_test.go TestNewInstallsSelfEchoRecorder, TestStartWatchingRefusesUnobservableFS
+status: active
+---

--- a/tickets/entities/bug-analysis-checklists/BUGA-QFW7S6.md
+++ b/tickets/entities/bug-analysis-checklists/BUGA-QFW7S6.md
@@ -1,0 +1,26 @@
+---
+id: BUGA-QFW7S6
+type: bug-analysis-checklist
+title: 'Analysis: fsstore self-echo suppression is dead in production: SafeFS.OnPostWrite(RecordWrite) wiring was dropped with the encryption removal (#508)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Reproduction
+
+- [x] Bug reproduced locally — `TestFSFactoryWatcherSuppressesSelfEcho` (internal/app/factory_test.go) fails on develop: observer sees POL-1 twice and a spurious `EventEntityUpdated` for POL-1 precedes the external create.
+- [x] Minimal reproduction steps documented — open via `app.FSFactory` over `SafeFS(OsFS)`, `StartWatching`, `CreateEntity`, observe events.
+- [x] Environment/conditions noted — any process that starts the fsstore watcher (rela-server data-entry, MCP); CLI paths are unaffected because they never watch.
+
+## Root Cause
+
+- [x] Immediate cause identified (why1) — no production caller of `OnPostWrite(RecordWrite)`.
+- [x] Contributing factors found (why2-3) — PR #508 deleted the wiring with the encryption block it was framed as part of; the only test performed the wiring itself.
+- [x] Systemic cause explored (why4-5) — the wiring lived in a different package from the type whose correctness depended on it, and the review that noticed (RR-IL1WV) deferred it as pre-existing with no ticket.
+
+## Fix Planning
+
+- [x] Fix approach determined — install `echoes.Recorded` inside `fsstore.New` via a consumer-side `postWriteObservable` capability (SafeFS and MemFS both satisfy it); delete `RecordWrite`; `StartWatching` returns `ErrWatchNeedsObservableFS` when the FS could not be observed, so the degraded mode is unreachable.
+- [x] Regression test planned — production-path test in `internal/app` (real fsnotify, positive wait on an external write) plus two fsstore-internal pins (New wires echo; StartWatching refuses an opaque FS).
+- [x] Related areas checked for similar issues — every production `fsstore.New` goes through `app.FSFactory`; all production FS handles are `SafeFS` (appbuild.go:1178/1199, rela-desktop main.go:856). `cli/acl_test.go` uses a bare OsFS via appbuildtest but never starts the watcher.

--- a/tickets/entities/bugs/BUG-S24X52.md
+++ b/tickets/entities/bugs/BUG-S24X52.md
@@ -1,0 +1,67 @@
+---
+id: BUG-S24X52
+type: bug
+title: 'fsstore self-echo suppression is dead in production: SafeFS.OnPostWrite(RecordWrite) wiring was dropped with the encryption removal (#508)'
+description: 'FSFactory.OpenStore never installs SafeFS.OnPostWrite(store.RecordWrite), so the fsstore watcher treats every self-write as an external edit: extra parse, re-index, duplicate observer notify and a second EventEntityUpdated on Subscribe. Regression from PR #508 (encryption removal) which deleted the wiring block.'
+priority: medium
+effort: s
+why1: app/factory.go:66 constructs the FSStore but never calls safeFS.OnPostWrite(s.RecordWrite); the only caller of OnPostWrite with RecordWrite is watcher_internal_test.go:35, whose comment claims to 'mirror production wiring'.
+why2: Commit ea99547e (#508, remove in-process at-rest encryption) deleted the SafeFS type-assert block in FSFactory.OpenStore (old lines 142-188) that installed the observer, because the block was framed as an ENCRYPTION requirement (ErrEncryptedRepoNeedsSafeFS) rather than a watcher requirement.
+why3: The echo LRU's correctness was only asserted by a test that performs the wiring itself, so no test exercised the production construction path with a running watcher; a review finding (RR-IL1WV, TKT-3TA1H era) had already deferred this exact gap as pre-existing.
+why4: The observer wiring lived in app.FSFactory, a different package from fsstore, whose watcher correctness depended on it; a cross-package invariant with no test on the production construction path is exactly what a refactor deletes without noticing.
+why5: Review findings deferred as 'pre-existing' (RR-IL1WV) had no ticket to land in, so the known gap fell out of the tracker and re-surfaced only during an unrelated survey months later.
+prevention: 'Wiring moved INTO fsstore.New (consumer-side postWriteObservable capability) so no construction site can forget it; StartWatching fails closed with ErrWatchNeedsObservableFS instead of running degraded; TestFSFactoryWatcherSuppressesSelfEcho exercises the production path with a real watcher (AM-fsstore-self-write-single-event-via-factory). Process: a ''pre-existing, deferred'' review finding must get its own bug ticket, not a deferral note.'
+status: done
+---
+
+Found while surveying `fsstore.FSStore` for [[TKT-N0IKN9]]. Verified against
+develop (e0187047) and the git history.
+
+## Symptom
+
+In `rela-server` / MCP (anywhere `StartWatching` runs —
+`internal/dataentry/watcher.go:26`, `internal/cli/mcp_wiring.go:101`), every
+fsstore self-write is seen by the fsnotify watcher as an EXTERNAL edit:
+`reconcileEntityPath` (`internal/store/fsstore/watcher.go:179`) reads the file
+back, `echoes.IsEcho` misses (nothing was ever `Recorded`), the entity is
+re-parsed, re-indexed, `notifyPut` re-fires to observers (search re-index), and
+a second `EventEntityUpdated` is emitted on the subscription — after the write
+path already emitted `EventEntityCreated`/`Updated` under `mu`. Net: one extra
+parse + index + observer pass + SSE event per write, and the create→update
+double-fire is observable by SSE clients.
+
+## Evidence
+
+- `grep -rn "OnPostWrite(" --include='*.go' . | grep -v _test.go` — zero
+callers. `RecordWrite` (`fsstore.go:229`) has no production caller.
+- `git show ea99547e -- internal/app/factory.go` removes
+`safe.OnPostWrite(s.RecordWrite)` (old line 188) along with
+`ErrEncryptedRepoNeedsSafeFS`.
+- `internal/appbuild/appbuild.go:1178,1199` construct `SafeFS` without an
+observer.
+- `watcher_internal_test.go:35` wires it manually ("Mirror production wiring").
+
+## Fix (decide deliberately, don't just re-add the line)
+
+Two honest options:
+
+1. **Wire it.** `FSFactory.OpenStore` (`internal/app/factory.go:66`) installs
+`OnPostWrite(s.RecordWrite)` when `f.FS` supports it. Make the capability a
+consumer-side interface (`interface{ OnPostWrite(storage.WriteObserver) }`)
+rather than a `*storage.SafeFS` type assertion — the silent-cast failure mode
+was RR-Z2YI2 last time. `MemFS` supports it too, so tests exercise the same
+path.
+2. **Delete the observer path** and rely on the watcher's own
+`echoes.Recorded` after reconcile, if the double-fire is judged acceptable. Then
+`RecordWrite`, the `echoes` recording in `SafeFS`, and the test go.
+
+Option 1 is the design the code documents (`markdown.go:439`, `echo.go:25`,
+`layout.go:71`). Whichever is chosen, the fsstore decomposition tickets that
+follow must not bake the dead field in.
+
+## Preventive measure
+
+A test that constructs the store THROUGH `FSFactory.OpenStore` (production
+path), starts the watcher, performs a write, and asserts exactly ONE event is
+delivered on `Subscribe` and `notifyPut` fires once. Register it as the
+`adds-measure` automated-measure on this bug.

--- a/tickets/entities/implementation-checklists/IMPL-RUUZ6S.md
+++ b/tickets/entities/implementation-checklists/IMPL-RUUZ6S.md
@@ -1,0 +1,43 @@
+---
+id: IMPL-RUUZ6S
+type: implementation-checklist
+title: 'Implementation: fsstore self-echo suppression is dead in production: SafeFS.OnPostWrite(RecordWrite) wiring was dropped with the encryption removal (#508)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code — `TestNewInstallsSelfEchoRecorder`, `TestStartWatchingRefusesUnobservableFS` (fsstore internal).
+- [x] Integration tests written (test full flow, not just units) — `TestFSFactoryWatcherSuppressesSelfEcho` (internal/app): real directory, `SafeFS(OsFS)`, real fsnotify watcher, one store write + one external write, asserts the exact event and observer sequence.
+- [x] Happy path implemented — `fsstore.New` installs `echoes.Recorded` on any FS satisfying the consumer-side `postWriteObservable`; `RecordWrite` deleted (FSStore 92→91 / 36→35).
+- [x] Edge cases from planning handled — FS without the capability: open succeeds (CLI never watches), `StartWatching` returns `ErrWatchNeedsObservableFS`.
+- [x] Error handling in place (errors surfaced, not swallowed) — the degraded mode is now an error at the seam whose guarantee it breaks, never a silent no-op.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data — `newTestStore`, `recordingObserver`, the existing factory fixtures.
+- [x] No hardcoded values in assertions when object is in scope — expected events built from the same ids/types as the writes.
+- [x] Only specifying values that matter for the test.
+- [x] Interpolated values constructed from objects, not hardcoded — paths via `paths.EntitiesDir`.
+- [x] Property comparisons use original object, not hardcoded strings.
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end — the integration test IS the production path (FSFactory → SafeFS → fsnotify); it failed on develop with `putIDs == [POL-1, POL-1, POL-2]` and a spurious `EventEntityUpdated`, and passes after the fix.
+- [x] Each acceptance criterion verified with test scenario from planning — one Subscribe event and one `EntityPut` per write: pinned.
+- [x] Edge cases manually verified — opaque FS refused at `StartWatching`: pinned.
+
+**Verification Evidence:** `go test -race -count=1` green on
+internal/store/fsstore, internal/app, internal/cli, internal/dataentry,
+internal/appbuild, internal/mcp, internal/attachment, internal/analysis,
+internal/store/storetest. `just ci` run recorded on the review checklist.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code) — consumer-side capability interface discovered by type assertion, like `store.Formatter` / `VersionServiceProvider`; sentinel error like `store.ErrNotFound`.
+- [x] Checked for DRY opportunities — `echoes.Recorded` already had the `storage.WriteObserver` signature, so `RecordWrite` was pure indirection and is gone.
+- [x] No security issues introduced — no new I/O paths; the observer receives bytes the store just wrote.
+- [x] No silent failures (errors logged AND returned) — `ErrWatchNeedsObservableFS` is returned; callers (`dataentry`, `mcp` wiring) already propagate `StartWatching` errors.
+- [x] No debug code left behind.

--- a/tickets/entities/review-checklists/REV-4DX4B9.md
+++ b/tickets/entities/review-checklists/REV-4DX4B9.md
@@ -1,0 +1,68 @@
+---
+id: REV-4DX4B9
+type: review-checklist
+title: 'Review: fsstore self-echo suppression is dead in production: SafeFS.OnPostWrite(RecordWrite) wiring was dropped with the encryption removal (#508)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`) — via `just ci`, 200 packages ok, race detector on.
+- [x] Lint clean (`just lint`) — golangci-lint 0 issues (two rounds fixed a misspelling and a testifylint require-error).
+- [x] Comment lint gate clean (`just comment-lint`) — no unresolvable doc links; one `[postWriteObservable]` bracket dropped because Go cannot link an unexported type.
+- [x] Coverage maintained (`just coverage-check`) — part of `just ci`, green.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent) — cranky-code-reviewer + rela-security-reviewer in parallel. Security: no findings (event path, echo LRU, git-crypt, fail-closed error all assessed; the single-slot hazard it flagged is the same as cranky C1).
+- [x] All critical review-responses addressed — none raised.
+- [x] All significant review-responses addressed — RR-AMRKMT (single observer slot → fan-out registry with remover, root-scoped recorder), RR-JYG7CA (fsnotify test pre-creates the leaf dir; verified failing on develop 3/3 in a throwaway worktree, passing 10/10 with -race on the branch).
+- [x] Self-reviewed the diff for unrelated changes — code diff is 8 files under internal/storage, internal/store/fsstore, internal/app. The plimsoll-plan ticket files from the earlier session are NOT part of this PR's commit.
+
+**Review Responses:** RR-AMRKMT, RR-JYG7CA (significant, addressed); RR-IMZGM5,
+RR-L3682D (minor, addressed); RR-9MLJMO (nit, addressed); RR-0FNW41 (nit,
+deferred — storetest hoist belongs to the fsstore arc).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist) — see below.
+- [x] Test evidence documented in implementation checklist — IMPL-RUUZ6S.
+
+**Acceptance Status:**
+- One Subscribe event and one observer EntityPut per store write with the watcher running, through the production FSFactory path: PASS (`TestFSFactoryWatcherSuppressesSelfEcho`; fails on develop with `[POL-1, POL-1, POL-2]`).
+- Wiring cannot be forgotten by a construction site: PASS (`fsstore.New` installs it; `TestNewInstallsSelfEchoRecorder` uses no manual OnPostWrite).
+- An FS without the capability fails closed at StartWatching, not silently: PASS (`TestStartWatchingRefusesUnobservableFS`).
+- A second store on the same FS does not evict the first's recorder, and Close uninstalls: PASS (`TestTwoStoresOnOneFSKeepTheirOwnEchoes`, `TestSafeFS_OnPostWrite_FanOutAndRemove`).
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix, no user-facing behaviour change)
+- [x] ~~User-facing documentation updated~~ (N/A: bug fix)
+- [x] ~~Docs-checklist marked as done~~ (N/A: bug fix)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-0FNW41.md
+++ b/tickets/entities/review-responses/RR-0FNW41.md
@@ -1,0 +1,9 @@
+---
+id: RR-0FNW41
+type: review-response
+title: Hoist the one-event-per-write contract into the storetest conformance harness and add a package-level guard
+finding: The 'a write through the store produces exactly one event' contract is backend-agnostic but is pinned only in internal/app, where a store author will not look; and the class 'capability that must be installed exactly once per FS' has no package-wide guard.
+severity: nit
+reason: Out of scope for the bug fix. With fan-out observers the install-exactly-once class no longer exists (nothing evicts). The conformance-harness hoist is a good follow-up for the fsstore arc (TKT-9XDEY0 onward) where storetest is already being exercised.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-9MLJMO.md
+++ b/tickets/entities/review-responses/RR-9MLJMO.md
@@ -1,0 +1,9 @@
+---
+id: RR-9MLJMO
+type: review-response
+title: echoesWired bool read outside mu and carried no reason; Config.FS doc overstated an unenforced guarantee
+finding: The boolean was read before mu.Lock in StartWatching (safe today by constructor happens-before, undocumented), the error message could mislead once eviction was the cause, and the Config.FS comment read 'must be the BOTTOM-MOST FS' as if enforced.
+severity: nit
+resolution: Replaced with echoWiringErr error (documented immutable after New, carrying the specific failure StartWatching returns); Config.FS doc now states the expectation, that it is not type-enforced, and the runtime consequence (ErrWatchNeedsObservableFS).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AMRKMT.md
+++ b/tickets/entities/review-responses/RR-AMRKMT.md
@@ -1,0 +1,9 @@
+---
+id: RR-AMRKMT
+type: review-response
+title: 'Single SafeFS observer slot: a second store on the same FS evicted the first''s recorder while echoesWired stayed true'
+finding: SafeFS.OnPostWrite replaced the previous observer, so fsstore.New on a second store over one FS silently unsubscribed the first store's echo tracker; the first store's echoesWired flag still reported success and StartWatching ran a watcher with dead echo suppression — the exact BUG-S24X52 symptom, reconstituted. Reproduced by the reviewer with a two-store probe (duplicate EventEntityUpdated). Production is safe only by call-site accident (one OpenStore per factory; desktop mints a fresh SafeFS per project).
+severity: significant
+resolution: 'The post-write hook is now a fan-out registry shared by SafeFS and MemFS (internal/storage/postwrite.go): OnPostWrite appends and returns a remover, nothing evicts. fsstore installs an unexported recordSelfWrite scoped to its own entities/relations dirs, so stores over different roots on one FS record only their own writes. Pinned by TestTwoStoresOnOneFSKeepTheirOwnEchoes and TestSafeFS_OnPostWrite_FanOutAndRemove.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IMZGM5.md
+++ b/tickets/entities/review-responses/RR-IMZGM5.md
@@ -1,0 +1,9 @@
+---
+id: RR-IMZGM5
+type: review-response
+title: Close never uninstalled the observer; a closed store kept hashing into a dead LRU
+finding: New installed echoes.Recorded on the FS and nothing removed it, so after Close the FS held a strong reference to the closed store's 4096-entry LRU for the SafeFS's lifetime, and a sequentially reused FS fed the wrong tracker.
+severity: minor
+resolution: OnPostWrite returns a remover; fsstore keeps it as unwireEchoes and Close calls it. Pinned in TestTwoStoresOnOneFSKeepTheirOwnEchoes (a write after Close is not recorded).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JYG7CA.md
+++ b/tickets/entities/review-responses/RR-JYG7CA.md
@@ -1,0 +1,9 @@
+---
+id: RR-JYG7CA
+type: review-response
+title: Real-fsnotify regression test could pass because the self-write was never observed, not because it was suppressed
+finding: TestFSFactoryWatcherSuppressesSelfEcho only pre-created entities/ and relations/. SafeFS.WriteFile MkdirAll's entities/policies/ during the first write, and the watcher registers a new subdirectory only on its Create event, so POL-1's own file event could slip through unwatched — a green result for the wrong reason that would stay green after a regression.
+severity: significant
+resolution: 'The test pre-creates the entities/policies leaf so the self-write is genuinely observed by fsnotify and then suppressed. Verified: with the leaf pre-created the test fails on develop''s code (duplicate EntityPut and spurious Updated) and passes 10/10 with -race on the fix.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-L3682D.md
+++ b/tickets/entities/review-responses/RR-L3682D.md
@@ -1,0 +1,9 @@
+---
+id: RR-L3682D
+type: review-response
+title: Observer was installed before syncIndex, so a failed New left it on the caller's FS
+finding: New installed the observer, then syncIndex could return an error; the caller got (nil, err) with no handle to undo the install, and a retry on the same FS landed in the eviction scenario.
+severity: minor
+resolution: Installation moved to the last step of New, after syncIndex and loadAttachmentsIndex succeed.
+status: addressed
+---

--- a/tickets/relations/AM-fsstore-self-write-single-event-via-factory--protects--store-backends.md
+++ b/tickets/relations/AM-fsstore-self-write-single-event-via-factory--protects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: AM-fsstore-self-write-single-event-via-factory
+relation: protects
+to: store-backends
+---

--- a/tickets/relations/BUG-S24X52--adds-measure--AM-fsstore-self-write-single-event-via-factory.md
+++ b/tickets/relations/BUG-S24X52--adds-measure--AM-fsstore-self-write-single-event-via-factory.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: adds-measure
+to: AM-fsstore-self-write-single-event-via-factory
+---

--- a/tickets/relations/BUG-S24X52--affects--store-backends.md
+++ b/tickets/relations/BUG-S24X52--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-S24X52--fixes--FEAT-025.md
+++ b/tickets/relations/BUG-S24X52--fixes--FEAT-025.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: fixes
+to: FEAT-025
+---

--- a/tickets/relations/BUG-S24X52--has-bug-analysis--BUGA-QFW7S6.md
+++ b/tickets/relations/BUG-S24X52--has-bug-analysis--BUGA-QFW7S6.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-bug-analysis
+to: BUGA-QFW7S6
+---

--- a/tickets/relations/BUG-S24X52--has-implementation--IMPL-RUUZ6S.md
+++ b/tickets/relations/BUG-S24X52--has-implementation--IMPL-RUUZ6S.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-implementation
+to: IMPL-RUUZ6S
+---

--- a/tickets/relations/BUG-S24X52--has-review--REV-4DX4B9.md
+++ b/tickets/relations/BUG-S24X52--has-review--REV-4DX4B9.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-review
+to: REV-4DX4B9
+---

--- a/tickets/relations/BUG-S24X52--has-review-response--RR-0FNW41.md
+++ b/tickets/relations/BUG-S24X52--has-review-response--RR-0FNW41.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-review-response
+to: RR-0FNW41
+---

--- a/tickets/relations/BUG-S24X52--has-review-response--RR-9MLJMO.md
+++ b/tickets/relations/BUG-S24X52--has-review-response--RR-9MLJMO.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-review-response
+to: RR-9MLJMO
+---

--- a/tickets/relations/BUG-S24X52--has-review-response--RR-AMRKMT.md
+++ b/tickets/relations/BUG-S24X52--has-review-response--RR-AMRKMT.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-review-response
+to: RR-AMRKMT
+---

--- a/tickets/relations/BUG-S24X52--has-review-response--RR-IMZGM5.md
+++ b/tickets/relations/BUG-S24X52--has-review-response--RR-IMZGM5.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-review-response
+to: RR-IMZGM5
+---

--- a/tickets/relations/BUG-S24X52--has-review-response--RR-JYG7CA.md
+++ b/tickets/relations/BUG-S24X52--has-review-response--RR-JYG7CA.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-review-response
+to: RR-JYG7CA
+---

--- a/tickets/relations/BUG-S24X52--has-review-response--RR-L3682D.md
+++ b/tickets/relations/BUG-S24X52--has-review-response--RR-L3682D.md
@@ -1,0 +1,5 @@
+---
+from: BUG-S24X52
+relation: has-review-response
+to: RR-L3682D
+---


### PR DESCRIPTION
Resolves BUG-S24X52.

## Problem

Since PR #508 removed the encryption block from `app.FSFactory.OpenStore`, nothing called `SafeFS.OnPostWrite(store.RecordWrite)`. In every process that starts the fsstore watcher (rela-server data entry, MCP), each store write was seen by fsnotify as an external edit: re-parse, re-index, a duplicate observer `EntityPut` (search re-index), and a second `EventEntityUpdated` on the change feed. Found during the plimsoll survey; a review finding (RR-IL1WV) had deferred the same gap as pre-existing.

## Fix

- `fsstore.New` installs the self-echo recorder itself through a consumer-side `postWriteObservable` capability (SafeFS in production, MemFS in tests), so no construction site can forget it again. The recorder is unexported, scoped to the store's own entities/relations dirs, installed last, and removed on `Close`.
- `StartWatching` fails closed with `ErrWatchNeedsObservableFS` when the FS could not be observed, instead of running degraded.
- `SafeFS`/`MemFS` post-write observers are now a fan-out registry with a removal handle (`internal/storage/postwrite.go`). The old single slot meant a second store on one FS silently evicted the first's recorder (review finding RR-AMRKMT).
- `FSStore.RecordWrite` deleted; plimsoll exported directive 36 → 35.

## Tests

- `TestFSFactoryWatcherSuppressesSelfEcho` (internal/app): production path, real fsnotify, positive wait on an external write. Fails on develop 3/3 with `putIDs == [POL-1, POL-1, POL-2]`; passes 10/10 with `-race` here.
- `TestNewInstallsSelfEchoRecorder`, `TestStartWatchingRefusesUnobservableFS`, `TestTwoStoresOnOneFSKeepTheirOwnEchoes` (fsstore internal).
- `TestSafeFS_OnPostWrite_FanOutAndRemove` and updated MemFS observer tests.

`just ci` green locally (200 packages, race detector, lint, arch-lint, plimsoll, comment-lint, coverage). Reviewed by cranky-code-reviewer and rela-security-reviewer (no security findings); all significant findings addressed, one nit deferred to the fsstore arc.

https://claude.ai/code/session_01AVcDvHP3jVYi58CA9RHi8h
