### PR TITLE
ci: move govulncheck off the PR path, scan daily instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,46 +104,6 @@ jobs:
           name: reachability-report
           path: reachability.out
 
-  vulncheck:
-    name: Vulnerability Check
-    # Only gate PRs that touch Go dependencies. Non-dep PRs get their vuln signal
-    # from the weekly schedule in security.yml, which auto-opens an update PR.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 2
-
-      - name: Detect go.mod / go.sum changes
-        id: detect
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Non-PR event — running vulncheck."
-            exit 0
-          fi
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          if git diff --name-only "$BASE_SHA"...HEAD -- go.mod go.sum | grep -q .; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "go.mod or go.sum changed — running vulncheck."
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No dep changes — skipping (weekly schedule covers this)."
-          fi
-
-      - name: Set up Go
-        if: steps.detect.outputs.changed == 'true'
-        uses: actions/setup-go@v7
-        with:
-          go-version: '1.26.6'
-
-      - name: Run govulncheck
-        if: steps.detect.outputs.changed == 'true'
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          ./scripts/govulncheck-filtered.sh
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -730,7 +690,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [test, vulncheck, lint, arch-lint, plimsoll, lint-markdown, fuzz, postgres, cross-compile, frontend, e2e]
+    needs: [test, lint, arch-lint, plimsoll, lint-markdown, fuzz, postgres, cross-compile, frontend, e2e]
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,9 +1,25 @@
+# Go vulnerability scanning lives HERE, not on the PR path.
+#
+# ci.yml used to carry a `Vulnerability Check` job. It only scanned when a PR
+# changed go.mod/go.sum, but the merge queue runs on `merge_group` rather than
+# `pull_request`, which took the unconditional-scan branch. So an advisory
+# published against an existing dependency would pass on the PR (skipped in
+# ~6s), then fail in the queue and dequeue a change that had nothing to do with
+# dependencies. That is what happened to #1520: two x/crypto/ssh advisories,
+# already latent on develop, blocked a path-validation PR twice.
+#
+# A vulnerability in an already-merged dependency is not a defect in the PR that
+# happens to be in flight, so it should not block it. This workflow scans on a
+# schedule and opens an auto-merging fix PR instead — which is also what
+# actually resolves the vulnerability, rather than just reporting it.
 name: Security Scan
 
 on:
   schedule:
-    # Run weekly on Monday at 9:00 UTC
-    - cron: "0 9 * * 1"
+    # Daily at 9:00 UTC. This is now the primary gate on Go vulnerabilities,
+    # so the cadence here is the window in which a newly-published advisory
+    # sits unnoticed. Weekly made that window up to 7 days.
+    - cron: "0 9 * * *"
   workflow_dispatch: # Allow manual trigger
 
 permissions:
@@ -113,7 +129,7 @@ jobs:
           git add go.mod go.sum
           git commit -m "chore(deps): govulncheck auto-update for fixable vulnerabilities
 
-          Automated by the weekly Security Scan workflow. See run:
+          Automated by the daily Security Scan workflow. See run:
           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           git push -u origin "$BRANCH"
 
@@ -128,7 +144,7 @@ jobs:
             --head "$BRANCH" \
             --title "chore(deps): govulncheck auto-update" \
             --label security,automated,dependencies \
-            --body "Auto-applied \`go get\` updates to resolve vulnerabilities found by the weekly scan. Verified locally that post-update \`govulncheck\` is clean. Enabled auto-merge once CI passes.")
+            --body "Auto-applied \`go get\` updates to resolve vulnerabilities found by the daily scan. Verified locally that post-update \`govulncheck\` is clean. Enabled auto-merge once CI passes.")
 
           gh pr merge "$PR_URL" --auto --squash
 
@@ -148,7 +164,7 @@ jobs:
           LOG=$(tail -c 8000 /tmp/vulncheck.log 2>/dev/null || echo '(no log captured)')
 
           BODY=$(cat <<'BODY_EOF'
-          The weekly `govulncheck` scan found actionable vulnerabilities that the auto-update workflow could not resolve (no upstream fix, or update did not clear the finding).
+          The daily `govulncheck` scan found actionable vulnerabilities that the auto-update workflow could not resolve (no upstream fix, or update did not clear the finding).
 
           Scan run: __RUN_URL__
 
@@ -166,7 +182,7 @@ jobs:
           - If upstream has a fix that the auto-update script missed, upgrade manually.
           - If no fix is available, add the OSV id to `IGNORED_OSVS` in `scripts/govulncheck-filtered.sh` and `scripts/govulncheck-fixable.sh` with a justification and tracking link.
 
-          This issue will be updated by subsequent weekly runs rather than duplicated.
+          This issue will be updated by subsequent daily runs rather than duplicated.
           BODY_EOF
           )
           BODY=${BODY//__RUN_URL__/$RUN_URL}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -774,10 +774,23 @@ matters.
 
 ## Security
 
-`govulncheck` runs on every PR touching `go.mod` / `go.sum` (the `vulncheck`
-job in `ci.yml`) and weekly from `security.yml`. Known-unfixable vulns are
-filtered via `scripts/govulncheck-filtered.sh` — keep `IGNORED_OSVS` in sync
-with `scripts/govulncheck-fixable.sh`. Run locally: `just govulncheck`.
+`govulncheck` runs **daily** from `security.yml`, which auto-opens an
+auto-merging `go get` PR when a fix exists and files a tracking issue when one
+does not. It also gates releases (the `security` job in `release.yml`) — a
+release must not ship a known vulnerability.
+
+It deliberately does **not** run on the PR path. A vulnerability in an
+already-merged dependency is not a defect in whatever PR happens to be in
+flight, and gating there blocks unrelated work: the old `ci.yml` job scanned
+only on a `go.mod`/`go.sum` diff, but the merge queue runs on `merge_group`
+(not `pull_request`) and took the unconditional-scan branch — so an advisory
+would pass on the PR and then dequeue it from the merge queue. Don't
+reintroduce a blocking vulnerability check on PRs; raise the scan cadence
+instead.
+
+Known-unfixable vulns are filtered via `scripts/govulncheck-filtered.sh` —
+keep `IGNORED_OSVS` in sync with `scripts/govulncheck-fixable.sh`. Run
+locally: `just govulncheck`.
 
 ## Commands
 


### PR DESCRIPTION
Removes the `Vulnerability Check` job from `ci.yml` and raises `security.yml`
from weekly to daily.

## The problem

The job gated PRs on a vulnerability scan, but only *ran* the scan when a PR
changed `go.mod`/`go.sum`:

```yaml
if [ "${{ github.event_name }}" != "pull_request" ]; then
  echo "changed=true"   # non-PR event → always scan
```

The merge queue runs on `merge_group`, not `pull_request`, so it took that
unconditional branch. The result is a check that behaves differently in the two
places it runs: an advisory published against an **already-merged** dependency
passes on the PR (skipped, green in ~6s) and then fails in the queue, dequeuing
a change that had nothing to do with dependencies.

#1520 hit this twice. Two `x/crypto/ssh` advisories (GO-2026-6355, GO-2026-6354)
already latent on `develop` blocked a path-validation PR, and the only way
through was to bump an unrelated dependency on that branch.

A vulnerability in an already-merged dependency is not a defect in whatever PR
happens to be in flight. Gating there blocks unrelated work and doesn't even fix
the vulnerability.

## What replaces it

Nothing new — `security.yml` already scans, auto-applies `go get`, opens a PR
with auto-merge, and files a tracking issue when there's no upstream fix. That
both catches the advisory *and* resolves it. This PR only raises its cadence
from weekly to daily, shrinking the unnoticed-advisory window from up to 7 days
to 1.

Dependabot independently covers `gomod` weekly with a 3-day cooldown, so a
fixable advisory has two paths to a PR.

**Releases are unaffected.** `release.yml` has its own independent govulncheck
gate. A release genuinely shouldn't ship a known vulnerability, and that gate
blocks nobody's unrelated work.

## Changes

- `ci.yml`: drop the `vulncheck` job, and drop it from `build`'s `needs:`
  (a dangling `needs:` entry invalidates the workflow).
- `security.yml`: `0 9 * * 1` → `0 9 * * *`; header comment recording why
  scanning lives here and not on the PR path; the four issue/PR body strings
  that said "weekly" now say "daily".
- `CLAUDE.md`: security section rewritten to match, with an explicit
  "don't reintroduce a blocking PR check; raise the cadence instead."

## Ruleset change (already applied)

`Vulnerability Check` was a **required status check** on the `develop` ruleset.
Deleting the job without removing it there would leave the merge queue waiting
60 minutes for a status that never arrives, then failing every PR.

It has been removed from ruleset `12210307` via the API. Verified after the
change: enforcement still `active`, all 6 rule types intact, merge-queue config
byte-identical, 19 required checks (was 20). Backup of the prior state was taken
before the edit.

## Verification

- Both workflows parse as valid YAML; no dangling `needs:` anywhere in `ci.yml`.
- `just lint-md` clean (268 files, 0 issues).
- Removal was done by locating the job's start/end markers and asserting on the
  extracted block, not by line numbers.