### PR TITLE
tickets: plimsoll decomposition plan (15 sub-tickets under TKT-N0IKN9)

### DIFF
--- a/tickets/entities/tickets/TKT-8FXP1B.md
+++ b/tickets/entities/tickets/TKT-8FXP1B.md
@@ -1,0 +1,57 @@
+---
+id: TKT-8FXP1B
+type: ticket
+title: 'Extract fsIndexLoader off fsstore.FSStore: index build/persist as a pure config→data value (84 → 72)'
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]], `fsstore.FSStore` arc. Follows the attachmentStore
+extraction. Same shape as `fileLayout` (layout.go:41): a value type whose
+methods are pure functions of construction-time config plus the index handed to
+them.
+
+## What moves (12 methods, all `internal/store/fsstore/index.go`)
+
+`loadPersistedIndex` (:46), `savePersistedIndex` (:62), `syncIndex` (:97),
+`syncEntities` (:119), `syncRelations` (:137), `rebuildPropCache` (:159),
+`scanEntityDirs` (:176), `scanRelationDir` (:252), `newestEntityFileMtime`
+(:313), `newestRelationFileMtime` (:328), `entitiesDirMtime` (:342),
+`relationsDirMtime` (:369). `cacheKey` is touched by index.go only (4 sites) and
+leaves FSStore.
+
+```go
+type fsIndexLoader struct {
+    rooted   *storage.RootedFS
+    layout   fileLayout
+    codec    mdCodec
+    cacheKey string
+}
+func (l fsIndexLoader) load() (entities map[string]entityMeta, order []string, relations …, propCache …, err error)
+func (l fsIndexLoader) save(…) error
+func (l fsIndexLoader) mtimes() (entities, relations time.Time)
+```
+
+(If the metaIndex ticket lands first, `load` returns a `*metaIndex` and `save`
+takes one; otherwise return the raw maps and let FSStore assign. Either order
+works — coordinate so the two PRs don't both rewrite `New`.)
+
+## Watch
+
+- `scanEntityDirs` spawns concurrent goroutines (index.go:198-235); keep the
+fan-in exactly as is and run with `-race`.
+- No lock on the new type (see the arc-wide locking rule on the
+attachmentStore ticket). `New` calls `load` before the store is published, so no
+`mu` is involved; `savePersistedIndex` is called under `mu` today — keep that
+call site's locking unchanged.
+- The persisted-index format on disk (`.rela/` cache) must not change;
+`TestPersistence*`/recovery tests pin it.
+
+## Done when
+
+storetest conformance + fuzz corpus green, `go test -race ./internal/store/...`,
+ratchet `//plimsoll:max-methods` (fsstore.go:159).

--- a/tickets/entities/tickets/TKT-8FXP1B.md
+++ b/tickets/entities/tickets/TKT-8FXP1B.md
@@ -7,7 +7,7 @@ priority: medium
 effort: m
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]], `fsstore.FSStore` arc. Follows the attachmentStore

--- a/tickets/entities/tickets/TKT-9XDEY0.md
+++ b/tickets/entities/tickets/TKT-9XDEY0.md
@@ -1,0 +1,83 @@
+---
+id: TKT-9XDEY0
+type: ticket
+title: 'Extract attachmentStore off fsstore.FSStore: the on-disk attachment set as a closed type (92 → 84)'
+kind: refactor
+priority: medium
+effort: s
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]], continuing the `fsstore.FSStore` arc opened by
+[[TKT-Y683LJ]] (`fileLayout` + `mdCodec`). First extraction after the self-echo
+bug is settled — it must not bake the dead `RecordWrite` path in.
+
+## Context: what the numbers actually mean here
+
+Of FSStore's 36 exported methods, **31 are mandated** by `store.Store` (31
+methods across its 10 embedded interfaces) and 2 are `store.Formatter`; only
+`StartWatching`/`StopWatching` (already consumed via consumer-side interfaces)
+and `RecordWrite` are surplus. The exported directive can move 36 → 31 at best.
+**The ratchet target is the 56 unexported helpers**, and the question for each
+extraction is "which fields form a closed set only reachable through a narrow
+contract?" — not "how do I get under 40".
+
+## The closed set
+
+Fields `attachments`, `attachKey`, `streamingSupported` are touched only by
+`attachment.go` (10 sites) and one loader in `fsstore.go`. Verified by grep.
+
+## What moves (8 methods → `internal/store/fsstore/attachmentstore.go`)
+
+`attachFile` (attachment.go:36), `writeAttachment` (:101), `deleteAttachment`
+(:137), `removeAttachmentDir` (:185), `renameAttachmentDir` (:239),
+`streamToFile` (:271), `loadAttachmentsIndex` (fsstore.go:299),
+`loadPropertyAttachments` (:337).
+
+```go
+type attachmentStore struct {
+    rooted    *storage.RootedFS
+    key       string // root-relative, "" disables
+    streaming bool
+    metas     map[string]attachMeta // "entityID/property/fileName"
+}
+func (a *attachmentStore) load() error
+func (a *attachmentStore) put(entityID, property, name string, r io.Reader) error
+func (a *attachmentStore) open(entityID, property, name string) (io.ReadCloser, error)
+func (a *attachmentStore) remove(entityID, property, name string) error
+func (a *attachmentStore) list(entityID string) []store.AttachmentInfo
+func (a *attachmentStore) removeEntity(entityID string) error
+func (a *attachmentStore) renameEntity(oldID, newID string) error
+```
+
+FSStore keeps the 4 mandated `AttachmentManager` wrappers. The existence check
+`s.entities[entityID]` (attachment.go:47) STAYS in the wrapper — that is index
+knowledge, and keeping it out is what makes the type closed.
+
+## Locking rule (applies to the whole fsstore arc)
+
+**Extracted types take NO lock of their own.** `mu` (fsstore.go:195) guards
+every index field with one flat lock; `deleteEntity` (entity.go:406-505) touches
+index + attachments + observers + subscribers atomically under it. A per-type
+mutex would fragment that into non-atomic steps and create a lock hierarchy. The
+caller holds `s.mu`; document "must be called under mu" on the type. Readers
+must never take `txMu` (fsstore.go:188-192;
+`TestTx_ReadsViaOuterHandleDoNotDeadlock`).
+
+## Sharing note
+
+Not shareable across backends — memstore holds `[]byte`, pgstore BYTEA,
+sqlitestore BLOB. Only `attachmentKey` (verbatim in `fsstore/attachment.go:31`
+and `memstore/memstore.go:1085`) is worth hoisting to `storeutil`. Adjacent
+drift worth a one-liner in this PR or a note: `pgstore/attachment.go:29-34`
+open-codes the size cap with `io.LimitReader` and returns a bare error where the
+others use `storeutil.LimitAttachmentReader` + `ErrAttachmentTooLarge`.
+
+## Done when
+
+`storetest.RunAll` conformance (`fsstore/conformance_test.go:52`) + the fuzz
+corpus, especially `FuzzAttachmentKeyCollision`, run green — not just compiled.
+`go test -race ./internal/store/...`. Ratchet `//plimsoll:max-methods`
+(fsstore.go:159) to the new exact count.

--- a/tickets/entities/tickets/TKT-9XDEY0.md
+++ b/tickets/entities/tickets/TKT-9XDEY0.md
@@ -7,7 +7,7 @@ priority: medium
 effort: s
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]], continuing the `fsstore.FSStore` arc opened by

--- a/tickets/entities/tickets/TKT-CU105Y.md
+++ b/tickets/entities/tickets/TKT-CU105Y.md
@@ -8,7 +8,7 @@ effort: l
 tags:
     - tech-debt
     - security
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).

--- a/tickets/entities/tickets/TKT-CU105Y.md
+++ b/tickets/entities/tickets/TKT-CU105Y.md
@@ -1,0 +1,104 @@
+---
+id: TKT-CU105Y
+type: ticket
+title: 'Extract entityAPI off dataentry.App: the v1 entity read surface that exclusively owns the reader seams (~60 → ~45)'
+kind: refactor
+priority: medium
+effort: l
+tags:
+    - tech-debt
+    - security
+status: ready
+---
+
+Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).
+Largest App extraction; do it LAST in the arc so the other three have already
+shrunk what it must reason about.
+
+## Why this is an abstraction
+
+It is the complete answer to "serve one entity or a page of them over v1,
+correctly gated", with a real invariant to defend: **every entity body it emits
+has passed the row-level read gate AND been resolved through the request's
+world.** Today that invariant is spread across 13 App methods and is guarded
+from the outside by `TestWorldCapableRoutesDoNotUseUngatedReader`
+(entityreader.go doc) — i.e. by convention. After this PR the four seams that
+decide it — `reader` (ungated, default-world), `visibleReader` (row-gated),
+`worldNeighbors` (world-resolved links), `serializer` — are held on this type
+and **nowhere else in the package**, so a new read path cannot acquire an
+ungated handle by reaching through App. The compiler enforces what the guard
+test currently asserts.
+
+## What moves (13 methods + 2 helpers, `internal/dataentry/api_v1.go`)
+
+`handleV1DynamicRoutes` (:176), `handleV1EntityCollection` (:261),
+`handleV1SingleEntity` (:766), `handleV1ListEntities` (:648),
+`handleV1GetEntity` (:814), `handleV1EntityRelations` (:964),
+`handleV1EntityRelationType` (:1162), `handleV1GetRelationType` (:1182),
+`handleV1RelationTarget` (:1247), `handleV1EntityAction` (:1266),
+`resolveV1Includes` (:1775), `filterVisibleIncludes` (:1837),
+`computeEntityETag` (:2131).
+
+Two become package functions, which is SAFER than the status quo:
+- `gateReadOrNotFound` (:801) uses zero App fields. As
+`gateReadOrNotFound(w, r, typeName, entityID) bool` it cannot be handed a wider
+handle. The uniform-404 rule at :795-798 ("any handler that 404s on the read
+path MUST use this const") travels with it.
+- `currentEdgesByPeer` (relations_direction.go:183) uses only `a.reader` —
+takes an `entityReader` parameter.
+
+## Shape
+
+```go
+type entityAPI struct {
+    schema        func() *Schema
+    reader        entityReader
+    visibleReader visibleReader
+    serializer    entitySerializer
+    affordances   affordanceService
+    // scoped is App.scopedSortedEntities as a closure — gantt, export and
+    // next-action call the SAME function; a second implementation here would
+    // be the ACL-ordering divergence its doc (api_v1.go:307-326) warns about.
+    scoped     func(ctx context.Context, typeName string, q map[string][]string) ([]*entity.Entity, error)
+    // worldLinks: closure because SetWorldNeighbors runs AFTER construction.
+    worldLinks func() *worldNeighbors
+    // Sub-resource surfaces, held as consumer-side interfaces so the read
+    // dispatcher cannot reach the write nucleus's collaborators.
+    write       entityWriteRoutes   // 7 methods of writeHandler
+    attachments attachmentRoutes
+    export      entityExportRoutes
+}
+```
+
+Constructor takes explicit deps and rejects nil; no `app *App` parameter.
+
+## Do NOT
+
+- Move `scopedSortedEntities` / `applyRelationFilters` / `matchRelationFilter`
+/ `resolveScope` / `handleV1EntityPosition` into this type. Five consumers
+across four would-be types; absorbing it makes gantt/export/next-action depend
+on `entityAPI` — a hub-and-spoke worse than today. Stays on App.
+- Keep delegation methods on App so old test call sites compile. That
+defeats the count. Tests call the moved handlers directly
+(`handleV1ListEntities` 41×, `handleV1GetEntity` 24×, `computeEntityETag` 11×,
+`handleV1EntityRelations` 10×); rewrite them to `app.entities.X` — a sed-able
+diff across ~40 test files, and the bulk of this PR.
+
+## Guard to add
+
+A test asserting `App` has no field of type `entityReader` / `visibleReader`
+after the move (or rely on the fields being deleted — then the compiler is the
+guard, and `TestWorldCapableRoutesDoNotUseUngatedReader` can be re-pointed at
+`entityAPI`).
+
+## Invariants
+
+- One `schema()` snapshot per handler.
+- ACL regression pins that must stay green: everything under
+`acl*_test.go`, `TestV1Views_MentionsPopulated`, the uniform-404 tests.
+- `registerAPIV1Routes` becomes a table of `a.entities.*` — which also makes
+the route table readable as surface-to-owner.
+
+Ratchet `//plimsoll:max-methods` (app.go:172). After this PR App is roughly
+lifecycle/setters (15) + list hub (5) + leaf handlers; the epic decides whether
+a `listPipeline` type follows.

--- a/tickets/entities/tickets/TKT-EK1JO8.md
+++ b/tickets/entities/tickets/TKT-EK1JO8.md
@@ -1,0 +1,79 @@
+---
+id: TKT-EK1JO8
+type: ticket
+title: 'SchemaOutput / EntityOutput views: typed JSON-serialisation surface off Metamodel and EntityDef, delete 4 dead EntityDef methods (25 → 18 and 24 → 13 exported)'
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]]. Follows the migration SchemaAdapter ticket. Clears
+BOTH metamodel offenders: `Metamodel` (types.go:22) and `EntityDef`
+(types.go:278). The model to copy is `AttachmentPolicy`
+(`internal/metamodel/attachments.go:86-96`) — the extraction the epic already
+records as "the ratchet working as intended".
+
+## The smell
+
+`internal/metamodel/schema_output.go` is 16 methods of field getters for two
+consumers: `internal/cli/schema_json.go` (which declares its own local
+interfaces at :17-33 to bind them) and `internal/mcp/{tools_schema.go:31,
+resources.go:52, prompts.go:285}`. Three return `any` (`GetEntities`,
+`GetRelations`, `GetTypes`) and one more on EntityDef (`GetProperties() any`) —
+CLAUDE.md's "don't leak interface{}" rule violated on the producer side. Six
+EntityDef getters (`GetAliases`, `GetIDPatterns`, `GetProperties`, `GetRDFType`,
+`GetColor`, `GetBorderColor`) have exactly one caller each — the same caller,
+`schema_json.go:94-104` — and five are one-line returns of an already-exported
+field.
+
+## Shape
+
+```go
+// SchemaOutput is a focused view over the JSON-serialisable surface: the
+// `rela schema --json` writer and the MCP schema resource. Consumers depend
+// on the narrow output shape, not the whole schema.
+type SchemaOutput struct{ m *Metamodel }
+func NewSchemaOutput(m *Metamodel) SchemaOutput          // m non-nil
+func (s SchemaOutput) Version() string
+func (s SchemaOutput) Namespace() string
+func (s SchemaOutput) Entities() map[string]EntityDef    // was any
+func (s SchemaOutput) Relations() map[string]RelationDef // was any
+func (s SchemaOutput) Types() map[string]CustomType      // was any
+func (s SchemaOutput) TypeDefault(name string) string    // was GetTypeDefault
+func (s SchemaOutput) WidgetForType(t string) string     // was ResolveWidgetFromType (presentation concern)
+func (s SchemaOutput) EntityType(name string) (EntityOutput, bool)
+
+type EntityOutput struct{ e *EntityDef }
+func (o EntityOutput) Aliases() []string
+func (o EntityOutput) IDPatterns() []string
+func (o EntityOutput) Properties() map[string]PropertyDef // was any
+func (o EntityOutput) RDFType() string
+func (o EntityOutput) Color() string
+func (o EntityOutput) BorderColor() string
+```
+
+The two local interfaces in `schema_json.go:17-33` are then deleted — there is
+one implementation and a concrete value type is what the consumer wanted.
+
+## Delete (zero external callers, verify in-package/test use first)
+
+`EntityDef.GetLabelPlural` (entity_def.go:87), `IsSequentialID` (:290),
+`HasPattern` (:319), `HasContent` (types.go:576). `MatchesID` (:324) has an
+in-package caller → unexport.
+
+## Not in this pass
+
+An `IDPolicy` view (`GetIDType`/`GetIDCaps`/`GetIDPrefixes`/`IsShortID`/
+`IsManualID`/`MatchesID` — the genuinely cohesive "how are ids minted and
+recognised" cluster, consumed mostly by entitymanager). It would take EntityDef
+to 7 and give entitymanager a narrow thing to bind, but is not needed to clear
+the line. Record as the next ratchet step if EntityDef grows.
+
+## Result
+
+`Metamodel` 18 exported, `EntityDef` 13 — both directives DELETED (under 20).
+Golden tests for `rela schema --json` and the MCP schema resource pin the output
+bytes; run them.

--- a/tickets/entities/tickets/TKT-EK1JO8.md
+++ b/tickets/entities/tickets/TKT-EK1JO8.md
@@ -7,7 +7,7 @@ priority: medium
 effort: m
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]]. Follows the migration SchemaAdapter ticket. Clears

--- a/tickets/entities/tickets/TKT-K9GL4J.md
+++ b/tickets/entities/tickets/TKT-K9GL4J.md
@@ -7,7 +7,7 @@ priority: medium
 effort: m
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).

--- a/tickets/entities/tickets/TKT-K9GL4J.md
+++ b/tickets/entities/tickets/TKT-K9GL4J.md
@@ -1,0 +1,78 @@
+---
+id: TKT-K9GL4J
+type: ticket
+title: 'Extract liveFeed off dataentry.App: one owner for the reload/SSE lifecycle with Start/Stop (~69 → ~60)'
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).
+
+## Why this is an abstraction
+
+This is the one App cluster with a lifecycle and goroutines, and its ownership
+is currently muddled: `startStoreEventBridge` (watcher.go:209) spawns `go
+a.pumpStoreEvents(events)` and parks the cancel in an App field; `StopWatching`
+(app.go:439) releases it. "Own the two subscriptions and the goroutine that
+drains them" becomes a single object with `Start`/`Stop`, so it cannot be
+half-stopped. It also owns `rebuildState` — the atomic Schema publish — which
+pairs correctly with subscribe: they are the two halves of "react to a change",
+and this type becomes the SOLE writer of the published snapshot.
+
+## What moves (8 methods, `internal/dataentry/watcher.go`)
+
+`StartWatching` (:145), `startStoreEventBridge` (:209), `pumpStoreEvents`
+(:217), `StartGitFetch` (:242), `rebuildState` (:280), `handleSSE` (:329),
+`runSSELoop` (:385), `freshReadGate` (:471). `entityTypeVisible` (:500) has an
+unused receiver — package function. `StopWatching` stays on App as a delegation
+(public API). `noCacheMiddleware` stays on App (reads `principalHeader`, applied
+in `NewRouter`).
+
+Fields leaving App: `cfgLoader`, `broker`, `gitOps`, `stopConfigWatch`,
+`stopStoreWatch`.
+
+## Shape
+
+```go
+type liveFeed struct {
+    schema    schemaProvider
+    cfgLoader config.Loader
+    palette   *paletteService
+    events    storeSubscriber  // consumer-side: Subscribe only
+    watcher   storeWatcher     // consumer-side: StartWatching only
+    gitOps    *git.Ops
+    broker    *eventBroker
+    acl       func() acl.ACL   // closure: tests rebind app.acl (183 sites)
+
+    mu       sync.Mutex
+    stopCfg  func()
+    stopFeed func()
+}
+
+// storeSubscriber is the change-feed capability liveFeed needs — declared
+// at the consumer. One method of store.Store's ~30.
+type storeSubscriber interface {
+    Subscribe(buf int) (<-chan store.Event, func())
+}
+
+func (f *liveFeed) Start() error   // was App.StartWatching
+func (f *liveFeed) Stop()          // releases exactly what Start acquired
+```
+
+## Invariants
+
+- The SSE broadcast carries NO audit detail and NO entity id
+(`startStoreEventBridge`'s audit-isolation invariant, pinned by
+`TestSSE_DoesNotFlowAuditEvents`). Move the comment with the code.
+- `Stop` is idempotent and releases exactly what `Start` acquired; add a test
+for double-Stop and Stop-before-Start.
+- Tests reassign `app.broker` (54 sites) and `app.acl` (183 sites) after
+construction: hold those as closures or via a rebind hook, never captured
+values. Check for a shared test builder before hand-editing files.
+- Race detector: `go test -race ./internal/dataentry/...` is the gate.
+
+Ratchet `//plimsoll:max-methods` (app.go:172) to the new count.

--- a/tickets/entities/tickets/TKT-M3X3JO.md
+++ b/tickets/entities/tickets/TKT-M3X3JO.md
@@ -8,7 +8,7 @@ effort: s
 tags:
     - tech-debt
     - security
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]], continuing the `lua.Runtime` arc after

--- a/tickets/entities/tickets/TKT-M3X3JO.md
+++ b/tickets/entities/tickets/TKT-M3X3JO.md
@@ -1,0 +1,84 @@
+---
+id: TKT-M3X3JO
+type: ticket
+title: 'Extract graphReads off lua.Runtime: the read-out bindings holding only the ACL-gated reader (46 → 36)'
+kind: refactor
+priority: medium
+effort: s
+tags:
+    - tech-debt
+    - security
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]], continuing the `lua.Runtime` arc after
+[[TKT-4WBLG6]] and [[TKT-DOPCTI]]. Clears the 40 line by itself.
+
+## The established pattern (follow it exactly)
+
+Four prior extractions are recorded in the `Runtime` struct doc at
+`internal/lua/runtime.go:64-101` — append the new entry there. Invariant shape
+(`ai.go:49`, `http.go:113`, `cache.go:260`, `urls.go:25`, `markdown.go:77-120`):
+
+1. Small unexported struct in the cluster's own file holding **only the deps
+its bindings touch — never `*Runtime`**.
+2. The `registerXBindings` seam STAYS on Runtime, constructs the struct from
+`r`'s fields, and does the `SetField` wiring.
+3. Mutable runtime state is passed as **closures** (`cacheBindings.scriptPath
+func() string`, `mdEntityRefs.ctx func() context.Context`), not captured.
+4. Bindings register as **method values**, never inline closures —
+`contextcheck` otherwise demands a ctx at every `NewReader`/`NewWriter`
+(rationale at mail.go:87-96).
+5. A held `*lua.LState` may be used only for `NewTable`; `Push`/`RaiseError`/
+`CheckX` use the `ls` parameter, because coroutines invoke bindings on a thread
+LState (markdown.go:79-86).
+
+## What moves (10 methods → `internal/lua/graphreads.go`)
+
+`reader` (runtime.go:1123 — the TKT-ZF2DTV choke point), `luaGetEntity` (:1132),
+`luaListEntities` (:1154), `luaGetRelations` (:1234), `luaTraceFrom` (:1268),
+`luaTraceTo` (:1286), `luaSearch` (:1731), `luaFindPath` (:2361 — currently
+misfiled among the write bindings), `luaGetEntityTypes` (:2409),
+`luaGetRelationTypes` (:2448). `luaSortEntities` (:2487) is pure LState — the
+same category as `urlHelpers`; move it too or make it a free function.
+
+## Shape
+
+```go
+// graphReads implements the read-OUT rela.* bindings. reader is the SOLE
+// read handle: there is no store field beside it and no *Runtime
+// back-pointer, so readerOrRaise is a choke point that cannot be reached
+// around (TKT-ZF2DTV).
+type graphReads struct {
+    reader   EntityReader   // Nil: accepted at construction, DENIED at call — raises, never falls back (RR-X9NVHI)
+    tracer   tracer.Tracer
+    searcher search.Searcher // Nil: accepted — rela.search raises "not available"
+    meta     *metamodel.Metamodel
+    ctx      func() context.Context // Runtime.callerCtx, read at CALL time
+}
+```
+
+`registerReadBindings` (runtime.go:842) becomes construction +
+`r.L.SetField(rela, "get_entity", r.L.NewFunction(g.luaGetEntity))` etc.
+
+## Risks (MEDIUM — this is the ACL surface)
+
+- Renaming/moving `reader()` must not turn "nil ⇒ raise" into "nil ⇒ fall
+through". Pinned by `aclreads_test.go`, `acl_bypass_reads_test.go`,
+`list_entities_bound_test.go`.
+- `luaSearch`'s hydration-is-the-gate behaviour (:1751-1770) incl. the
+`errors.Is(err, store.ErrNotFound)` silent-skip vs `slog.Warn` split (RR-QSP6X2)
+moves verbatim.
+- `relationQuery` is shared with the elevated `admin.get_relations`
+(RR-D7KXKV) — leave that free function where it is.
+- `mdEntityRefs` (markdown.go:104) already holds `deps.VisibleReader`
+directly, bypassing `reader()`. Pre-existing asymmetry: note, don't fix here.
+- `capabilityguard_test.go` greps package source for the AI/HTTP/write_file
+gates; this PR touches none of its needles.
+
+## Done when
+
+Receiver + field renames only, no logic edits. Struct doc entry `46 → 36
+(TKT-…)` with the reason the cluster was separable. Ratchet
+`//plimsoll:max-methods` at runtime.go:102 to 36. `go test ./internal/lua/...`,
+`just plimsoll`, `just comment-lint`, `just coverage-check`.

--- a/tickets/entities/tickets/TKT-N0IKN9.md
+++ b/tickets/entities/tickets/TKT-N0IKN9.md
@@ -9,10 +9,9 @@ status: backlog
 ---
 
 We added the [plimsoll](https://github.com/sourcehaven-bv/plimsoll) god-object
-linter (caps method/exported-field count per type) to CI. Five existing types
-are over the load line and are grandfathered with `//plimsoll:max-*` directives
-pinned to their CURRENT count, so they can't grow. This ticket tracks ratcheting
-those numbers down.
+linter (caps method/exported-field count per type) to CI. Existing offenders are
+grandfathered with `//plimsoll:max-*` directives pinned to their CURRENT count,
+so they can't grow. This ticket tracks ratcheting those numbers down.
 
 ## Why this happened
 
@@ -22,38 +21,111 @@ Nothing failed when `App` grew its 200th method. (Root cause from the sync
 read-ACL review: the same "convention, not enforcement" gap.) plimsoll is the
 structural brake; this ticket is the cleanup of the debt that accrued before it.
 
-## Offenders (cap pinned at current count)
+## Current offenders (develop e0187047, 2026-09-04, directives stripped)
 
-| Type | Surface | File |
-| --- | --- | --- |
-| `dataentry.App` | 226 methods | `internal/dataentry/app.go` |
-| `lua.Runtime` | 119 methods | `internal/lua/runtime.go` |
-| `fsstore.FSStore` | 84 methods | `internal/store/fsstore/fsstore.go` |
-| `mcp.Server` | 47 methods | `internal/mcp/server.go` |
-| `cli.CLI` | 37 exported fields | `internal/cli/kong.go` |
+| Type | Now | Line | Directive |
+| --- | --- | --- | --- |
+| `dataentry.App` | 87 methods | 40 | app.go:172 |
+| `fsstore.FSStore` | 92 methods / 36 exported | 40 / 20 | fsstore.go:159-160 |
+| `lua.Runtime` | 46 methods | 40 | runtime.go:102 |
+| `metamodel.Metamodel` | 32 exported | 20 | types.go:22 |
+| `metamodel.EntityDef` | 24 exported | 20 | types.go:278 |
+| `appbuild.Services` | 30 exported | 20 | appbuild.go:100 |
+| `cli.CLI` | 47 exported fields | 20 | kong.go:70 |
+| `dataentryconfig.Config` | 22 exported fields | 20 | config.go:93 |
+| `memstore` / `pgstore` / `sqlitestore` | 50/32, 51/42, 53/32 | required-interface exception | — |
 
-## Approach
+Dead directives (type already under the line): `internal/docs/runtime.go:87`
+(29) and `internal/mcp/server.go:214` (25).
 
-Per type: extract cohesive responsibilities into their own types with narrow,
-injected dependencies (consumer-side interfaces per the project rules), then
-lower the `//plimsoll:max-*` number. `App` is the priority — its decomposition
-into an `api` package with a gated read interface also closes the read-ACL class
-of bug (a route package that never holds `store.Store` can't skip the read
-gate). `CLI` growth is structural (kong binds one field per subcommand); revisit
-grouping into sub-structs but it may stay grandfathered.
+**Ratchet regression.** The worlds feature (#1452) RAISED directives instead of
+holding them: fsstore 81→92 / 33→36, memstore 43→50, sqlitestore 43→53, pgstore
+49→52 / 39→42, app 86→87. Exported bumps are legitimate (`store.Store` grew);
+the total-method bumps are the ratchet being defeated by a large feature PR. A
+directive bump in a feature PR should be a review flag.
 
-## Progress
+## Plan (2026-09-04) — one PR per ticket, real abstractions only
 
-- `dataentry.App` decomposition tracked in sub-arc TKT-N26KLB (227 → ~166
-methods; the `visibleReader` ACL seam landed), remainder in TKT-R68TV8.
-- `metamodel.Metamodel`: the attachment-scan accessors (`ScanCommandFor`,
-`HasUnconfiguredScan`) were moved behind a focused `AttachmentPolicy` view
-rather than widening the metamodel's public surface — the plimsoll line held at
-30 instead of being bumped when the attachment feature landed. This is the
-ratchet working as intended: the linter forced the extraction at write time.
-- `cli.cliServices` (grandfathered at 29 exported methods): **removed
-entirely** (TKT-45QYI) after PR #1142 pushed it to 30 and broke CI. Replaced by
-`readServices`/`writeServices` field bundles (à la `lua.ReadDeps`/ `WriteDeps`)
-plus direct kong bindings for the CLI-owned services; the directive was deleted,
-not bumped. `cli.CLI`'s `max-fields=45` directive is the one remaining CLI
-grandfather (structural — one field per subcommand).
+Survey principle: extract a type only where a **closed field set** exists that
+callers can only reach through a narrow contract, or where the type makes a
+prose rule structural. Moving methods to free functions to duck the counter
+(pgstore/entity.go:872-875 did this) is explicitly NOT the goal.
+
+**dataentry.App arc** (sub-epic [[TKT-R68TV8]], 87 → ~45; order = safest first):
+1. [[TKT-XDJTDC]] `configAPI` — the principal-independent metadata surface; no
+store/reader/ACL fields, making "config is not a secret" structural.
+2. [[TKT-NLX424]] `nextActionAPI` — suggestion adapter; fixes the unsynchronised
+`SetUserState`/`SetNextActionMatchers` writes with a mutex.
+3. [[TKT-K9GL4J]] `liveFeed` — one owner for reload/SSE lifecycle (Start/Stop),
+consumer-side `storeSubscriber`.
+4. [[TKT-CU105Y]] `entityAPI` — the v1 read surface that EXCLUSIVELY holds
+`reader`/`visibleReader`/`serializer`/`worldNeighbors`, so the compiler enforces
+what `TestWorldCapableRoutesDoNotUseUngatedReader` asserts.
+`scopedSortedEntities` (5 consumers) stays on App; a `listPipeline` type is the
+possible sixth step, decided after these four.
+
+**lua.Runtime arc** (46 → 29; parallelisable):
+- [[TKT-M3X3JO]] `graphReads` — read bindings with the ACL reader as the SOLE
+handle (clears the line alone).
+- [[TKT-V9NKZY]] `graphWrites` — mutation + `bypass_acl` elevation, writer-only.
+
+**fsstore.FSStore arc** (92 → ~66 unexported; exported floor is 31 =
+`store.Store`):
+0. [[BUG-S24X52]] self-echo observer never wired in production since #508 —
+FIX FIRST so the extractions don't bake a dead field in.
+1. [[TKT-9XDEY0]] `attachmentStore` (closed set: attachments/attachKey/streaming).
+2. [[TKT-8FXP1B]] `fsIndexLoader` (pure config→data, like `fileLayout`).
+3. [[TKT-W9E1NC]] `metaIndex` — map+order pairing as one mutation; removes the
+comparator-mismatch bug class documented at fsstore.go:452-472.
+4. [[TKT-ONFXVS]] `storeutil.ObserverSet` (cross-backend; needs-design; two
+surveys disagreed — recorded on the ticket). Known floor: the 24 `tx.go`
+wrappers are structural duplication (fs/mem); a shared `SubscriberSet` is out of
+scope because the four `emit`s have deliberately different timing guarantees.
+Extracted types take NO lock.
+
+**metamodel** (32 → 18, 24 → 13; both directives deleted):
+- [[TKT-OBC7QI]] `migration.SchemaAdapter` in the CONSUMER package (the
+interface was already right; the impl landed on the producer) + delete dead
+`IsEnumType`.
+- [[TKT-EK1JO8]] `SchemaOutput`/`EntityOutput` views (AttachmentPolicy shape),
+kills 4 `any` returns and 2 redundant cli interfaces; delete 4 dead EntityDef
+methods. `IDPolicy` view is the next step only if EntityDef grows.
+
+**appbuild.Services** (30 → 28, then documented exception):
+- [[TKT-R3SMEK]] `ScheduledMailer` — scheduler behaviour off the wiring facade;
+restore `FieldRedactor()` (the cap had turned it into a field); convert the
+directive to a required-seam exception. Sub-bundles (`Read()`/`Write()`) are
+REJECTED: they break every consumer-side interface bound on `*Services`.
+Follow-up idea: `dataentry.Deps` struct for the 12-arg `NewApp`.
+
+**cli.CLI** (47 → 7 fields): [[TKT-YJDD7C]] `embed:""` command groups (verified
+syntax-preserving) + replace the package-level invocation globals with a bound
+`Globals` — the latter is the real fix.
+
+**Housekeeping**: [[TKT-RKR7VX]] dead directives, stale prose (copylist.go:91
+cites a directive Manager doesn't have; worldneighbors.go:85 cites 104), and the
+two settled exceptions below.
+
+## Settled: not offenders to fix
+
+- **Store backends.** Exported surplus over `store.Store` + optional
+capabilities: memstore 0, sqlitestore 1, fsstore 3, pgstore 7 — all consumed
+through narrow consumer-side interfaces; versioning already sits behind
+`VersionServiceProvider`. `//plimsoll:max-exported-methods` on stores is a
+required-interface exception, not a ratchet target.
+- **`dataentryconfig.Config`.** Read-only format mirror of `data-entry.yaml`;
+`yaml:",inline"` grouping works but is arbitrary and costs 131 call sites. Keep
+the directive, document why.
+
+## History
+
+- `dataentry.App`: 227 → 87 across [[TKT-N26KLB]] / [[TKT-R68TV8]] sub-tickets
+(`visibleReader` ACL seam, sync/command/attachment/write/views handlers).
+- `lua.Runtime`: 119 → 46 ([[TKT-4WBLG6]], [[TKT-DOPCTI]]).
+- `fsstore.FSStore`: 95 → 81 ([[TKT-Y683LJ]] fileLayout + mdCodec), then 92
+after #1452.
+- `mcp.Server`: 49 → 25 ([[TKT-YUETL7]] + round 2). Directive now dead.
+- `metamodel.Metamodel`: `AttachmentPolicy` extraction held the line at 30
+when attachments landed — the ratchet working as intended.
+- `cli.cliServices`: removed entirely ([[TKT-45QYI]]).
+- `output.Writer`: directive deleted ([[TKT-NS3XPE]]).

--- a/tickets/entities/tickets/TKT-NLX424.md
+++ b/tickets/entities/tickets/TKT-NLX424.md
@@ -7,7 +7,7 @@ priority: medium
 effort: m
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).

--- a/tickets/entities/tickets/TKT-NLX424.md
+++ b/tickets/entities/tickets/TKT-NLX424.md
@@ -1,0 +1,81 @@
+---
+id: TKT-NLX424
+type: ticket
+title: 'Extract nextActionAPI off dataentry.App: the advisory-suggestion adapter with mutex-guarded late-set state (~80 → ~69)'
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).
+
+## Why this is an abstraction
+
+The next-action cluster is a genuine domain adapter, not "the handlers for one
+route": it binds `internal/nextaction` to this package's ACL-gated read paths,
+owns a per-user feedback backend, has its own world-resolution rule (the source
+world REPLACES the request world, nextaction.go:44), and carries its own
+redaction obligation (`redactedForSuggestion`, closing the BUG-R9EHKV class
+through a distinct door). The reason it lives in `dataentry` and not in
+`nextaction` is stated at nextaction.go:20: the read gate is per-request here.
+
+It also fixes a latent race: `SetUserState` writes `a.userState`
+(nextaction.go:333) and `SetNextActionMatchers` writes `a.nextActionMatchers`
+(:342) with no synchronisation while `handleV1NextActionPost` reads them
+(nextaction_handler.go:157). Safe today only by the wire-before-serve
+convention. The new type guards both behind a mutex, so it is safe by
+construction.
+
+## What moves (11 methods)
+
+`handleV1NextAction` (nextaction_handler.go:92), `handleV1NextActionGet` (:103),
+`handleV1NextActionPost` (:155), `nextActionEngine` (:288),
+`nextActionCandidates` (nextaction.go:41), `nextActionOptions` (:161),
+`queryCandidates` (:216), `redactedForSuggestion` (:233), `countCandidates`
+(:255), `countIsZero` (:277). `applyNextActionFeedback`
+(nextaction_handler.go:231) has an unused receiver — package function.
+
+`SetUserState` / `SetNextActionMatchers` **stay on App** as one-line
+delegations: they are public opt-in wiring API.
+
+## Shape
+
+```go
+type nextActionAPI struct {
+    schema      func() *Schema
+    worlds      func() WorldLookup     // closure: SetWorlds runs AFTER NewApp
+    queries     *queryService
+    affordances affordanceService
+    // Two ACL postures a source may take, named separately because the
+    // difference between them IS the count_ungated disclosure decision
+    // (see countCandidates' doc). One "read entities" seam would hide it.
+    scoped     func(ctx context.Context, typeName string, q map[string][]string) ([]*entity.Entity, error)
+    graphCount func(ctx context.Context, q store.GraphQuery) (any, int, error)
+
+    mu       sync.Mutex // guards the late-set pair below
+    userState userstate.Store
+    matchers  NextActionMatcherFunc
+}
+```
+
+`scoped` is `App.scopedSortedEntities` passed as a closure. **Do not move
+`scopedSortedEntities` into this type** — it has five consumers (gantt, export,
+list, scope, next-action); it stays on App for this arc (see the epic).
+
+## Invariants
+
+- `redactedForSuggestion` moves WITH `queryCandidates`; splitting them leaves
+a raw-entity path into a suggestion message.
+- Late-set fields (`worlds`, `userState`, `matchers`) are closures or
+mutex-guarded — never captured by value at construction.
+`viewsHandler.faceEdges`' doc records the bug that captured-values cause.
+- One `schema()` snapshot per handler; `nextActionEngine` (:290) already
+documents why.
+
+## Also
+
+Ratchet `//plimsoll:max-methods` (app.go:172) to the new count. Constructor
+takes explicit deps, rejects nil, no `app *App` parameter.

--- a/tickets/entities/tickets/TKT-OBC7QI.md
+++ b/tickets/entities/tickets/TKT-OBC7QI.md
@@ -1,0 +1,65 @@
+---
+id: TKT-OBC7QI
+type: ticket
+title: Move the migration MetamodelProvider implementation into internal/migration (SchemaAdapter); delete dead Metamodel.IsEnumType (32 → 25 exported)
+kind: refactor
+priority: medium
+effort: s
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]] — the `metamodel.Metamodel` exported-surface
+offender (32 exported methods, line is 20; directive at
+`internal/metamodel/types.go:22`).
+
+## Diagnosis
+
+`Metamodel` is not a god-object. It is a wide read API over a wide schema PLUS a
+foreign interface implementation bolted on to satisfy one consumer.
+`internal/migration/migration.go:14` already declares `MetamodelProvider` as a
+correct consumer-side interface, and `dataentry_cleanup_test.go:11` already has
+a `mockMetamodel` for it. Six methods exist on `Metamodel` purely so
+`*Metamodel` structurally satisfies that interface — the consumer interface was
+right; the implementation landed on the producer.
+
+This is the named counterpart of the consumer-side-interfaces rule and it recurs
+(appbuild.Services has the identical shape with the scheduler). Worth one
+paragraph in `docs/architecture/consumer-side-interfaces.md`.
+
+## What moves
+
+Migration-only accessors from `internal/metamodel/schema_output.go`:
+`GetPropertyType` (:33), `IsPropertyRequired` (:46), `GetPropertyDefault` (:59),
+`GetRelationLabel` (:88), `GetRelationFrom` (:97), `GetRelationTo` (:106). Each
+has 1-2 callers, all in `internal/migration`.
+
+```go
+// internal/migration/metaadapter.go — in the CONSUMER package.
+// SchemaAdapter satisfies MetamodelProvider over a loaded *metamodel.Metamodel.
+type SchemaAdapter struct{ Meta *metamodel.Metamodel }
+func (a SchemaAdapter) GetPropertyType(entityType, property string) string { … } // 3-6 lines each over public fields
+```
+
+Call-site change: `migration.ApplyWithMetamodel(path, ft, fs, svc.Meta)` → `…,
+migration.SchemaAdapter{Meta: svc.Meta})` in `internal/cli/migrate.go`.
+
+`GetTypeDefault` (:72) and `ResolveWidgetFromType` (:117) each have a second,
+non-migration caller — they stay for now (the SchemaOutput ticket takes them).
+
+## Delete
+
+`IsEnumType` (schema_output.go:80) — **zero callers**.
+
+## Keep (deliberately)
+
+- Core lookups (`GetEntityDef` 126 callers/22 pkgs, `GetRelationDef`,
+`EntityTypes`, `RelationTypes`, `HasEntityType`, `ResolveAlias`).
+- Value validation (`ValidateEntity` 14 callers/6 pkgs and friends) — schema
+owns value semantics; a view would add a hop on a hot path for 4 slots.
+- `RenderProjection`/`ShapeProjection` — two hashes with a load-bearing
+difference documented in CLAUDE.md; a `Projections()` view saves 1 slot and
+obscures it.
+
+Ratchet `//plimsoll:max-exported-methods` at types.go:22 to 25.

--- a/tickets/entities/tickets/TKT-OBC7QI.md
+++ b/tickets/entities/tickets/TKT-OBC7QI.md
@@ -7,7 +7,7 @@ priority: medium
 effort: s
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]] — the `metamodel.Metamodel` exported-surface

--- a/tickets/entities/tickets/TKT-ONFXVS.md
+++ b/tickets/entities/tickets/TKT-ONFXVS.md
@@ -1,0 +1,73 @@
+---
+id: TKT-ONFXVS
+type: ticket
+title: 'storeutil.ObserverSet: one home for the FaceObserver/bare-id dispatch contract currently copied into four backends'
+kind: refactor
+priority: low
+effort: m
+tags:
+    - tech-debt
+    - needs-design
+status: backlog
+---
+
+Sub-ticket of [[TKT-N0IKN9]], `fsstore.FSStore` arc — cross-backend, so it lands
+AFTER the fsstore-local extractions and needs a `/design-review` before
+starting. Two survey agents disagreed on whether this should be done; the
+disagreement is recorded here so the reviewer can decide.
+
+## The duplication
+
+`notifyPut` / `notifyFaceDelete` / `notifyLastFaceDelete` / `notifyRenamed`
+exist in all four backends: `fsstore/fsstore.go:389-430`,
+`memstore/memstore.go:151-186`, `sqlitestore/observer.go:39-100`,
+`pgstore/entity.go:861-915`. fs and mem are identical modulo receiver. The
+mutual-exclusion rule between `FaceObserver` and bare-id observers is a subtle
+correctness contract stated in four separate doc comments — one home means one
+place to get it right.
+
+pgstore turned `notifyFaceDelete` into a package function purely to stay under
+the plimsoll line (pgstore/entity.go:872-875 says so). That is the method cap
+being gamed, and this ticket lets it be undone.
+
+## The case against (sqlitestore/observer.go:40-47)
+
+pg and sqlite prepend a `txPending` deferral: an observer that fires inside a
+transaction that later rolls back leaves the search index holding an entity the
+store does not have, and `RunTxRollbackTests` does not catch it. A shared helper
+would have to take that seam as a parameter, re-introducing per-backend
+divergence inside the function whose purpose was to remove it. Four small
+correct copies may beat one parameterised abstraction.
+
+## Proposed shape, if it proceeds
+
+```go
+// storeutil/observers.go
+type ObserverSet struct{ obs []store.EntityObserver }
+func (o *ObserverSet) Add(x store.EntityObserver)              // nil-drop
+func (o *ObserverSet) Put(e *entity.Entity)
+func (o *ObserverSet) FaceDelete(id string, f entity.Face)     // FaceObserver only
+func (o *ObserverSet) LastFaceDelete(id string)                // bare-id only
+func (o *ObserverSet) Renamed(oldID string, e *entity.Entity)
+```
+
+Zero value usable. For the tx-deferred backends the set is invoked from inside
+the existing `txPending` hook, so the set itself knows nothing about
+transactions — the deferral stays where it is, the dispatch body is shared.
+Decide at design review whether that boundary is clean enough to be worth it.
+
+## Explicitly out of scope
+
+- A shared `SubscriberSet`/event hub. The four `emit` implementations are NOT
+equivalent: fs/mem emit under `mu`, sqlite sends outside the lock
+(events.go:61-77), pg/sqlite buffer through `txPending`. Flattening those
+silently changes documented per-backend guarantees.
+- A shared `txSerializer` for the 24 duplicated `tx.go` wrappers in fs/mem:
+the duplication is structural (each wrapper names a distinct interface method);
+erasing it needs generics over method sets or codegen, and would break the
+compile-time `var _ store.Store = txStore{}` check. Document it as the known
+floor instead.
+
+arch-lint: all four backends may depend on `storeutil` (.go-arch-lint.yml
+:1118-1165); `storeutil` may depend only on `store` (:1166) — confirm `entity`
+is reachable or route via `store`'s aliases.

--- a/tickets/entities/tickets/TKT-R3SMEK.md
+++ b/tickets/entities/tickets/TKT-R3SMEK.md
@@ -7,7 +7,7 @@ priority: medium
 effort: m
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]] — `appbuild.Services` (30 exported, directive at

--- a/tickets/entities/tickets/TKT-R3SMEK.md
+++ b/tickets/entities/tickets/TKT-R3SMEK.md
@@ -1,0 +1,86 @@
+---
+id: TKT-R3SMEK
+type: ticket
+title: 'appbuild: extract ScheduledMailer (scheduler behaviour off the wiring facade), then make Services'' exported-method directive a documented exception'
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]] — `appbuild.Services` (30 exported, directive at
+`internal/appbuild/appbuild.go:100`).
+
+## Diagnosis: three groups, one of which does not belong
+
+1. **21 plain accessors** (`FS`, `Paths`, `Meta`, `Store`, … `CalDAVAliases`),
+each returning one unexported field. Their purpose is to be the structural seam
+a consumer-side interface binds against — `dataentry.ResolverServices`
+(affordances_stub.go:104) declares exactly `ACLDeclarative()/Meta()/Store()` and
+takes `svc`. That is the project's central rule working. **Do not group these
+into `Read()`/`Write()` sub-bundles**: a method set on a RETURNED struct cannot
+be satisfied by `*Services`, so every such consumer interface breaks.
+(`cli.readServices` is a precedent for consumers building bundles FROM Services
+— cli_wiring.go:126-135 — not for restructuring the producer.) Exported fields
+instead would trade the method cap for the field cap (26 fields, line 20) and
+destroy the `Close` invariants (`Close()` nils
+`mailStop`/`searchCloser`/`jobQueue`, :1779-1795).
+2. **4 constructed bundles** (`LuaReadDeps`, `LuaWriteDeps`,
+`ScheduledLuaWriteDeps`, `GatedReads`) — already the sub-bundle pattern.
+3. **4 scheduler behaviours** — `RunScheduledTemplate` (scheduled_mail.go:20),
+`ValidateScheduledMailRecipients` (scheduled_mail_validate.go:19),
+`ScheduledForEachEntities` / `ScheduledForEachPrincipal`
+(scheduler_foreach.go:14, :59). A wiring facade that constructs collaborators
+should not also render and send mail. They sit on Services only so `*Services`
+structurally satisfies the scheduler's narrow interfaces (foreach.go:16-25,
+scheduler.go:90-94) — the same shape as Metamodel growing a migration provider.
+
+## The extraction
+
+```go
+// ScheduledMailer is the scheduler-facing behaviour surface. A separate type
+// because Services is a WIRING facade — it constructs collaborators, it does
+// not render and send mail. Valid only while svc is open.
+type ScheduledMailer struct{ svc *Services }
+func (s *Services) Scheduled() ScheduledMailer { return ScheduledMailer{svc: s} } // fresh value, NOT a cached field (max-fields)
+func (m ScheduledMailer) RunScheduledTemplate(ctx, name, recipientID string) error
+func (m ScheduledMailer) ValidateScheduledMailRecipients(ctx) error
+func (m ScheduledMailer) ScheduledForEachEntities(…) ([]string, int, error)
+func (m ScheduledMailer) ScheduledForEachPrincipal(ctx, entityID string) (string, error)
+func (m ScheduledMailer) ScheduledLuaWriteDeps(…)  // forward, so scheduler.WorkspaceProvider binds ONE value
+```
+
+Bodies move verbatim (they reach only `svc.ScheduledLuaWriteDeps()`, `svc.mail`,
+`svc.meta`). Call sites: scheduler wiring passes `svc.Scheduled()`;
+`internal/cli/validate.go:85` becomes
+`mailSvc.Scheduled().ValidateScheduledMailRecipients(ctx)`.
+
+## Then: stop letting the cap distort the type
+
+`fieldRedactor` is documented at appbuild.go:151-160 as "a FIELD, not an
+accessor, on purpose — Services sits at its ceiling". That is the cap causing a
+design wart. Restore `FieldRedactor()` as a proper accessor and delete the
+rationale. `ACLPolicy()` has zero production callers but `sharedbase_test.go:75`
+pins the shared-policy invariant through it — keep, note it.
+
+Net 30 − 4 + 1 + 1 = **28**, still over 20. Convert the directive from a ratchet
+target to a documented exception in the same words CLAUDE.md uses for store
+implementations: each exported method returns exactly one constructed
+collaborator and exists to be a consumer-side seam; the count tracks how many
+collaborators the application has, not internal sprawl.
+
+## Invariants (sharedbase_test.go:66-115)
+
+- Assembly never mutates `meta` / `aclPolicy`; `Close` tears down only
+per-assembly state. `ScheduledMailer` holds `*Services` and adds no resource, so
+both hold — pin with a one-line test that `Scheduled()` returns a value with no
+shared state.
+
+## Follow-up worth its own ticket (not here)
+
+`cmd/rela-server/main.go:456-460` calls `dataentry.NewApp` with 12 positional
+arguments — a `dataentry.Deps` struct (the `lua.ReadDeps` pattern) is the
+capability-bundle rule applied to the biggest consumer. A `dataentry` problem,
+not a `Services` one.

--- a/tickets/entities/tickets/TKT-R68TV8.md
+++ b/tickets/entities/tickets/TKT-R68TV8.md
@@ -12,64 +12,68 @@ status: backlog
 
 > **Update (2026-07-25): M5.4 write nucleus carved — [[TKT-HKY8RJ]] / PR #1191 merged, then [[TKT-6NDSH9]] moved the Lua action + webhook dispatch in as well. App at 114 methods, directive 114. The write surface is COMPLETE on writeHandler: no App method takes writeMu directly anymore. writeMu itself remains App-owned and pointer-shared; deleting it outright stays the [[DEC-8UIL0]] Tx arc, which now has a single obvious seam.**
 
-> **Update (2026-07-26): views cluster carved — [[TKT-I37338]]. App at 90 methods, directive 90. The dead server-rendered nav path was deleted, closing GitHub #1043 (ungated nav-badge counts). Remaining toward <40: read handlers (list/get/relations/search/analyze/includes on api_v1.go, the largest cluster), config/schema/docs/templates endpoints, and the misc app.go surface.**
+> **Update (2026-07-26): views cluster carved — [[TKT-I37338]]. App at 90 methods, directive 90. The dead server-rendered nav path was deleted, closing GitHub #1043 (ungated nav-badge counts).**
+
+> **Update (2026-09-04): App at 87 (the worlds feature added one). Remaining
+> arc re-planned as four extractions, each a real type with a closed field set
+> and an explicit-deps constructor (no more `newX(app *App, …)` — that shape,
+> used by viewsHandler/appearanceHandler/queryService/exportHandler, is a
+> service-locator seam and is not repeated). See M6 below.**
 
 **Epic / parent ticket** for the remainder of the `dataentry.App` decomposition.
 Each shippable step is its own sub-ticket (moved to `done` with its PR); this
 parent stays in `backlog` until the whole arc lands — App under the 40-method
-line with the plimsoll directive deleted. (Per-PR sub-tickets satisfy the
-done-before-merge gate honestly: a multi-PR epic can't be `done` while work
-remains, and `backlog` is the allowed "not-touched-by-this-PR" parent state.)
+line with the plimsoll directive deleted.
 
 Follow-up to the earlier decomposition that drove `dataentry.App` from 227
 methods down to ~166 and landed the structural payoff — the ACL-bounded
 `visibleReader` seam that closes the #1010 read-ACL bug class — but stopped
-short of the original `<40` end goal. The AppState state-decomposition
-prerequisite ([[TKT-XSWFXQ]]) is also done, so the snapshot/`writeMu` publish
-coupling is gone and the handler clusters can move off `App` one at a time.
+short of the original `<40` end goal.
 
 ## Sub-tickets
 
 - **M5.2 — extract command + sync handlers off `App`.**
   - [x] [[TKT-VG9P1]] — sync route cluster → `syncHandler` (170 → 154). PR #1134.
-  - [x] [[TKT-KUFLD]] — command route cluster → `commandHandler` (154 → 143).
-PR #1138.
-  - [x] [[TKT-QTPUA]] — attachment cluster → `attachmentHandler` + package
-functions (143 → 131). PR #1149.
-- **M5.4 — write nucleus.** Carve the entity/relation/attachment write handlers
-behind one shared `writeMu`; drive `App` under 40 and delete the
-`//plimsoll:max-methods` directive in `internal/dataentry/app.go`.
-  - [x] [[TKT-HKY8RJ]] — write nucleus (entity/relation CRUD + dry-run, clone,
-conflict-resolve, relations reconciler; 18 methods) → `writeHandler` (131 →
-114). PR #1191.
-  - [x] [[TKT-6NDSH9]] — Lua action handler + webhook dispatch → `writeHandler`
-(115 → 114 after develop drift), completing the write surface.
-  - **Open question — settled.** Researched in [[RES-Z1SJ5]], decided in
-[[DEC-8UIL0]]: write serialization becomes a `Tx` contract on `store.Store` (fs
-= mutex, postgres = native transactions + advisory lock), implemented as its
-**own follow-up arc** that deletes `writeMu` outright. M5.4 itself proceeds
-conservatively: the mutex moves with the write-nucleus struct, semantics
-untouched — refactors don't change concurrency behavior.
+  - [x] [[TKT-KUFLD]] — command route cluster → `commandHandler` (154 → 143). PR #1138.
+  - [x] [[TKT-QTPUA]] — attachment cluster → `attachmentHandler` (143 → 131). PR #1149.
+- **M5.4 — write nucleus.**
+  - [x] [[TKT-HKY8RJ]] — write nucleus → `writeHandler` (131 → 114). PR #1191.
+  - [x] [[TKT-6NDSH9]] — Lua action handler + webhook dispatch → `writeHandler`.
+  - Settled in [[RES-Z1SJ5]] / [[DEC-8UIL0]]: write serialization becomes a
+`Tx` contract on `store.Store`, its own follow-up arc.
 - **M5.5 — views cluster.**
-  - [x] [[TKT-I37338]] — view traversal + section builders + /_views,
-/_sidepanel, /_sidebar → `viewsHandler`; 3 helpers package-leveled; dead ungated
-nav path deleted (114 → 90), closing GitHub #1043.
+  - [x] [[TKT-I37338]] — views/sidepanel/sidebar → `viewsHandler` (114 → 90).
+- **M6 — the remaining four surfaces (87 → ~45), safest first:**
+  - [ ] [[TKT-XDJTDC]] — `configAPI`: principal-independent metadata surface
+(schema/config/openapi/templates/apps). No store, no reader, no ACL field. Also
+fixes the stale worldneighbors.go:85 prose. (−7)
+  - [ ] [[TKT-NLX424]] — `nextActionAPI`: suggestion adapter; mutex-guards the
+late-set `userState`/`matchers`. (−11)
+  - [ ] [[TKT-K9GL4J]] — `liveFeed`: reload + store-event bridge + SSE as one
+Start/Stop lifecycle; sole writer of the published Schema. (−9)
+  - [ ] [[TKT-CU105Y]] — `entityAPI`: v1 entity read surface; exclusively
+owns `reader`/`visibleReader`/`serializer`/`worldNeighbors`; consumer-side
+`entityWriteRoutes` interface toward writeHandler. (−15)
+- **M7 (decide after M6)** — `listPipeline` for `scopedSortedEntities` +
+`applyRelationFilters` + `matchRelationFilter` + `resolveScope` +
+`handleV1EntityPosition` (5 methods, 5 consumers). Deliberately NOT in M6:
+absorbing it into `entityAPI` would make gantt/export/next-action depend on the
+read surface — a hub-and-spoke worse than today.
 
 ## Invariants (unchanged)
 
 - Read handlers take the ACL-bounded `visibleReader` only — never `store.Store`.
-- `writeMu` stays a single shared instance across all write handlers (race
-detector guards). The extracted handlers hold a *pointer* to `App`'s `writeMu`,
-preserving this. (Holds until the [[DEC-8UIL0]] arc replaces the mutex with
-store `Tx`.)
-
-## Related finding
-
-The read-path audit also surfaced an ungated nav-badge count leak
-(`enrichNavEntry`, same #1010 read-ACL class) — tracked as GitHub issue #1043.
-**Closed by [[TKT-I37338]]**: the leaky path was production-dead (SPA-era);
-deleting it removes the leak, and the live gated sidebar count path is pinned by
-`TestACLSidebar_CountsMatchList`.
+- Late-set App fields (`worlds`, `worldNeighbors`, `userState`,
+`nextActionMatchers`, `caldavAliases`, `webhook`) are set by public setters
+AFTER `NewApp`; extracted types hold them as closures or behind a mutex, never
+captured by value (the `viewsHandler.faceEdges` lesson).
+- Tests reassign App fields post-construction (`app.acl` 183×, `app.broker`
+54×, `app.fieldResolver` 52×): closures over App, not copies.
+- One `State()` snapshot per handler.
+- Free-win package functions (unused receivers): `renderHelpContent`,
+`gatherRelations`, `toDocumentRenderConfig`, `entityTypeVisible`,
+`applyNextActionFeedback`, `gateReadOrNotFound`, `currentEdgesByPeer`,
+`denyAffordance` — each M6 ticket takes the ones in its cluster.
 
 ## Done when
 

--- a/tickets/entities/tickets/TKT-RKR7VX.md
+++ b/tickets/entities/tickets/TKT-RKR7VX.md
@@ -1,0 +1,64 @@
+---
+id: TKT-RKR7VX
+type: ticket
+title: 'plimsoll housekeeping: drop two dead directives, fix two stale prose references, document the store/Config exceptions and the #1452 ratchet bumps'
+kind: chore
+priority: low
+effort: xs
+tags:
+    - tech-debt
+    - good-first
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]]. One small PR; everything below is verified on
+develop (e0187047).
+
+## Dead directives (both under the 40 line; deleting them changes nothing)
+
+- `internal/docs/runtime.go:87` `//plimsoll:max-methods=29` — docRuntime is
+at 29 methods.
+- `internal/mcp/server.go:214` `//plimsoll:max-methods=25` — mcp.Server is
+at 25 methods.
+
+A directive at or below the default reads as "grandfathered offender" to the
+next person — a false signal. Remove them; if the ratchet intent matters, say it
+in a plain comment ("29 methods; keep shrinking").
+
+## Stale prose (the commentlint `duplication` failure mode)
+
+- `internal/entitymanager/copylist.go:91` claims `Manager` carries a
+`//plimsoll:max-methods=40` load line. **There is no directive on Manager** (37
+methods / 13 exported). The decision — `CopiesForSource` as a package function —
+is right; reword the justification to the true one (Manager is at 37 of 40 and
+the headroom is not a budget).
+- `internal/dataentry/worldneighbors.go:85` cites `max-methods=104`; the
+directive is 87 (app.go:172). Replace with a `[App]` doc link rather than
+restating a number that lives elsewhere. (If the configAPI ticket [[TKT-XDJTDC]]
+lands first it fixes this one — check.)
+
+## Document two settled exceptions so nobody opens a ticket for them
+
+- **Store backends.** memstore's exported surplus over `store.Store` +
+optional capabilities is **0**; sqlitestore's is 1 (`JournalMode`); fsstore's is
+3; pgstore's is 7, every one already consumed through a narrow consumer-side
+interface, and versioning is ALREADY behind `VersionServiceProvider`
+(store.go:1164), contributing one method. There is nothing to ratchet on the
+exported line; CLAUDE.md's exception is correct. Note the pgstore free-function
+shuffle at pgstore/entity.go:872-875 as the anti-pattern (method moved off the
+receiver purely to duck the counter).
+- **`dataentryconfig.Config`** (22 fields). A read-only format mirror of
+`data-entry.yaml` — never marshalled back, never JSON-encoded wholesale.
+Grouping via `yaml:",inline"` works (verified) but costs 131 non-test call sites
+for an arbitrary grouping (`Dashboard` under Views or Behaviour?). Leave the
+directive; say so in its doc comment. Separately, the `json:",inline"` tags at
+theme.go:70 and config.go:1740 are no-ops (`encoding/json` has no inline option)
+— drop them.
+
+## Record in the epic (TKT-N0IKN9)
+
+The worlds feature (#1452, e0187047) RAISED directives rather than holding them:
+fsstore 81→92 / 33→36, memstore 43→50 / 29→32, sqlitestore 43→53 / 29→32,
+pgstore 49→52 / 39→42, app 86→87. The exported bumps are legitimate
+(`store.Store` grew); the total-method bumps are the ratchet being defeated by a
+large feature PR and are what the fsstore arc now pays back.

--- a/tickets/entities/tickets/TKT-RKR7VX.md
+++ b/tickets/entities/tickets/TKT-RKR7VX.md
@@ -8,7 +8,7 @@ effort: xs
 tags:
     - tech-debt
     - good-first
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]]. One small PR; everything below is verified on

--- a/tickets/entities/tickets/TKT-V9NKZY.md
+++ b/tickets/entities/tickets/TKT-V9NKZY.md
@@ -1,0 +1,84 @@
+---
+id: TKT-V9NKZY
+type: ticket
+title: 'Extract graphWrites off lua.Runtime: mutation bindings + bypass_acl elevation as a writer-only type (36 → 29)'
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - tech-debt
+    - security
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]], `lua.Runtime` arc. Follows the graphReads
+extraction; textually independent of it (touches `registerWriteBindings`, not
+`registerReadBindings`), so it can be developed in parallel — only the struct
+doc comment at runtime.go:64-101 will conflict.
+
+## Why a separate type from graphReads
+
+The read/write split is the same one `ReadDeps`/`WriteDeps` draws (CLAUDE.md
+capability bundles): a reader runtime never constructs this, so read-only code
+cannot reach a mutator by holding the wrong struct. Follow the established
+pattern listed in the graphReads ticket (deps-only struct, seam stays on
+Runtime, closures for mutable state, method values, `ls` parameter for
+Push/Raise).
+
+## What moves (7 methods → `internal/lua/graphwrites.go`)
+
+Writes: `luaCreateEntity` (runtime.go:1791), `luaUpdateEntity` (:1833 —
+PatchEntity), `luaDeleteEntity` (:2300), `luaCreateRelation` (:2319),
+`luaDeleteRelation` (:2341). Elevation: `luaBypassACL` (:1918),
+`newElevatedHandle` (:2023). `readUsage` (:2001) and `recordElevatedReads`
+(:2016) are already Runtime-free and move as-is.
+
+`luaWriteFile` stays behind under its `r.caps.WriteFile` gate — see the
+`capabilityguard_test.go` constraint below.
+
+## Shape
+
+```go
+type graphWrites struct {
+    manager Mutator // never nil on a writer runtime — NewWriter panics without it (runtime.go:400)
+    // bypass_acl. Both nil ⇒ binding not registered. Nil elevatedReader with
+    // non-nil elevatedManager leaves the admin read methods PRESENT and
+    // RAISING (TKT-Y3JVFK) — move that comment with newElevatedHandle.
+    elevatedManager   Mutator
+    elevatedReader    EntityReader
+    elevationRecorder ElevationRecorder
+    ctx func() context.Context
+}
+```
+
+`registerWriteBindings` (runtime.go:889) constructs it. Keep the
+`r.deps.ElevatedManager != nil || r.deps.ElevatedReader != nil` condition
+(runtime.go:803) textually where it is to avoid re-reviewing it.
+
+## Risks (MEDIUM-HIGH — the elevation boundary)
+
+- The `live` invalidation defer (runtime.go:1941-1949) and audit-rides-the-
+same-defer property move intact. Pinned by `acl_bypass_test.go`,
+`audit_spoofing_test.go`.
+- `isEntityNotFound` structural check in `luaUpdateEntity` (:1863) — do not
+let the move turn it back into a string match.
+- `capabilityguard_test.go:28-46` greps all package source: exactly one
+`SetField(rela, "write_file"` within 200 bytes of `if r.caps.WriteFile {`. Leave
+that block untouched.
+- `internal/dataentry/elevated_document_test.go:315,327` constructs
+`lua.NewWriter` directly and relies on the panic-without-EntityManager.
+- If the diff feels large, split elevation into its own `elevatedBindings`
+PR — but only then; two types where one suffices is its own cost.
+
+## Explicitly NOT in scope
+
+- Extracting a `runner`/`executor` for `RunFile`/`RunString`/`applyTimeout`/
+`pcallWithCapture`: that is the VM lifecycle and Runtime's identity; a facade
+delegating method-for-method is not a decomposition.
+- Extracting the `registerX` seams. All prior extractions kept them.
+- An `outputBindings` type (`luaPrint`/`luaOutput`/`luaWriteFile`, −3): marginal
+once the two above land; the `print` override at runtime.go:438 runs before
+`registerBindings`, which makes it awkward. Skip unless headroom is wanted.
+
+Ratchet `//plimsoll:max-methods` (runtime.go:102) to 29; append the struct doc
+entry.

--- a/tickets/entities/tickets/TKT-V9NKZY.md
+++ b/tickets/entities/tickets/TKT-V9NKZY.md
@@ -8,7 +8,7 @@ effort: m
 tags:
     - tech-debt
     - security
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]], `lua.Runtime` arc. Follows the graphReads

--- a/tickets/entities/tickets/TKT-W9E1NC.md
+++ b/tickets/entities/tickets/TKT-W9E1NC.md
@@ -7,7 +7,7 @@ priority: medium
 effort: l
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]], `fsstore.FSStore` arc. The highest-value

--- a/tickets/entities/tickets/TKT-W9E1NC.md
+++ b/tickets/entities/tickets/TKT-W9E1NC.md
@@ -1,0 +1,70 @@
+---
+id: TKT-W9E1NC
+type: ticket
+title: 'Extract metaIndex off fsstore.FSStore: make the map+order pairing a single mutation so the comparator-mismatch bug class is unrepresentable'
+kind: refactor
+priority: medium
+effort: l
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]], `fsstore.FSStore` arc. The highest-value
+extraction in the arc: it removes a **class of bug**, not just methods.
+
+## The problem it solves
+
+`entities`/`entityOrder` and `relations`/`relationOrder` always mutate in the
+same statement pair — 9 sites for `entityOrder`, 10 for `relationOrder`, across
+`entity.go`, `index.go`, `relation.go`, `watcher.go`, `attachment.go`. Nothing
+enforces the pairing today. `fsstore.go:452-472` documents a real past bug:
+`SortedRemoveFunc` panicking because construction used a different comparator
+than mutation. `propCache` co-mutates with `entities` at the same sites. Making
+each pair ONE method on a type that owns all five fields makes the invariant
+unbreakable.
+
+## Shape (`internal/store/fsstore/metaindex.go`)
+
+```go
+type metaIndex struct {
+    entities      map[string]entityMeta
+    entityOrder   []string
+    relations     map[string]relationMeta
+    relationOrder []string
+    propCache     map[string]map[string]int
+}
+func (x *metaIndex) putEntity(m entityMeta)                  // map + SortedInsertFunc, one comparator
+func (x *metaIndex) removeEntity(key string) (entityMeta, bool)
+func (x *metaIndex) putRelation(m relationMeta)
+func (x *metaIndex) removeRelation(key string) bool
+func (x *metaIndex) stateFamily(id string) ([]entityMeta, []relationMeta) // was FSStore.stateFamily (entity.go:391)
+func (x *metaIndex) familySize(id string) int                            // was entity.go:612
+func (x *metaIndex) idTaken(id, except string) bool
+func (x *metaIndex) countProp(e *entity.Entity, delta int)               // add/removeEntityFromCache
+```
+
+Plain data structure, **no mutex** — `mu` stays on FSStore (arc-wide rule on the
+attachmentStore ticket). Net method delta on FSStore is modest (~−6) but ~20
+mutation sites collapse into the type.
+
+## Consider in the same PR
+
+`memstore.MemStore` holds the same five fields (memstore.go:73-88 are a strict
+subset of fsstore's) and pairs them at its own sites. If `metaIndex` ends up
+storage-agnostic, hoist it to `storeutil` and let memstore adopt it in a
+follow-up — do not widen this PR to two backends.
+
+## Do NOT
+
+- Add a lock to the type.
+- Shadow promoted methods: `txStore` (tx.go:132) embeds `*FSStore`; extracted
+types must be reachable as plain fields.
+- Touch `tx.go`, `emit`/observer notification ordering, or `notifyRenamed`
+single-event semantics (do-not-touch list from TKT-Y683LJ still applies).
+
+## Done when
+
+`storetest.RunAll` + full fuzz corpus (`FuzzRenameKeyCollapse` guards this
+directly), `go test -race ./internal/store/...`, ratchet
+`//plimsoll:max-methods` (fsstore.go:159).

--- a/tickets/entities/tickets/TKT-XDJTDC.md
+++ b/tickets/entities/tickets/TKT-XDJTDC.md
@@ -7,7 +7,7 @@ priority: medium
 effort: m
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).

--- a/tickets/entities/tickets/TKT-XDJTDC.md
+++ b/tickets/entities/tickets/TKT-XDJTDC.md
@@ -1,0 +1,83 @@
+---
+id: TKT-XDJTDC
+type: ticket
+title: 'Extract configAPI off dataentry.App: the principal-independent metadata surface (87 → ~80)'
+kind: refactor
+priority: medium
+effort: m
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-R68TV8]] (the `dataentry.App` arc under [[TKT-N0IKN9]]).
+Recommended FIRST App PR: smallest blast radius, and it establishes the
+constructor pattern the following three extractions copy.
+
+## Why this is an abstraction, not a file move
+
+CLAUDE.md's rule "the configuration is not a secret; the data is" is prose
+today. Every handler in this cluster serves operator-authored config
+byte-identically to every principal, touches no store, and takes no read gate.
+Making that a type turns the rule into structure: `configAPI` has **no store, no
+reader, no ACL field**, so a reviewer can see at a glance that no entity data
+can leak through it, and a change that needs one has to justify adding the
+field.
+
+## What moves (7 methods, `internal/dataentry/`)
+
+- `handleV1Schema` (api_v1.go:1282), `handleV1SchemaRoutes` (:1337),
+`handleV1Config` (:1566), `handleV1OpenAPI` (:2653), `handleV1Templates`
+(:2608), `handleV1App` (apps_handler.go:88).
+- `scanAppsOrLog` (apps_handler.go:209) becomes a package function taking
+`root string`.
+
+Field set used (verified): `{schema, palette, templater, paths, versions}`.
+`templater` and `versions` leave `App` entirely.
+
+## Shape
+
+```go
+// configAPI serves the principal-independent metadata surface: /_schema,
+// /_schema/*, /_config, /_openapi.json, /_templates/*, /_apps/*.
+// It deliberately holds NO store, NO reader and NO ACL (CLAUDE.md: the
+// configuration is not a secret). A change that needs a store handle here
+// has left this surface — say so in review rather than adding the field.
+type configAPI struct {
+    schema    func() *Schema      // App.State — snapshot ONCE per handler
+    palette   *paletteService
+    templater templating.Templater
+    root      string              // project root for the apps/ scan
+    // historyEnabled: a predicate, not the store.VersionService — this
+    // surface must not be able to READ a version.
+    historyEnabled func() bool
+}
+
+func newConfigAPI(schema func() *Schema, palette *paletteService,
+    templater templating.Templater, root string, historyEnabled func() bool) (*configAPI, error)
+```
+
+Constructor validates required deps (CLAUDE.md: constructors reject nil). **Do
+not** take `app *App` in the constructor — `newViewsHandler(app *App,…)`
+(app.go:1333), `newAppearanceHandler`, `newQueryService`, `newExportHandler` did
+that and it is a service-locator-shaped seam; this arc stops repeating it.
+
+## Also in this PR
+
+- Fix the stale prose at `worldneighbors.go:85` (cites `max-methods=104`;
+the directive is 87 at app.go:172). Replace the restated number with a `[App]`
+doc link — the commentlint `duplication` rule's remedy.
+- Ratchet `//plimsoll:max-methods` at app.go:172 to the new exact count.
+- Route ownership changes: verify `router_walk_test.go` still probes every
+moved path (router.go:56).
+
+## Invariants
+
+- One `schema()` snapshot per handler (CLAUDE.md: capture state once).
+`handleV1Config` (:1571) and `handleV1Schema` (:1289) already do this; keep it.
+- No behaviour change; responses byte-identical for every principal.
+
+## Done when
+
+`go test -race ./internal/dataentry/...` green, `just plimsoll` with the lowered
+directive, `just arch-lint`, `just comment-lint`, `just coverage-check`.

--- a/tickets/entities/tickets/TKT-YJDD7C.md
+++ b/tickets/entities/tickets/TKT-YJDD7C.md
@@ -7,7 +7,7 @@ priority: low
 effort: m
 tags:
     - tech-debt
-status: ready
+status: backlog
 ---
 
 Sub-ticket of [[TKT-N0IKN9]] — `cli.CLI` (47 exported fields, directive at

--- a/tickets/entities/tickets/TKT-YJDD7C.md
+++ b/tickets/entities/tickets/TKT-YJDD7C.md
@@ -1,0 +1,63 @@
+---
+id: TKT-YJDD7C
+type: ticket
+title: 'cli.CLI: group subcommands into embed:"" command-group structs and replace the package-level invocation globals with a bound Globals value'
+kind: refactor
+priority: low
+effort: m
+tags:
+    - tech-debt
+status: ready
+---
+
+Sub-ticket of [[TKT-N0IKN9]] — `cli.CLI` (47 exported fields, directive at
+`internal/cli/kong.go:70`). Two steps; step 1 is cheap, step 2 is the real
+design fix.
+
+## Step 1 — command groups via `embed:""` (47 → 7 fields, directive deleted)
+
+Verified empirically against kong v1.16.1 and plimsoll v0.2.0:
+- `embed:""` splices the embedded struct's fields into the PARENT's field
+list (kong build.go:88-90) — `rela show` stays `rela show`, `ktx.Command()` is
+unchanged, so `requiresProject` (kong.go:256-277) and its token parsing keep
+working. `cmd:""` on a group struct would create a node (`rela group show`) — do
+NOT use it.
+- plimsoll counts the syntactic struct literal only (analyzer.go:255-278); an
+embedded exported type counts as 1.
+- Global flags embed too, keeping `--project`/`-v`/`-o`/`-q` at the root with
+`env:`/`short:` tags intact.
+
+```go
+type CLI struct {
+    Globals        `embed:""`   // Project, Output, Verbose, Quiet
+    EntityCmds     `embed:""`   // Show List Create Update Delete Link Unlink Renumber
+    GraphCmds      `embed:""`   // Trace Graph Analyze
+    ContentCmds    `embed:""`   // Export Render Import Sync Fmt Normalize Rename Gc Attach Attachments Detach
+    VersioningCmds `embed:""`   // History Restore RelationHistory RelationRestore HistoryPurge RelationHistoryPurge
+    ProjectCmds    `embed:""`   // Schema Template Validate Migrate ACL Secrets Init
+    RuntimeCmds    `embed:""`   // Script Scheduler Flow Mcp Db Apps Version Completion
+}
+```
+
+Each group lives in its own file beside its commands — the versioning six (all
+postgres-only) become one greppable cluster instead of six fields in a 50-line
+block. Keep the doc comment at kong.go:53-68 explaining that the struct is a
+kong format mirror.
+
+## Step 2 — the actual smell: package-level mutable invocation state
+
+`out`, `verbose`, `quiet`, `outputFormat`, `projectPath` (kong.go:44-49) are
+package globals copied out of the four flag fields in `runKong`
+(kong.go:174-177) and read implicitly by every subcommand. kong.go:6-10
+acknowledges it. Thread a `*Globals` (or an `invocation` value built from it)
+through `ktx.Bind(...)` so `Run` methods receive it as a parameter, and delete
+the globals. This is a larger, mechanical change across the `*Cmd.Run`
+signatures; do it as its own commit (or PR) after step 1, and it is the part
+that makes the CLI testable without process-global state.
+
+## Note, not in scope
+
+`plimsoll ./...` also reports `package cli has 91 exported types, over the load
+line of 40` (`max-exported-types`, not gated in CI today). Grouping fields does
+not change that; it is the more accurate signal about this package and should be
+discussed separately.

--- a/tickets/relations/TKT-8FXP1B--affects--store-backends.md
+++ b/tickets/relations/TKT-8FXP1B--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8FXP1B
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-8FXP1B--depends-on--TKT-9XDEY0.md
+++ b/tickets/relations/TKT-8FXP1B--depends-on--TKT-9XDEY0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8FXP1B
+relation: depends-on
+to: TKT-9XDEY0
+---

--- a/tickets/relations/TKT-8FXP1B--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-8FXP1B--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-8FXP1B
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-9XDEY0--affects--store-backends.md
+++ b/tickets/relations/TKT-9XDEY0--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9XDEY0
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-9XDEY0--depends-on--BUG-S24X52.md
+++ b/tickets/relations/TKT-9XDEY0--depends-on--BUG-S24X52.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9XDEY0
+relation: depends-on
+to: BUG-S24X52
+---

--- a/tickets/relations/TKT-9XDEY0--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-9XDEY0--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-9XDEY0
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-CU105Y--affects--authorization.md
+++ b/tickets/relations/TKT-CU105Y--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CU105Y
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-CU105Y--affects--data-entry-server.md
+++ b/tickets/relations/TKT-CU105Y--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CU105Y
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-CU105Y--depends-on--TKT-K9GL4J.md
+++ b/tickets/relations/TKT-CU105Y--depends-on--TKT-K9GL4J.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CU105Y
+relation: depends-on
+to: TKT-K9GL4J
+---

--- a/tickets/relations/TKT-CU105Y--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-CU105Y--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-CU105Y
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-EK1JO8--affects--metamodel-types.md
+++ b/tickets/relations/TKT-EK1JO8--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EK1JO8
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-EK1JO8--depends-on--TKT-OBC7QI.md
+++ b/tickets/relations/TKT-EK1JO8--depends-on--TKT-OBC7QI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EK1JO8
+relation: depends-on
+to: TKT-OBC7QI
+---

--- a/tickets/relations/TKT-EK1JO8--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-EK1JO8--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-EK1JO8
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-K9GL4J--affects--data-entry-server.md
+++ b/tickets/relations/TKT-K9GL4J--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K9GL4J
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-K9GL4J--depends-on--TKT-NLX424.md
+++ b/tickets/relations/TKT-K9GL4J--depends-on--TKT-NLX424.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K9GL4J
+relation: depends-on
+to: TKT-NLX424
+---

--- a/tickets/relations/TKT-K9GL4J--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-K9GL4J--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-K9GL4J
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-M3X3JO--affects--lua-scripting.md
+++ b/tickets/relations/TKT-M3X3JO--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M3X3JO
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-M3X3JO--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-M3X3JO--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-M3X3JO
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-N0IKN9--depends-on--TKT-EK1JO8.md
+++ b/tickets/relations/TKT-N0IKN9--depends-on--TKT-EK1JO8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N0IKN9
+relation: depends-on
+to: TKT-EK1JO8
+---

--- a/tickets/relations/TKT-N0IKN9--depends-on--TKT-M3X3JO.md
+++ b/tickets/relations/TKT-N0IKN9--depends-on--TKT-M3X3JO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N0IKN9
+relation: depends-on
+to: TKT-M3X3JO
+---

--- a/tickets/relations/TKT-N0IKN9--depends-on--TKT-ONFXVS.md
+++ b/tickets/relations/TKT-N0IKN9--depends-on--TKT-ONFXVS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N0IKN9
+relation: depends-on
+to: TKT-ONFXVS
+---

--- a/tickets/relations/TKT-N0IKN9--depends-on--TKT-R3SMEK.md
+++ b/tickets/relations/TKT-N0IKN9--depends-on--TKT-R3SMEK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N0IKN9
+relation: depends-on
+to: TKT-R3SMEK
+---

--- a/tickets/relations/TKT-N0IKN9--depends-on--TKT-RKR7VX.md
+++ b/tickets/relations/TKT-N0IKN9--depends-on--TKT-RKR7VX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N0IKN9
+relation: depends-on
+to: TKT-RKR7VX
+---

--- a/tickets/relations/TKT-N0IKN9--depends-on--TKT-V9NKZY.md
+++ b/tickets/relations/TKT-N0IKN9--depends-on--TKT-V9NKZY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N0IKN9
+relation: depends-on
+to: TKT-V9NKZY
+---

--- a/tickets/relations/TKT-N0IKN9--depends-on--TKT-YJDD7C.md
+++ b/tickets/relations/TKT-N0IKN9--depends-on--TKT-YJDD7C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-N0IKN9
+relation: depends-on
+to: TKT-YJDD7C
+---

--- a/tickets/relations/TKT-NLX424--affects--data-entry-server.md
+++ b/tickets/relations/TKT-NLX424--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NLX424
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-NLX424--depends-on--TKT-XDJTDC.md
+++ b/tickets/relations/TKT-NLX424--depends-on--TKT-XDJTDC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NLX424
+relation: depends-on
+to: TKT-XDJTDC
+---

--- a/tickets/relations/TKT-NLX424--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-NLX424--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-NLX424
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-OBC7QI--affects--data-migration.md
+++ b/tickets/relations/TKT-OBC7QI--affects--data-migration.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OBC7QI
+relation: affects
+to: data-migration
+---

--- a/tickets/relations/TKT-OBC7QI--affects--metamodel-types.md
+++ b/tickets/relations/TKT-OBC7QI--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OBC7QI
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-OBC7QI--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-OBC7QI--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OBC7QI
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-ONFXVS--affects--store-backends.md
+++ b/tickets/relations/TKT-ONFXVS--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ONFXVS
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-ONFXVS--depends-on--TKT-W9E1NC.md
+++ b/tickets/relations/TKT-ONFXVS--depends-on--TKT-W9E1NC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ONFXVS
+relation: depends-on
+to: TKT-W9E1NC
+---

--- a/tickets/relations/TKT-ONFXVS--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-ONFXVS--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ONFXVS
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-R3SMEK--affects--workspace.md
+++ b/tickets/relations/TKT-R3SMEK--affects--workspace.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R3SMEK
+relation: affects
+to: workspace
+---

--- a/tickets/relations/TKT-R3SMEK--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-R3SMEK--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R3SMEK
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-R68TV8--depends-on--TKT-CU105Y.md
+++ b/tickets/relations/TKT-R68TV8--depends-on--TKT-CU105Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-R68TV8
+relation: depends-on
+to: TKT-CU105Y
+---

--- a/tickets/relations/TKT-RKR7VX--affects--ci-pipeline.md
+++ b/tickets/relations/TKT-RKR7VX--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RKR7VX
+relation: affects
+to: ci-pipeline
+---

--- a/tickets/relations/TKT-RKR7VX--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-RKR7VX--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RKR7VX
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-V9NKZY--affects--lua-scripting.md
+++ b/tickets/relations/TKT-V9NKZY--affects--lua-scripting.md
@@ -1,0 +1,5 @@
+---
+from: TKT-V9NKZY
+relation: affects
+to: lua-scripting
+---

--- a/tickets/relations/TKT-V9NKZY--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-V9NKZY--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-V9NKZY
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-W9E1NC--affects--store-backends.md
+++ b/tickets/relations/TKT-W9E1NC--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W9E1NC
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-W9E1NC--depends-on--TKT-9XDEY0.md
+++ b/tickets/relations/TKT-W9E1NC--depends-on--TKT-9XDEY0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W9E1NC
+relation: depends-on
+to: TKT-9XDEY0
+---

--- a/tickets/relations/TKT-W9E1NC--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-W9E1NC--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-W9E1NC
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-XDJTDC--affects--data-entry-server.md
+++ b/tickets/relations/TKT-XDJTDC--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XDJTDC
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-XDJTDC--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-XDJTDC--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-XDJTDC
+relation: implements
+to: FEAT-GE1YY
+---

--- a/tickets/relations/TKT-YJDD7C--affects--cli-flags.md
+++ b/tickets/relations/TKT-YJDD7C--affects--cli-flags.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YJDD7C
+relation: affects
+to: cli-flags
+---

--- a/tickets/relations/TKT-YJDD7C--implements--FEAT-GE1YY.md
+++ b/tickets/relations/TKT-YJDD7C--implements--FEAT-GE1YY.md
@@ -1,0 +1,5 @@
+---
+from: TKT-YJDD7C
+relation: implements
+to: FEAT-GE1YY
+---


### PR DESCRIPTION
Ticket-only change. Stacked on #1522 because TKT-9XDEY0 depends on BUG-S24X52, which that PR introduces; GitHub retargets this PR to develop when #1522 merges.

Re-plans the plimsoll god-object epic TKT-N0IKN9 as one PR per ticket, one owner each, real abstractions only (closed field sets, invariants the new type defends). Also updates TKT-R68TV8 (the App sub-epic) with the M6 arc.

| Arc | Tickets | Order |
|---|---|---|
| dataentry.App | TKT-XDJTDC configAPI, TKT-NLX424 nextActionAPI, TKT-K9GL4J liveFeed, TKT-CU105Y entityAPI | sequential |
| lua.Runtime | TKT-M3X3JO graphReads, TKT-V9NKZY graphWrites | parallel |
| fsstore.FSStore | TKT-9XDEY0 attachmentStore, TKT-8FXP1B fsIndexLoader, TKT-W9E1NC metaIndex, TKT-ONFXVS ObserverSet (needs-design) | sequential, after #1522 |
| metamodel | TKT-OBC7QI migration SchemaAdapter, TKT-EK1JO8 SchemaOutput/EntityOutput | sequential |
| appbuild | TKT-R3SMEK ScheduledMailer + documented exception | — |
| cli | TKT-YJDD7C embed:"" groups + bound Globals | — |
| chore | TKT-RKR7VX dead directives, stale prose, documented exceptions | — |

Settled as not-offenders (documented in TKT-RKR7VX): store backend exported counts and dataentryconfig.Config.

`rela validate --project tickets` passes (cardinality, properties, 120 validation rules).

https://claude.ai/code/session_01AVcDvHP3jVYi58CA9RHi8h

