### PR TITLE
⚡ perf: query-efficient data-entry reads on PostgreSQL (TKT-1U8XYN)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -134,6 +134,10 @@ components:
 
   # Project bootstrap utilities
   projectsetup:     { in: internal/projectsetup }
+  # Deterministic graph generator for the perf demo project. A leaf over the
+  # store contract: it emits entities/relations and loads them through
+  # store.Store, and must never learn about entitymanager or the metamodel.
+  perfseed:         { in: internal/perfseed }
 
   # Infrastructure
   acl:              { in: internal/acl }
@@ -340,6 +344,7 @@ deps:
       - memstore
       - metamodel
       - output
+      - perfseed
       - pgstore
       - sqlitestore
       - predicate
@@ -1205,6 +1210,10 @@ deps:
   state:
     mayDependOn:
       - storage
+  perfseed:
+    mayDependOn:
+      - store
+      - storeutil
   storage:
     anyProjectDeps: true
     canUse:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -274,6 +274,18 @@ linters:
       - linters:
           - usetesting
         path: internal/testutil/.*\.go
+      # internal/perfseed is a data generator: its body IS tuning constants
+      # (counts per type, date spans, body sizes, edge fan-out) and a seeded
+      # math/rand PRNG is the whole point — determinism, not secrecy. Naming
+      # every literal would bury the shape of the graph under fifty consts,
+      # and G404 has no security meaning for synthetic demo data.
+      - linters:
+          - mnd
+        path: internal/perfseed/
+      - linters:
+          - gosec
+        path: internal/perfseed/
+        text: G404
       # G706 (log injection) in internal/dataentry: false positives.
       #
       # gosec's taint analysis treats slog.Info/Warn/Error/Debug as a sink and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -660,6 +660,14 @@ Rules when touching this:
   rows). Migration steps must stay idempotent — re-run IS the crash
   recovery. The Lua step is a pure transform (patch in, patch out, engine
   applies); never hand it a write handle.
+- **Perf seeding** (TKT-1U8XYN, `internal/perfseed`, `rela dev seed`) is the
+  fourth raw-store exception, under the same terms: operator shell, attributed
+  (`perf-seed` tool), one `perf-seed` audit record, and it refuses a non-empty
+  store. Because nothing above the store runs, the generator keeps the
+  invariants the store cannot: ids minted by construction and validated, the
+  single `unique:` property unique by construction, every edge endpoint
+  emitted by the same generator. Do not route it through entitymanager to
+  "fix" that — 20k automations per seed is the cost it exists to avoid.
 - DSN is read from the `RELA_DATABASE_URL` env var **only** — there is no
   `--database-url` flag, so the credential never lands in `ps`/shell history.
   `appbuild.Discover` reads the env into `appbuild.Config.DatabaseURL`; the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,23 @@
   there is no signal handler, so pending mail is lost on every restart with no
   drain. Mail is notification, never a system of record. A durable queue with
   swappable backends is IDEA-WIJ2H1.
+- **Collection reads are content-free, batched per page, and paged in the
+  store when they can be** (TKT-1U8XYN). A list, search, kanban or scope
+  pipeline reads `store.EntityHeader` rows (`ListEntityHeaders`,
+  `GraphQueryHeaders`) and never a body it will not render; a body is loaded
+  for the served rows only, on `include_content=true`. Per-row lookups are
+  the defect this rule exists to prevent: a page loads its edges with ONE
+  `RelationQuery.EntityIDs` query, its neighbours with ONE header batch, a
+  table section its relation columns with one query per (column, row type).
+  Write authorization reuses the request's `acl.Request` (the membership walk
+  runs once per operation, not once per verb per row). When the request's
+  shape allows it, the list handler pushes paging, ordering and equality
+  filters into `store.GraphQuery` (`listpushdown.go`) and takes the scoped
+  count through `store.CountMatched`, never `GraphCount`'s total. New read
+  paths pin their cost with a `storetest.Counting` budget test asserting the
+  count is the same at 10 and 50 rows. Measure on the postgres backend with
+  `rela-server -verbose` (`Server-Timing`, one `request` log line each) against
+  `prototypes/perf/project` seeded by `rela dev seed`.
 - **Boundaries are enforced.** `just arch-lint` checks package import
   rules; run it before PR.
 

--- a/docs-project/entities/guides/GUIDE-acl-security.md
+++ b/docs-project/entities/guides/GUIDE-acl-security.md
@@ -899,6 +899,21 @@ caches from leaking one principal's view to another:
   `Vary: <that header>` — defense in depth for any cache layer that
   ignores `no-store`.
 
+### Query accounting is a Debug-only diagnostic
+
+With `-verbose`, every API response carries a `Server-Timing` header with the
+number of SQL statements the request issued and their summed database time,
+and the log gets one `request` record per request (see
+`docs/postgres-backend.md`, "Observing query cost"). Below Debug neither
+exists. The gate is a security property, not a convenience: on a path that
+still resolves neighbors one by one, the statement count varies with rows the
+principal cannot see, so a machine-readable count on every response would be
+an existence channel of exactly the kind the row-level rule above forbids.
+Wall time is already observable by any client and is accepted as coarse
+timing exposure; the statement count is not, and stays an operator tool.
+Do not enable `-verbose` on a multi-principal deployment to "get metrics" —
+put the numbers in the log, not on the wire.
+
 ### Sidebar menu structure is principal-independent
 
 The sidebar's *structure* (groups, labels, links) reveals metamodel

--- a/docs-project/entities/guides/GUIDE-cli-reference.md
+++ b/docs-project/entities/guides/GUIDE-cli-reference.md
@@ -1851,6 +1851,53 @@ rela gc --temp-files --dry-run  # Preview what would be removed
 
 ---
 
+### rela dev seed
+
+Fill an **empty** project store with generated data for performance work.
+
+```bash
+rela dev seed [flags]
+```
+
+The data comes from a deterministic generator (`internal/perfseed`) shaped for
+the perf demo project in `prototypes/perf/project`: teams, people, projects,
+tasks, controls, risks, policies with draft/published faces and documents with
+en/nl faces, plus the relations between them. The same `--seed` and `--scale`
+always produce the same graph, on every backend — on the default build it
+writes markdown files, on the postgres build it writes straight into the
+database named by `RELA_DATABASE_URL`.
+
+This is a raw store write: no automations, validations or ACL run, the writes
+are attributed to the operator with tool `perf-seed`, and the run leaves one
+`perf-seed` audit record. It refuses a store that already holds entities so a
+second run cannot sit beside real data.
+
+**Flags:**
+
+| Flag        | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `--profile` | Which graph to generate; only `perf` exists today                           |
+| `--scale`   | Size multiplier in (0, 10]; `1` is roughly 20k entities and 45k relations   |
+| `--seed`    | PRNG seed (default 1)                                                       |
+| `--batch`   | Writes per transaction (default 500)                                        |
+| `--force`   | Seed even though the store already holds entities                           |
+
+**Examples:**
+
+```bash
+cp -R prototypes/perf/project /tmp/perf && cd /tmp/perf
+rela dev seed --scale 0.05                 # a few hundred entities as markdown files
+
+export RELA_DATABASE_URL='postgres://rela@localhost/rela_perf?sslmode=disable'
+rela-postgres dev seed --project prototypes/perf/project --scale 1
+```
+
+The filesystem backend writes one file per row and indexes each for search,
+so keep the scale small there; the full graph is meant for PostgreSQL, where
+scale 1 loads in well under a minute.
+
+---
+
 ### rela validate
 
 Validate project configuration files.

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1176,6 +1176,12 @@ sort:
 
 You can also sort by the virtual properties `id` (entity ID) and `modified` (file modification time).
 
+Values compare as text, byte by byte. An entity that lacks the sort property
+sorts as if it held the largest value: after every entity that has one when
+ascending, before them when descending. On the PostgreSQL backend a sorted list
+page is served straight from an index when the sort keys are string-shaped
+properties (see the PostgreSQL guide on derived list indexes).
+
 If no sort is configured, the list falls back to the entity type's `default_sort` from the metamodel,
 or sorts by ID ascending.
 

--- a/docs-project/entities/guides/GUIDE-postgres-backend.md
+++ b/docs-project/entities/guides/GUIDE-postgres-backend.md
@@ -66,6 +66,12 @@ The connecting role needs privileges to create the `pg_trgm` extension on
 first run (typically a superuser, or have an administrator run
 `CREATE EXTENSION pg_trgm;` once in the target database beforehand).
 
+Migration 14 rewrites the `search_text` column of every entity once, inside
+the migration transaction, so the first start after upgrading pauses for a
+time proportional to the entity table — seconds at twenty thousand rows,
+longer on a large one. Run `rela db migrate` as a deploy step if that pause
+must not land on the first web request.
+
 ### Applying migrations explicitly
 
 If you would rather apply the schema as a separate, controlled step
@@ -109,10 +115,20 @@ next start — and in the steady state (nothing changed) it does no work.
 PostgreSQL also derives ordinary B-tree indexes from eligible static queries in
 `data-entry.yaml`. Dashboard cards, global next-action queries, and `pick_one`
 option queries qualify when they target exactly one entity type and all pushed
-filters are non-empty equality checks on declared, scalar string properties.
-rela creates one composite `rela_derived_query__…` index for the complete set
-of properties in each query shape. Equivalent queries share an index even when
+filters are non-empty equality checks on declared, scalar string-shaped
+properties (`string`, `enum`, `date`, `datetime`, or a custom type). rela
+creates one composite `rela_derived_query__…` index for the complete set of
+properties in each query shape. Equivalent queries share an index even when
 their literal values or filter order differ.
+
+Lists get the same treatment. A list with a `sort:` whose keys (and whose
+static `=` filters, if any) are string-shaped properties gets one
+`rela_derived_list__…` index over its type, its filters, its sort keys and the
+id — the exact scan a list page performs when the server pushes paging into the
+database. With it, page 40 of an 11,000-row list is an index range scan; without
+it the database sorts the whole type for every page. A list sorted on an
+integer, a list-valued property, or with a `!=` or range filter gets no index,
+because such a page is not pushed down (see "Observing query cost").
 
 Runtime and URL queries are not observed. Free text, relations, sorting, glob,
 not-equal, empty-value, list-valued, and non-string filters do not produce an
@@ -152,10 +168,72 @@ planner, what the dry-run predicts is what startup does.
 
 ## Search
 
-In the PostgreSQL build, search runs **in the database** (a `tsvector`
-GIN index for ranked full-text plus `pg_trgm` for substring and fuzzy
-matching) — there is no bleve index. Text search matches the same fields
-as the default backend: entity ID, content, and string-valued properties.
+In the PostgreSQL build, search runs **in the database** — there is no bleve
+index. Matching is a case-insensitive substring match over a maintained
+`search_text` column (the id, then string properties, then the body),
+accelerated by a `pg_trgm` GIN index. Results are ranked by trigram similarity
+between the query and the first kilobyte of that column — the identity and the
+title-like properties — so an entity *about* the term outranks one that merely
+mentions it in a long body, and ranking stays cheap on a common word. Text
+search matches the same fields as the default backend: entity ID, content, and
+string-valued properties.
+
+## Observing query cost
+
+A page in the web app is one HTTP request that may turn into many SQL
+statements. To see how many, and how long the database spent on them, run the
+server with Debug logging:
+
+```bash
+rela-server-postgres --project . -verbose
+```
+
+With `-verbose` every API response carries a `Server-Timing` header — shown
+under *Timing* in the browser's network inspector — and the server log gets one
+`request` line per request:
+
+```text
+Server-Timing: db;dur=12.4;desc="7 queries"
+level=DEBUG msg=request method=GET path=/api/v1/tickets status=200 wall_ms=18.2 queries=7 db_ms=12.4
+```
+
+`queries` is the number of statements the request issued (a transaction's
+`BEGIN`/`COMMIT` count too); `db_ms` is their summed database time, which is
+less than wall time because Go work between statements is excluded. A count
+that grows with the number of rows on the page is the signature of a per-row
+lookup and the first thing to fix; `db_ms` that stays high with a small count
+points at a statement missing an index. Each individual statement is also
+logged at Debug (`msg="pgstore: query"`) with its SQL, arguments and duration.
+
+What a well-behaved page costs today: a list page is one scoped count and one
+bounded read for the rows, one query for every edge touching the page, one
+content-free read of the neighbours those edges name, and the membership walk
+for the principal — a handful of statements whatever the page size. Collection
+rows are read as headers (no markdown body) throughout; see the API reference
+for `include_content`. The list page is pushed into the database — paging,
+ordering and equality filters in SQL — when the request carries no free-text
+search, no relation filter, and only `=`/`!=` filters and sort keys on
+string-shaped properties; anything else takes the whole-type path in Go, which
+still reads headers only.
+
+Ordering, on either path, compares property values byte-wise as text and puts
+a row without the property after every row that has one when ascending and
+before them when descending (SQL's default null placement). That asymmetry is
+what lets one index serve both directions.
+
+Below Debug nothing is emitted and no header is set. That is deliberate: a
+per-response query count can vary with rows the principal is not allowed to
+see, so it is an operator diagnostic, not part of the API — see
+`docs/acl-security.md`.
+
+For the database's own view, turn on PostgreSQL's slow-statement log for the
+rela database (no restart needed; new sessions pick it up):
+
+```sql
+ALTER DATABASE rela SET log_min_duration_statement = '20ms';
+ALTER DATABASE rela SET session_preload_libraries = 'auto_explain';
+ALTER DATABASE rela SET auto_explain.log_min_duration = '20ms';
+```
 
 ## Multiple writers
 

--- a/docs/acl-security.md
+++ b/docs/acl-security.md
@@ -893,6 +893,21 @@ caches from leaking one principal's view to another:
   `Vary: <that header>` — defense in depth for any cache layer that
   ignores `no-store`.
 
+### Query accounting is a Debug-only diagnostic
+
+With `-verbose`, every API response carries a `Server-Timing` header with the
+number of SQL statements the request issued and their summed database time,
+and the log gets one `request` record per request (see
+`docs/postgres-backend.md`, "Observing query cost"). Below Debug neither
+exists. The gate is a security property, not a convenience: on a path that
+still resolves neighbors one by one, the statement count varies with rows the
+principal cannot see, so a machine-readable count on every response would be
+an existence channel of exactly the kind the row-level rule above forbids.
+Wall time is already observable by any client and is accepted as coarse
+timing exposure; the statement count is not, and stays an operator tool.
+Do not enable `-verbose` on a multi-principal deployment to "get metrics" —
+put the numbers in the log, not on the wire.
+
 ### Sidebar menu structure is principal-independent
 
 The sidebar's *structure* (groups, labels, links) reveals metamodel

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1845,6 +1845,53 @@ rela gc --temp-files --dry-run  # Preview what would be removed
 
 ---
 
+### rela dev seed
+
+Fill an **empty** project store with generated data for performance work.
+
+```bash
+rela dev seed [flags]
+```
+
+The data comes from a deterministic generator (`internal/perfseed`) shaped for
+the perf demo project in `prototypes/perf/project`: teams, people, projects,
+tasks, controls, risks, policies with draft/published faces and documents with
+en/nl faces, plus the relations between them. The same `--seed` and `--scale`
+always produce the same graph, on every backend — on the default build it
+writes markdown files, on the postgres build it writes straight into the
+database named by `RELA_DATABASE_URL`.
+
+This is a raw store write: no automations, validations or ACL run, the writes
+are attributed to the operator with tool `perf-seed`, and the run leaves one
+`perf-seed` audit record. It refuses a store that already holds entities so a
+second run cannot sit beside real data.
+
+**Flags:**
+
+| Flag        | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `--profile` | Which graph to generate; only `perf` exists today                           |
+| `--scale`   | Size multiplier in (0, 10]; `1` is roughly 20k entities and 45k relations   |
+| `--seed`    | PRNG seed (default 1)                                                       |
+| `--batch`   | Writes per transaction (default 500)                                        |
+| `--force`   | Seed even though the store already holds entities                           |
+
+**Examples:**
+
+```bash
+cp -R prototypes/perf/project /tmp/perf && cd /tmp/perf
+rela dev seed --scale 0.05                 # a few hundred entities as markdown files
+
+export RELA_DATABASE_URL='postgres://rela@localhost/rela_perf?sslmode=disable'
+rela-postgres dev seed --project prototypes/perf/project --scale 1
+```
+
+The filesystem backend writes one file per row and indexes each for search,
+so keep the scale small there; the full graph is meant for PostgreSQL, where
+scale 1 loads in well under a minute.
+
+---
+
 ### rela validate
 
 Validate project configuration files.

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1170,6 +1170,12 @@ sort:
 
 You can also sort by the virtual properties `id` (entity ID) and `modified` (file modification time).
 
+Values compare as text, byte by byte. An entity that lacks the sort property
+sorts as if it held the largest value: after every entity that has one when
+ascending, before them when descending. On the PostgreSQL backend a sorted list
+page is served straight from an index when the sort keys are string-shaped
+properties (see the PostgreSQL guide on derived list indexes).
+
 If no sort is configured, the list falls back to the entity type's `default_sort` from the metamodel,
 or sorts by ID ascending.
 

--- a/docs/data-entry/api-reference.md
+++ b/docs/data-entry/api-reference.md
@@ -46,6 +46,31 @@ All top-level fields are optional. Field absence means "leave alone".
 | `content` | Markdown body. **Upsert**: present (including empty string) replaces; absent leaves alone. |
 | `relations` | Map of relation type → desired-state wrapper. See below. |
 
+## Collection rows are content-free
+
+`GET /api/v1/{plural}` and `GET /api/v1/_search` return each row's `id`,
+`type`, `_title`, `properties`, relations and affordances, but **not** its
+markdown body: `content` is absent from collection rows. A list, kanban or
+dashboard renders titles and properties, and shipping every row's body made a
+100-row page half a megabyte and the dashboard's count cards tens of megabytes
+at 20k entities (TKT-1U8XYN). On the PostgreSQL backend the bodies never leave
+the database — the server reads content-free headers for the whole pipeline
+(filter, sort, paginate) and loads bodies only for the rows it serves, only
+when asked.
+
+Ask with `include_content=true` (any value `strconv.ParseBool` accepts; anything
+else is `false`):
+
+```text
+GET /api/v1/tickets?page=1&per_page=25&include_content=true
+GET /api/v1/_search?q=type:ticket&include_content=true
+```
+
+The per-entity `GET /api/v1/{plural}/{id}`, `_views` and `?include=` peers are
+unchanged: they always carry `content`, as do ETags computed over it. A row
+whose entity has an empty body looks the same with or without the flag, which
+is the reason the field is omitted rather than sent empty.
+
 ## Relations field
 
 Each value of the `relations` map is one of TWO shapes:

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -146,10 +146,52 @@ planner, what the dry-run predicts is what startup does.
 
 ## Search
 
-In the PostgreSQL build, search runs **in the database** (a `tsvector`
-GIN index for ranked full-text plus `pg_trgm` for substring and fuzzy
-matching) — there is no bleve index. Text search matches the same fields
+In the PostgreSQL build, search runs **in the database** — there is no bleve
+index. Matching is a case-insensitive substring match over a maintained
+`search_text` column, accelerated by a `pg_trgm` GIN index, and results are
+ranked by trigram similarity to the query. Text search matches the same fields
 as the default backend: entity ID, content, and string-valued properties.
+
+## Observing query cost
+
+A page in the web app is one HTTP request that may turn into many SQL
+statements. To see how many, and how long the database spent on them, run the
+server with Debug logging:
+
+```bash
+rela-server-postgres --project . -verbose
+```
+
+With `-verbose` every API response carries a `Server-Timing` header — shown
+under *Timing* in the browser's network inspector — and the server log gets one
+`request` line per request:
+
+```text
+Server-Timing: db;dur=12.4;desc="7 queries"
+level=DEBUG msg=request method=GET path=/api/v1/tickets status=200 wall_ms=18.2 queries=7 db_ms=12.4
+```
+
+`queries` is the number of statements the request issued (a transaction's
+`BEGIN`/`COMMIT` count too); `db_ms` is their summed database time, which is
+less than wall time because Go work between statements is excluded. A count
+that grows with the number of rows on the page is the signature of a per-row
+lookup and the first thing to fix; `db_ms` that stays high with a small count
+points at a statement missing an index. Each individual statement is also
+logged at Debug (`msg="pgstore: query"`) with its SQL, arguments and duration.
+
+Below Debug nothing is emitted and no header is set. That is deliberate: a
+per-response query count can vary with rows the principal is not allowed to
+see, so it is an operator diagnostic, not part of the API — see
+`docs/acl-security.md`.
+
+For the database's own view, turn on PostgreSQL's slow-statement log for the
+rela database (no restart needed; new sessions pick it up):
+
+```sql
+ALTER DATABASE rela SET log_min_duration_statement = '20ms';
+ALTER DATABASE rela SET session_preload_libraries = 'auto_explain';
+ALTER DATABASE rela SET auto_explain.log_min_duration = '20ms';
+```
 
 ## Multiple writers
 

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -60,6 +60,12 @@ The connecting role needs privileges to create the `pg_trgm` extension on
 first run (typically a superuser, or have an administrator run
 `CREATE EXTENSION pg_trgm;` once in the target database beforehand).
 
+Migration 14 rewrites the `search_text` column of every entity once, inside
+the migration transaction, so the first start after upgrading pauses for a
+time proportional to the entity table — seconds at twenty thousand rows,
+longer on a large one. Run `rela db migrate` as a deploy step if that pause
+must not land on the first web request.
+
 ### Applying migrations explicitly
 
 If you would rather apply the schema as a separate, controlled step

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -103,10 +103,20 @@ next start — and in the steady state (nothing changed) it does no work.
 PostgreSQL also derives ordinary B-tree indexes from eligible static queries in
 `data-entry.yaml`. Dashboard cards, global next-action queries, and `pick_one`
 option queries qualify when they target exactly one entity type and all pushed
-filters are non-empty equality checks on declared, scalar string properties.
-rela creates one composite `rela_derived_query__…` index for the complete set
-of properties in each query shape. Equivalent queries share an index even when
+filters are non-empty equality checks on declared, scalar string-shaped
+properties (`string`, `enum`, `date`, `datetime`, or a custom type). rela
+creates one composite `rela_derived_query__…` index for the complete set of
+properties in each query shape. Equivalent queries share an index even when
 their literal values or filter order differ.
+
+Lists get the same treatment. A list with a `sort:` whose keys (and whose
+static `=` filters, if any) are string-shaped properties gets one
+`rela_derived_list__…` index over its type, its filters, its sort keys and the
+id — the exact scan a list page performs when the server pushes paging into the
+database. With it, page 40 of an 11,000-row list is an index range scan; without
+it the database sorts the whole type for every page. A list sorted on an
+integer, a list-valued property, or with a `!=` or range filter gets no index,
+because such a page is not pushed down (see "Observing query cost").
 
 Runtime and URL queries are not observed. Free text, relations, sorting, glob,
 not-equal, empty-value, list-valued, and non-string filters do not produce an
@@ -148,9 +158,13 @@ planner, what the dry-run predicts is what startup does.
 
 In the PostgreSQL build, search runs **in the database** — there is no bleve
 index. Matching is a case-insensitive substring match over a maintained
-`search_text` column, accelerated by a `pg_trgm` GIN index, and results are
-ranked by trigram similarity to the query. Text search matches the same fields
-as the default backend: entity ID, content, and string-valued properties.
+`search_text` column (the id, then string properties, then the body),
+accelerated by a `pg_trgm` GIN index. Results are ranked by trigram similarity
+between the query and the first kilobyte of that column — the identity and the
+title-like properties — so an entity *about* the term outranks one that merely
+mentions it in a long body, and ranking stays cheap on a common word. Text
+search matches the same fields as the default backend: entity ID, content, and
+string-valued properties.
 
 ## Observing query cost
 
@@ -178,6 +192,22 @@ that grows with the number of rows on the page is the signature of a per-row
 lookup and the first thing to fix; `db_ms` that stays high with a small count
 points at a statement missing an index. Each individual statement is also
 logged at Debug (`msg="pgstore: query"`) with its SQL, arguments and duration.
+
+What a well-behaved page costs today: a list page is one scoped count and one
+bounded read for the rows, one query for every edge touching the page, one
+content-free read of the neighbours those edges name, and the membership walk
+for the principal — a handful of statements whatever the page size. Collection
+rows are read as headers (no markdown body) throughout; see the API reference
+for `include_content`. The list page is pushed into the database — paging,
+ordering and equality filters in SQL — when the request carries no free-text
+search, no relation filter, and only `=`/`!=` filters and sort keys on
+string-shaped properties; anything else takes the whole-type path in Go, which
+still reads headers only.
+
+Ordering, on either path, compares property values byte-wise as text and puts
+a row without the property after every row that has one when ascending and
+before them when descending (SQL's default null placement). That asymmetry is
+what lets one index serve both directions.
 
 Below Debug nothing is emitted and no header is set. That is deliberate: a
 per-response query count can vary with rows the principal is not allowed to

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -250,7 +250,7 @@ func (d *Declarative) AuthorizeWrite(ctx context.Context, req WriteRequest) Deci
 		}
 	}
 
-	r, err := d.ForPrincipal(principal.From(ctx))
+	r, err := d.requestFor(ctx)
 	if err != nil {
 		return Decision{
 			Allow:    false,
@@ -260,6 +260,27 @@ func (d *Declarative) AuthorizeWrite(ctx context.Context, req WriteRequest) Deci
 		}
 	}
 	return r.AuthorizeWrite(ctx, req)
+}
+
+// requestFor returns the per-operation [Request] for ctx: the one the
+// operation's entry point attached via [WithRequest] when it is bound to
+// THIS policy and to ctx's principal, else a fresh one for ctx's principal.
+//
+// Reusing the attached scope is what keeps write authorization O(1) in graph
+// traffic per operation. A Request memoizes the principal's membership walk;
+// opening a new one per AuthorizeWrite re-ran that walk for every verb of
+// every row on a list page — six membership queries per row, more SQL than
+// the page itself (TKT-1U8XYN baseline). The two guards are what make reuse
+// safe: a Request from another Declarative would evaluate another tenant's
+// policy, and one bound to a different principal (the provisioning seam
+// re-stamps ctx, see dataentry.enterWrite) would evaluate the wrong identity.
+// Both cases fall back to a fresh scope, which is exactly the old behavior.
+func (d *Declarative) requestFor(ctx context.Context) (*Request, error) {
+	p := principal.From(ctx)
+	if r := FromContext(ctx); r != nil && r.d == d && r.principal.User == p.User && r.principal.Tool == p.Tool {
+		return r, nil
+	}
+	return d.ForPrincipal(p)
 }
 
 // (roleGrantsWrite removed in TKT-4LQMWP — write grants are now per-verb;

--- a/internal/acl/declarative.go
+++ b/internal/acl/declarative.go
@@ -277,7 +277,11 @@ func (d *Declarative) AuthorizeWrite(ctx context.Context, req WriteRequest) Deci
 // Both cases fall back to a fresh scope, which is exactly the old behavior.
 func (d *Declarative) requestFor(ctx context.Context) (*Request, error) {
 	p := principal.From(ctx)
-	if r := FromContext(ctx); r != nil && r.d == d && r.principal.User == p.User && r.principal.Tool == p.Tool {
+	// Equal compares the whole principal — identity AND the verified claims
+	// (type, scopes, roles) the Request's client ceiling was compiled from —
+	// so a scope-attenuated client can never borrow a wider scope bound to
+	// the same user by an earlier layer.
+	if r := FromContext(ctx); r != nil && r.d == d && r.principal.Equal(p) {
 		return r, nil
 	}
 	return d.ForPrincipal(p)

--- a/internal/acl/principallookup.go
+++ b/internal/acl/principallookup.go
@@ -14,13 +14,15 @@ type PrincipalLookup interface {
 	LookupEntityByProperty(ctx context.Context, entityType, property, value string) ([]string, error)
 }
 
-// PrincipalStore is the store capability the lookup needs: a graph query
-// with the property equality PUSHED DOWN. Consumer-side on purpose — the
-// lookup must never fall back to scanning a whole entity type in Go, which
-// is what it did before TKT-1U8XYN: every request began by loading every
-// user entity with its body to compare one string, a ~25 ms floor under
-// each API call on the postgres backend regardless of what the request
-// did. store.Store satisfies this.
+// PrincipalStore is the store capability the lookup needs: exactly the
+// graph-query surface store.GraphQueryHeaders takes, so the property
+// equality is PUSHED DOWN and only headers come back. Named here so the
+// dependency reads as what it is — the lookup must never fall back to
+// scanning a whole entity type in Go, which is what it did before
+// TKT-1U8XYN: every request began by loading every user entity with its
+// body to compare one string, a ~25 ms floor under each API call on the
+// postgres backend regardless of what the request did. store.Store
+// satisfies this.
 type PrincipalStore interface {
 	store.GraphQueryer
 }

--- a/internal/acl/principallookup.go
+++ b/internal/acl/principallookup.go
@@ -2,9 +2,7 @@ package acl
 
 import (
 	"context"
-	"iter"
 
-	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -24,7 +22,7 @@ type PrincipalLookup interface {
 // each API call on the postgres backend regardless of what the request
 // did. store.Store satisfies this.
 type PrincipalStore interface {
-	GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error]
+	store.GraphQueryer
 }
 
 type storePrincipalLookup struct {
@@ -48,14 +46,16 @@ func (l *storePrincipalLookup) LookupEntityByProperty(
 		return nil, nil
 	}
 	var ids []string
-	for e, err := range l.s.GraphQuery(ctx, store.GraphQuery{
+	// Headers, not rows: the lookup wants ids and nothing else, and the user
+	// entity may carry a body the resolver has no business reading.
+	for h, err := range store.GraphQueryHeaders(ctx, l.s, store.GraphQuery{
 		EntityType: entityType,
 		Props:      []store.PropPredicate{{Property: property, Op: store.PropEqual, Value: value, Scalar: true}},
 	}) {
 		if err != nil {
 			return nil, err
 		}
-		ids = append(ids, e.ID)
+		ids = append(ids, h.ID)
 	}
 	return ids, nil
 }

--- a/internal/acl/principallookup.go
+++ b/internal/acl/principallookup.go
@@ -2,53 +2,45 @@ package acl
 
 import (
 	"context"
+	"iter"
 
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// PrincipalLookup resolves the raw principal identifier to a user entity
-// by property equality. It is the narrow, consumer-side contract the
-// resolver needs for `principal_property` substitution — declared here
-// (not next to the store) per CLAUDE.md's "interfaces at the call site"
-// rule. The wiring site supplies a store-backed implementation
-// (StorePrincipalLookup).
-//
-// The method returns EVERY matching entity ID so the resolver can
-// distinguish the three outcomes it cares about: zero (no match — keep
-// the raw principal), one (substitute), and more than one (ambiguous —
-// a data-integrity failure the resolver refuses to guess through).
+// PrincipalLookup resolves a raw principal string to entity ids by a
+// natural-key property (`principal_property` on `user_entity_type`).
+// Returned ids are in store order; the caller treats more than one match
+// as an ambiguous key.
 type PrincipalLookup interface {
-	// LookupEntityByProperty returns the IDs of entities of entityType
-	// whose property equals value (exact string match). A blank value
-	// returns nil without querying — an empty principal never resolves.
-	// Backend errors propagate so the resolver can fail-open-to-raw and
-	// warn rather than silently drop a match.
 	LookupEntityByProperty(ctx context.Context, entityType, property, value string) ([]string, error)
 }
 
-// storePrincipalLookup adapts a store entity reader to [PrincipalLookup].
-// It scans the entities of the requested type and matches the property's
-// string value. Production wiring (appbuild) constructs it over the
-// store; the ACL resolver only ever sees the [PrincipalLookup] interface.
-//
-// The scan is O(entities of type) per lookup, run at most once per
-// request (upstream of the cached member-of walk). For large user-entity
-// sets operators can push the equality into a backend index (see
-// docs/security.md); this adapter is the portable default.
-type storePrincipalLookup struct {
-	s store.EntityReader
+// PrincipalStore is the store capability the lookup needs: a graph query
+// with the property equality PUSHED DOWN. Consumer-side on purpose — the
+// lookup must never fall back to scanning a whole entity type in Go, which
+// is what it did before TKT-1U8XYN: every request began by loading every
+// user entity with its body to compare one string, a ~25 ms floor under
+// each API call on the postgres backend regardless of what the request
+// did. store.Store satisfies this.
+type PrincipalStore interface {
+	GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error]
 }
 
-// NewStorePrincipalLookup constructs a store-backed [PrincipalLookup]
-// over s. Returned as the interface so callers depend on the contract,
-// not the adapter.
-func NewStorePrincipalLookup(s store.EntityReader) PrincipalLookup {
+type storePrincipalLookup struct {
+	s PrincipalStore
+}
+
+// NewStorePrincipalLookup adapts a store to [PrincipalLookup].
+func NewStorePrincipalLookup(s PrincipalStore) PrincipalLookup {
 	return &storePrincipalLookup{s: s}
 }
 
-// LookupEntityByProperty implements [PrincipalLookup] by scanning
-// entities of entityType and collecting those whose property equals
-// value.
+// LookupEntityByProperty runs one scalar-equality graph query. The
+// predicate is marked Scalar so the postgres backend emits the
+// `(properties ->> $p) = $v` shape its derived unique index (the
+// `unique: true` the policy loader requires on this property) serves
+// directly; fs/mem evaluate the same predicate over their in-memory rows.
 func (l *storePrincipalLookup) LookupEntityByProperty(
 	ctx context.Context, entityType, property, value string,
 ) ([]string, error) {
@@ -56,13 +48,14 @@ func (l *storePrincipalLookup) LookupEntityByProperty(
 		return nil, nil
 	}
 	var ids []string
-	for e, err := range l.s.ListEntities(ctx, store.EntityQuery{Type: entityType}) {
+	for e, err := range l.s.GraphQuery(ctx, store.GraphQuery{
+		EntityType: entityType,
+		Props:      []store.PropPredicate{{Property: property, Op: store.PropEqual, Value: value, Scalar: true}},
+	}) {
 		if err != nil {
 			return nil, err
 		}
-		if e.GetString(property) == value {
-			ids = append(ids, e.ID)
-		}
+		ids = append(ids, e.ID)
 	}
 	return ids, nil
 }

--- a/internal/acl/requestreuse_test.go
+++ b/internal/acl/requestreuse_test.go
@@ -73,6 +73,7 @@ func TestAuthorizeWrite_NoContextRequestOpensFresh(t *testing.T) {
 func TestAuthorizeWrite_IgnoresForeignContextRequest(t *testing.T) {
 	t.Parallel()
 	t.Run("different principal", func(t *testing.T) {
+		t.Parallel()
 		g := membershipGraph()
 		d := newTestDeclarative(t, membershipPolicy(), g)
 		bobReq, err := d.ForPrincipal(principal.Principal{User: "bob", Tool: principal.ToolDataEntry})
@@ -85,6 +86,7 @@ func TestAuthorizeWrite_IgnoresForeignContextRequest(t *testing.T) {
 		}
 	})
 	t.Run("different declarative", func(t *testing.T) {
+		t.Parallel()
 		g := membershipGraph()
 		d := newTestDeclarative(t, membershipPolicy(), g)
 		other := newTestDeclarative(t, &Policy{Roles: map[string]RoleDef{"nobody": {}}}, newFakeGraph())

--- a/internal/acl/requestreuse_test.go
+++ b/internal/acl/requestreuse_test.go
@@ -84,6 +84,32 @@ func TestAuthorizeWrite_IgnoresForeignContextRequest(t *testing.T) {
 		if got := d.AuthorizeWrite(ctx, writeTicket(OpCreate)); !got.Allow {
 			t.Fatalf("alice must be evaluated as alice (allowed), got %+v", got)
 		}
+		if g.outgoingCalls == 0 {
+			t.Error("bob's Request must not be reused for alice; d had to open its own scope")
+		}
+	})
+	t.Run("same user, different verified claims", func(t *testing.T) {
+		t.Parallel()
+		// Same User and Tool, but the ctx principal carries verified claims
+		// (a principal type and scopes — the inputs of a client ceiling) the
+		// bound Request was not built from. Reusing it would evaluate the
+		// wrong ceiling, so it must be ignored.
+		g := membershipGraph()
+		d := newTestDeclarative(t, membershipPolicy(), g)
+		plain := aliceDataEntry()
+		wideReq, err := d.ForPrincipal(plain)
+		if err != nil {
+			t.Fatal(err)
+		}
+		g.outgoingCalls = 0
+		attenuated := principal.VerifiedFrom(plain.User, plain.Tool, principal.Claims{
+			PrincipalType: "rela.client", Scopes: []string{"read"},
+		})
+		ctx := WithRequest(principal.With(context.Background(), attenuated), wideReq)
+		d.AuthorizeWrite(ctx, writeTicket(OpCreate))
+		if g.outgoingCalls == 0 {
+			t.Error("a Request bound to a principal with different claims must not be reused")
+		}
 	})
 	t.Run("different declarative", func(t *testing.T) {
 		t.Parallel()

--- a/internal/acl/requestreuse_test.go
+++ b/internal/acl/requestreuse_test.go
@@ -1,0 +1,103 @@
+package acl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// membershipPolicy grants `editor` to the group `team`; alice reaches it
+// through one member-of hop, so every fresh Request costs a walk.
+func membershipPolicy() *Policy {
+	return &Policy{
+		Roles: map[string]RoleDef{
+			"editor": {Create: []string{"ticket"}, Update: []string{"ticket"}, Delete: []string{"ticket"}},
+		},
+		Assignments: map[string]string{"team": "editor"},
+	}
+}
+
+func membershipGraph() *fakeGraph {
+	g := newFakeGraph()
+	g.add("alice", "member-of", "team")
+	return g
+}
+
+func writeTicket(op Op) WriteRequest {
+	return WriteRequest{Op: op, Subject: EntitySubject{Type: "ticket", ID: "T-1"}}
+}
+
+// A ctx that carries the operation's Request must not pay the membership
+// walk again per AuthorizeWrite: three verbs on one row are one walk, not
+// three (TKT-1U8XYN — this was six membership queries per list row).
+func TestAuthorizeWrite_ReusesContextRequest(t *testing.T) {
+	t.Parallel()
+	g := membershipGraph()
+	d := newTestDeclarative(t, membershipPolicy(), g)
+	p := aliceDataEntry()
+	req, err := d.ForPrincipal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := WithRequest(principal.With(context.Background(), p), req)
+
+	for _, verb := range []Op{OpCreate, OpUpdate, OpDelete} {
+		if got := d.AuthorizeWrite(ctx, writeTicket(verb)); !got.Allow {
+			t.Fatalf("%v: Allow = false, want true: %+v", verb, got)
+		}
+	}
+	if g.outgoingCalls != 2 {
+		t.Errorf("membership walk ran %d OutgoingRelations calls, want 2 (one walk: alice, team)", g.outgoingCalls)
+	}
+}
+
+// Without a bound Request the old behavior stands: each call opens its own
+// scope. This is the fallback single-entity handlers and tests rely on.
+func TestAuthorizeWrite_NoContextRequestOpensFresh(t *testing.T) {
+	t.Parallel()
+	g := membershipGraph()
+	d := newTestDeclarative(t, membershipPolicy(), g)
+	ctx := principal.With(context.Background(), aliceDataEntry())
+	d.AuthorizeWrite(ctx, writeTicket(OpCreate))
+	d.AuthorizeWrite(ctx, writeTicket(OpUpdate))
+	if g.outgoingCalls != 4 {
+		t.Errorf("OutgoingRelations calls = %d, want 4 (two fresh walks)", g.outgoingCalls)
+	}
+}
+
+// A Request bound to a different principal than ctx's (the provisioning
+// seam re-stamps ctx) or to a different Declarative (another tenant's
+// policy) must NOT be reused — that would evaluate the wrong identity or
+// the wrong policy.
+func TestAuthorizeWrite_IgnoresForeignContextRequest(t *testing.T) {
+	t.Parallel()
+	t.Run("different principal", func(t *testing.T) {
+		g := membershipGraph()
+		d := newTestDeclarative(t, membershipPolicy(), g)
+		bobReq, err := d.ForPrincipal(principal.Principal{User: "bob", Tool: principal.ToolDataEntry})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := WithRequest(principal.With(context.Background(), aliceDataEntry()), bobReq)
+		if got := d.AuthorizeWrite(ctx, writeTicket(OpCreate)); !got.Allow {
+			t.Fatalf("alice must be evaluated as alice (allowed), got %+v", got)
+		}
+	})
+	t.Run("different declarative", func(t *testing.T) {
+		g := membershipGraph()
+		d := newTestDeclarative(t, membershipPolicy(), g)
+		other := newTestDeclarative(t, &Policy{Roles: map[string]RoleDef{"nobody": {}}}, newFakeGraph())
+		otherReq, err := other.ForPrincipal(aliceDataEntry())
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := WithRequest(principal.With(context.Background(), aliceDataEntry()), otherReq)
+		if got := d.AuthorizeWrite(ctx, writeTicket(OpCreate)); !got.Allow {
+			t.Fatalf("d's own policy must decide (allowed), got %+v", got)
+		}
+		if g.outgoingCalls == 0 {
+			t.Error("a foreign Request must not be reused; d had to open its own scope")
+		}
+	})
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -121,6 +121,12 @@ const (
 	// declares. Summary carries the ledger keys and counts, never content.
 	// Isolate with `op == "data-gc"`.
 	OpDataGC = "data-gc"
+
+	// OpPerfSeed records a `rela dev seed` run: a raw-store bulk load of
+	// generated data (internal/perfseed). One record per run with the
+	// profile, scale, seed and counts — never the content, which is
+	// reproducible from those anyway.
+	OpPerfSeed = "perf-seed"
 )
 
 // Subject identifies what an op acted on. Exactly one of {Type, ID}

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -34,7 +34,7 @@ type DevSeedCmd struct {
 	Scale   float64 `default:"1" help:"Size multiplier; 1 is roughly 20k entities and 45k relations."`
 	Seed    uint64  `default:"1" help:"PRNG seed; the same seed and scale always produce the same graph."`
 	Batch   int     `default:"500" help:"Writes per transaction."`
-	Force   bool    `help:"Seed even though the store already holds entities."`
+	Force   bool    `help:"Seed even though the store already holds entities. The generated rows then sit beside the real ones; they carry tool attribution 'perf-seed' and the run's audit record, which is how to find and remove them."`
 }
 
 // seedTool is the attribution tool name stamped on every seeded row and the

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/perfseed"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// DevCmd groups developer tooling that is not part of operating a project.
+// Each subcommand says in its help what it bypasses.
+type DevCmd struct {
+	Seed DevSeedCmd `cmd:"" help:"Fill an EMPTY store with generated data for performance work (raw store write, no automations or validation)."`
+}
+
+// DevSeedCmd is `rela dev seed`: it loads the perfseed graph into the
+// project's store — markdown files on the default build, PostgreSQL on the
+// postgres build — so the data-entry app can be measured at scale.
+//
+// This is the fourth sanctioned raw-store write path (after `db migrate`,
+// `history-purge` and data migration) and carries the same obligations: the
+// trust boundary is the operator shell, every write is attributed
+// (store.WithAttribution) and the run leaves one audit record. It refuses a
+// store that already holds entities unless --force is given, because the
+// generator mints fixed ids and a second run would collide with or sit
+// beside real data.
+type DevSeedCmd struct {
+	Profile string  `default:"perf" enum:"perf" help:"Which graph to generate (only 'perf' today: prototypes/perf/project)."`
+	Scale   float64 `default:"1" help:"Size multiplier; 1 is roughly 20k entities and 45k relations."`
+	Seed    uint64  `default:"1" help:"PRNG seed; the same seed and scale always produce the same graph."`
+	Batch   int     `default:"500" help:"Writes per transaction."`
+	Force   bool    `help:"Seed even though the store already holds entities."`
+}
+
+// seedTool is the attribution tool name stamped on every seeded row and the
+// audit record's op, so seeded data is distinguishable from real edits.
+const seedTool = "perf-seed"
+
+// Run executes `rela dev seed`.
+func (c *DevSeedCmd) Run(ctx context.Context, write *writeServices) error {
+	if c.Scale <= 0 || c.Scale > 10 {
+		return errors.New("--scale must be in (0, 10]")
+	}
+	if c.Batch <= 0 {
+		return errors.New("--batch must be positive")
+	}
+	existing, err := write.Store.CountEntities(ctx, store.EntityQuery{})
+	if err != nil {
+		return fmt.Errorf("count entities: %w", err)
+	}
+	if existing > 0 && !c.Force {
+		return fmt.Errorf("store already holds %d entities; seeding needs an empty store (or --force)", existing)
+	}
+
+	p := principal.From(ctx)
+	user := p.User
+	if user == "" {
+		user = principal.ReservedPrefix + seedTool
+	}
+	ctx = store.WithAttribution(ctx, store.Attribution{User: user, Tool: seedTool})
+
+	gen := perfseed.New(perfseed.Perf(c.Scale), c.Seed)
+	prof := gen.Profile()
+	out.WriteMessage("Seeding profile %s at scale %g (seed %d): %d teams, %d people, %d projects, %d tasks, "+
+		"%d controls, %d risks, %d policies, %d documents",
+		c.Profile, c.Scale, c.Seed, prof.Teams, prof.People, prof.Projects, prof.Tasks,
+		prof.Controls, prof.Risks, prof.Policies, prof.Documents)
+
+	last := time.Now()
+	sum, err := perfseed.Load(ctx, write.Store, gen, perfseed.LoadOptions{
+		BatchSize: c.Batch,
+		Progress: func(s perfseed.Summary) {
+			if time.Since(last) < 2*time.Second {
+				return
+			}
+			last = time.Now()
+			out.WriteMessage("  %d entities, %d relations (%s)", s.Entities, s.Relations, s.Elapsed.Round(time.Second))
+		},
+	})
+	summary := fmt.Sprintf("perf seed %s scale=%g seed=%d: %d entities, %d relations in %s",
+		c.Profile, c.Scale, c.Seed, sum.Entities, sum.Relations, sum.Elapsed.Round(time.Millisecond))
+	if err != nil {
+		summary += " (FAILED: " + err.Error() + ")"
+	}
+	if write.Audit != nil {
+		write.Audit.Record(audit.Record{
+			Time:      time.Now().UTC(),
+			Op:        audit.OpPerfSeed,
+			Principal: p,
+			Summary:   summary,
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("seed: %w (wrote %d entities, %d relations before failing)", err, sum.Entities, sum.Relations)
+	}
+	out.WriteSuccess("%s", summary)
+	return nil
+}

--- a/internal/cli/kong.go
+++ b/internal/cli/kong.go
@@ -67,7 +67,11 @@ var (
 // out of scope for a secrets-hygiene change. `secrets` is itself a sub-struct
 // holding its subcommand, so it adds one field rather than one per verb.
 //
-//plimsoll:max-fields=47
+// Raised 47 → 48 for `dev` (TKT-1U8XYN), a sub-struct grouping developer
+// tooling (`dev seed` today), so later developer commands nest under it
+// rather than adding fields here.
+//
+//plimsoll:max-fields=48
 type CLI struct {
 	// Global flags.
 	Project string `help:"Project directory (default: auto-detect from cwd)." env:"RELA_PROJECT"`
@@ -99,6 +103,7 @@ type CLI struct {
 	Completion CompletionCmd `cmd:"" help:"Generate shell completion scripts."`
 	Mcp        McpCmd        `cmd:"" name:"mcp" help:"Start the MCP server."`
 	Db         DBCmd         `cmd:"" name:"db" help:"Manage the PostgreSQL schema (postgres build)."`
+	Dev        DevCmd        `cmd:"" help:"Developer tooling (seed generated data)."`
 	Flow       FlowCmd       `cmd:"" help:"Run an interactive Lua flow."`
 	Validate   ValidateCmd   `cmd:"" help:"Validate project configuration files."`
 
@@ -260,7 +265,8 @@ func requiresProject(cmd string) bool {
 		"detach", "import", "normalize", "script", "scheduler",
 		"rename", "analyze", "acl", "attach", "attachments", "gc", "renumber",
 		"sync", "history", "restore", "secrets",
-		"relation-history", "relation-restore", "history-purge", "relation-history-purge":
+		"relation-history", "relation-restore", "history-purge", "relation-history-purge",
+		"dev":
 		return true
 	case "migrate":
 		// Bare `rela migrate` (config-file migration) deliberately gets NO

--- a/internal/dataentry/acl_list_test.go
+++ b/internal/dataentry/acl_list_test.go
@@ -506,3 +506,22 @@ func (s failingListStore) ListEntities(context.Context, store.EntityQuery) iter.
 		yield(nil, errors.New("synthetic list failure"))
 	}
 }
+
+// The pushed page path (listpushdown.go) reads through GraphCount and
+// GraphQuery, and the header projection through ListEntityHeaders; a store
+// that fails to load fails on every one of them.
+func (s failingListStore) GraphCount(context.Context, store.GraphQuery) (matched, total int, err error) {
+	return 0, 0, errors.New("synthetic list failure")
+}
+
+func (s failingListStore) GraphQuery(context.Context, store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	return func(yield func(*entity.Entity, error) bool) {
+		yield(nil, errors.New("synthetic list failure"))
+	}
+}
+
+func (s failingListStore) ListEntityHeaders(context.Context, store.EntityQuery) iter.Seq2[store.EntityHeader, error] {
+	return func(yield func(store.EntityHeader, error) bool) {
+		yield(store.EntityHeader{}, errors.New("synthetic list failure"))
+	}
+}

--- a/internal/dataentry/acl_views_test.go
+++ b/internal/dataentry/acl_views_test.go
@@ -145,7 +145,7 @@ func TestACLViews_RedactsHiddenPrimaryTitle(t *testing.T) {
 
 // TestACLViews_RelationColumnRedactsHiddenNeighborTitle pins the review finding
 // on BUG-R9EHKV's table-cell surface: a table section's relation column resolves
-// neighbor titles via resolveRelationColumnValues, which fetched the target raw
+// neighbor titles via the section relation-column resolver, which fetched the target raw
 // from the store and titled it against raw properties — leaking a hidden
 // neighbor's display value. The fix routes the targets through viewReader.Filter
 // (row-gate + redact), so a hidden primary falls back to the id. This surface is
@@ -170,7 +170,7 @@ func TestACLViews_RelationColumnRedactsHiddenNeighborTitle(t *testing.T) {
 	}, app.store)
 	app.acl = d
 
-	titles := app.views.resolveRelationColumnValues(gateCtxFor(aliceCtx(), t, d), "TKT-001", "implements", dataentryconfig.DirectionOutgoing)
+	titles := relationColumnValuesFor(gateCtxFor(aliceCtx(), t, d), app, "TKT-001", "ticket", "implements", dataentryconfig.DirectionOutgoing)
 	for _, tt := range titles {
 		if strings.Contains(tt, "SECRET-FEATURE") {
 			t.Errorf("LEAK: hidden neighbor display value in relation column: %v", titles)
@@ -197,7 +197,7 @@ func TestACLViews_RelationColumnDropsUnreadableNeighbor(t *testing.T) {
 	}, app.store)
 	app.acl = d
 
-	titles := app.views.resolveRelationColumnValues(gateCtxFor(aliceCtx(), t, d), "TKT-001", "implements", dataentryconfig.DirectionOutgoing)
+	titles := relationColumnValuesFor(gateCtxFor(aliceCtx(), t, d), app, "TKT-001", "ticket", "implements", dataentryconfig.DirectionOutgoing)
 	if len(titles) != 0 {
 		t.Errorf("unreadable neighbor leaked into relation column: %v", titles)
 	}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -562,7 +562,10 @@ func (a *App) applyRelationFilters(
 		}
 
 		direction, _ := cfg.RelationFilterDirection(typeName, relation)
-		matched := matchRelationFilterMany(ctx, a.Services(), entities, relation, direction, want)
+		matched, merr := matchRelationFilterMany(ctx, a.Services(), entities, relation, direction, want)
+		if merr != nil {
+			return nil, fmt.Errorf("%w: relation filter %q: %w", errListLoad, relation, merr)
+		}
 		filtered := entities[:0]
 		for _, e := range entities {
 			if (operator == "eq" && matched[e.ID]) || (operator == "ne" && !matched[e.ID]) {
@@ -583,13 +586,17 @@ func (a *App) applyRelationFilters(
 // wanted display title (RR-HK1XNO) — but the cost no longer grows with the
 // type's row count times its fan-out. A free function taking its read seam,
 // not an App method — App sits at its load line (see worldneighbors.go).
+//
+// A store failure is returned, never folded into an empty verdict map: an
+// empty map reads as "no row matches", which for a `ne` filter admits EVERY
+// row — a backend fault would silently widen a filter whose job is to narrow.
 func matchRelationFilterMany(
 	ctx context.Context, svc Services, rows []*entityPkg.Entity,
 	relation string, direction dataentryconfig.Direction, want string,
-) map[string]bool {
+) (map[string]bool, error) {
 	matched := make(map[string]bool, len(rows))
 	if len(rows) == 0 {
-		return matched
+		return matched, nil
 	}
 	ids := make([]string, 0, len(rows))
 	for _, e := range rows {
@@ -601,7 +608,7 @@ func matchRelationFilterMany(
 	seen := make(map[string]struct{})
 	for r, err := range svc.Store.ListRelations(ctx, q) {
 		if err != nil {
-			return matched
+			return nil, err
 		}
 		rowID, targetID := r.From, r.To
 		if direction.IsIncoming() {
@@ -614,14 +621,14 @@ func matchRelationFilterMany(
 		}
 	}
 	if len(neighborIDs) == 0 {
-		return matched
+		return matched, nil
 	}
 
 	// Which neighbors carry the wanted title, by type — then gate per type.
 	candidatesByType := map[string][]string{}
 	for h, err := range store.ListEntityHeaders(ctx, svc.Store, store.EntityQuery{IDs: neighborIDs}) {
 		if err != nil {
-			return matched
+			return nil, err
 		}
 		if svc.Meta.DisplayTitle(h.ID, h.Type, h.Properties) == want {
 			candidatesByType[h.Type] = append(candidatesByType[h.Type], h.ID)
@@ -648,7 +655,7 @@ func matchRelationFilterMany(
 			}
 		}
 	}
-	return matched
+	return matched, nil
 }
 
 // parseRelationFilterKey parses a `filter[<rel>]` or `filter[<rel>][<op>]` key
@@ -2106,8 +2113,11 @@ func applyV1Sorting(entities []*entityPkg.Entity, query map[string][]string) []*
 	// between digits and letters.
 	sort.SliceStable(sorted, func(i, j int) bool {
 		for _, spec := range sortSpecs {
+			// A JSON null is "no value" here as it is in SQL (`->>` yields
+			// NULL), so both paths place it with the absent rows.
 			vi, oki := sorted[i].Properties[spec.Property]
 			vj, okj := sorted[j].Properties[spec.Property]
+			oki, okj = oki && vi != nil, okj && vj != nil
 			if oki != okj {
 				return oki != spec.IsDescending()
 			}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -336,6 +336,8 @@ func (a *App) scopedSortedEntities(
 	}
 	rqr := readGateFromContext(ctx).ReadQuery(ctx, typeName)
 
+	// Content-free rows throughout (rowcontent.go): the pipeline below reads
+	// properties only, and the served page loads bodies afterwards if asked.
 	var entities []*entityPkg.Entity
 	switch {
 	case rqr.DenyAll:
@@ -353,7 +355,7 @@ func (a *App) scopedSortedEntities(
 		// (TKT-O7R2A1): a face allowlist carried on only the GraphQuery
 		// would leave the AllowAll population — the most privileged — with
 		// no face narrowing, and the two paths would disagree.
-		for e, err := range a.Services().Store.ListEntities(ctx, store.EntityQuery{
+		for h, err := range store.ListEntityHeaders(ctx, a.Services().Store, store.EntityQuery{
 			Type:   typeName,
 			World:  worldScopeFrom(ctx),
 			FaceIn: rqr.Faces,
@@ -361,7 +363,7 @@ func (a *App) scopedSortedEntities(
 			if err != nil {
 				return nil, fmt.Errorf("%w: %w", errListLoad, err)
 			}
-			entities = append(entities, e)
+			entities = append(entities, headerEntity(h))
 		}
 	case rqr.Query == nil:
 		// Defensive: a zero ReadQueryResult would otherwise alias
@@ -375,11 +377,11 @@ func (a *App) scopedSortedEntities(
 		wq := *rqr.Query
 		wq.World = worldScopeFrom(ctx)
 		wq.FaceIn = rqr.Faces
-		for e, err := range a.Services().Store.GraphQuery(ctx, wq) {
+		for h, err := range store.GraphQueryHeaders(ctx, a.Services().Store, wq) {
 			if err != nil {
 				return nil, fmt.Errorf("%w: %w", errACLListQuery, err)
 			}
-			entities = append(entities, e)
+			entities = append(entities, headerEntity(h))
 		}
 	}
 
@@ -535,16 +537,90 @@ func (a *App) applyRelationFilters(
 		}
 
 		direction, _ := cfg.RelationFilterDirection(typeName, relation)
+		matched := a.matchRelationFilterMany(ctx, entities, relation, direction, want)
 		filtered := entities[:0]
 		for _, e := range entities {
-			matched := a.matchRelationFilter(ctx, e.ID, relation, direction, want)
-			if (operator == "eq" && matched) || (operator == "ne" && !matched) {
+			if (operator == "eq" && matched[e.ID]) || (operator == "ne" && !matched[e.ID]) {
 				filtered = append(filtered, e)
 			}
 		}
 		entities = filtered
 	}
 	return entities, nil
+}
+
+// matchRelationFilterMany is [App.matchRelationFilter] for every row at once
+// (TKT-1U8XYN): one relation query for all rows, one content-free header
+// read for every distinct neighbor, one gate probe per neighbor type. The
+// verdict per row is the same — the row matches when at least one READABLE
+// neighbor over the relation carries the wanted display title (RR-HK1XNO) —
+// but the cost no longer grows with the type's row count times its fan-out.
+func (a *App) matchRelationFilterMany(
+	ctx context.Context, rows []*entityPkg.Entity, relation string, direction dataentryconfig.Direction, want string,
+) map[string]bool {
+	matched := make(map[string]bool, len(rows))
+	if len(rows) == 0 {
+		return matched
+	}
+	svc := a.Services()
+	ids := make([]string, 0, len(rows))
+	for _, e := range rows {
+		ids = append(ids, e.ID)
+	}
+	q := store.RelationQuery{EntityIDs: ids, Type: relation, Direction: relationDirection(direction)}
+	neighborsOf := make(map[string][]string, len(rows)) // row id → neighbor ids
+	var neighborIDs []string
+	seen := make(map[string]struct{})
+	for r, err := range svc.Store.ListRelations(ctx, q) {
+		if err != nil {
+			return matched
+		}
+		rowID, targetID := r.From, r.To
+		if direction.IsIncoming() {
+			rowID, targetID = r.To, r.From
+		}
+		neighborsOf[rowID] = append(neighborsOf[rowID], targetID)
+		if _, dup := seen[targetID]; !dup {
+			seen[targetID] = struct{}{}
+			neighborIDs = append(neighborIDs, targetID)
+		}
+	}
+	if len(neighborIDs) == 0 {
+		return matched
+	}
+
+	// Which neighbors carry the wanted title, by type — then gate per type.
+	candidatesByType := map[string][]string{}
+	for h, err := range store.ListEntityHeaders(ctx, svc.Store, store.EntityQuery{IDs: neighborIDs}) {
+		if err != nil {
+			return matched
+		}
+		if svc.Meta.DisplayTitle(h.ID, h.Type, h.Properties) == want {
+			candidatesByType[h.Type] = append(candidatesByType[h.Type], h.ID)
+		}
+	}
+	readable := make(map[string]bool)
+	gate := readGateFromContext(ctx)
+	for typ, cids := range candidatesByType {
+		perm, err := gate.PermitsReadMany(ctx, typ, cids)
+		if err != nil {
+			continue
+		}
+		for _, id := range cids {
+			if perm[id] {
+				readable[id] = true
+			}
+		}
+	}
+	for rowID, targets := range neighborsOf {
+		for _, t := range targets {
+			if readable[t] {
+				matched[rowID] = true
+				break
+			}
+		}
+	}
+	return matched
 }
 
 // parseRelationFilterKey parses a `filter[<rel>]` or `filter[<rel>][<op>]` key
@@ -569,71 +645,6 @@ func parseRelationFilterKey(key string) (relation, operator string, ok bool) {
 		operator = parts[1]
 	}
 	return parts[0], operator, true
-}
-
-// matchRelationFilter reports whether entityID has an edge of the given
-// relation+direction to a neighbor the caller can READ whose display title
-// equals want. It gates neighbor entities through the read gate so a hidden
-// neighbor cannot be used as a title-match inference channel (RR-HK1XNO), and
-// short-circuits as soon as a readable neighbor's title matches (RR-38K7K9).
-//
-// Neighbors are gated in batches grouped by type via readGate.PermitsReadMany
-// (one call per neighbor type on the row), rather than a per-neighbor gate
-// call. When the sibling helper App.visibleRelationIDs (TKT-ODHV2D) merges,
-// this should converge on it.
-func (a *App) matchRelationFilter(
-	ctx context.Context, entityID, relation string, direction dataentryconfig.Direction, want string,
-) bool {
-	svc := a.Services()
-	q := store.RelationQuery{
-		EntityID:  entityID,
-		Type:      relation,
-		Direction: relationDirection(direction),
-	}
-
-	// Load each neighbor once, keeping only those whose title matches want.
-	// Group the candidates by type so the read gate can batch per type.
-	candidatesByType := map[string][]string{}
-	entByID := map[string]*entityPkg.Entity{}
-	for r, err := range svc.Store.ListRelations(ctx, q) {
-		if err != nil {
-			return false
-		}
-		targetID := r.To
-		if direction.IsIncoming() {
-			targetID = r.From
-		}
-		if _, seen := entByID[targetID]; seen {
-			continue
-		}
-		e, err := svc.Store.GetEntity(ctx, targetID)
-		if err != nil {
-			continue // dangling relation
-		}
-		entByID[targetID] = e
-		if svc.Meta.DisplayTitle(e.ID, e.Type, e.Properties) == want {
-			candidatesByType[e.Type] = append(candidatesByType[e.Type], targetID)
-		}
-	}
-	if len(candidatesByType) == 0 {
-		return false
-	}
-
-	// A row matches iff at least one title-matching neighbor is READABLE. Gate
-	// only the title-matching candidates (the minimal set) per type.
-	gate := readGateFromContext(ctx)
-	for typ, ids := range candidatesByType {
-		perm, err := gate.PermitsReadMany(ctx, typ, ids)
-		if err != nil {
-			continue
-		}
-		for _, id := range ids {
-			if perm[id] {
-				return true // readable title match (RR-HK1XNO honored)
-			}
-		}
-	}
-	return false
 }
 
 // queryGet returns the first value for key from a raw query map, or "".
@@ -666,6 +677,15 @@ func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeN
 		end = total
 	}
 	entities = entities[start:end]
+
+	// Bodies are opt-in for a collection (rowcontent.go): one read per
+	// distinct face on the page, never for the rows that were paged out.
+	if wantContent(query) {
+		if err := loadRowContent(r.Context(), a.Services().Store, entities); err != nil {
+			writeListPipelineError(w, r, fmt.Errorf("%w: %w", errListLoad, err))
+			return
+		}
+	}
 
 	// Check if includes are requested (for relation columns)
 	includes := query.Get("include")
@@ -1647,6 +1667,14 @@ func (a *App) handleV1Search(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		entities = filtered
+	}
+	// Search rows are content-free (rowcontent.go); bodies are opt-in and
+	// bounded by the search result cap.
+	if wantContent(r.URL.Query()) {
+		if err := loadRowContent(r.Context(), a.Services().Store, entities); err != nil {
+			writeListPipelineError(w, r, fmt.Errorf("%w: %w", errListLoad, err))
+			return
+		}
 	}
 
 	meta := a.State().Meta

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -324,6 +324,31 @@ var errListLoad = errors.New("list load failed")
 // search_failed at the call site); ACL query failures are wrapped in
 // errACLListQuery so call sites map them via writeGateError. Everything
 // else degrades to an empty/whole set as the list endpoint always did.
+// listPage returns one page of the list plus the scoped total. A request the
+// store can page by itself (listpushdown.go) costs one count and one bounded
+// read; everything else takes the whole-type Go pipeline and slices it.
+func (a *App) listPage(
+	ctx context.Context, typeName string, query map[string][]string, page, perPage int,
+) (rows []*entityPkg.Entity, total int, err error) {
+	if !worldFromContext(ctx).blocksAllReads() {
+		rqr := readGateFromContext(ctx).ReadQuery(ctx, typeName)
+		isRelationKey := relationFilterClassifier(a.Meta(), a.Cfg(), typeName)
+		if plan, ok := planListPushdown(
+			a.Meta(), typeName, query, rqr, worldScopeFrom(ctx), page, perPage, isRelationKey,
+		); ok {
+			return plan.run(ctx, a.Services().Store)
+		}
+	}
+	all, err := a.scopedSortedEntities(ctx, typeName, query)
+	if err != nil {
+		return nil, 0, err
+	}
+	total = len(all)
+	start := min((page-1)*perPage, total)
+	end := min(start+perPage, total)
+	return all[start:end], total, nil
+}
+
 func (a *App) scopedSortedEntities(
 	ctx context.Context,
 	typeName string,
@@ -658,25 +683,14 @@ func queryGet(query map[string][]string, key string) string {
 
 func (a *App) handleV1ListEntities(w http.ResponseWriter, r *http.Request, typeName, plural string) {
 	query := r.URL.Query()
+	page, perPage := parseV1Pagination(query)
 
-	entities, err := a.scopedSortedEntities(r.Context(), typeName, query)
+	entities, total, err := a.listPage(r.Context(), typeName, query, page, perPage)
 	if err != nil {
 		writeListPipelineError(w, r, err)
 		return
 	}
-
-	// Pagination
-	total := len(entities)
-	page, perPage := parseV1Pagination(query)
-	start := (page - 1) * perPage
-	end := start + perPage
-	if start > total {
-		start = total
-	}
-	if end > total {
-		end = total
-	}
-	entities = entities[start:end]
+	end := (page-1)*perPage + len(entities)
 
 	// Bodies are opt-in for a collection (rowcontent.go): one read per
 	// distinct face on the page, never for the rows that were paged out.
@@ -2081,24 +2095,33 @@ func applyV1Sorting(entities []*entityPkg.Entity, query map[string][]string) []*
 	sorted := make([]*entityPkg.Entity, len(entities))
 	copy(sorted, entities)
 
-	sort.Slice(sorted, func(i, j int) bool {
+	// Byte-wise on the string form, a row WITHOUT the property sorting as
+	// the largest value (last ascending, first descending), id as the final
+	// tiebreak — the same order a store pages by (store.GraphQuery.OrderBy),
+	// so a request served either way reads the same. That replaced the
+	// accident of comparing "<nil>" as text, which put missing values
+	// between digits and letters.
+	sort.SliceStable(sorted, func(i, j int) bool {
 		for _, spec := range sortSpecs {
-			vi := sorted[i].Properties[spec.Property]
-			vj := sorted[j].Properties[spec.Property]
-
+			vi, oki := sorted[i].Properties[spec.Property]
+			vj, okj := sorted[j].Properties[spec.Property]
+			if oki != okj {
+				return oki != spec.IsDescending()
+			}
+			if !oki {
+				continue
+			}
 			si := fmt.Sprintf("%v", vi)
 			sj := fmt.Sprintf("%v", vj)
-
 			if si == sj {
 				continue
 			}
-
 			if spec.IsDescending() {
 				return si > sj
 			}
 			return si < sj
 		}
-		return false
+		return sorted[i].ID < sorted[j].ID
 	})
 
 	return sorted

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -562,7 +562,7 @@ func (a *App) applyRelationFilters(
 		}
 
 		direction, _ := cfg.RelationFilterDirection(typeName, relation)
-		matched := a.matchRelationFilterMany(ctx, entities, relation, direction, want)
+		matched := matchRelationFilterMany(ctx, a.Services(), entities, relation, direction, want)
 		filtered := entities[:0]
 		for _, e := range entities {
 			if (operator == "eq" && matched[e.ID]) || (operator == "ne" && !matched[e.ID]) {
@@ -574,20 +574,23 @@ func (a *App) applyRelationFilters(
 	return entities, nil
 }
 
-// matchRelationFilterMany is [App.matchRelationFilter] for every row at once
+// matchRelationFilterMany evaluates a relation filter for every row at once
 // (TKT-1U8XYN): one relation query for all rows, one content-free header
-// read for every distinct neighbor, one gate probe per neighbor type. The
-// verdict per row is the same — the row matches when at least one READABLE
-// neighbor over the relation carries the wanted display title (RR-HK1XNO) —
-// but the cost no longer grows with the type's row count times its fan-out.
-func (a *App) matchRelationFilterMany(
-	ctx context.Context, rows []*entityPkg.Entity, relation string, direction dataentryconfig.Direction, want string,
+// read for every distinct neighbor, one gate probe per neighbor type. It
+// replaced a per-row helper that ran one relation query plus one entity load
+// per neighbor for each row. The verdict per row is unchanged — the row
+// matches when at least one READABLE neighbor over the relation carries the
+// wanted display title (RR-HK1XNO) — but the cost no longer grows with the
+// type's row count times its fan-out. A free function taking its read seam,
+// not an App method — App sits at its load line (see worldneighbors.go).
+func matchRelationFilterMany(
+	ctx context.Context, svc Services, rows []*entityPkg.Entity,
+	relation string, direction dataentryconfig.Direction, want string,
 ) map[string]bool {
 	matched := make(map[string]bool, len(rows))
 	if len(rows) == 0 {
 		return matched
 	}
-	svc := a.Services()
 	ids := make([]string, 0, len(rows))
 	for _, e := range rows {
 		ids = append(ids, e.ID)

--- a/internal/dataentry/entityreader.go
+++ b/internal/dataentry/entityreader.go
@@ -82,6 +82,45 @@ func (er entityReader) incomingRelations(ctx context.Context, id string) []*enti
 	return er.relations(ctx, id, store.DirectionIncoming)
 }
 
+// pageRelations loads every edge touching any of entities in ONE query and
+// splits them per row: outgoing[i] holds the edges whose source is
+// entities[i], incoming[i] those whose target is. Index-aligned with
+// entities; a row with no edges keeps a nil entry. An edge between two page
+// rows appears in both rows' slices, once each — the same result the former
+// per-row outgoing+incoming pair produced (TKT-1U8XYN).
+func (er entityReader) pageRelations(
+	ctx context.Context, entities []*entity.Entity,
+) (outgoing, incoming [][]*entity.Relation) {
+	outgoing = make([][]*entity.Relation, len(entities))
+	incoming = make([][]*entity.Relation, len(entities))
+	if len(entities) == 0 {
+		return outgoing, incoming
+	}
+	rowIdx := make(map[string]int, len(entities))
+	ids := make([]string, 0, len(entities))
+	for i, e := range entities {
+		if _, dup := rowIdx[e.ID]; dup {
+			continue
+		}
+		rowIdx[e.ID] = i
+		ids = append(ids, e.ID)
+	}
+	rels, err := listRelationsCtx(ctx, er.store, store.RelationQuery{EntityIDs: ids, Direction: store.DirectionBoth})
+	if err != nil {
+		slog.Warn("dataentry: entityReader: listing page relations failed; result truncated",
+			"rows", len(ids), "err", err)
+	}
+	for _, r := range rels {
+		if i, ok := rowIdx[r.From]; ok {
+			outgoing[i] = append(outgoing[i], r)
+		}
+		if i, ok := rowIdx[r.To]; ok {
+			incoming[i] = append(incoming[i], r)
+		}
+	}
+	return outgoing, incoming
+}
+
 func (er entityReader) relations(ctx context.Context, id string, dir store.Direction) []*entity.Relation {
 	rels, err := listRelationsCtx(ctx, er.store, store.RelationQuery{EntityID: id, Direction: dir})
 	if err != nil {

--- a/internal/dataentry/helpers.go
+++ b/internal/dataentry/helpers.go
@@ -550,14 +550,16 @@ func visibleEntitiesOfType(
 ) ([]*entity.Entity, error) {
 	if ts.AllowAll && len(props) == 0 {
 		var out []*entity.Entity
-		for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{
+		// Content-free rows (rowcontent.go): search results render titles
+		// and properties, and a body is loaded only on request.
+		for h, err := range store.ListEntityHeaders(ctx, svc.Store, store.EntityQuery{
 			Type:  typ,
 			World: worldScopeFrom(ctx),
 		}) {
 			if err != nil {
 				return nil, fmt.Errorf("%w: %w", errListLoad, err)
 			}
-			out = append(out, e)
+			out = append(out, headerEntity(h))
 		}
 		return out, nil
 	}
@@ -579,10 +581,11 @@ func visibleEntitiesOfType(
 	q.World = worldScopeFrom(ctx)
 
 	var out []*entity.Entity
-	for e, err := range svc.Store.GraphQuery(ctx, q) {
+	for h, err := range store.GraphQueryHeaders(ctx, svc.Store, q) {
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", errClass, err)
 		}
+		e := headerEntity(h)
 		out = append(out, e)
 	}
 	return out, nil

--- a/internal/dataentry/helpers_test.go
+++ b/internal/dataentry/helpers_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+
 	"golang.org/x/net/html"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -686,7 +688,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	app := newAppFromParts(nil, meta, g)
 
 	t.Run("resolves multiple targets", func(t *testing.T) {
-		got := app.views.resolveRelationColumnValues(context.Background(), assessment.ID, "assessmentBy", "")
+		got := relationColumnValuesFor(context.Background(), app, assessment.ID, "assessment", "assessmentBy", "")
 		want := []string{"Alice", "Bob"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -694,7 +696,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("filters by relation type", func(t *testing.T) {
-		got := app.views.resolveRelationColumnValues(context.Background(), assessment.ID, "otherRel", "")
+		got := relationColumnValuesFor(context.Background(), app, assessment.ID, "assessment", "otherRel", "")
 		want := []string{"Alice"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -702,21 +704,21 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("returns empty for no matching relations", func(t *testing.T) {
-		got := app.views.resolveRelationColumnValues(context.Background(), assessment.ID, "nonexistent", "")
+		got := relationColumnValuesFor(context.Background(), app, assessment.ID, "assessment", "nonexistent", "")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
 	})
 
 	t.Run("returns empty for unknown entity", func(t *testing.T) {
-		got := app.views.resolveRelationColumnValues(context.Background(), "UNKNOWN", "assessmentBy", "")
+		got := relationColumnValuesFor(context.Background(), app, "UNKNOWN", "assessment", "assessmentBy", "")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
 	})
 
 	t.Run("direction outgoing explicit", func(t *testing.T) {
-		got := app.views.resolveRelationColumnValues(context.Background(), assessment.ID, "assessmentBy", "outgoing")
+		got := relationColumnValuesFor(context.Background(), app, assessment.ID, "assessment", "assessmentBy", "outgoing")
 		want := []string{"Alice", "Bob"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -726,7 +728,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	t.Run("direction incoming returns sources", func(t *testing.T) {
 		// PER-001 has an incoming edge from ASS-001 via assessmentBy
 		// Assessment title is not required, so falls back to ID
-		got := app.views.resolveRelationColumnValues(context.Background(), person1.ID, "assessmentBy", "incoming")
+		got := relationColumnValuesFor(context.Background(), app, person1.ID, "person", "assessmentBy", "incoming")
 		want := []string{assessment.ID}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -735,7 +737,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 
 	t.Run("direction incoming returns multiple sources", func(t *testing.T) {
 		// PER-001 is target of both assessmentBy and otherRel from ASS-001
-		got := app.views.resolveRelationColumnValues(context.Background(), person1.ID, "otherRel", "incoming")
+		got := relationColumnValuesFor(context.Background(), app, person1.ID, "person", "otherRel", "incoming")
 		want := []string{assessment.ID}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
@@ -743,7 +745,7 @@ func TestResolveRelationColumnValue(t *testing.T) {
 	})
 
 	t.Run("direction incoming no matches", func(t *testing.T) {
-		got := app.views.resolveRelationColumnValues(context.Background(), assessment.ID, "assessmentBy", "incoming")
+		got := relationColumnValuesFor(context.Background(), app, assessment.ID, "assessment", "assessmentBy", "incoming")
 		if len(got) != 0 {
 			t.Errorf("got %v, want empty slice", got)
 		}
@@ -1136,4 +1138,18 @@ func TestCompareValues_DatetimeMismatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+// relationColumnValuesFor is the single-row probe the batched section
+// resolver replaced: the display titles of one entity's neighbors over
+// relation in direction (outgoing when empty).
+func relationColumnValuesFor(
+	ctx context.Context, app *App, entityID, entityType, relation string, direction dataentryconfig.Direction,
+) []string {
+	if direction == "" {
+		direction = dataentryconfig.DirectionOutgoing
+	}
+	cols := []dataentryconfig.ListColumn{{Relation: relation, Direction: direction}}
+	rows := []*entity.Entity{{ID: entityID, Type: entityType}}
+	return app.views.resolveRelationColumns(ctx, app.views.schema(), cols, rows)[entityID][0]
 }

--- a/internal/dataentry/listpushdown.go
+++ b/internal/dataentry/listpushdown.go
@@ -1,0 +1,152 @@
+package dataentry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/queryplan"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// List paging pushdown (TKT-1U8XYN).
+//
+// The list pipeline's general shape — load the whole type, filter, sort and
+// slice in Go — exists because some of its inputs cannot be expressed to
+// the store: free-text search, relation filters, typed comparisons. Most
+// requests carry none of those: the SPA's default list is "this type,
+// maybe an equality filter, sorted by one property, page N". For that shape
+// the store can do the filtering, ordering and paging itself, so a page
+// costs one bounded read plus one count instead of a scan of the type.
+//
+// The pushed and the Go path must return the same rows in the same order,
+// and that is a matter of eligibility, not of translation cleverness: the
+// plan only pushes what both sides evaluate identically. Equality and
+// inequality on scalar STRING-shaped properties (string, enum, date,
+// datetime, custom types) compare byte-for-byte on both sides; ordering by
+// such a property is byte-wise on both sides with absent values last (see
+// applyV1Sorting). Anything else — integers (byte order is not numeric
+// order), lists, `contains`/`in`/range operators, free text, relation
+// filters — stays on the Go path. Pinned by the differential test in
+// listpushdown_test.go.
+//
+// The ACL is honored by construction: the pushed query IS the principal's
+// compiled read query (or an unconstrained one for an allow-all principal)
+// with the request's world and face set stamped on a copy, and the total is
+// the scoped count — never the type's row count (RR-SSPCCI, RR-J1VAW0).
+
+// listPlan is a list request the store can page by itself. errClass is
+// the failure the Go path would have reported for the same principal —
+// errListLoad for an allow-all read, errACLListQuery for a compiled one —
+// so a backend fault surfaces identically on either path.
+type listPlan struct {
+	query    store.GraphQuery
+	errClass error
+}
+
+// planListPushdown decides whether the request is eligible and, if so,
+// builds the paged query. ok=false means "take the Go path"; it is never
+// an error, because ineligibility is the ordinary case for a request the
+// planner does not understand.
+func planListPushdown(
+	meta *metamodel.Metamodel, typeName string, query map[string][]string,
+	rqr acl.ReadQueryResult, world store.WorldScope, page, perPage int,
+	isRelationKey func(string) bool,
+) (listPlan, bool) {
+	if queryGet(query, "q") != "" || rqr.DenyAll {
+		return listPlan{}, false
+	}
+	def, ok := meta.GetEntityDef(typeName)
+	if !ok {
+		return listPlan{}, false
+	}
+	stringShaped := func(property string) bool {
+		pd, ok := def.Properties[property]
+		return ok && queryplan.StringShaped(meta, pd)
+	}
+
+	var props []store.PropPredicate
+	for key, values := range query {
+		if !strings.HasPrefix(key, "filter[") || len(values) == 0 {
+			continue
+		}
+		property, operator, ok := parseRelationFilterKey(key)
+		if !ok || strings.HasSuffix(key, "[]") || (isRelationKey != nil && isRelationKey(property)) {
+			return listPlan{}, false
+		}
+		if !stringShaped(property) || len(values) != 1 {
+			return listPlan{}, false
+		}
+		value := resolveFilterVariable(values[0])
+		switch operator {
+		case "eq":
+			props = append(props, store.PropPredicate{
+				Property: property, Op: store.PropEqual, Value: value, Scalar: value != "",
+			})
+		case "ne":
+			if strings.Contains(value, ",") {
+				return listPlan{}, false // a NOT IN list; the Go path handles it
+			}
+			props = append(props, store.PropPredicate{Property: property, Op: store.PropNotEqual, Value: value})
+		default:
+			return listPlan{}, false
+		}
+	}
+
+	var order []store.OrderSpec
+	for _, spec := range parseSortParam(query) {
+		if !stringShaped(spec.Property) {
+			return listPlan{}, false
+		}
+		order = append(order, store.OrderSpec{Property: spec.Property, Descending: spec.IsDescending()})
+	}
+
+	var gq store.GraphQuery
+	errClass := errACLListQuery
+	switch {
+	case rqr.AllowAll:
+		gq = store.GraphQuery{EntityType: typeName}
+		errClass = errListLoad
+	case rqr.Query != nil:
+		gq = *rqr.Query // COPY: the ACL layer reuses its result per principal
+	default:
+		return listPlan{}, false
+	}
+	gq.World = world
+	gq.FaceIn = rqr.Faces
+	gq.Props = append(append([]store.PropPredicate(nil), gq.Props...), props...)
+	gq.OrderBy = order
+	gq.Limit = perPage
+	gq.Offset = (page - 1) * perPage
+	return listPlan{query: gq, errClass: errClass}, true
+}
+
+// run executes the plan: the scoped total in one count and the page in one
+// content-free read. Rows come back as content-free entities
+// (rowcontent.go), exactly what the Go path hands the handler.
+func (p listPlan) run(ctx context.Context, st store.Store) (rows []*entityPkg.Entity, total int, err error) {
+	total, err = scopedTotal(ctx, st, p.query)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", p.errClass, err)
+	}
+	rows = make([]*entityPkg.Entity, 0, p.query.Limit)
+	for h, herr := range store.GraphQueryHeaders(ctx, st, p.query) {
+		if herr != nil {
+			return nil, 0, fmt.Errorf("%w: %w", p.errClass, herr)
+		}
+		rows = append(rows, headerEntity(h))
+	}
+	return rows, total, nil
+}
+
+// scopedTotal returns the number of rows the (ACL-scoped) query matches. It
+// deliberately exposes only the matched count: GraphCount also reports the
+// type's total, which for a gated principal is a count over rows they may
+// not see (RR-SSPCCI), a handler holding both integers can ship the wrong
+// one, and computing it is the costlier of the two statements.
+func scopedTotal(ctx context.Context, st store.Store, q store.GraphQuery) (int, error) {
+	return store.CountMatched(ctx, st, q)
+}

--- a/internal/dataentry/listpushdown_test.go
+++ b/internal/dataentry/listpushdown_test.go
@@ -23,10 +23,14 @@ import (
 func pushdownApp(t *testing.T) (*App, *acl.Declarative) {
 	t.Helper()
 	app := newTestAppV1(t)
-	dues := []string{"2026-03-01", "", "2026-01-15", "2026-03-01", "", "2025-12-31", "2026-02-02", "", "2026-01-15", "2026-12-31", "2026-05-05", ""}
+	dues := []string{"2026-03-01", "", "2026-01-15", "2026-03-01", "null", "2025-12-31", "2026-02-02", "", "2026-01-15", "2026-12-31", "2026-05-05", "null"}
 	for i, due := range dues {
 		props := map[string]any{"title": fmt.Sprintf("Ticket %02d", 11-i), "status": []string{"open", "done", "open"}[i%3]}
-		if due != "" {
+		switch due {
+		case "":
+		case "null":
+			props["due"] = nil // a JSON null sorts with the absent rows on both paths
+		default:
 			props["due"] = due
 		}
 		seedEntity(app, &entity.Entity{ID: fmt.Sprintf("TKT-%03d", i+1), Type: "ticket", Properties: props})

--- a/internal/dataentry/listpushdown_test.go
+++ b/internal/dataentry/listpushdown_test.go
@@ -1,0 +1,199 @@
+package dataentry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// The pushed page and the Go page must be the same page (listpushdown.go).
+
+// pushdownApp seeds tickets whose sort keys collide, are missing, or are
+// out of insertion order, so an ordering difference between the two paths
+// cannot hide.
+func pushdownApp(t *testing.T) (*App, *acl.Declarative) {
+	t.Helper()
+	app := newTestAppV1(t)
+	dues := []string{"2026-03-01", "", "2026-01-15", "2026-03-01", "", "2025-12-31", "2026-02-02", "", "2026-01-15", "2026-12-31", "2026-05-05", ""}
+	for i, due := range dues {
+		props := map[string]any{"title": fmt.Sprintf("Ticket %02d", 11-i), "status": []string{"open", "done", "open"}[i%3]}
+		if due != "" {
+			props["due"] = due
+		}
+		seedEntity(app, &entity.Entity{ID: fmt.Sprintf("TKT-%03d", i+1), Type: "ticket", Properties: props})
+	}
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"*"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+	return app, d
+}
+
+// goPath runs the whole-type pipeline the pushdown replaces and slices it.
+func goPath(
+	ctx context.Context, t *testing.T, app *App, typeName string, query map[string][]string, page, perPage int,
+) (ids []string, total int) {
+	t.Helper()
+	all, err := app.scopedSortedEntities(ctx, typeName, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := min((page-1)*perPage, len(all))
+	end := min(start+perPage, len(all))
+	ids = make([]string, 0, end-start)
+	for _, e := range all[start:end] {
+		ids = append(ids, e.ID)
+	}
+	return ids, len(all)
+}
+
+func TestListPushdown_MatchesGoPathPageForPage(t *testing.T) {
+	// The test metamodel declares no `due`, so declare a string-shaped one
+	// for the sort key; status is a plain string already.
+	app, d := pushdownApp(t)
+	meta := app.Meta()
+	tk := meta.Entities["ticket"]
+	tk.Properties["due"] = metamodelProp("date")
+	meta.Entities["ticket"] = tk
+
+	for _, rq := range []string{
+		"sort=due", "sort=-due", "sort=due,title", "sort=-title",
+		"filter%5Bstatus%5D=open&sort=due", "filter%5Bstatus%5D%5Bne%5D=open&sort=-due",
+		"filter%5Bstatus%5D=open", "",
+	} {
+		for _, perPage := range []int{3, 5} {
+			for page := 1; page <= 3; page++ {
+				name := fmt.Sprintf("%s per_page=%d page=%d", rq, perPage, page)
+				t.Run(name, func(t *testing.T) {
+					q := rq
+					if q != "" {
+						q += "&"
+					}
+					q += fmt.Sprintf("per_page=%d&page=%d", perPage, page)
+					ctx := gateCtxFor(aliceCtx(), t, d)
+					// The handler picks the pushed path when eligible …
+					resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", q)
+					if rec.Code != http.StatusOK {
+						t.Fatalf("status %d: %s", rec.Code, rec.Body)
+					}
+					// … and this is what the Go path would have served.
+					query := parseQuery(q)
+					wantIDs, wantTotal := goPath(ctx, t, app, "ticket", query, page, perPage)
+					var gotIDs []string
+					for _, e := range resp.Data {
+						gotIDs = append(gotIDs, e.ID)
+					}
+					if strings.Join(gotIDs, ",") != strings.Join(wantIDs, ",") {
+						t.Errorf("rows differ: pushed %v, go %v", gotIDs, wantIDs)
+					}
+					if resp.Meta.Total != wantTotal {
+						t.Errorf("total: pushed %d, go %d", resp.Meta.Total, wantTotal)
+					}
+					wantMore := (page-1)*perPage+len(wantIDs) < wantTotal
+					if resp.Meta.HasMore != wantMore {
+						t.Errorf("has_more: pushed %v, go %v", resp.Meta.HasMore, wantMore)
+					}
+				})
+			}
+		}
+	}
+}
+
+// planListPushdown must refuse what the store cannot evaluate identically.
+func TestListPushdown_Eligibility(t *testing.T) {
+	app, _ := pushdownApp(t)
+	meta := app.Meta()
+	tk := meta.Entities["ticket"]
+	tk.Properties["due"] = metamodelProp("date")
+	tk.Properties["estimate"] = metamodelProp("integer")
+	meta.Entities["ticket"] = tk
+	allow := acl.ReadQueryResult{AllowAll: true}
+	isRel := func(k string) bool { return k == "implements" }
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"plain", "", true},
+		{"sort string prop", "sort=due", true},
+		{"eq filter", "filter%5Bstatus%5D=open", true},
+		{"ne filter", "filter%5Bstatus%5D%5Bne%5D=open", true},
+		{"free text", "q=foo", false},
+		{"relation filter", "filter%5Bimplements%5D=Feature", false},
+		{"integer sort", "sort=estimate", false},
+		{"undeclared sort", "sort=nope", false},
+		{"contains", "filter%5Btitle%5D%5Bcontains%5D=x", false},
+		{"in list", "filter%5Bstatus%5D%5Bin%5D=a,b", false},
+		{"ne list", "filter%5Bstatus%5D%5Bne%5D=a,b", false},
+		{"array form", "filter%5Bstatus%5D%5B%5D=open", false},
+		{"range", "filter%5Bdue%5D%5Bgte%5D=2026-01-01", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := planListPushdown(meta, "ticket", parseQuery(tc.query), allow, store.WorldScope{}, 1, 25, isRel)
+			if ok != tc.want {
+				t.Errorf("eligible = %v, want %v", ok, tc.want)
+			}
+		})
+	}
+	t.Run("deny all", func(t *testing.T) {
+		_, ok := planListPushdown(meta, "ticket", parseQuery(""), acl.ReadQueryResult{DenyAll: true}, store.WorldScope{}, 1, 25, isRel)
+		if ok {
+			t.Error("a denied type must not be pushed")
+		}
+	})
+}
+
+// A gated principal's total is the count of rows they may read, never the
+// type's row count (RR-SSPCCI / RR-J1VAW0), and the page holds only those.
+func TestListPushdown_ScopedTotalForGatedPrincipal(t *testing.T) {
+	app := newTestAppV1(t)
+	for i := 1; i <= 6; i++ {
+		seedEntity(app, &entity.Entity{ID: fmt.Sprintf("TKT-%03d", i), Type: "ticket",
+			Properties: map[string]any{"title": fmt.Sprintf("T%d", i), "status": []string{"open", "done"}[i%2]}})
+	}
+	// bob may read only tickets with status=open, through a predicate-free
+	// type grant narrowed by a field-level read query shape: emulate with a
+	// role that reads tickets and a request-level filter, then compare to the
+	// Go path for the same principal.
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"bob": "viewer"},
+	}, app.store)
+	app.acl = d
+	resp, rec := listEntitiesAs(principalCtx("bob"), t, app, d, "ticket", "tickets", "filter%5Bstatus%5D=open&per_page=2")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body)
+	}
+	if resp.Meta.Total != 3 || len(resp.Data) != 2 || !resp.Meta.HasMore {
+		t.Errorf("total=%d rows=%d has_more=%v, want 3/2/true", resp.Meta.Total, len(resp.Data), resp.Meta.HasMore)
+	}
+	// A type bob may not read at all: empty, total 0, no pushdown leak.
+	resp, rec = listEntitiesAs(principalCtx("bob"), t, app, d, "feature", "features", "")
+	if rec.Code != http.StatusOK || resp.Meta.Total != 0 || len(resp.Data) != 0 {
+		t.Errorf("denied type: status %d total %d rows %d", rec.Code, resp.Meta.Total, len(resp.Data))
+	}
+}
+
+var _ = v1.ListResponse{}
+
+func parseQuery(raw string) map[string][]string {
+	vals, err := url.ParseQuery(raw)
+	if err != nil {
+		panic(err)
+	}
+	return vals
+}
+
+func metamodelProp(typ string) metamodel.PropertyDef {
+	return metamodel.PropertyDef{Type: typ}
+}

--- a/internal/dataentry/querybudget_test.go
+++ b/internal/dataentry/querybudget_test.go
@@ -205,8 +205,9 @@ func TestQueryBudget_SearchIsSizeIndependent(t *testing.T) {
 // Pinned budgets: the measured store-call count per request shape after
 // TKT-1U8XYN. Raise one only with a reason in the commit.
 const (
-	// list page: whole-type read, page edges, neighbor headers, membership walk.
-	listPageBudget = 5
+	// list page: scoped count + one bounded page read (listpushdown.go),
+	// page edges, neighbor headers, membership walk.
+	listPageBudget = 6
 	// view: entry, two traverse passes, collection load, section columns +
 	// target headers, entry edges, membership walk.
 	viewSectionBudget = 11

--- a/internal/dataentry/querybudget_test.go
+++ b/internal/dataentry/querybudget_test.go
@@ -1,0 +1,215 @@
+package dataentry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild/appbuildtest"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+	"github.com/Sourcehaven-BV/rela/internal/store/storetest"
+)
+
+// Query budgets (TKT-1U8XYN). Each test drives one SPA-shaped request over a
+// counting store at two sizes and asserts the store-call count does not
+// grow with the number of rows — the property an N+1 violates — and then
+// pins the measured constant so a regression names itself. The pre-change
+// counts in the comments come from the same fixtures before batching.
+
+// budgetMeta: tickets implement features, block other tickets and are
+// assigned to people; people belong to teams, which is what the ACL walks.
+func budgetMeta() *metamodel.Metamodel {
+	str := map[string]metamodel.PropertyDef{"title": {Type: "string", Required: true}}
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Label: "Ticket", Properties: map[string]metamodel.PropertyDef{
+				"title": {Type: "string", Required: true}, "status": {Type: "string"},
+			}, PropertyOrder: []string{"title", "status"}},
+			"feature": {Label: "Feature", Properties: str, PropertyOrder: []string{"title"}},
+			"person":  {Label: "Person", Properties: str, PropertyOrder: []string{"title"}},
+			"team":    {Label: "Team", Properties: str, PropertyOrder: []string{"title"}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"implements":  {Label: "implements", From: []string{"ticket"}, To: []string{"feature"}},
+			"blocks":      {Label: "blocks", From: []string{"ticket"}, To: []string{"ticket"}},
+			"assigned-to": {Label: "assigned to", From: []string{"ticket"}, To: []string{"person"}},
+			"member-of":   {Label: "member of", From: []string{"person"}, To: []string{"team"}},
+		},
+	}
+}
+
+func budgetConfig() *Config {
+	return &Config{
+		App: dataentryconfig.AppConfig{Name: "budget"},
+		Lists: map[string]dataentryconfig.List{
+			"tickets": {EntityType: "ticket", Columns: []dataentryconfig.ListColumn{
+				{Property: "title"}, {Property: "status"},
+				{Relation: "implements", Label: "Feature"},
+				{Relation: "assigned-to", Label: "Assignee"},
+			}},
+		},
+		Views: map[string]dataentryconfig.ViewConfig{
+			"ticket": {
+				Title: "Ticket",
+				Entry: dataentryconfig.ViewEntry{Type: "ticket"},
+				Traverse: []dataentryconfig.ViewTraverse{
+					{From: "entry", FollowIncoming: "blocks", CollectAs: "blockers"},
+				},
+				Sections: []dataentryconfig.ViewSection{
+					{Heading: "Blocked by", Source: "blockers", Display: "table", Columns: []dataentryconfig.ListColumn{
+						{Property: "title"},
+						{Relation: "implements", Label: "Feature"},
+						{Relation: "assigned-to", Label: "Assignee"},
+					}},
+				},
+			},
+		},
+		Forms:      map[string]dataentryconfig.Form{},
+		Kanbans:    map[string]dataentryconfig.Kanban{},
+		Navigation: []dataentryconfig.NavigationEntry{},
+	}
+}
+
+// newBudgetApp seeds n tickets (each implementing a feature, assigned to a
+// person, and blocking TKT-0001) into a counting memstore BEFORE the app is
+// assembled, so the search index backfills from it, then wires an ACL whose
+// role is reached through a member-of walk (person P1 → team T1).
+func newBudgetApp(t *testing.T, n int) (*App, *storetest.Counting, *acl.Declarative, context.Context) {
+	t.Helper()
+	counting := storetest.NewCounting(memstore.New())
+	ctx := context.Background()
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk := func(id, typ, title string) {
+		e := entity.New(id, typ)
+		e.SetString("title", title)
+		must(counting.CreateEntity(ctx, e))
+	}
+	mk("T1", "team", "Team one")
+	for i := 1; i <= 3; i++ {
+		mk(fmt.Sprintf("P%d", i), "person", fmt.Sprintf("Person %d", i))
+		_, err := counting.CreateRelation(ctx, fmt.Sprintf("P%d", i), "member-of", "T1", nil)
+		must(err)
+	}
+	for i := 1; i <= 5; i++ {
+		mk(fmt.Sprintf("F%d", i), "feature", fmt.Sprintf("Feature %d", i))
+	}
+	for i := 1; i <= n; i++ {
+		id := fmt.Sprintf("TKT-%04d", i)
+		e := entity.New(id, "ticket")
+		e.SetString("title", "Ticket "+id)
+		e.SetString("status", []string{"open", "done"}[i%2])
+		must(counting.CreateEntity(ctx, e))
+		_, err := counting.CreateRelation(ctx, id, "implements", fmt.Sprintf("F%d", i%5+1), nil)
+		must(err)
+		_, err = counting.CreateRelation(ctx, id, "assigned-to", fmt.Sprintf("P%d", i%3+1), nil)
+		must(err)
+		if i > 1 {
+			_, err = counting.CreateRelation(ctx, id, "blocks", "TKT-0001", nil)
+			must(err)
+		}
+	}
+
+	app := newAppFromParts(budgetConfig(), budgetMeta(), newFixture(), appbuildtest.WithStore(counting))
+	d := mustNewACL(t, &acl.Policy{
+		Roles: map[string]acl.RoleDef{"editor": {
+			Read: []string{"*"}, Create: []string{"ticket"}, Update: []string{"ticket"}, Delete: []string{"ticket"},
+		}},
+		Assignments: map[string]string{"T1": "editor"},
+	}, app.store)
+	app.acl = d
+	counting.Reset()
+	return app, counting, d, principalCtx("P1")
+}
+
+// readsFor runs op at both sizes and returns the read counts.
+func readsFor(t *testing.T, op func(t *testing.T, app *App, d *acl.Declarative, ctx context.Context)) (small, large int, detail string) {
+	t.Helper()
+	counts := make([]int, 0, 2)
+	for _, n := range []int{10, 50} {
+		app, counting, d, ctx := newBudgetApp(t, n)
+		op(t, app, d, ctx)
+		counts = append(counts, counting.Reads())
+		detail = counting.String()
+	}
+	return counts[0], counts[1], detail
+}
+
+func assertBudget(t *testing.T, name string, small, large, pinned int, detail string) {
+	t.Helper()
+	if small != large {
+		t.Errorf("%s: store reads grow with page size: %d at 10 rows, %d at 50 rows (%s)", name, small, large, detail)
+	}
+	if large != pinned {
+		t.Errorf("%s: store reads = %d, pinned budget %d (%s) — update the pin if the change is deliberate",
+			name, large, pinned, detail)
+	}
+}
+
+// A list page with two relation columns. Before batching: 7 + 8×rows reads
+// (per row: outgoing + incoming edges, a GetEntity per neighbor, and two
+// membership walks per affordance verb).
+func TestQueryBudget_ListPageIsSizeIndependent(t *testing.T) {
+	small, large, detail := readsFor(t, func(t *testing.T, app *App, d *acl.Declarative, ctx context.Context) {
+		t.Helper()
+		resp, rec := listEntitiesAs(ctx, t, app, d, "ticket", "tickets", "per_page=100")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("list: %d %s", rec.Code, rec.Body)
+		}
+		if len(resp.Data) < 10 {
+			t.Fatalf("list returned %d rows", len(resp.Data))
+		}
+	})
+	assertBudget(t, "list page", small, large, listPageBudget, detail)
+}
+
+// A view whose table section has two relation columns over the blockers of
+// TKT-0001 (n-1 rows). Before batching: ~4 + 4×rows reads.
+func TestQueryBudget_ViewTableSectionIsSizeIndependent(t *testing.T) {
+	small, large, detail := readsFor(t, func(t *testing.T, app *App, d *acl.Declarative, ctx context.Context) {
+		t.Helper()
+		rec := viewsAs(ctx, t, app, d, "ticket", "TKT-0001")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("view: %d %s", rec.Code, rec.Body)
+		}
+	})
+	assertBudget(t, "view table section", small, large, viewSectionBudget, detail)
+}
+
+// A structured search (the dashboard card shape). Before batching: 2 +
+// 6×hits reads from the per-hit affordance membership walks.
+func TestQueryBudget_SearchIsSizeIndependent(t *testing.T) {
+	small, large, detail := readsFor(t, func(t *testing.T, app *App, d *acl.Declarative, ctx context.Context) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?q=type%3Aticket", http.NoBody)
+		req = req.WithContext(gateCtxFor(ctx, t, d))
+		rec := httptest.NewRecorder()
+		app.handleV1Search(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("search: %d %s", rec.Code, rec.Body)
+		}
+	})
+	assertBudget(t, "search", small, large, searchBudget, detail)
+}
+
+// Pinned budgets: the measured store-call count per request shape after
+// TKT-1U8XYN. Raise one only with a reason in the commit.
+const (
+	// list page: whole-type read, page edges, neighbor headers, membership walk.
+	listPageBudget = 5
+	// view: entry, two traverse passes, collection load, section columns +
+	// target headers, entry edges, membership walk.
+	viewSectionBudget = 11
+	// search: whole-type read, membership walk.
+	searchBudget = 3
+)

--- a/internal/dataentry/queryservice.go
+++ b/internal/dataentry/queryservice.go
@@ -206,7 +206,7 @@ func (q *queryService) runVisibleFreeTextSearch(
 	// searcher already resolved which face matched; a bare-id re-read would
 	// render default-face bytes for a hit scored against another face the
 	// moment /_search stops being world-refused by the route allowlist.
-	loaded, err := loadHitFaces(ctx, svc.Store, hits)
+	loaded, err := loadHitHeaders(ctx, svc.Store, hits)
 	if err != nil {
 		return nil, fmt.Errorf("free-text search: %w", err)
 	}
@@ -215,7 +215,7 @@ func (q *queryService) runVisibleFreeTextSearch(
 	// coherent set of currently-existing entities.
 	out := make([]*entity.Entity, 0, len(hits))
 	for _, hit := range hits {
-		if e, ok := loaded[hitKey{hit.ID, hit.Face}]; ok {
+		if e, ok := loaded[rowKey{hit.ID, hit.Face}]; ok {
 			out = append(out, e)
 		}
 	}
@@ -303,37 +303,32 @@ func (q *queryService) matchesPropertyFilters(e *entity.Entity, filters []*filte
 	return err == nil && matched
 }
 
-// hitKey addresses one (id, face) row a search hit named.
-type hitKey struct {
-	id   string
-	face entity.Face
-}
-
-// loadHitFaces reads the rows the hits name, grouped by face: default-face
-// hits in one IDs query, each other face in one AllStates query narrowed to
-// that face on the way out. Returns only rows that exist.
-func loadHitFaces(ctx context.Context, st store.Store, hits []search.Hit) (map[hitKey]*entity.Entity, error) {
+// loadHitHeaders reads the content-free rows the hits name, grouped by
+// face: default-face hits in one IDs query, each other face in one
+// AllStates query narrowed to that face on the way out. Returns only rows
+// that exist, as content-free entities (see rowcontent.go).
+func loadHitHeaders(ctx context.Context, st store.Store, hits []search.Hit) (map[rowKey]*entity.Entity, error) {
 	byFace := make(map[entity.Face][]string)
-	seen := make(map[hitKey]struct{}, len(hits))
+	seen := make(map[rowKey]struct{}, len(hits))
 	for _, h := range hits {
-		k := hitKey{h.ID, h.Face}
+		k := rowKey{h.ID, h.Face}
 		if _, dup := seen[k]; dup {
 			continue
 		}
 		seen[k] = struct{}{}
 		byFace[h.Face] = append(byFace[h.Face], h.ID)
 	}
-	out := make(map[hitKey]*entity.Entity, len(seen))
+	out := make(map[rowKey]*entity.Entity, len(seen))
 	for face, ids := range byFace {
 		q := store.EntityQuery{IDs: ids, AllStates: !face.IsDefault()}
-		for e, err := range st.ListEntities(ctx, q) {
+		for h, err := range store.ListEntityHeaders(ctx, st, q) {
 			if err != nil {
 				return nil, err
 			}
-			if e.Face != face {
+			if h.Face != face {
 				continue // AllStates over-returns the family's other faces
 			}
-			out[hitKey{e.ID, e.Face}] = e
+			out[rowKey{h.ID, h.Face}] = headerEntity(h)
 		}
 	}
 	return out, nil

--- a/internal/dataentry/queryservice.go
+++ b/internal/dataentry/queryservice.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // queryService owns the search-query pipeline: the `/_search` and
@@ -189,7 +190,7 @@ func (q *queryService) runVisibleFreeTextSearch(
 		Types: sq.EntityTypes,
 		Limit: limit,
 	}
-	out := make([]*entity.Entity, 0)
+	var hits []search.Hit
 	for hit, err := range searchVisibleHits(ctx, q.visibleSearcher(), q.affordances(), sQuery, scope) {
 		if err != nil {
 			if errors.Is(err, search.ErrScope) {
@@ -197,21 +198,26 @@ func (q *queryService) runVisibleFreeTextSearch(
 			}
 			return nil, fmt.Errorf("free-text search: %w", err)
 		}
-		// Load the FACE the hit matched, not the bare id. Under the default
-		// world hit.Face is the zero face and this IS GetEntity, so nothing
-		// changes today — but /_search is world-refused only by the route
-		// allowlist, and a bare-id re-read here would render default-face
-		// bytes for a hit scored against another face the moment that
-		// allowlist widens. The searcher already resolved which face matched;
-		// discarding it and re-reading is the wrong-face serve.
-		e, getErr := svc.Store.GetEntityState(ctx, hit.ID, hit.Face)
-		if getErr != nil {
-			// Stale index hit (entity deleted between index query and
-			// store read). Skip silently — the result stays a coherent
-			// set of currently-existing entities.
-			continue
+		hits = append(hits, hit)
+	}
+	// Load the FACE each hit matched, not the bare id, in ONE read per
+	// distinct face rather than one per hit (TKT-1U8XYN). Under the default
+	// world every hit carries the zero face and this is one query. The
+	// searcher already resolved which face matched; a bare-id re-read would
+	// render default-face bytes for a hit scored against another face the
+	// moment /_search stops being world-refused by the route allowlist.
+	loaded, err := loadHitFaces(ctx, svc.Store, hits)
+	if err != nil {
+		return nil, fmt.Errorf("free-text search: %w", err)
+	}
+	// Emit in ranked hit order; a hit the store no longer has (deleted
+	// between index query and read) is skipped so the result stays a
+	// coherent set of currently-existing entities.
+	out := make([]*entity.Entity, 0, len(hits))
+	for _, hit := range hits {
+		if e, ok := loaded[hitKey{hit.ID, hit.Face}]; ok {
+			out = append(out, e)
 		}
-		out = append(out, e)
 	}
 	return out, nil
 }
@@ -295,4 +301,40 @@ func (q *queryService) matchesPropertyFilters(e *entity.Entity, filters []*filte
 	}
 	matched, err := filter.MatchAll(entityRecord(e), filters, entDef, s.Meta)
 	return err == nil && matched
+}
+
+// hitKey addresses one (id, face) row a search hit named.
+type hitKey struct {
+	id   string
+	face entity.Face
+}
+
+// loadHitFaces reads the rows the hits name, grouped by face: default-face
+// hits in one IDs query, each other face in one AllStates query narrowed to
+// that face on the way out. Returns only rows that exist.
+func loadHitFaces(ctx context.Context, st store.Store, hits []search.Hit) (map[hitKey]*entity.Entity, error) {
+	byFace := make(map[entity.Face][]string)
+	seen := make(map[hitKey]struct{}, len(hits))
+	for _, h := range hits {
+		k := hitKey{h.ID, h.Face}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		byFace[h.Face] = append(byFace[h.Face], h.ID)
+	}
+	out := make(map[hitKey]*entity.Entity, len(seen))
+	for face, ids := range byFace {
+		q := store.EntityQuery{IDs: ids, AllStates: !face.IsDefault()}
+		for e, err := range st.ListEntities(ctx, q) {
+			if err != nil {
+				return nil, err
+			}
+			if e.Face != face {
+				continue // AllStates over-returns the family's other faces
+			}
+			out[hitKey{e.ID, e.Face}] = e
+		}
+	}
+	return out, nil
 }

--- a/internal/dataentry/relation_visibility.go
+++ b/internal/dataentry/relation_visibility.go
@@ -2,8 +2,10 @@ package dataentry
 
 import (
 	"context"
+	"log/slog"
 
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // neighborIDsOf collects the DISTINCT neighbor entity IDs referenced by a
@@ -67,17 +69,22 @@ func neighborIDsOf(outgoing, incoming []*entityPkg.Relation) []string {
 func visibleRelationIDs(
 	ctx context.Context, reader entityReader, visible visibleReader, neighborIDs []string,
 ) map[string]bool {
-	candidates := make([]*entityPkg.Entity, 0, len(neighborIDs))
-	for _, id := range neighborIDs {
-		if e, found := reader.getEntity(ctx, id); found {
-			candidates = append(candidates, e)
+	if len(neighborIDs) == 0 {
+		return map[string]bool{}
+	}
+	// ONE content-free read for the page's neighbor set (TKT-1U8XYN): the
+	// gate needs each neighbor's type and id, never its body, and a header
+	// batch is what store.EntityQuery.IDs exists for. An id the store no
+	// longer has (a dangling edge) is simply absent, as the per-id lookup's
+	// not-found was.
+	candidates := make([]store.EntityHeader, 0, len(neighborIDs))
+	for h, err := range store.ListEntityHeaders(ctx, reader.store, store.EntityQuery{IDs: neighborIDs}) {
+		if err != nil {
+			slog.Warn("dataentry: visibleRelationIDs: header batch failed; neighbors dropped fail-closed",
+				"neighbors", len(neighborIDs), "err", err)
+			return map[string]bool{}
 		}
+		candidates = append(candidates, h)
 	}
-
-	vis := visible.filterVisible(ctx, candidates)
-	out := make(map[string]bool, len(vis))
-	for _, e := range vis {
-		out[e.ID] = true
-	}
-	return out
+	return visible.visibleHeaderIDs(ctx, candidates)
 }

--- a/internal/dataentry/requeststats.go
+++ b/internal/dataentry/requeststats.go
@@ -1,0 +1,128 @@
+package dataentry
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// requestStats is the outermost middleware. When slog's default handler is
+// enabled at Debug it attaches a [store.QueryStats] to the request context,
+// so a database-backed store accounts every statement the request issues,
+// and reports the result twice: a `Server-Timing` response header
+// (`db;dur=<ms>;desc="<n> queries"`, visible in browser devtools) and one
+// `request` log record with method, path, status, wall time, query count
+// and database time.
+//
+// Below Debug it is a pass-through: nothing is attached, nothing is
+// emitted, no header is set. That gate is deliberate and security-relevant,
+// not a convenience. A per-response query count varies with the rows a
+// request touched — on a path that still loads neighbors one by one it
+// varies with rows the principal is NOT allowed to see — so it is an
+// existence side channel of the kind docs/acl-security.md rules out. Wall
+// time is already observable by any client; a machine-readable statement
+// count is not, and it stays an operator diagnostic (RR-64OR7D).
+//
+// SSE responses carry no header: their WriteHeader fires before the stream
+// does any work, so the numbers would be meaningless; the log record on
+// disconnect is still emitted.
+func requestStats(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !slog.Default().Enabled(r.Context(), slog.LevelDebug) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		ctx, stats := store.WithQueryStats(r.Context())
+		start := time.Now()
+		sw := &statsResponseWriter{
+			ResponseWriter: w,
+			stats:          stats,
+			header:         !isSSEPath(r.URL.Path),
+		}
+		next.ServeHTTP(sw, r.WithContext(ctx))
+		slog.DebugContext(ctx, "request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", sw.statusOrDefault(),
+			"wall_ms", millis(time.Since(start)),
+			"queries", stats.Queries(),
+			"db_ms", millis(stats.Duration()),
+		)
+	})
+}
+
+// isSSEPath names the two event-stream routes registered on the outer mux
+// (see NewRouter). Kept here rather than derived from the mux so the
+// middleware needs no handle on the router.
+func isSSEPath(p string) bool {
+	return p == "/api/events" || p == "/api/v1/_events"
+}
+
+// statsResponseWriter records the status code and, on the first
+// WriteHeader, stamps the Server-Timing header from the stats accumulated
+// so far. Handlers finish their store reads before writing (they build the
+// response body in memory), so the number at WriteHeader time is the
+// request's total.
+//
+// Flush is forwarded so the SSE and command-stream handlers, which assert
+// http.Flusher on the writer they receive, keep working when wrapped.
+// Unwrap serves http.ResponseController for any other optional interface.
+type statsResponseWriter struct {
+	http.ResponseWriter
+	stats   *store.QueryStats
+	header  bool
+	status  int
+	written bool
+}
+
+func (w *statsResponseWriter) WriteHeader(code int) {
+	if !w.written {
+		w.written = true
+		w.status = code
+		if w.header {
+			w.ResponseWriter.Header().Set("Server-Timing", serverTimingValue(w.stats))
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statsResponseWriter) Write(b []byte) (int, error) {
+	if !w.written {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *statsResponseWriter) Flush() {
+	if !w.written {
+		w.WriteHeader(http.StatusOK)
+	}
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *statsResponseWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func (w *statsResponseWriter) statusOrDefault() int {
+	if w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+// serverTimingValue formats one Server-Timing metric. `dur` is the summed
+// database time in milliseconds (the unit the header specifies); `desc`
+// carries the count because Server-Timing has no other slot for it.
+func serverTimingValue(s *store.QueryStats) string {
+	return fmt.Sprintf(`db;dur=%.1f;desc="%d queries"`, millis(s.Duration()), s.Queries())
+}
+
+// millis renders a duration as fractional milliseconds with microsecond
+// resolution — the unit both Server-Timing and the request log use.
+func millis(d time.Duration) float64 {
+	return float64(d.Microseconds()) / float64(time.Millisecond/time.Microsecond)
+}

--- a/internal/dataentry/requeststats.go
+++ b/internal/dataentry/requeststats.go
@@ -69,7 +69,10 @@ func isSSEPath(p string) bool {
 //
 // Flush is forwarded so the SSE and command-stream handlers, which assert
 // http.Flusher on the writer they receive, keep working when wrapped.
-// Unwrap serves http.ResponseController for any other optional interface.
+// Unwrap serves http.ResponseController for any other optional interface;
+// a direct `w.(http.Hijacker)` assertion would NOT see through this wrapper,
+// which is fine only because no handler hijacks — add a forwarder here
+// before one does, or Debug mode would change its behavior.
 type statsResponseWriter struct {
 	http.ResponseWriter
 	stats   *store.QueryStats

--- a/internal/dataentry/requeststats_test.go
+++ b/internal/dataentry/requeststats_test.go
@@ -1,0 +1,149 @@
+package dataentry
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// withLogLevel installs a default slog logger at the given level writing to
+// the returned buffer, restoring the previous default on cleanup.
+func withLogLevel(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// countingHandler simulates a store-backed handler: it records two
+// statements against the request's stats (as the pgx tracer would) and
+// writes a body.
+func countingHandler(t *testing.T, wantStats bool) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		stats := store.QueryStatsFrom(r.Context())
+		if wantStats != (stats != nil) {
+			t.Errorf("stats on context = %v, want present=%v", stats != nil, wantStats)
+		}
+		if stats != nil {
+			stats.Record(1500 * time.Microsecond)
+			stats.Record(500 * time.Microsecond)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+func TestRequestStats_DebugEmitsHeaderAndLog(t *testing.T) {
+	buf := withLogLevel(t, slog.LevelDebug)
+	h := requestStats(countingHandler(t, true))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/tickets?page=2", http.NoBody))
+
+	if got, want := rec.Header().Get("Server-Timing"), `db;dur=2.0;desc="2 queries"`; got != want {
+		t.Errorf("Server-Timing = %q, want %q", got, want)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status passthrough = %d, want 201", rec.Code)
+	}
+	out := buf.String()
+	for _, want := range []string{"msg=request", "method=GET", "path=/api/v1/tickets", "status=201", "queries=2", "db_ms=2", "wall_ms="} {
+		if !strings.Contains(out, want) {
+			t.Errorf("request log missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestRequestStats_InfoIsPassThrough(t *testing.T) {
+	buf := withLogLevel(t, slog.LevelInfo)
+	h := requestStats(countingHandler(t, false))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/tickets", http.NoBody))
+
+	if got := rec.Header().Get("Server-Timing"); got != "" {
+		t.Errorf("Server-Timing must be absent below Debug, got %q", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("no request record below Debug, got %q", buf.String())
+	}
+}
+
+func TestRequestStats_SSEGetsNoHeaderButFlushes(t *testing.T) {
+	withLogLevel(t, slog.LevelDebug)
+	flushed := false
+	h := requestStats(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("wrapped writer must still satisfy http.Flusher for SSE")
+		}
+		_, _ = w.Write([]byte("data: x\n\n"))
+		f.Flush()
+		flushed = true
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/_events", http.NoBody))
+	if !flushed {
+		t.Fatal("handler did not run to Flush")
+	}
+	if got := rec.Header().Get("Server-Timing"); got != "" {
+		t.Errorf("SSE response must not carry Server-Timing, got %q", got)
+	}
+	if !rec.Flushed {
+		t.Error("Flush was not forwarded to the underlying writer")
+	}
+}
+
+func TestRequestStats_ImplicitWriteHeaderStillStamps(t *testing.T) {
+	withLogLevel(t, slog.LevelDebug)
+	h := requestStats(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		store.QueryStatsFrom(r.Context()).Record(time.Millisecond)
+		_, _ = w.Write([]byte("body without explicit WriteHeader"))
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody))
+	if got, want := rec.Header().Get("Server-Timing"), `db;dur=1.0;desc="1 queries"`; got != want {
+		t.Errorf("Server-Timing = %q, want %q", got, want)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("implicit status = %d, want 200", rec.Code)
+	}
+}
+
+// The router wires requestStats outermost; prove a real API route through
+// NewRouter carries the header under Debug and not under Info.
+func TestRequestStats_WiredIntoRouter(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		level slog.Level
+		want  bool
+	}{
+		{"debug", slog.LevelDebug, true},
+		{"info", slog.LevelInfo, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withLogLevel(t, tc.level)
+			app := newTestAppV1(t)
+			router := app.NewRouter()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody).WithContext(context.Background())
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status %d", rec.Code)
+			}
+			if got := rec.Header().Get("Server-Timing") != ""; got != tc.want {
+				t.Errorf("Server-Timing present = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -257,6 +257,10 @@ func (a *App) NewRouter() http.Handler {
 		handler = requireVerifiedJWT(handler, *a.jwtGate)
 	}
 	handler = stampAuditPrincipal(handler, resolver)
+	// Outermost of all: per-request query accounting must wrap the whole
+	// chain so the principal resolution and ACL compilation above (which
+	// read the store) are counted with the handler, not missed.
+	handler = requestStats(handler)
 	return handler
 }
 

--- a/internal/dataentry/rowcontent.go
+++ b/internal/dataentry/rowcontent.go
@@ -44,12 +44,13 @@ func wantContent(query map[string][]string) bool {
 // file comment for where these may and may not travel.
 func headerEntity(h store.EntityHeader) *entityPkg.Entity {
 	return &entityPkg.Entity{
-		ID:         h.ID,
-		Type:       h.Type,
-		Face:       h.Face,
-		Properties: h.Properties,
-		UpdatedAt:  h.UpdatedAt,
-		Redacted:   h.Redacted,
+		ID:           h.ID,
+		Type:         h.Type,
+		Face:         h.Face,
+		Properties:   h.Properties,
+		UpdatedAt:    h.UpdatedAt,
+		Redacted:     h.Redacted,
+		Inaccessible: h.Inaccessible,
 	}
 }
 

--- a/internal/dataentry/rowcontent.go
+++ b/internal/dataentry/rowcontent.go
@@ -1,0 +1,114 @@
+package dataentry
+
+import (
+	"context"
+	"strconv"
+
+	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Content-free rows (TKT-1U8XYN).
+//
+// The list, search and scope-navigation pipelines filter, sort and paginate
+// over a whole type before they know which rows they will serve, and the
+// rows they do serve render titles and properties, never bodies. So those
+// pipelines read HEADERS and carry them as content-free entities; a page's
+// bodies are loaded afterwards, and only when the caller asked for them
+// with `include_content=true`.
+//
+// A content-free entity is an *entity.Entity whose Content is empty because
+// it was never read — indistinguishable, by type, from an entity with an
+// empty body. That is the trade TKT-1ESTYJ warned about, and it is
+// contained rather than avoided: the only code that receives these rows is
+// the list pipeline (which reads properties) and the serializer (whose
+// `content` field is omitempty, so an unloaded body is simply absent on
+// the wire — the same shape as an entity without one). Nothing here may
+// hand such a row to a body-dependent consumer (ETag computation, mention
+// scanning, export); those keep reading whole entities.
+
+// includeContentParam is the query parameter that asks a collection
+// response to carry each row's body. Off by default: no SPA collection
+// surface renders a body, and a 100-row kanban page shipped ~500 KB of
+// markdown nobody read.
+const includeContentParam = "include_content"
+
+// wantContent reports whether the request opted into row bodies. Anything
+// but a parseable true is false.
+func wantContent(query map[string][]string) bool {
+	v, _ := strconv.ParseBool(queryGet(query, includeContentParam))
+	return v
+}
+
+// headerEntity is the content-free entity a header projects to. See the
+// file comment for where these may and may not travel.
+func headerEntity(h store.EntityHeader) *entityPkg.Entity {
+	return &entityPkg.Entity{
+		ID:         h.ID,
+		Type:       h.Type,
+		Face:       h.Face,
+		Properties: h.Properties,
+		UpdatedAt:  h.UpdatedAt,
+		Redacted:   h.Redacted,
+	}
+}
+
+// rowKey addresses one (id, face) row.
+type rowKey struct {
+	id   string
+	face entityPkg.Face
+}
+
+// loadRows reads the rows keys name, grouped by face: default-face rows in
+// one IDs query, each other face in one AllStates query narrowed to that
+// face on the way out. Returns only rows that exist.
+func loadRows(ctx context.Context, st store.Store, keys []rowKey) (map[rowKey]*entityPkg.Entity, error) {
+	byFace := make(map[entityPkg.Face][]string)
+	seen := make(map[rowKey]struct{}, len(keys))
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		byFace[k.face] = append(byFace[k.face], k.id)
+	}
+	out := make(map[rowKey]*entityPkg.Entity, len(seen))
+	for face, ids := range byFace {
+		q := store.EntityQuery{IDs: ids, AllStates: !face.IsDefault()}
+		for e, err := range st.ListEntities(ctx, q) {
+			if err != nil {
+				return nil, err
+			}
+			if e.Face != face {
+				continue // AllStates over-returns the family's other faces
+			}
+			out[rowKey{e.ID, e.Face}] = e
+		}
+	}
+	return out, nil
+}
+
+// loadRowContent replaces each content-free row with its whole entity, in
+// place, in one read per distinct face. A row the store no longer has keeps
+// its content-free form rather than vanishing from a page that was already
+// counted. Redaction survives: the whole entity is re-projected onto the
+// row's redacted property set, so a hidden value never rides in on the body.
+func loadRowContent(ctx context.Context, st store.Store, rows []*entityPkg.Entity) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	keys := make([]rowKey, 0, len(rows))
+	for _, r := range rows {
+		keys = append(keys, rowKey{r.ID, r.Face})
+	}
+	loaded, err := loadRows(ctx, st, keys)
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if full, ok := loaded[rowKey{r.ID, r.Face}]; ok {
+			r.Content = full.Content
+		}
+	}
+	return nil
+}

--- a/internal/dataentry/rowcontent.go
+++ b/internal/dataentry/rowcontent.go
@@ -89,11 +89,12 @@ func loadRows(ctx context.Context, st store.Store, keys []rowKey) (map[rowKey]*e
 	return out, nil
 }
 
-// loadRowContent replaces each content-free row with its whole entity, in
-// place, in one read per distinct face. A row the store no longer has keeps
-// its content-free form rather than vanishing from a page that was already
-// counted. Redaction survives: the whole entity is re-projected onto the
-// row's redacted property set, so a hidden value never rides in on the body.
+// loadRowContent fills each content-free row's body, in place, in one read
+// per distinct face. A row the store no longer has keeps its content-free
+// form rather than vanishing from a page that was already counted. Only the
+// body is copied: field redaction is property-only (visibility.Redact never
+// touches Content), so a body carries nothing the row gate did not already
+// clear, and the row's redacted property map is left exactly as gated.
 func loadRowContent(ctx context.Context, st store.Store, rows []*entityPkg.Entity) error {
 	if len(rows) == 0 {
 		return nil

--- a/internal/dataentry/rowcontent_test.go
+++ b/internal/dataentry/rowcontent_test.go
@@ -1,0 +1,119 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	v1 "github.com/Sourcehaven-BV/rela/internal/apiwire/v1"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+)
+
+// Collection rows are content-free unless asked (rowcontent.go).
+
+func rowContentApp(t *testing.T) (*App, *acl.Declarative) {
+	t.Helper()
+	app := newTestAppV1(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-001", Type: "ticket",
+		Properties: map[string]any{"title": "With body"}, Content: "# Body\n\nsecret-ish prose"})
+	seedEntity(app, &entity.Entity{ID: "TKT-002", Type: "ticket",
+		Properties: map[string]any{"title": "Without body"}})
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"*"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+	return app, d
+}
+
+func TestListRows_OmitContentUnlessRequested(t *testing.T) {
+	app, d := rowContentApp(t)
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"default omits", "", false},
+		{"opt in", "include_content=true", true},
+		{"opt in numeric", "include_content=1", true},
+		{"garbage is false", "include_content=maybe", false},
+		{"explicit false", "include_content=false", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", tc.query)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status %d: %s", rec.Code, rec.Body)
+			}
+			if len(resp.Data) != 2 {
+				t.Fatalf("rows = %d, want 2", len(resp.Data))
+			}
+			for _, row := range resp.Data {
+				got := row.Content != ""
+				if row.ID == "TKT-001" && got != tc.want {
+					t.Errorf("%s content present = %v, want %v (%q)", row.ID, got, tc.want, row.Content)
+				}
+				if row.ID == "TKT-002" && got {
+					t.Errorf("%s has no body but content = %q", row.ID, row.Content)
+				}
+				if row.Title == "" || row.Properties["title"] == nil {
+					t.Errorf("%s lost its title/properties: %+v", row.ID, row)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchRows_OmitContentUnlessRequested(t *testing.T) {
+	app, d := rowContentApp(t)
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"default omits", "q=type%3Aticket", false},
+		{"opt in", "q=type%3Aticket&include_content=true", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/_search?"+tc.query, http.NoBody)
+			req = req.WithContext(gateCtxFor(aliceCtx(), t, d))
+			rec := httptest.NewRecorder()
+			app.handleV1Search(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status %d: %s", rec.Code, rec.Body)
+			}
+			var resp v1.ListResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			found := false
+			for _, row := range resp.Data {
+				if row.ID != "TKT-001" {
+					continue
+				}
+				found = true
+				if got := row.Content != ""; got != tc.want {
+					t.Errorf("content present = %v, want %v", got, tc.want)
+				}
+			}
+			if !found {
+				t.Fatal("TKT-001 missing from search results")
+			}
+		})
+	}
+}
+
+// Content-free rows still paginate, sort and count exactly as whole rows
+// did: a body was never an input to any of those.
+func TestListRows_ContentFreePipelineKeepsOrderAndTotal(t *testing.T) {
+	app, d := rowContentApp(t)
+	// Titles sort "With body" before "Without body", so page 2 of one row is TKT-002.
+	resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", "sort=title&per_page=1&page=2")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body)
+	}
+	if resp.Meta.Total != 2 || len(resp.Data) != 1 || resp.Data[0].ID != "TKT-002" {
+		t.Errorf("page 2 of sort=title: total=%d rows=%d data=%+v", resp.Meta.Total, len(resp.Data), resp.Data)
+	}
+}

--- a/internal/dataentry/rowcontent_test.go
+++ b/internal/dataentry/rowcontent_test.go
@@ -117,3 +117,27 @@ func TestListRows_ContentFreePipelineKeepsOrderAndTotal(t *testing.T) {
 		t.Errorf("page 2 of sort=title: total=%d rows=%d data=%+v", resp.Meta.Total, len(resp.Data), resp.Data)
 	}
 }
+
+// A header row keeps the storage-level lock (git-crypt) its entity carried:
+// a content-free list must show the same lock indicators as the whole-row
+// list did. Pinned after the e2e suite caught the projection dropping it.
+func TestListRows_KeepInaccessibleMarker(t *testing.T) {
+	app, d := rowContentApp(t)
+	seedEntity(app, &entity.Entity{ID: "TKT-003", Type: "ticket",
+		Properties:   map[string]any{"title": "Encrypted"},
+		Inaccessible: []entity.InaccessibleField{{Name: "status", Reason: entity.InaccessibleReasonGitCrypt}}})
+	resp, rec := listEntitiesAs(aliceCtx(), t, app, d, "ticket", "tickets", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body)
+	}
+	for _, row := range resp.Data {
+		if row.ID != "TKT-003" {
+			continue
+		}
+		if len(row.Inaccessible) != 1 || row.Inaccessible[0].Name != "status" {
+			t.Fatalf("lock marker lost on a header row: %+v", row.Inaccessible)
+		}
+		return
+	}
+	t.Fatal("TKT-003 missing")
+}

--- a/internal/dataentry/sections.go
+++ b/internal/dataentry/sections.go
@@ -292,19 +292,20 @@ func (h *viewsHandler) buildSections(ctx context.Context, sections []ViewSection
 				}
 			case "table":
 				sd.Columns = sec.Columns
+				// Relation columns are resolved for the WHOLE section up front —
+				// one relation query per (column, row type) and one header batch
+				// for every target — instead of one relation query plus one
+				// entity load per row per column (TKT-1U8XYN).
+				relValues := h.resolveRelationColumns(ctx, s, sec.Columns, entities)
 				buildRow := func(e *entity.Entity) SectionRowData {
 					eDef, _ := s.Meta.GetEntityDef(e.Type)
 					row := SectionRowData{EntityID: e.ID, EntityType: e.Type, EditFormID: h.editFormForType(e.Type)}
-					for _, col := range sec.Columns {
+					for ci, col := range sec.Columns {
 						cell := SectionColumnData{
 							Link: resolveLinkTarget(col.Link, e.Type, e.ID), EntityID: e.ID, EntityType: e.Type,
 						}
 						if col.Relation != "" {
-							// The row entity's own type anchors the inference: a
-							// section's rows come from a traversal, so the type is
-							// only known per row, not from the section declaration.
-							dir := resolveConfigDirection(s, e.Type, col.Relation, col.Direction)
-							cell.Values = h.resolveRelationColumnValues(ctx, e.ID, col.Relation, dir)
+							cell.Values = relValues[e.ID][ci]
 						} else {
 							var pd metamodel.PropertyDef
 							if eDef != nil {

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -341,7 +341,7 @@ func reseedStore(dst, src store.Store) {
 // Populates the co-derived Schema fields with safe defaults (UserDefaults,
 // Palette, UserPalette, OpenAPIGen) so handlers that touch the
 // less-common fields don't nil-deref in tests that didn't ask for them.
-func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
+func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture, opts ...appbuildtest.Option) *App {
 	app := &App{
 		scriptEngine:  script.NewEngine(),
 		fieldResolver: NopFieldVerdictResolver{},
@@ -355,7 +355,7 @@ func newAppFromParts(cfg *Config, meta *metamodel.Metamodel, f *fixture) *App {
 		fs := storage.NewMemFS()
 		ctx := &project.Context{Root: "/project", CacheDir: "/project/.rela"}
 		_ = fs.MkdirAll(ctx.CacheDir, 0o755)
-		svc := appbuildtest.New(meta, appbuildtest.WithFS(fs, ctx))
+		svc := appbuildtest.New(meta, append([]appbuildtest.Option{appbuildtest.WithFS(fs, ctx)}, opts...)...)
 		rebindApp(app, fs, ctx, svc)
 		seedFromFixture(app.store, f)
 	}

--- a/internal/dataentry/views.go
+++ b/internal/dataentry/views.go
@@ -173,62 +173,6 @@ func (h *viewsHandler) applyViewTraverse(
 	}
 }
 
-// traverseViewOnce returns the neighbor IDS one hop from sourceID.
-//
-// It returns IDS, not entities, so the caller can resolve the whole rule's
-// neighbors in one batch — see applyViewTraverse. It also means this function
-// does no entity read at all, which is what removes the per-hop
-// default-world `GetEntity` that made the traversal world-blind.
-//
-// The relation query keeps a NIL tail deliberately. A view traverses the
-// entity GRAPH: it follows an edge to reach a neighbor, and per design §2.3
-// heads are entity-level, so which face the SOURCE is standing on does not
-// change which ids it can reach. Filtering by the source's face here would
-// hide identity edges from any entity whose prime is not the default state —
-// the "fallback trap" documented on worldreader.RelationReader.Neighbors,
-// where the zero face as a FromFace VALUE means default-tail-only rather
-// than unfiltered.
-//
-// (Content-scoped edges are therefore over-returned here relative to what item
-// 4's entity GET shows. That is a known divergence, not an oversight: making
-// view traversal honor edge scope needs the per-type dispatch, which is its
-// own change with its own tests. Recorded in the PR body.)
-func (h *viewsHandler) traverseViewOnce(ctx context.Context, sourceID string, rule ViewTraverse) []string {
-	st := h.store
-	var out []string
-
-	var relType string
-	var direction store.Direction
-	var useTarget bool // true: collect edge.To; false: collect edge.From
-	switch {
-	case rule.Follow != "":
-		relType = rule.Follow
-		direction = store.DirectionOutgoing
-		useTarget = true
-	case rule.FollowIncoming != "":
-		relType = rule.FollowIncoming
-		direction = store.DirectionIncoming
-		useTarget = false
-	default:
-		return nil
-	}
-
-	q := store.RelationQuery{EntityID: sourceID, Type: relType, Direction: direction}
-	for r, err := range st.ListRelations(ctx, q) {
-		if err != nil {
-			break
-		}
-		targetID := r.To
-		if !useTarget {
-			targetID = r.From
-		}
-		if targetID != "" {
-			out = append(out, targetID)
-		}
-	}
-	return out
-}
-
 // traverseViewMany is [viewsHandler.traverseViewOnce] for many sources in ONE
 // relation query. The result is ordered as the per-source calls would have
 // been concatenated: by source in the given order, then by the store's edge
@@ -288,7 +232,7 @@ func (h *viewsHandler) traverseViewBreadthFirst(
 		visited[id] = true
 		frontier = append(frontier, id)
 	}
-	var all []string
+	all := make([]string, 0, len(frontier))
 	for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
 		found := h.traverseViewMany(ctx, frontier, rule)
 		all = append(all, found...)

--- a/internal/dataentry/views.go
+++ b/internal/dataentry/views.go
@@ -112,18 +112,22 @@ func (h *viewsHandler) applyViewTraverse(
 	// decide where to step next, while LOADING an entity under a world costs a
 	// resolution. Collect the whole rule's ids first, then resolve once.
 	maxRecursionDepth := 10
-	var foundIDs []string
+	sourceIDs := make([]string, 0, len(sources))
 	for _, src := range sources {
-		if rule.Recursive {
-			maxD := rule.MaxDepth
-			if maxD <= 0 {
-				maxD = maxRecursionDepth
-			}
-			foundIDs = append(foundIDs,
-				h.traverseViewRecursive(ctx, src.ID, rule, 0, maxD, map[string]bool{})...)
-		} else {
-			foundIDs = append(foundIDs, h.traverseViewOnce(ctx, src.ID, rule)...)
+		sourceIDs = append(sourceIDs, src.ID)
+	}
+	var foundIDs []string
+	if rule.Recursive {
+		maxD := rule.MaxDepth
+		if maxD <= 0 {
+			maxD = maxRecursionDepth
 		}
+		foundIDs = h.traverseViewBreadthFirst(ctx, sourceIDs, rule, maxD)
+	} else {
+		// One relation query for every source at once (TKT-1U8XYN), in the
+		// same order the per-source loop produced: sources in collection
+		// order, each source's edges in store order.
+		foundIDs = h.traverseViewMany(ctx, sourceIDs, rule)
 	}
 
 	// ONE resolution for the whole rule application, not one per hop.
@@ -225,21 +229,78 @@ func (h *viewsHandler) traverseViewOnce(ctx context.Context, sourceID string, ru
 	return out
 }
 
-// traverseViewRecursive walks the relation graph depth-first, returning the
-// neighbor IDS found. Like traverseViewOnce it loads no entities — the walk
-// steps by id, so it never needed them.
-func (h *viewsHandler) traverseViewRecursive(
-	ctx context.Context, sourceID string, rule ViewTraverse, depth, maxDepth int, visited map[string]bool,
-) []string {
-	if depth >= maxDepth || visited[sourceID] {
+// traverseViewMany is [viewsHandler.traverseViewOnce] for many sources in ONE
+// relation query. The result is ordered as the per-source calls would have
+// been concatenated: by source in the given order, then by the store's edge
+// order within a source. A source with no edges contributes nothing.
+func (h *viewsHandler) traverseViewMany(ctx context.Context, sourceIDs []string, rule ViewTraverse) []string {
+	if len(sourceIDs) == 0 {
 		return nil
 	}
-	visited[sourceID] = true
-	immediate := h.traverseViewOnce(ctx, sourceID, rule)
+	var relType string
+	var direction store.Direction
+	var useTarget bool
+	switch {
+	case rule.Follow != "":
+		relType, direction, useTarget = rule.Follow, store.DirectionOutgoing, true
+	case rule.FollowIncoming != "":
+		relType, direction, useTarget = rule.FollowIncoming, store.DirectionIncoming, false
+	default:
+		return nil
+	}
+	bySource := make(map[string][]string, len(sourceIDs))
+	q := store.RelationQuery{EntityIDs: sourceIDs, Type: relType, Direction: direction}
+	for r, err := range h.store.ListRelations(ctx, q) {
+		if err != nil {
+			break
+		}
+		sourceID, targetID := r.From, r.To
+		if !useTarget {
+			sourceID, targetID = r.To, r.From
+		}
+		if targetID != "" {
+			bySource[sourceID] = append(bySource[sourceID], targetID)
+		}
+	}
+	var out []string
+	for _, id := range sourceIDs {
+		out = append(out, bySource[id]...)
+	}
+	return out
+}
+
+// traverseViewBreadthFirst walks the relation graph from every source at
+// once, one relation query per level (TKT-1U8XYN) instead of one per visited
+// node, up to maxDepth levels. It returns the neighbor IDS found, level by
+// level; like traverseViewMany it loads no entities. A node is expanded at
+// most once, but an id reached again is still reported — the caller dedupes
+// when it loads the collection, exactly as it did for the former depth-first
+// walk, and the recursive tests pin the SET of ids, not their order.
+func (h *viewsHandler) traverseViewBreadthFirst(
+	ctx context.Context, sourceIDs []string, rule ViewTraverse, maxDepth int,
+) []string {
+	visited := make(map[string]bool, len(sourceIDs))
+	frontier := make([]string, 0, len(sourceIDs))
+	for _, id := range sourceIDs {
+		if visited[id] {
+			continue
+		}
+		visited[id] = true
+		frontier = append(frontier, id)
+	}
 	var all []string
-	all = append(all, immediate...)
-	for _, id := range immediate {
-		all = append(all, h.traverseViewRecursive(ctx, id, rule, depth+1, maxDepth, visited)...)
+	for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
+		found := h.traverseViewMany(ctx, frontier, rule)
+		all = append(all, found...)
+		next := make([]string, 0, len(found))
+		for _, id := range found {
+			if visited[id] {
+				continue
+			}
+			visited[id] = true
+			next = append(next, id)
+		}
+		frontier = next
 	}
 	return all
 }

--- a/internal/dataentry/views_bfs_test.go
+++ b/internal/dataentry/views_bfs_test.go
@@ -1,0 +1,61 @@
+package dataentry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/testutil"
+)
+
+// Recursive traversal is breadth-first since TKT-1U8XYN (one relation query
+// per level instead of one per node). The collection order follows: every
+// direct neighbor before any second-level one. This pins that order so a
+// later change to the walk is a deliberate one, not a silent reorder.
+//
+//	TKT-001 --blocks--> TKT-002 --blocks--> TKT-004
+//	TKT-001 --blocks--> TKT-003
+//
+// Depth-first would have given [TKT-002, TKT-004, TKT-003].
+func TestViewTraversal_RecursiveIsBreadthFirst(t *testing.T) {
+	meta := &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"ticket": {Properties: map[string]metamodel.PropertyDef{"title": {Type: "string"}}},
+		},
+		Relations: map[string]metamodel.RelationDef{
+			"blocks": {From: []string{"ticket"}, To: []string{"ticket"}},
+		},
+	}
+	g := newFixture()
+	for _, id := range []string{"TKT-001", "TKT-002", "TKT-003", "TKT-004"} {
+		g.AddNode(testutil.EntityFor(meta, "ticket").ID(id).With("title", id).Build())
+	}
+	g.AddEdge(testutil.NewRelation("TKT-001", "blocks", "TKT-002").Build())
+	g.AddEdge(testutil.NewRelation("TKT-001", "blocks", "TKT-003").Build())
+	g.AddEdge(testutil.NewRelation("TKT-002", "blocks", "TKT-004").Build())
+	app := newAppFromParts(nil, meta, g)
+
+	view := ViewConfig{
+		Entry:    ViewEntry{Type: "ticket"},
+		Traverse: []ViewTraverse{{From: "entry", Follow: "blocks", CollectAs: "all", Recursive: true}},
+	}
+	result, err := app.views.executeView(context.Background(), view, "TKT-001", defaultViewWorld())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, 3)
+	for _, e := range result.Collections["all"] {
+		got = append(got, e.ID)
+	}
+	want := []string{"TKT-002", "TKT-003", "TKT-004"}
+	if len(got) != len(want) {
+		t.Fatalf("collection = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("collection = %v, want breadth-first %v", got, want)
+		}
+	}
+	var _ *entity.Entity
+}

--- a/internal/dataentry/views_handler.go
+++ b/internal/dataentry/views_handler.go
@@ -3,6 +3,7 @@ package dataentry
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -831,23 +832,6 @@ func (h *viewsHandler) resolveRelationColumns(
 	return out
 }
 
-// resolveRelationColumnValues is the single-row form of
-// [viewsHandler.resolveRelationColumns]: the display titles of entityID's
-// related entities over relationType in the given direction (outgoing when
-// empty). It exists for callers that hold one entity rather than a section;
-// the section builder must not loop over it — that is the per-row shape the
-// batched form replaced.
-func (h *viewsHandler) resolveRelationColumnValues(
-	ctx context.Context, entityID, relationType string, direction dataentryconfig.Direction,
-) []string {
-	if direction == "" {
-		direction = dataentryconfig.DirectionOutgoing
-	}
-	cols := []dataentryconfig.ListColumn{{Relation: relationType, Direction: direction}}
-	rows := []*entityPkg.Entity{{ID: entityID}}
-	return h.resolveRelationColumns(ctx, h.schema(), cols, rows)[entityID][0]
-}
-
 // relationColumnTargets runs one relation query per (relation column, row
 // type) and returns targets[rowID][columnIndex] as the ordered neighbor ids
 // of that cell, plus the distinct neighbor ids in first-seen order.
@@ -869,6 +853,10 @@ func (h *viewsHandler) relationColumnTargets(
 			q := store.RelationQuery{EntityIDs: ids, Type: col.Relation, Direction: relationDirection(dir)}
 			for r, err := range svc.Store.ListRelations(ctx, q) {
 				if err != nil {
+					// A view is a presentation surface; a section renders what it
+					// could load, but never quietly — the operator sees the fault.
+					slog.Warn("dataentry: view section relation column truncated; store read failed",
+						"relation", col.Relation, "type", typ, "rows", len(ids), "err", err)
 					break
 				}
 				rowID, targetID := r.From, r.To
@@ -896,6 +884,8 @@ func (h *viewsHandler) visibleTitles(ctx context.Context, svc Services, ids []st
 	var headers []store.EntityHeader
 	for hd, err := range store.ListEntityHeaders(ctx, svc.Store, store.EntityQuery{IDs: ids}) {
 		if err != nil {
+			slog.Warn("dataentry: view section relation titles dropped; header read failed",
+				"targets", len(ids), "err", err)
 			return map[string]string{}
 		}
 		headers = append(headers, hd)
@@ -908,6 +898,8 @@ func (h *viewsHandler) visibleTitles(ctx context.Context, svc Services, ids []st
 		ents := make([]*entityPkg.Entity, 0, len(headers))
 		for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{IDs: ids}) {
 			if err != nil {
+				slog.Warn("dataentry: view section relation titles dropped; entity read failed",
+					"targets", len(ids), "err", err)
 				return map[string]string{}
 			}
 			ents = append(ents, e)

--- a/internal/dataentry/views_handler.go
+++ b/internal/dataentry/views_handler.go
@@ -787,45 +787,130 @@ func findListByEntityType(s *Schema, entries []NavigationEntry, entityType strin
 	return ""
 }
 
-// resolveRelationColumnValues returns display titles for all targets of the given
-// relation type from an entity. Direction controls whether to follow edges pointing
-// to the entity (incoming) or from the entity (outgoing, the default).
+// resolveRelationColumns returns, for every row and every relation column,
+// the display titles of that row's related entities: result[rowID][columnIndex].
+// Property columns have no entry.
 //
-// The targets are routed through viewReader.Filter (DEC-ZBI39P) before their
-// titles are derived: a neighbor the principal may not read is dropped
-// (row-gate), and a survivor whose display property is hidden has it redacted so
-// DisplayTitle falls back to the id (BUG-R9EHKV). Without this, a table
-// relation-column leaked a hidden neighbor's title via the raw store read —
-// the one builder path the executeView redaction did not cover, since these
-// targets are fetched fresh here rather than carried in result.Collections.
+// It is batched per section (TKT-1U8XYN): one relation query per (column,
+// row type) — the row entity's own type anchors the direction inference, since
+// a section's rows come from a traversal and the type is only known per row —
+// then ONE content-free header read for every target of every column. The
+// former shape was one relation query plus one entity load per row per
+// column, which put a project view with a 40-row work table at over a
+// thousand statements.
+//
+// Targets are gated and redacted through the same viewReader seam as before
+// (DEC-ZBI39P), now over headers: a neighbor the principal may not read is
+// dropped, and a survivor whose display property is hidden falls back to its
+// id (BUG-R9EHKV). A viewReader without the header capability degrades to the
+// whole-entity Filter over the same batch — strictly more data, never less
+// gating.
+func (h *viewsHandler) resolveRelationColumns(
+	ctx context.Context, s *Schema, columns []dataentryconfig.ListColumn, rows []*entityPkg.Entity,
+) map[string]map[int][]string {
+	svc := h.services()
+	byType := make(map[string][]string)
+	for _, e := range rows {
+		byType[e.Type] = append(byType[e.Type], e.ID)
+	}
+	// targets[rowID][ci] is the ordered list of neighbor ids for that cell.
+	targets := make(map[string]map[int][]string, len(rows))
+	var targetIDs []string
+	seenTarget := make(map[string]struct{})
+	for ci, col := range columns {
+		if col.Relation == "" {
+			continue
+		}
+		for typ, ids := range byType {
+			dir := resolveConfigDirection(s, typ, col.Relation, col.Direction)
+			q := store.RelationQuery{EntityIDs: ids, Type: col.Relation, Direction: relationDirection(dir)}
+			for r, err := range svc.Store.ListRelations(ctx, q) {
+				if err != nil {
+					break
+				}
+				rowID, targetID := r.From, r.To
+				if dir.IsIncoming() {
+					rowID, targetID = r.To, r.From
+				}
+				if targets[rowID] == nil {
+					targets[rowID] = make(map[int][]string)
+				}
+				targets[rowID][ci] = append(targets[rowID][ci], targetID)
+				if _, dup := seenTarget[targetID]; !dup {
+					seenTarget[targetID] = struct{}{}
+					targetIDs = append(targetIDs, targetID)
+				}
+			}
+		}
+	}
+	if len(targetIDs) == 0 {
+		return targets
+	}
+
+	titles := h.visibleTitles(ctx, svc, targetIDs)
+	out := make(map[string]map[int][]string, len(targets))
+	for rowID, cols := range targets {
+		out[rowID] = make(map[int][]string, len(cols))
+		for ci, ids := range cols {
+			vals := make([]string, 0, len(ids))
+			for _, id := range ids {
+				if title, ok := titles[id]; ok {
+					vals = append(vals, title)
+				}
+			}
+			out[rowID][ci] = vals
+		}
+	}
+	return out
+}
+
+// resolveRelationColumnValues is the single-row form of
+// [viewsHandler.resolveRelationColumns]: the display titles of entityID's
+// related entities over relationType in the given direction (outgoing when
+// empty). It exists for callers that hold one entity rather than a section;
+// the section builder must not loop over it — that is the per-row shape the
+// batched form replaced.
 func (h *viewsHandler) resolveRelationColumnValues(
 	ctx context.Context, entityID, relationType string, direction dataentryconfig.Direction,
 ) []string {
-	svc := h.services()
-	q := store.RelationQuery{
-		EntityID:  entityID,
-		Type:      relationType,
-		Direction: relationDirection(direction),
+	if direction == "" {
+		direction = dataentryconfig.DirectionOutgoing
 	}
+	cols := []dataentryconfig.ListColumn{{Relation: relationType, Direction: direction}}
+	rows := []*entityPkg.Entity{{ID: entityID}}
+	return h.resolveRelationColumns(ctx, h.schema(), cols, rows)[entityID][0]
+}
 
-	var targets []*entityPkg.Entity
-	for r, err := range svc.Store.ListRelations(ctx, q) {
+// visibleTitles resolves ids to display titles for the ids the principal may
+// read, in one header batch gated through the viewReader; ids the gate drops
+// (or the store no longer has) are absent from the result.
+func (h *viewsHandler) visibleTitles(ctx context.Context, svc Services, ids []string) map[string]string {
+	var headers []store.EntityHeader
+	for hd, err := range store.ListEntityHeaders(ctx, svc.Store, store.EntityQuery{IDs: ids}) {
 		if err != nil {
-			break
+			return map[string]string{}
 		}
-		targetID := r.To
-		if direction.IsIncoming() {
-			targetID = r.From
+		headers = append(headers, hd)
+	}
+	var visible []store.EntityHeader
+	if hf, ok := h.viewReader.(visibility.HeaderFilterer); ok {
+		visible = hf.FilterHeaders(ctx, headers)
+	} else {
+		// No header capability: gate the same batch as whole entities.
+		ents := make([]*entityPkg.Entity, 0, len(headers))
+		for e, err := range svc.Store.ListEntities(ctx, store.EntityQuery{IDs: ids}) {
+			if err != nil {
+				return map[string]string{}
+			}
+			ents = append(ents, e)
 		}
-		if e, gerr := svc.Store.GetEntity(ctx, targetID); gerr == nil {
-			targets = append(targets, e)
+		for _, e := range h.viewReader.Filter(ctx, ents) {
+			visible = append(visible, store.HeaderOf(e))
 		}
 	}
-
-	visible := h.viewReader.Filter(ctx, targets)
-	titles := make([]string, 0, len(visible))
-	for _, e := range visible {
-		titles = append(titles, svc.Meta.DisplayTitle(e.ID, e.Type, e.Properties))
+	titles := make(map[string]string, len(visible))
+	for _, hd := range visible {
+		titles[hd.ID] = svc.Meta.DisplayTitle(hd.ID, hd.Type, hd.Properties)
 	}
 	return titles
 }

--- a/internal/dataentry/views_handler.go
+++ b/internal/dataentry/views_handler.go
@@ -809,40 +809,7 @@ func (h *viewsHandler) resolveRelationColumns(
 	ctx context.Context, s *Schema, columns []dataentryconfig.ListColumn, rows []*entityPkg.Entity,
 ) map[string]map[int][]string {
 	svc := h.services()
-	byType := make(map[string][]string)
-	for _, e := range rows {
-		byType[e.Type] = append(byType[e.Type], e.ID)
-	}
-	// targets[rowID][ci] is the ordered list of neighbor ids for that cell.
-	targets := make(map[string]map[int][]string, len(rows))
-	var targetIDs []string
-	seenTarget := make(map[string]struct{})
-	for ci, col := range columns {
-		if col.Relation == "" {
-			continue
-		}
-		for typ, ids := range byType {
-			dir := resolveConfigDirection(s, typ, col.Relation, col.Direction)
-			q := store.RelationQuery{EntityIDs: ids, Type: col.Relation, Direction: relationDirection(dir)}
-			for r, err := range svc.Store.ListRelations(ctx, q) {
-				if err != nil {
-					break
-				}
-				rowID, targetID := r.From, r.To
-				if dir.IsIncoming() {
-					rowID, targetID = r.To, r.From
-				}
-				if targets[rowID] == nil {
-					targets[rowID] = make(map[int][]string)
-				}
-				targets[rowID][ci] = append(targets[rowID][ci], targetID)
-				if _, dup := seenTarget[targetID]; !dup {
-					seenTarget[targetID] = struct{}{}
-					targetIDs = append(targetIDs, targetID)
-				}
-			}
-		}
-	}
+	targets, targetIDs := h.relationColumnTargets(ctx, svc, s, columns, rows)
 	if len(targetIDs) == 0 {
 		return targets
 	}
@@ -879,6 +846,47 @@ func (h *viewsHandler) resolveRelationColumnValues(
 	cols := []dataentryconfig.ListColumn{{Relation: relationType, Direction: direction}}
 	rows := []*entityPkg.Entity{{ID: entityID}}
 	return h.resolveRelationColumns(ctx, h.schema(), cols, rows)[entityID][0]
+}
+
+// relationColumnTargets runs one relation query per (relation column, row
+// type) and returns targets[rowID][columnIndex] as the ordered neighbor ids
+// of that cell, plus the distinct neighbor ids in first-seen order.
+func (h *viewsHandler) relationColumnTargets(
+	ctx context.Context, svc Services, s *Schema, columns []dataentryconfig.ListColumn, rows []*entityPkg.Entity,
+) (targets map[string]map[int][]string, targetIDs []string) {
+	byType := make(map[string][]string)
+	for _, e := range rows {
+		byType[e.Type] = append(byType[e.Type], e.ID)
+	}
+	targets = make(map[string]map[int][]string, len(rows))
+	seenTarget := make(map[string]struct{})
+	for ci, col := range columns {
+		if col.Relation == "" {
+			continue
+		}
+		for typ, ids := range byType {
+			dir := resolveConfigDirection(s, typ, col.Relation, col.Direction)
+			q := store.RelationQuery{EntityIDs: ids, Type: col.Relation, Direction: relationDirection(dir)}
+			for r, err := range svc.Store.ListRelations(ctx, q) {
+				if err != nil {
+					break
+				}
+				rowID, targetID := r.From, r.To
+				if dir.IsIncoming() {
+					rowID, targetID = r.To, r.From
+				}
+				if targets[rowID] == nil {
+					targets[rowID] = make(map[int][]string)
+				}
+				targets[rowID][ci] = append(targets[rowID][ci], targetID)
+				if _, dup := seenTarget[targetID]; !dup {
+					seenTarget[targetID] = struct{}{}
+					targetIDs = append(targetIDs, targetID)
+				}
+			}
+		}
+	}
+	return targets, targetIDs
 }
 
 // visibleTitles resolves ids to display titles for the ids the principal may

--- a/internal/dataentry/viewworld.go
+++ b/internal/dataentry/viewworld.go
@@ -254,40 +254,31 @@ func (h *viewsHandler) loadViewEntities(
 	}
 	byID := make(map[string]*entityPkg.Entity, len(ids))
 
-	if w.isDefault() {
-		// Point reads, as before. The default world has no chain to resolve, so
-		// a batch query would buy nothing and would change the error handling
-		// of a path this ticket must leave byte-identical.
-		for _, id := range ids {
-			if _, seen := byID[id]; seen {
-				continue
-			}
-			if e, err := h.store.GetEntity(ctx, id); err == nil {
-				byID[id] = e
-			}
+	// ONE batched read for every world, the default one included
+	// (TKT-1U8XYN): the default world's query carries a zero WorldScope, so
+	// the store serves default rows exactly as the former per-id GetEntity
+	// loop did, without a round-trip per collected id. An id the store no
+	// longer has is simply absent, as the per-id not-found was.
+	unique := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			continue
 		}
-	} else {
-		unique := make([]string, 0, len(ids))
-		seen := make(map[string]struct{}, len(ids))
-		for _, id := range ids {
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-			unique = append(unique, id)
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	for e, err := range h.store.ListEntities(ctx, store.EntityQuery{
+		IDs:   unique,
+		World: w.scope,
+	}) {
+		if err != nil {
+			slog.Warn("dataentry: view traversal: loading collected entities failed; "+
+				"collection truncated",
+				"world", w.name, "ids", len(unique), "err", err)
+			break
 		}
-		for e, err := range h.store.ListEntities(ctx, store.EntityQuery{
-			IDs:   unique,
-			World: w.scope,
-		}) {
-			if err != nil {
-				slog.Warn("dataentry: view traversal: world resolution failed; "+
-					"collection truncated",
-					"world", w.name, "ids", len(unique), "err", err)
-				break
-			}
-			byID[e.ID] = e
-		}
+		byID[e.ID] = e
 	}
 
 	out := make([]*entityPkg.Entity, 0, len(byID))

--- a/internal/dataentry/visiblereader.go
+++ b/internal/dataentry/visiblereader.go
@@ -183,6 +183,37 @@ var errWorldEntityAbsent = errors.New("entity has no face in this world")
 //
 // This is the extraction of the former App.filterVisibleIncludes; behavior is
 // preserved, including the nil return for empty input.
+// visibleHeaderIDs is the row-gate half of filterVisible over content-free
+// headers: the set of candidate ids the principal may read, probed once per
+// distinct type. No redaction is involved because only ids leave here — the
+// caller uses the set to decide which neighbor ids may appear in a
+// relations map, never to serve a property.
+func (vr visibleReader) visibleHeaderIDs(ctx context.Context, candidates []store.EntityHeader) map[string]bool {
+	out := make(map[string]bool, len(candidates))
+	if len(candidates) == 0 {
+		return out
+	}
+	gate := readGateFromContext(ctx)
+	byType := make(map[string][]string)
+	for _, c := range candidates {
+		byType[c.Type] = append(byType[c.Type], c.ID)
+	}
+	for typeName, ids := range byType {
+		perm, err := gate.PermitsReadMany(ctx, typeName, ids)
+		if err != nil {
+			slog.Warn("dataentry: visibleReader.visibleHeaderIDs: PermitsReadMany failed; dropping type",
+				"type", typeName, "candidates", len(ids), "err", err)
+			continue
+		}
+		for id, ok := range perm {
+			if ok {
+				out[id] = true
+			}
+		}
+	}
+	return out
+}
+
 func (vr visibleReader) filterVisible(ctx context.Context, candidates []*entitypkg.Entity) []*entitypkg.Entity {
 	if len(candidates) == 0 {
 		return nil

--- a/internal/dataentry/visiblereader.go
+++ b/internal/dataentry/visiblereader.go
@@ -198,6 +198,7 @@ func (vr visibleReader) visibleHeaderIDs(ctx context.Context, candidates []store
 	for _, c := range candidates {
 		byType[c.Type] = append(byType[c.Type], c.ID)
 	}
+	allowed := make(map[string]bool, len(candidates))
 	for typeName, ids := range byType {
 		perm, err := gate.PermitsReadMany(ctx, typeName, ids)
 		if err != nil {
@@ -207,8 +208,16 @@ func (vr visibleReader) visibleHeaderIDs(ctx context.Context, candidates []store
 		}
 		for id, ok := range perm {
 			if ok {
-				out[id] = true
+				allowed[id] = true
 			}
+		}
+	}
+	// The face grant is the other half of filterVisible's gate (TKT-O7R2A1);
+	// a header carries its Face, so applying it here keeps the two gates
+	// from drifting when a caller one day passes AllStates or a World.
+	for _, c := range candidates {
+		if allowed[c.ID] && faceReadable(ctx, c.Type, c.Face) {
+			out[c.ID] = true
 		}
 	}
 	return out

--- a/internal/dataentry/worldneighbors.go
+++ b/internal/dataentry/worldneighbors.go
@@ -416,21 +416,13 @@ func worldOutgoingForEntity(
 // and the world path has no reason to be worse. So: edges per row, then ONE
 // head resolution and ONE gate pass over the union.
 //
-// # What is NOT batched, stated plainly
+// # The edge queries are batched too
 //
-// The EDGE queries are still per row, and [worldreader.RelationReader.Neighbors]
-// issues two apiece (identity-tail and content-tail), so a 50-row page costs
-// 100 relation queries. That is not a regression — the default-world path also
-// queries per row (outgoingRelations + incomingRelations) — but it is not an
-// improvement either, and the doc should not imply the whole thing is one
-// round-trip.
-//
-// It is not batchable through Neighbors as it stands: the content-tail query
-// filters on the row's OWN resolved face, so fifty rows can carry fifty
-// different tails, and store.RelationQuery has no multi-endpoint selector to
-// express that in one shot. Widening it is a store-layer change (and DOFYR1's
-// FromFace contract is deliberately frozen), so it belongs in its own
-// ticket rather than being smuggled in here.
+// [worldreader.RelationReader.NeighborsForPage] issues one identity-tail
+// query for the page plus one content-tail query per DISTINCT face on the
+// page (store.RelationQuery.EntityIDs, TKT-1U8XYN). A 50-row page at two faces
+// is therefore three relation queries, not a hundred, while each row still
+// receives exactly the edges its own resolved face carries.
 //
 // Rows are matched to their edges positionally, so the returned slices are
 // index-aligned with entities — a row with no links keeps a nil entry rather
@@ -449,17 +441,21 @@ func worldNeighborsForPage(
 		return outgoing, incoming, nil, nil
 	}
 
-	// Pass 1: each row's edges, under that row's own resolved face.
-	edgesByRow := make([][]*entityPkg.Relation, len(entities))
+	// Pass 1: each row's edges, under that row's own resolved face — batched
+	// into one identity query plus one content query per distinct face on the
+	// page (TKT-1U8XYN), with the same per-row result the per-row calls gave.
+	rows := make([]worldreader.Resolved, len(entities))
+	for i, e := range entities {
+		rows[i] = resolvedFromStoreFace(ctx, e)
+	}
+	edgesByRow, nerr := wn.relations.NeighborsForPage(ctx, rows, store.DirectionBoth)
+	if nerr != nil {
+		return nil, nil, nil, fmt.Errorf("world neighbors for page: %w", nerr)
+	}
 	var headIDs []string
 	seen := make(map[string]struct{})
 	for i, e := range entities {
-		edges, nerr := wn.relations.Neighbors(
-			ctx, resolvedFromStoreFace(ctx, e), store.DirectionBoth)
-		if nerr != nil {
-			return nil, nil, nil, fmt.Errorf("world neighbors for %s: %w", e.ID, nerr)
-		}
-		edgesByRow[i] = edges
+		edges := edgesByRow[i]
 		for _, id := range headIDsOf(edges, e.ID) {
 			if _, dup := seen[id]; dup {
 				continue
@@ -843,12 +839,13 @@ func servedFacePageEdges(
 	if wn != nil {
 		return worldNeighborsForPage(ctx, wn, visReader, entities)
 	}
-	outgoing = make([][]*entityPkg.Relation, len(entities))
-	incoming = make([][]*entityPkg.Relation, len(entities))
+	// ONE relation query for the whole page (TKT-1U8XYN): every edge touching
+	// any row, split per row by which endpoint is the row. An edge between two
+	// page rows is outgoing for one and incoming for the other, exactly as the
+	// former two-queries-per-row loop produced.
+	outgoing, incoming = reader.pageRelations(ctx, entities)
 	var neighborIDs []string
-	for i, e := range entities {
-		outgoing[i] = reader.outgoingRelations(ctx, e.ID)
-		incoming[i] = reader.incomingRelations(ctx, e.ID)
+	for i := range entities {
 		neighborIDs = append(neighborIDs, neighborIDsOf(outgoing[i], incoming[i])...)
 	}
 	return outgoing, incoming, visibleRelationIDs(ctx, reader, visReader, neighborIDs), nil

--- a/internal/dataentry/worldneighbors.go
+++ b/internal/dataentry/worldneighbors.go
@@ -193,15 +193,18 @@ func (wn *worldNeighbors) worldScopedNeighbors(
 func (wn *worldNeighbors) resolveHeads(
 	ctx context.Context, ids []string,
 ) (map[string]*entityPkg.Entity, error) {
+	// Heads are gated and linked, never rendered, so they are read as
+	// content-free headers (rowcontent.go) — a page's neighbor set can be
+	// hundreds of rows whose bodies nothing here would look at.
 	out := make(map[string]*entityPkg.Entity, len(ids))
-	for e, err := range wn.store.ListEntities(ctx, store.EntityQuery{
+	for h, err := range store.ListEntityHeaders(ctx, wn.store, store.EntityQuery{
 		IDs:   ids,
 		World: worldScopeFrom(ctx),
 	}) {
 		if err != nil {
 			return nil, fmt.Errorf("resolving neighbor heads: %w", err)
 		}
-		out[e.ID] = e
+		out[h.ID] = headerEntity(h)
 	}
 	return out, nil
 }

--- a/internal/dataentry/worldneighbors.go
+++ b/internal/dataentry/worldneighbors.go
@@ -82,7 +82,7 @@ type worldNeighbors struct {
 //
 // A package-level FUNCTION rather than a method on App, for the reason the
 // world code has taken this shape throughout: App carries a
-// `//plimsoll:max-methods=104` directive pinning it at its current count, and
+// `//plimsoll:max-methods=87` directive pinning it at its current count, and
 // the project rule is to split the type rather than raise the number. The
 // world feature has added ONE method to App so far ([App.SetWorlds]) and four
 // package functions (resolveWorld, attachWorld, worldCapablePath, and this),

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -390,40 +390,41 @@ func (e *Engine) eligibleFromSource(
 		cands = cands[:e.cap]
 	}
 
-	out := make([]Suggestion, 0, len(cands))
+	sugs := make([]Suggestion, 0, len(cands))
+	keys := make([]userstate.Key, 0, len(cands))
 	for _, c := range cands {
 		sug := buildSuggestion(id, bandID, src, c)
 		sug.Key.User = user
-
-		suppressed, err := e.suppressed(ctx, sug.Key, src, now)
-		if err != nil {
-			return nil, err
+		sugs = append(sugs, sug)
+		keys = append(keys, sug.Key)
+	}
+	// Two round-trips for the whole candidate set instead of two per
+	// candidate (TKT-1U8XYN); the verdict per key is suppressed's.
+	snoozed, err := e.state.SnoozedUntilMany(ctx, keys, now)
+	if err != nil {
+		return nil, fmt.Errorf("nextaction: snooze lookup for %q: %w", id, err)
+	}
+	shown, err := e.state.LastShownMany(ctx, keys)
+	if err != nil {
+		return nil, fmt.Errorf("nextaction: last-shown lookup for %q: %w", id, err)
+	}
+	out := make([]Suggestion, 0, len(sugs))
+	for _, sug := range sugs {
+		if _, ok := snoozed[sug.Key]; ok {
+			continue
 		}
-		if !suppressed {
-			out = append(out, sug)
+		lastShown, everShown := shown[sug.Key]
+		if everShown && inCooldown(src, lastShown, now) {
+			continue
 		}
+		out = append(out, sug)
 	}
 	return out, nil
 }
 
-// suppressed reports whether a snooze or a cooldown hides this suggestion.
-func (e *Engine) suppressed(
-	ctx context.Context, k userstate.Key, src dataentryconfig.NextActionSource, now time.Time,
-) (bool, error) {
-	if _, snoozed, err := e.state.SnoozedUntil(ctx, k, now); err != nil {
-		return false, fmt.Errorf("nextaction: snooze lookup for %q: %w", k.Source, err)
-	} else if snoozed {
-		return true, nil
-	}
-
-	lastShown, everShown, err := e.state.LastShown(ctx, k)
-	if err != nil {
-		return false, fmt.Errorf("nextaction: last-shown lookup for %q: %w", k.Source, err)
-	}
-	if !everShown {
-		return false, nil
-	}
-
+// inCooldown reports whether a suggestion shown at lastShown is still
+// within its source's cooldown at now.
+func inCooldown(src dataentryconfig.NextActionSource, lastShown, now time.Time) bool {
 	cooldown := DefaultCooldown
 	if src.Cooldown != "" {
 		// Already validated at config load; a parse failure here means the
@@ -433,7 +434,7 @@ func (e *Engine) suppressed(
 			cooldown = d
 		}
 	}
-	return now.Before(lastShown.Add(cooldown)), nil
+	return now.Before(lastShown.Add(cooldown))
 }
 
 // sourceIDsForBand returns the ids in a band, sorted for determinism. Sort

--- a/internal/openapi/paths.go
+++ b/internal/openapi/paths.go
@@ -423,6 +423,7 @@ func (g *Generator) listParameters() []Parameter {
 		{Name: "sort", In: "query", Description: "Sort fields (comma-separated, prefix with - for descending)", Schema: StringSchema()},
 		{Name: "filter[property]", In: "query", Description: "Filter by property value (e.g., filter[status]=active)", Schema: StringSchema()},
 		{Name: "filter[property][operator]", In: "query", Description: "Filter with operator: eq, ne, contains, in", Schema: StringSchema()},
+		{Name: "include_content", In: "query", Description: "Include each row's markdown body (default: false; collection rows are content-free)", Schema: BooleanSchema()},
 	}
 }
 

--- a/internal/perfseed/doc.go
+++ b/internal/perfseed/doc.go
@@ -1,0 +1,35 @@
+// Package perfseed generates a deterministic, realistically shaped entity
+// graph for the perf demo project (prototypes/perf/project) and loads it
+// into any store.Store.
+//
+// # Why a generator and not a fixture
+//
+// The read paths this data exists to measure — list pages with relation
+// columns, views with table sections, kanbans, the dashboard, the gantt —
+// misbehave in proportion to graph size, and a checked-in fixture large
+// enough to show that would be tens of megabytes of markdown. A generator
+// with a seed reproduces the same graph on every machine from a few hundred
+// lines, and `scale` turns the same shape up or down.
+//
+// # Determinism
+//
+// Every entity and relation is a pure function of (seed, kind, index): each
+// gets its own PRNG seeded from those three values, so the entity stream and
+// the relation stream can be produced independently and still agree on
+// which policies have a published face, which documents have a Dutch one,
+// and which project window a task falls inside. Nothing is drawn from a
+// shared stream, so adding a property to one type cannot shift another
+// type's values.
+//
+// # What it writes, and what it does not
+//
+// [Load] writes through store.Store directly — no entitymanager, so no
+// automations, validations, or ACL. That is the fourth sanctioned raw-store
+// path (after `db migrate`, `history-purge` and data migration) and carries
+// the same obligations: operator-shell trust, store.WithAttribution, and an
+// explicit audit record, all supplied by the `rela dev seed` command. The
+// generator keeps itself honest where the store cannot: ids are minted by
+// construction and validated, the one `unique:` property (person.email) is
+// unique by construction, and every relation endpoint names an entity the
+// same generator emits.
+package perfseed

--- a/internal/perfseed/load.go
+++ b/internal/perfseed/load.go
@@ -1,0 +1,114 @@
+package perfseed
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// LoadOptions tunes [Load].
+type LoadOptions struct {
+	// BatchSize is the number of writes per store.Tx. Zero means 500. On
+	// the postgres backend a Tx holds the schema-wide write lock, so a
+	// batch bounds how long other writers wait; on fs/mem it is a mutex
+	// and the size only affects progress granularity.
+	BatchSize int
+	// Progress, when set, is called after each committed batch.
+	Progress func(Summary)
+}
+
+// Summary counts what a load wrote.
+type Summary struct {
+	Entities  int
+	Relations int
+	Elapsed   time.Duration
+}
+
+// Load writes every entity and relation g produces into st, in batches of
+// one store.Tx each. It writes through the raw store on purpose — see the
+// package doc — and expects the caller to have stamped attribution on ctx.
+//
+// A batch that fails stops the load; earlier batches stay committed. Re-run
+// on an empty store rather than resuming: the generator is deterministic,
+// and `rela dev seed` refuses a non-empty store for exactly that reason.
+func Load(ctx context.Context, st store.Store, g *Generator, opts LoadOptions) (Summary, error) {
+	batch := opts.BatchSize
+	if batch <= 0 {
+		batch = 500
+	}
+	start := time.Now()
+	var sum Summary
+	report := func() {
+		sum.Elapsed = time.Since(start)
+		if opts.Progress != nil {
+			opts.Progress(sum)
+		}
+	}
+
+	err := inBatches(ctx, st, batch, g.Entities(), func(view store.Store, e *entity.Entity) error {
+		if err := view.CreateEntity(ctx, e); err != nil {
+			return fmt.Errorf("create %s@%s: %w", e.ID, e.Face, err)
+		}
+		return nil
+	}, func(n int) { sum.Entities += n; report() })
+	if err != nil {
+		return sum, err
+	}
+	err = inBatches(ctx, st, batch, g.Relations(), func(view store.Store, r Relation) error {
+		data := &store.RelationData{FromFace: r.FromFace}
+		if _, cerr := view.CreateRelation(ctx, r.From, r.Type, r.To, data); cerr != nil {
+			return fmt.Errorf("create %s --%s--> %s: %w", r.From, r.Type, r.To, cerr)
+		}
+		return nil
+	}, func(n int) { sum.Relations += n; report() })
+	if err != nil {
+		return sum, err
+	}
+	sum.Elapsed = time.Since(start)
+	return sum, nil
+}
+
+// inBatches drains seq into st, `size` items per Tx, calling write for each
+// item inside the transaction and done(n) after each commit. It stops at
+// the first error or when ctx is cancelled.
+func inBatches[T any](
+	ctx context.Context, st store.Store, size int, seq iter.Seq[T],
+	write func(view store.Store, item T) error, done func(n int),
+) error {
+	buf := make([]T, 0, size)
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		err := st.Tx(ctx, func(view store.Store) error {
+			for _, item := range buf {
+				if err := write(view, item); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		done(len(buf))
+		buf = buf[:0]
+		return nil
+	}
+	for item := range seq {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		buf = append(buf, item)
+		if len(buf) == size {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	return flush()
+}

--- a/internal/perfseed/perfseed.go
+++ b/internal/perfseed/perfseed.go
@@ -1,0 +1,619 @@
+package perfseed
+
+import (
+	"fmt"
+	"hash/fnv"
+	"iter"
+	"math/rand/v2"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
+)
+
+// Profile sizes one generated graph: how many entities of each type, and
+// how often the faced types carry a second face.
+type Profile struct {
+	Teams, People, Projects, Tasks, Controls, Risks, Policies, Documents int
+
+	// PublishedShare is the fraction of policies that also have a
+	// `published` face; DutchShare the fraction of documents with an `nl`
+	// face. Both in [0, 1].
+	PublishedShare, DutchShare float64
+}
+
+// Perf is the profile behind `rela dev seed --profile perf`: at scale 1
+// roughly 20k entity rows (faces included) and 45k relations, in the
+// proportions of a mid-sized organisation's portfolio plus ISMS. Scale
+// multiplies every count; it is clamped so a typo cannot ask for a
+// million rows.
+func Perf(scale float64) Profile {
+	scale = min(max(scale, 0.001), 10)
+	n := func(base int) int { return max(1, int(float64(base)*scale+0.5)) }
+	return Profile{
+		// Never fewer than the named teams: acl.yaml and the demo people
+		// refer to them by id, so a tiny scale must still produce them.
+		Teams:          max(len(teamNames), n(8)),
+		People:         n(800),
+		Projects:       n(300),
+		Tasks:          n(11000),
+		Controls:       n(400),
+		Risks:          n(1200),
+		Policies:       n(1500),
+		Documents:      n(2000),
+		PublishedShare: 0.6,
+		DutchShare:     0.5,
+	}
+}
+
+// Generator produces the entities and relations of one profile under one
+// seed. Both streams are independent pure functions of the seed (see the
+// package doc), so they may be consumed in either order or twice.
+type Generator struct {
+	p    Profile
+	seed uint64
+}
+
+// New returns a generator for p under seed.
+func New(p Profile, seed uint64) *Generator {
+	return &Generator{p: p, seed: seed}
+}
+
+// Profile returns the sizing the generator was built with.
+func (g *Generator) Profile() Profile { return g.p }
+
+// The graph is dated relative to a fixed origin so two runs on different
+// days still produce identical rows.
+var origin = time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// Team names are fixed rather than generated: acl.yaml assigns roles to
+// team ids, so the ids must be knowable before the data exists. Beyond the
+// eight named teams, extra teams (at scale > 1) get numbered engineering ids
+// and no role.
+var teamNames = []struct{ id, title, department string }{
+	{"TEAM-leadership", "Leadership", "leadership"},
+	{"TEAM-security", "Security office", "security"},
+	{"TEAM-engineering-1", "Platform engineering", "engineering"},
+	{"TEAM-engineering-2", "Product engineering", "engineering"},
+	{"TEAM-engineering-3", "Data engineering", "engineering"},
+	{"TEAM-operations-1", "Site operations", "operations"},
+	{"TEAM-operations-2", "Service desk", "operations"},
+	{"TEAM-finance", "Finance & control", "finance"},
+}
+
+// Demo principals, one per role in acl.yaml. They are the first three
+// people so a tiny scale still produces them.
+var demoPeople = []struct{ name, email, team string }{
+	{"Alice Manager", "alice@perf.example", "TEAM-leadership"},
+	{"Bob Editor", "bob@perf.example", "TEAM-engineering-1"},
+	{"Carol Reader", "carol@perf.example", "TEAM-finance"},
+}
+
+// PRNG stream families. Each (kind, index) pair owns one stream; the
+// relation streams use kindRel with an index offset per relation family so
+// a project's edges and a task's edges never share a sequence.
+const (
+	kindTeam = iota + 1
+	kindPerson
+	kindProject
+	kindTask
+	kindControl
+	kindRisk
+	kindPolicy
+	kindDocument
+	kindBody // a separate stream per entity so body length never shifts property draws
+	kindRel
+)
+
+const (
+	relPeople    = 1_000_000
+	relProjects  = 2_000_000
+	relTasks     = 3_000_000
+	relControls  = 4_000_000
+	relPolicies  = 5_000_000
+	relDocuments = 6_000_000
+)
+
+// rng returns the PRNG for one (kind, index) pair: the same pair always
+// yields the same sequence, and no two pairs share one.
+func (g *Generator) rng(kind, i int) *rand.Rand {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%d:%d:%d", g.seed, kind, i)
+	return rand.New(rand.NewPCG(g.seed, h.Sum64()))
+}
+
+// IDs are prefix plus zero-padded index: unique by construction, sortable,
+// and valid under entity.ValidateID (letters, digits, one dash).
+func teamID(i int) string {
+	if i < len(teamNames) {
+		return teamNames[i].id
+	}
+	return fmt.Sprintf("TEAM-engineering-%d", i-len(teamNames)+4)
+}
+func personID(i int) string   { return fmt.Sprintf("PERS-%05d", i+1) }
+func projectID(i int) string  { return fmt.Sprintf("PRJ-%04d", i+1) }
+func taskID(i int) string     { return fmt.Sprintf("TSK-%05d", i+1) }
+func controlID(i int) string  { return fmt.Sprintf("CTL-%04d", i+1) }
+func riskID(i int) string     { return fmt.Sprintf("RSK-%04d", i+1) }
+func policyID(i int) string   { return fmt.Sprintf("POL-%04d", i+1) }
+func documentID(i int) string { return fmt.Sprintf("DOC-%04d", i+1) }
+
+// Face decisions are the one thing both streams must agree on, so they are
+// derived from the (kind, index) PRNG's first draw and nothing else.
+func (g *Generator) policyPublished(i int) bool {
+	return g.rng(kindPolicy, i).Float64() < g.p.PublishedShare
+}
+func (g *Generator) documentDutch(i int) bool {
+	return g.rng(kindDocument, i).Float64() < g.p.DutchShare
+}
+
+// projectWindow is the project's planned span; tasks are dated inside it,
+// so both the project and its tasks derive it from the project's PRNG.
+func (g *Generator) projectWindow(i int) (start, end, target time.Time) {
+	r := g.rng(kindProject, i)
+	start = origin.AddDate(0, 0, r.IntN(300))
+	end = start.AddDate(0, 0, 30+r.IntN(210))
+	target = end.AddDate(0, 0, r.IntN(41)-20)
+	return start, end, target
+}
+
+// projectParent returns the containing project for a subproject, or -1.
+// Only earlier projects qualify, so containment is acyclic.
+func (g *Generator) projectParent(i int) int {
+	r := g.rng(kindRel, relProjects+i)
+	if i == 0 || r.Float64() >= 0.2 {
+		return -1
+	}
+	return r.IntN(i)
+}
+
+// taskParent returns (projectIndex, taskIndex): a task belongs to one
+// project directly (taskIndex == -1) or as a subtask of an earlier task in
+// the same project.
+func (g *Generator) taskParent(i int) (project, task int) {
+	r := g.rng(kindRel, relTasks+i)
+	project = r.IntN(g.p.Projects)
+	if i > 0 && r.Float64() < 0.15 {
+		// Pick an earlier task and use its project so the tree stays inside
+		// one project. Recomputing the earlier task's parent is a draw on
+		// that task's own stream, which is deterministic.
+		t := r.IntN(i)
+		p, _ := g.taskParent(t)
+		return p, t
+	}
+	return project, -1
+}
+
+func dateStr(t time.Time) string { return t.Format("2006-01-02") }
+
+func pick[T any](r *rand.Rand, xs []T) T { return xs[r.IntN(len(xs))] }
+
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func (g *Generator) title(r *rand.Rand) string {
+	return titleCase(pick(r, verbs)) + " " + pick(r, adjectives) + " " + pick(r, nouns) + " " + pick(r, nouns)
+}
+
+// body writes a markdown body of roughly the requested size (500 B – 8 KB)
+// from the sentence banks: an intro paragraph, then sections with prose, a
+// bullet list, and occasionally a table.
+func (g *Generator) body(kind, i int, title string) string {
+	r := g.rng(kindBody, kind*1_000_000+i)
+	target := 500 + r.IntN(7500)
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", title)
+	writeParagraph(&b, r)
+	for b.Len() < target {
+		fmt.Fprintf(&b, "## %s %s\n\n", titleCase(pick(r, adjectives)), pick(r, nouns))
+		writeParagraph(&b, r)
+		switch r.IntN(4) {
+		case 0:
+			for range 2 + r.IntN(5) {
+				fmt.Fprintf(&b, "- %s the %s %s\n", titleCase(pick(r, verbs)), pick(r, adjectives), pick(r, nouns))
+			}
+			b.WriteString("\n")
+		case 1:
+			b.WriteString("| Item | Owner | Due |\n| --- | --- | --- |\n")
+			for range 2 + r.IntN(4) {
+				fmt.Fprintf(&b, "| %s %s | %s | %s |\n", pick(r, adjectives), pick(r, nouns),
+					pick(r, firstNames), dateStr(origin.AddDate(0, 0, r.IntN(365))))
+			}
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func writeParagraph(b *strings.Builder, r *rand.Rand) {
+	for range 2 + r.IntN(5) {
+		b.WriteString(pick(r, sentenceStarts))
+		b.WriteByte(' ')
+		mid := pick(r, sentenceMiddles)
+		if strings.HasPrefix(mid, "the team") || strings.HasPrefix(mid, "we ") || strings.HasPrefix(mid, "someone") {
+			fmt.Fprintf(b, mid, pick(r, verbs), pick(r, adjectives), pick(r, nouns))
+		} else {
+			fmt.Fprintf(b, mid, pick(r, adjectives), pick(r, nouns), pick(r, verbs))
+		}
+		b.WriteByte(' ')
+		b.WriteString(pick(r, sentenceEnds))
+		b.WriteByte(' ')
+	}
+	b.WriteString("\n\n")
+}
+
+func newEntity(id, typ string, face entity.Face) *entity.Entity {
+	e := entity.New(id, typ)
+	e.Face = face
+	return e
+}
+
+// The two non-default faces this profile writes. Built through the codec
+// once, at init, so the generator never string-converts a Face itself.
+var (
+	facePublished = mustFace("published")
+	faceNL        = mustFace("nl")
+)
+
+func mustFace(s string) entity.Face {
+	f, err := entity.ParseFace(s)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// Entities yields every entity row in creation order: teams, people,
+// projects, tasks, controls, risks, policies (draft then, when present,
+// published), documents (en then nl). Each row's id passes
+// storeutil.ValidateID; the generator panics otherwise, since a bad id is a
+// generator bug rather than a data condition.
+func (g *Generator) Entities() iter.Seq[*entity.Entity] {
+	return func(yield func(*entity.Entity) bool) {
+		for _, seq := range []iter.Seq[*entity.Entity]{
+			g.teams(), g.people(), g.projects(), g.tasks(),
+			g.controls(), g.risks(), g.policies(), g.documents(),
+		} {
+			for e := range seq {
+				if err := storeutil.ValidateID(e.ID); err != nil {
+					panic("perfseed: generated invalid id: " + err.Error())
+				}
+				if !yield(e) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// each yields one entity per index in [0, n).
+func each(n int, build func(i int) *entity.Entity) iter.Seq[*entity.Entity] {
+	return func(yield func(*entity.Entity) bool) {
+		for i := range n {
+			if !yield(build(i)) {
+				return
+			}
+		}
+	}
+}
+
+func (g *Generator) teams() iter.Seq[*entity.Entity] {
+	return each(g.p.Teams, func(i int) *entity.Entity {
+		r := g.rng(kindTeam, i)
+		e := newEntity(teamID(i), "team", "")
+		if i < len(teamNames) {
+			e.SetString("title", teamNames[i].title)
+			e.SetString("department", teamNames[i].department)
+		} else {
+			e.SetString("title", titleCase(pick(r, adjectives))+" engineering")
+			e.SetString("department", "engineering")
+		}
+		e.Content = g.body(kindTeam, i, e.GetString("title"))
+		return e
+	})
+}
+
+func (g *Generator) people() iter.Seq[*entity.Entity] {
+	return each(g.p.People, func(i int) *entity.Entity {
+		r := g.rng(kindPerson, i)
+		e := newEntity(personID(i), "person", "")
+		if i < len(demoPeople) {
+			e.SetString("title", demoPeople[i].name)
+			e.SetString("email", demoPeople[i].email)
+		} else {
+			e.SetString("title", pick(r, firstNames)+" "+pick(r, lastNames))
+			e.SetString("email", fmt.Sprintf("person%05d@perf.example", i+1))
+		}
+		e.SetString("role_title", pick(r, roleTitles))
+		e.Properties["salary"] = 38000 + r.IntN(90)*1000
+		e.SetString("started", dateStr(origin.AddDate(-r.IntN(10), -r.IntN(12), 0)))
+		e.Content = g.body(kindPerson, i, e.GetString("title"))
+		return e
+	})
+}
+
+func (g *Generator) projects() iter.Seq[*entity.Entity] {
+	return each(g.p.Projects, func(i int) *entity.Entity {
+		r := g.rng(kindProject, i)
+		start, end, target := g.projectWindow(i)
+		e := newEntity(projectID(i), "project", "")
+		e.SetString("title", g.title(r))
+		e.SetString("status", pick(r, projectStatuses))
+		e.SetString("planned_start", dateStr(start))
+		e.SetString("planned_end", dateStr(end))
+		e.SetString("target_date", dateStr(target))
+		e.Properties["budget"] = (5 + r.IntN(400)) * 1000
+		e.Content = g.body(kindProject, i, e.GetString("title"))
+		return e
+	})
+}
+
+func (g *Generator) tasks() iter.Seq[*entity.Entity] {
+	return each(g.p.Tasks, func(i int) *entity.Entity {
+		r := g.rng(kindTask, i)
+		project, _ := g.taskParent(i)
+		pStart, pEnd, _ := g.projectWindow(project)
+		span := int(pEnd.Sub(pStart).Hours() / 24)
+		start := pStart.AddDate(0, 0, r.IntN(max(span, 1)))
+		due := start.AddDate(0, 0, 1+r.IntN(30))
+		e := newEntity(taskID(i), "task", "")
+		e.SetString("title", g.title(r))
+		e.SetString("status", pick(r, taskStatuses))
+		e.SetString("priority", pick(r, priorities))
+		e.SetString("start", dateStr(start))
+		e.SetString("due", dateStr(due))
+		e.Properties["estimate"] = 1 + r.IntN(40)
+		e.Content = g.body(kindTask, i, e.GetString("title"))
+		return e
+	})
+}
+
+func (g *Generator) controls() iter.Seq[*entity.Entity] {
+	return each(g.p.Controls, func(i int) *entity.Entity {
+		r := g.rng(kindControl, i)
+		e := newEntity(controlID(i), "control", "")
+		e.SetString("title", titleCase(pick(r, adjectives))+" "+pick(r, nouns)+" control")
+		e.SetString("family", pick(r, controlFamilies))
+		e.SetString("status", pick(r, controlStatuses))
+		e.Content = g.body(kindControl, i, e.GetString("title"))
+		return e
+	})
+}
+
+func (g *Generator) risks() iter.Seq[*entity.Entity] {
+	return each(g.p.Risks, func(i int) *entity.Entity {
+		r := g.rng(kindRisk, i)
+		e := newEntity(riskID(i), "risk", "")
+		e.SetString("title", "Risk of "+pick(r, adjectives)+" "+pick(r, nouns)+" "+pick(r, nouns))
+		e.SetString("level", pick(r, riskLevels))
+		e.Properties["likelihood"] = 1 + r.IntN(5)
+		e.Properties["impact"] = 1 + r.IntN(5)
+		e.SetString("status", pick(r, riskStatuses))
+		e.Content = g.body(kindRisk, i, e.GetString("title"))
+		return e
+	})
+}
+
+// policies yields each policy's draft row and, for the published share,
+// its published face right after it.
+func (g *Generator) policies() iter.Seq[*entity.Entity] {
+	return func(yield func(*entity.Entity) bool) {
+		for i := range g.p.Policies {
+			r := g.rng(kindPolicy, i)
+			_ = r.Float64() // the published decision (policyPublished) — keep draws aligned
+			title := titleCase(pick(r, adjectives)) + " " + pick(r, nouns) + " policy"
+			draft := newEntity(policyID(i), "policy", "")
+			draft.SetString("title", title)
+			draft.SetString("status", pick(r, policyStatuses))
+			draft.SetString("owner", pick(r, firstNames)+" "+pick(r, lastNames))
+			draft.SetString("version", fmt.Sprintf("%d.%d", 1+r.IntN(3), r.IntN(10)))
+			draft.Content = g.body(kindPolicy, i, title+" (draft)")
+			if !yield(draft) {
+				return
+			}
+			if !g.policyPublished(i) {
+				continue
+			}
+			pub := newEntity(policyID(i), "policy", facePublished)
+			pub.SetString("title", title)
+			pub.SetString("status", "done")
+			pub.SetString("owner", draft.GetString("owner"))
+			pub.SetString("version", fmt.Sprintf("%d.0", 1+r.IntN(3)))
+			pub.Content = g.body(kindPolicy, g.p.Policies+i, title)
+			if !yield(pub) {
+				return
+			}
+		}
+	}
+}
+
+// documents yields each document's English row and, for the Dutch share,
+// its nl face right after it.
+func (g *Generator) documents() iter.Seq[*entity.Entity] {
+	return func(yield func(*entity.Entity) bool) {
+		for i := range g.p.Documents {
+			r := g.rng(kindDocument, i)
+			_ = r.Float64() // the Dutch-face decision (documentDutch)
+			title := titleCase(pick(r, verbs)) + " " + pick(r, adjectives) + " " + pick(r, nouns)
+			en := newEntity(documentID(i), "document", "")
+			en.SetString("title", title)
+			en.SetString("category", pick(r, documentCategories))
+			en.Content = g.body(kindDocument, i, title)
+			if !yield(en) {
+				return
+			}
+			if !g.documentDutch(i) {
+				continue
+			}
+			nl := newEntity(documentID(i), "document", faceNL)
+			nl.SetString("title", title+" (NL)")
+			nl.SetString("category", en.GetString("category"))
+			nl.Content = g.body(kindDocument, g.p.Documents+i, title+" (NL)")
+			if !yield(nl) {
+				return
+			}
+		}
+	}
+}
+
+// Relation is one edge to create. FromFace is zero for identity-scoped
+// edges and for content-scoped edges from the default face.
+type Relation struct {
+	From, Type, To string
+	FromFace       entity.Face
+}
+
+// Relations yields every edge, after all entities it references exist in
+// the Entities order. Endpoints are chosen from earlier indices where the
+// relation is self-referential (contains, depends-on), so the graph is
+// acyclic where the app assumes it (the gantt hierarchy).
+func (g *Generator) Relations() iter.Seq[Relation] {
+	return func(yield func(Relation) bool) {
+		for _, seq := range []iter.Seq[Relation]{
+			g.membership(), g.projectEdges(), g.taskEdges(),
+			g.controlEdges(), g.policyEdges(), g.documentEdges(),
+		} {
+			for r := range seq {
+				if !yield(r) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// edgesPerIndex yields the edges emit produces for each index in [0, n).
+// emit appends to the slice it is handed and returns it.
+func edgesPerIndex(n int, emit func(i int, out []Relation) []Relation) iter.Seq[Relation] {
+	return func(yield func(Relation) bool) {
+		var buf []Relation
+		for i := range n {
+			buf = emit(i, buf[:0])
+			for _, r := range buf {
+				if !yield(r) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// distinct draws up to n indices below limit with r, without repeats.
+func distinct(r *rand.Rand, n, limit int) []int {
+	seen := make(map[int]bool, n)
+	var out []int
+	for range n {
+		v := r.IntN(limit)
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+func (g *Generator) membership() iter.Seq[Relation] {
+	return edgesPerIndex(g.p.People, func(i int, out []Relation) []Relation {
+		r := g.rng(kindRel, relPeople+i)
+		team := teamID(r.IntN(g.p.Teams))
+		if i < len(demoPeople) {
+			team = demoPeople[i].team
+		}
+		return append(out, Relation{From: personID(i), Type: "member-of", To: team})
+	})
+}
+
+func (g *Generator) projectEdges() iter.Seq[Relation] {
+	return edgesPerIndex(g.p.Projects, func(i int, out []Relation) []Relation {
+		r := g.rng(kindRel, relProjects+i)
+		_ = r.Float64() // projectParent's draw, kept aligned
+		out = append(out,
+			Relation{From: teamID(r.IntN(g.p.Teams)), Type: "owns", To: projectID(i)},
+			Relation{From: personID(r.IntN(g.p.People)), Type: "leads", To: projectID(i)},
+		)
+		if parent := g.projectParent(i); parent >= 0 {
+			out = append(out, Relation{From: projectID(parent), Type: "contains", To: projectID(i)})
+		}
+		return out
+	})
+}
+
+func (g *Generator) taskEdges() iter.Seq[Relation] {
+	return edgesPerIndex(g.p.Tasks, func(i int, out []Relation) []Relation {
+		project, parentTask := g.taskParent(i)
+		parent := projectID(project)
+		if parentTask >= 0 {
+			parent = taskID(parentTask)
+		}
+		out = append(out, Relation{From: parent, Type: "contains", To: taskID(i)})
+		r := g.rng(kindRel, relTasks+g.p.Tasks+i)
+		if r.Float64() < 0.9 {
+			out = append(out, Relation{From: taskID(i), Type: "assigned-to", To: personID(r.IntN(g.p.People))})
+		}
+		if i > 0 {
+			for _, dep := range distinct(r, r.IntN(3), i) {
+				out = append(out, Relation{From: taskID(i), Type: "depends-on", To: taskID(dep)})
+			}
+		}
+		return out
+	})
+}
+
+func (g *Generator) controlEdges() iter.Seq[Relation] {
+	return edgesPerIndex(g.p.Controls, func(i int, out []Relation) []Relation {
+		r := g.rng(kindRel, relControls+i)
+		for _, risk := range distinct(r, 1+r.IntN(4), g.p.Risks) {
+			out = append(out, Relation{From: controlID(i), Type: "mitigates", To: riskID(risk)})
+		}
+		return out
+	})
+}
+
+func (g *Generator) policyEdges() iter.Seq[Relation] {
+	return edgesPerIndex(g.p.Policies, func(i int, out []Relation) []Relation {
+		r := g.rng(kindRel, relPolicies+i)
+		out = append(out, Relation{From: policyID(i), Type: "owned-by", To: teamID(r.IntN(g.p.Teams))})
+		for _, c := range distinct(r, 1+r.IntN(4), g.p.Controls) {
+			out = append(out, Relation{From: policyID(i), Type: "implements", To: controlID(c)})
+		}
+		if g.policyPublished(i) {
+			// The published face implements a partly different set — the
+			// point of a content-scoped edge.
+			for _, c := range distinct(r, 1+r.IntN(3), g.p.Controls) {
+				out = append(out, Relation{From: policyID(i), Type: "implements", To: controlID(c), FromFace: facePublished})
+			}
+		}
+		return out
+	})
+}
+
+func (g *Generator) documentEdges() iter.Seq[Relation] {
+	return edgesPerIndex(g.p.Documents, func(i int, out []Relation) []Relation {
+		r := g.rng(kindRel, relDocuments+i)
+		refs := func(face entity.Face) {
+			seen := map[string]bool{}
+			for range 1 + r.IntN(3) {
+				to := controlID(r.IntN(g.p.Controls))
+				if r.Float64() < 0.6 {
+					to = policyID(r.IntN(g.p.Policies))
+				}
+				if seen[to] {
+					continue
+				}
+				seen[to] = true
+				out = append(out, Relation{From: documentID(i), Type: "references", To: to, FromFace: face})
+			}
+		}
+		refs("")
+		if g.documentDutch(i) {
+			refs(faceNL)
+		}
+		return out
+	})
+}

--- a/internal/perfseed/perfseed.go
+++ b/internal/perfseed/perfseed.go
@@ -7,6 +7,7 @@ import (
 	"math/rand/v2"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
@@ -189,11 +190,18 @@ func dateStr(t time.Time) string { return t.Format("2006-01-02") }
 
 func pick[T any](r *rand.Rand, xs []T) T { return xs[r.IntN(len(xs))] }
 
+// titleCase capitalizes the first rune of a generated sentence or title.
+// This is prose generation, not label derivation: the word banks are lower
+// case so they can be joined mid-sentence, and a title needs its first
+// letter up. Nothing here derives a display label from an identifier
+// (DEC-6C1NAA); the identifiers are `PRJ-0001`-style and never shown as text.
 func titleCase(s string) string {
-	if s == "" {
+	r := []rune(s)
+	if len(r) == 0 {
 		return s
 	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
 }
 
 func (g *Generator) title(r *rand.Rand) string {

--- a/internal/perfseed/perfseed_test.go
+++ b/internal/perfseed/perfseed_test.go
@@ -1,0 +1,181 @@
+package perfseed_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/perfseed"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+const testScale = 0.01
+
+// digest hashes everything a generator emits, in order, so two runs can be
+// compared byte for byte without holding both in memory.
+func digest(t *testing.T, g *perfseed.Generator) (sum string, entities, relations int) {
+	t.Helper()
+	h := sha256.New()
+	ents, rels := 0, 0
+	for e := range g.Entities() {
+		ents++
+		fmt.Fprintf(h, "E|%s|%s|%s|%v|%s\n", e.ID, e.Face, e.Type, e.Properties, e.Content)
+	}
+	for r := range g.Relations() {
+		rels++
+		fmt.Fprintf(h, "R|%s|%s|%s|%s\n", r.From, r.FromFace, r.Type, r.To)
+	}
+	return hex.EncodeToString(h.Sum(nil)), ents, rels
+}
+
+func TestGenerator_Deterministic(t *testing.T) {
+	a, ea, ra := digest(t, perfseed.New(perfseed.Perf(testScale), 7))
+	b, eb, rb := digest(t, perfseed.New(perfseed.Perf(testScale), 7))
+	require.Equal(t, a, b, "same profile and seed must produce identical streams")
+	require.Equal(t, ea, eb)
+	require.Equal(t, ra, rb)
+	require.Positive(t, ra)
+
+	c, _, _ := digest(t, perfseed.New(perfseed.Perf(testScale), 8))
+	require.NotEqual(t, a, c, "a different seed must produce a different graph")
+}
+
+func TestGenerator_StreamsAreIndependent(t *testing.T) {
+	// Consuming relations before entities (or only relations) must yield
+	// the same relations: nothing is drawn from a shared stream.
+	g := perfseed.New(perfseed.Perf(testScale), 3)
+	var first []perfseed.Relation
+	for r := range g.Relations() {
+		first = append(first, r)
+	}
+	for e := range g.Entities() {
+		_ = e
+	}
+	var second []perfseed.Relation
+	for r := range g.Relations() {
+		second = append(second, r)
+	}
+	require.Equal(t, first, second)
+}
+
+func TestGenerator_ShapeMatchesProfile(t *testing.T) {
+	p := perfseed.Perf(testScale)
+	g := perfseed.New(p, 1)
+	byType := map[string]int{}
+	faces := map[string]int{}
+	ids := map[string]bool{}
+	demo := map[string]bool{}
+	for e := range g.Entities() {
+		if e.Face.IsDefault() {
+			byType[e.Type]++ // one entity per default row; faces are counted below
+		} else {
+			faces[e.Type+"@"+e.Face.String()]++
+		}
+		key := e.ID + "@" + e.Face.String()
+		require.False(t, ids[key], "duplicate row %s", key)
+		ids[key] = true
+		require.NotEmpty(t, e.GetString("title"), "%s has no title", e.ID)
+		require.NotEmpty(t, e.Content, "%s has no body", e.ID)
+		if e.Type == "person" {
+			demo[e.GetString("email")] = true
+		}
+	}
+	require.Equal(t, p.Teams, byType["team"])
+	require.Equal(t, p.People, byType["person"])
+	require.Equal(t, p.Projects, byType["project"])
+	require.Equal(t, p.Tasks, byType["task"])
+	require.Equal(t, p.Controls, byType["control"])
+	require.Equal(t, p.Risks, byType["risk"])
+	require.Equal(t, p.Policies, byType["policy"])
+	require.Equal(t, p.Documents, byType["document"])
+	require.Positive(t, faces["policy@published"], "some policies must be published")
+	require.Less(t, faces["policy@published"], p.Policies, "not every policy is published")
+	require.Positive(t, faces["document@nl"])
+	for _, email := range []string{"alice@perf.example", "bob@perf.example", "carol@perf.example"} {
+		require.True(t, demo[email], "demo principal %s missing", email)
+	}
+}
+
+func TestGenerator_RelationsReferenceEmittedRows(t *testing.T) {
+	g := perfseed.New(perfseed.Perf(testScale), 5)
+	rows := map[string]bool{}
+	for e := range g.Entities() {
+		rows[e.ID+"@"+e.Face.String()] = true
+	}
+	n := 0
+	for r := range g.Relations() {
+		n++
+		require.True(t, rows[r.From+"@"+r.FromFace.String()], "edge from unknown row %s@%s", r.From, r.FromFace)
+		require.True(t, rows[r.To+"@"], "edge to unknown entity %s", r.To)
+		require.NotEqual(t, r.From, r.To, "self edge %s --%s--> %s", r.From, r.Type, r.To)
+	}
+	require.Positive(t, n)
+}
+
+func TestLoad_WritesEverythingIntoStore(t *testing.T) {
+	g := perfseed.New(perfseed.Perf(testScale), 1)
+	_, wantE, wantR := digest(t, g)
+
+	st := memstore.New()
+	var progress int
+	sum, err := perfseed.Load(context.Background(), st, g, perfseed.LoadOptions{
+		BatchSize: 50,
+		Progress:  func(perfseed.Summary) { progress++ },
+	})
+	require.NoError(t, err)
+	require.Equal(t, wantE, sum.Entities)
+	require.Equal(t, wantR, sum.Relations)
+	require.Positive(t, progress)
+
+	ctx := context.Background()
+	gotE, err := st.CountEntities(ctx, store.EntityQuery{AllStates: true})
+	require.NoError(t, err)
+	require.Equal(t, wantE, gotE, "every row, faces included, must be in the store")
+	gotR, err := st.CountRelations(ctx, store.RelationQuery{})
+	require.NoError(t, err)
+	require.Equal(t, wantR, gotR)
+
+	// A published face is addressable as a state, and its content-scoped
+	// edges hang off that face, not the draft.
+	pub := 0
+	for e := range g.Entities() {
+		if e.Type != "policy" || e.Face.IsDefault() {
+			continue
+		}
+		got, err := st.GetEntityState(ctx, e.ID, e.Face)
+		require.NoError(t, err)
+		require.Equal(t, e.GetString("title"), got.GetString("title"))
+		face := e.Face
+		n, err := st.CountRelations(ctx, store.RelationQuery{From: e.ID, Type: "implements", FromFace: &face})
+		require.NoError(t, err)
+		require.Positive(t, n)
+		pub++
+		if pub == 3 {
+			break
+		}
+	}
+	require.Equal(t, 3, pub)
+}
+
+func TestLoad_StopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sum, err := perfseed.Load(ctx, memstore.New(), perfseed.New(perfseed.Perf(testScale), 1), perfseed.LoadOptions{})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, sum.Entities)
+}
+
+func BenchmarkGenerate(b *testing.B) {
+	g := perfseed.New(perfseed.Perf(0.1), 1)
+	for b.Loop() {
+		for e := range g.Entities() {
+			_, _ = io.Discard.Write([]byte(e.Content))
+		}
+	}
+}

--- a/internal/perfseed/words.go
+++ b/internal/perfseed/words.go
@@ -1,0 +1,75 @@
+package perfseed
+
+// Word banks. Domain-flavored rather than lorem ipsum so that free-text
+// search over the seeded corpus hits something recognizable, and so a
+// title reads as a title in a screenshot.
+
+var nouns = []string{
+	"access", "audit", "backup", "baseline", "budget", "certificate", "change", "cluster",
+	"compliance", "contract", "control", "dashboard", "deployment", "encryption", "endpoint",
+	"evidence", "exception", "firewall", "gateway", "handover", "incident", "inventory",
+	"key", "ledger", "logging", "migration", "monitoring", "network", "onboarding", "outage",
+	"patch", "pipeline", "policy", "procedure", "recovery", "release", "retention", "review",
+	"rollout", "runbook", "schema", "segment", "server", "session", "storage", "supplier",
+	"telemetry", "tenant", "token", "training", "upgrade", "vault", "vendor", "workflow",
+}
+
+var adjectives = []string{
+	"annual", "automated", "critical", "customer", "deferred", "external", "internal",
+	"legacy", "manual", "mobile", "nightly", "primary", "quarterly", "regional", "remote",
+	"secondary", "shared", "staging", "temporary", "weekly",
+}
+
+var verbs = []string{
+	"align", "approve", "archive", "assess", "consolidate", "decommission", "document",
+	"harden", "migrate", "monitor", "provision", "reconcile", "renew", "replace", "restore",
+	"review", "rotate", "test", "validate", "verify",
+}
+
+var firstNames = []string{
+	"Alma", "Bram", "Cato", "Daan", "Eline", "Femke", "Gijs", "Hanna", "Ilse", "Joost",
+	"Kars", "Lotte", "Milan", "Noor", "Otto", "Pien", "Quirijn", "Roos", "Sem", "Tessa",
+	"Ubbo", "Vera", "Wout", "Xavi", "Yara", "Zoë", "Anouk", "Bas", "Carlijn", "Dirk",
+}
+
+var lastNames = []string{
+	"Bakker", "de Boer", "de Groot", "de Jong", "de Vries", "Dijkstra", "Hendriks",
+	"Jansen", "Janssen", "Kok", "Meijer", "Mulder", "Peters", "Smit", "van Dijk",
+	"van den Berg", "van der Meer", "Visser", "Vos", "Willems",
+}
+
+var roleTitles = []string{
+	"Engineer", "Senior engineer", "Team lead", "Analyst", "Auditor", "Product owner",
+	"Architect", "Operations specialist", "Security officer", "Controller",
+}
+
+var documentCategories = []string{"guide", "runbook", "reference", "decision"}
+var controlFamilies = []string{"organizational", "people", "physical", "technological"}
+var controlStatuses = []string{"missing", "partial", "implemented"}
+var riskLevels = []string{"low", "medium", "high"}
+var riskStatuses = []string{"open", "mitigated", "accepted"}
+var taskStatuses = []string{"todo", "doing", "review", "done"}
+var priorities = []string{"low", "medium", "high", "critical"}
+var projectStatuses = []string{"proposed", "active", "on-hold", "done"}
+var policyStatuses = []string{"to-do", "doing", "done"}
+
+// Sentence fragments for body prose. Bodies are assembled from these so the
+// markdown has real structure (headings, lists, a table) rather than one
+// long paragraph — the render and search paths see something shaped like
+// what people actually write.
+var sentenceStarts = []string{
+	"This item exists because", "The owning team agreed that", "During the last review it became clear that",
+	"For the coming period", "As a precondition", "The audit found that", "Operationally,",
+	"To keep the risk register current,", "Where the supplier is involved,", "Before sign-off,",
+}
+
+var sentenceMiddles = []string{
+	"the %s %s must be %sd", "every %s %s is %sd", "no %s %s may be %sd", "the %s %s was %sd",
+	"a %s %s should be %sd", "the team will %s the %s %s", "we %s each %s %s", "someone has to %s the %s %s",
+}
+
+var sentenceEnds = []string{
+	"before the next release.", "within the agreed window.", "and the outcome is recorded here.",
+	"unless an exception is approved.", "so the evidence stays current.", "with the change logged.",
+	"and reported to the owner.", "at the end of the quarter.", "without manual steps.", "as documented.",
+}

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -127,6 +127,14 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 		spec := store.DerivedObjectSpec{Kind: store.DerivedQueryIndex, Type: sq.EntityTypes[0], Properties: props}
 		byKey[spec.Type+"\x00"+strings.Join(props, "\x00")] = spec
 	}
+	for _, list := range cfg.Lists {
+		spec, ok := listIndexSpec(list, meta)
+		if !ok {
+			continue
+		}
+		byKey[string(spec.Kind)+"\x00"+spec.Type+"\x00"+strings.Join(spec.Properties, "\x00")+
+			"\x01"+strings.Join(spec.OrderBy, "\x00")] = spec
+	}
 	keys := make([]string, 0, len(byKey))
 	for key := range byKey {
 		keys = append(keys, key)
@@ -137,4 +145,46 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 		out = append(out, byKey[key])
 	}
 	return out
+}
+
+// listIndexSpec derives the index a list's default page uses: its static
+// equality filters (any order) then its sort keys (in order), all
+// string-shaped on the list's type. A list with no sort has no spec — the
+// id-ordered page is served by the fixed (type, id) index — and a list whose
+// filters or sort keys the store cannot evaluate byte-for-byte (see
+// StringShaped) has none either, because such a page never pushes down.
+func listIndexSpec(list dataentryconfig.List, meta *metamodel.Metamodel) (store.DerivedObjectSpec, bool) {
+	if len(list.Sort) == 0 {
+		return store.DerivedObjectSpec{}, false
+	}
+	def, ok := meta.GetEntityDef(list.EntityType)
+	if !ok {
+		return store.DerivedObjectSpec{}, false
+	}
+	shaped := func(prop string) bool {
+		pd, ok := def.Properties[prop]
+		return ok && StringShaped(meta, pd)
+	}
+	var props []string
+	for _, f := range list.Filters {
+		if f.Operator != "=" && f.Operator != "==" {
+			continue // only equality is pushed; the page is not indexable on it
+		}
+		if !shaped(f.Property) {
+			return store.DerivedObjectSpec{}, false
+		}
+		props = append(props, f.Property)
+	}
+	slices.Sort(props)
+	props = slices.Compact(props)
+	order := make([]string, 0, len(list.Sort))
+	for _, s := range list.Sort {
+		if !shaped(s.Property) {
+			return store.DerivedObjectSpec{}, false
+		}
+		order = append(order, s.Property)
+	}
+	return store.DerivedObjectSpec{
+		Kind: store.DerivedListIndex, Type: list.EntityType, Properties: props, OrderBy: order,
+	}, true
 }

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -47,6 +47,11 @@ func PushdownPrefilters(filters []*filter.Filter, meta *metamodel.Metamodel, typ
 	return pushed
 }
 
+// stringComparableOnEveryType reports whether prop is, on every listed type,
+// a scalar whose stored form is a string compared byte-for-byte: string,
+// enum, date, datetime, or a custom type (an enum declared under `types:`).
+// Integers and booleans are excluded — their string form is not their order —
+// as are lists.
 func stringComparableOnEveryType(meta *metamodel.Metamodel, types []string, prop string) bool {
 	for _, typ := range types {
 		def, ok := meta.GetEntityDef(typ)
@@ -54,11 +59,28 @@ func stringComparableOnEveryType(meta *metamodel.Metamodel, types []string, prop
 			return false
 		}
 		pd, ok := def.Properties[prop]
-		if !ok || pd.List || pd.Type != metamodel.PropertyTypeString {
+		if !ok || pd.List || !StringShaped(meta, pd) {
 			return false
 		}
 	}
 	return true
+}
+
+// StringShaped reports whether a scalar property's stored value is a string
+// whose byte order IS its order (string, enum, date, datetime, custom
+// type). The one definition the pushdown planners share, so the list page
+// pushdown and the derived indexes agree on what may be compared in SQL.
+func StringShaped(meta *metamodel.Metamodel, pd metamodel.PropertyDef) bool {
+	if pd.List {
+		return false
+	}
+	switch pd.Type {
+	case metamodel.PropertyTypeString, metamodel.PropertyTypeEnum,
+		metamodel.PropertyTypeDate, metamodel.PropertyTypeDatetime:
+		return true
+	}
+	_, custom := meta.Types[pd.Type]
+	return custom
 }
 
 // StaticIndexSpecs derives one composite index per canonical static query

--- a/internal/queryplan/queryplan_test.go
+++ b/internal/queryplan/queryplan_test.go
@@ -74,3 +74,36 @@ func TestLoadStaticIndexSpecsRejectsIncompleteConfig(t *testing.T) {
 		t.Fatalf("LoadStaticIndexSpecs() = %#v, %v; want nil specs and an error", got, err)
 	}
 }
+
+// A list with a sort gets a list index over its equality filters then its
+// sort keys; a list without a sort, or with a key the store cannot order
+// byte-for-byte, gets none (TKT-1U8XYN).
+func TestStaticIndexSpecsDerivesListIndexes(t *testing.T) {
+	t.Parallel()
+	cfg := &dataentryconfig.Config{
+		Lists: map[string]dataentryconfig.List{
+			"open": {
+				EntityType: "task",
+				Filters:    []dataentryconfig.FilterConfig{{Property: "status", Operator: "=", Value: "open"}},
+				Sort:       []dataentryconfig.SortSpec{{Property: "owner", Direction: "desc"}},
+			},
+			"all":      {EntityType: "task", Sort: []dataentryconfig.SortSpec{{Property: "owner"}}},
+			"unsorted": {EntityType: "task"},
+			"typed":    {EntityType: "task", Sort: []dataentryconfig.SortSpec{{Property: "count"}}},
+			"listkey":  {EntityType: "task", Sort: []dataentryconfig.SortSpec{{Property: "tags"}}},
+			"nefilter": {
+				EntityType: "task",
+				Filters:    []dataentryconfig.FilterConfig{{Property: "status", Operator: "!=", Value: "done"}},
+				Sort:       []dataentryconfig.SortSpec{{Property: "owner"}},
+			},
+		},
+	}
+	want := []store.DerivedObjectSpec{
+		{Kind: store.DerivedListIndex, Type: "task", Properties: nil, OrderBy: []string{"owner"}},
+		{Kind: store.DerivedListIndex, Type: "task", Properties: []string{"status"}, OrderBy: []string{"owner"}},
+	}
+	got := StaticIndexSpecs(cfg, testMeta())
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("StaticIndexSpecs() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/store/derivedschema.go
+++ b/internal/store/derivedschema.go
@@ -34,6 +34,11 @@ const (
 	DerivedUnique DerivedObjectKind = "unique"
 	// DerivedQueryIndex accelerates one static scalar-equality query shape.
 	DerivedQueryIndex DerivedObjectKind = "query-index"
+	// DerivedListIndex accelerates one list page shape (TKT-1U8XYN): the
+	// list's static equality filters followed by its sort keys, so a pushed
+	// page (listpushdown) is an index range scan instead of a sort over the
+	// type. Properties = filters (sorted), OrderBy = sort keys (in order).
+	DerivedListIndex DerivedObjectKind = "list-index"
 )
 
 // DerivedObjectSpec is one desired derived object, derived from validated
@@ -45,6 +50,11 @@ type DerivedObjectSpec struct {
 	Type       string
 	Property   string
 	Properties []string
+
+	// OrderBy names the sort keys, in order, of a [DerivedListIndex]: the
+	// list's `sort:` properties, each string-shaped. Properties then holds
+	// the list's static equality filters. Unused by the other kinds.
+	OrderBy []string
 }
 
 // DerivedObjectState is the outcome of reconciling one spec (or one discovered

--- a/internal/store/fsstore/relation.go
+++ b/internal/store/fsstore/relation.go
@@ -40,9 +40,10 @@ func (s *FSStore) GetRelation(_ context.Context, from, relType, to string) (*ent
 func (s *FSStore) ListRelations(_ context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
 	s.mu.RLock()
 
+	match := storeutil.NewRelationMatcher(q)
 	matches := make([]relationMeta, 0)
 	for _, key := range s.relationOrder {
-		if !matchRelationKey(s, key, q) {
+		if !matchRelationKey(s, key, match) {
 			continue
 		}
 		matches = append(matches, s.relations[key])
@@ -72,8 +73,9 @@ func (s *FSStore) ListRelationsPage(_ context.Context, q store.RelationQuery) (s
 	}
 
 	s.mu.RLock()
+	match := storeutil.NewRelationMatcher(q)
 	keys := storeutil.PaginateSortedKeys(s.relationOrder, cursorKey, q.Limit, func(key string) bool {
-		return matchRelationKey(s, key, q)
+		return matchRelationKey(s, key, match)
 	})
 
 	pairs := make([]relationMeta, 0, len(keys.Keys))
@@ -95,21 +97,20 @@ func (s *FSStore) ListRelationsPage(_ context.Context, q store.RelationQuery) (s
 
 // matchRelationKey reports whether the relation at key in s.relations
 // matches q. Callers must hold s.mu (at least for reading).
-func matchRelationKey(s *FSStore, key string, q store.RelationQuery) bool {
+func matchRelationKey(s *FSStore, key string, match func(*entity.Relation) bool) bool {
 	rm := s.relations[key]
 	r := &entity.Relation{From: rm.From, FromFace: rm.FromFace, Type: rm.Type, To: rm.To}
-	return storeutil.MatchRelation(r, q)
+	return match(r)
 }
 
 func (s *FSStore) CountRelations(_ context.Context, q store.RelationQuery) (int, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	match := storeutil.NewRelationMatcher(q)
 	count := 0
 	for _, key := range s.relationOrder {
-		rm := s.relations[key]
-		r := &entity.Relation{From: rm.From, FromFace: rm.FromFace, Type: rm.Type, To: rm.To}
-		if storeutil.MatchRelation(r, q) {
+		if matchRelationKey(s, key, match) {
 			count++
 		}
 	}

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -68,11 +68,67 @@ type GraphQuery struct {
 	// answer is exact at the store and paging, counts and search stay honest
 	// with no post-filter.
 	Any []GraphBranch
+
+	// OrderBy, Limit and Offset page a ROW query (GraphQuery,
+	// GraphQueryHeaders) inside the backend (TKT-1U8XYN), so a list page
+	// costs one bounded read instead of a whole-type scan sorted and sliced
+	// in Go. GraphCount and MatchingIDs IGNORE all three — a count answers
+	// for the matched set, and a page must never change it.
+	//
+	// OrderBy sorts by the STRING form of each property, byte-wise (the
+	// data-entry list comparator's semantics), rows without the property
+	// last in either direction, then by id ascending as the tiebreak. It is
+	// meant for scalar string-shaped properties (string, enum, date); a
+	// caller sorting anything else stays on its own comparator. Limit 0
+	// means unbounded; Offset counts rows in the ordered result.
+	OrderBy []OrderSpec
+	Limit   int
+	Offset  int
+}
+
+// OrderSpec is one GraphQuery sort key.
+type OrderSpec struct {
+	Property   string
+	Descending bool
 }
 
 // GraphBranch is one arm of [GraphQuery.Any]: a relation predicate and the
 // faces it grants. A nil FaceIn grants every face; a nil HasInbound holds for
 // every entity of the type (the branch is then only a face set).
+// GraphHeaderQueryer is the content-free projection of [GraphQueryer]:
+// the same predicate evaluation, yielding [EntityHeader] rows without the
+// markdown body. OPTIONAL — type-asserted like [HeaderReader], with
+// [GraphQueryHeaders] as the generic fallback — because it exists purely to
+// keep bodies from crossing the wire on backends where that is a real cost
+// (TKT-1U8XYN): a list page needs a type's ids and properties to filter,
+// sort and paginate, never its bodies.
+type GraphHeaderQueryer interface {
+	GraphQueryHeaders(ctx context.Context, q GraphQuery) iter.Seq2[EntityHeader, error]
+}
+
+// GraphQueryHeaders runs q as a content-free query on any GraphQueryer.
+//
+// Uses the backend's native [GraphHeaderQueryer] when it has one, so the
+// body never leaves the backend; otherwise falls back to
+// [GraphQueryer.GraphQuery] and projects each row as it is yielded. As with
+// [ListEntityHeaders], the fallback bounds retention, not transfer.
+func GraphQueryHeaders(ctx context.Context, gq GraphQueryer, q GraphQuery) iter.Seq2[EntityHeader, error] {
+	if hq, ok := gq.(GraphHeaderQueryer); ok {
+		return hq.GraphQueryHeaders(ctx, q)
+	}
+	return func(yield func(EntityHeader, error) bool) {
+		for e, err := range gq.GraphQuery(ctx, q) {
+			if err != nil {
+				yield(EntityHeader{}, err)
+				return
+			}
+			if !yield(HeaderOf(e), nil) {
+				return
+			}
+		}
+	}
+}
+
 type GraphBranch struct {
 	HasInbound *RelationPredicate
 	FaceIn     []entity.Face

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -76,8 +76,10 @@ type GraphQuery struct {
 	// for the matched set, and a page must never change it.
 	//
 	// OrderBy sorts by the STRING form of each property, byte-wise (the
-	// data-entry list comparator's semantics), rows without the property
-	// last in either direction, then by id ascending as the tiebreak. It is
+	// data-entry list comparator's semantics), then by id ascending as the
+	// tiebreak. A row WITHOUT the property sorts as if it held the largest
+	// value: last ascending, first descending — SQL's default null
+	// placement, kept on purpose so one index serves both directions. It is
 	// meant for scalar string-shaped properties (string, enum, date); a
 	// caller sorting anything else stays on its own comparator. Limit 0
 	// means unbounded; Offset counts rows in the ordered result.
@@ -104,6 +106,28 @@ type OrderSpec struct {
 // sort and paginate, never its bodies.
 type GraphHeaderQueryer interface {
 	GraphQueryHeaders(ctx context.Context, q GraphQuery) iter.Seq2[EntityHeader, error]
+}
+
+// MatchedCounter is the half of [GraphQueryer.GraphCount] a paged list needs:
+// the number of rows q matches, and nothing about the type's total.
+// OPTIONAL, type-asserted with [CountMatched] as the generic fallback. It
+// exists because GraphCount answers two questions with two statements, and
+// the second — the unscoped total — is both the one a gated handler must not
+// expose (RR-SSPCCI) and, under a world, a count(DISTINCT) over every row of
+// the table (TKT-1U8XYN: 35 ms of a list page's 80).
+type MatchedCounter interface {
+	CountMatched(ctx context.Context, q GraphQuery) (int, error)
+}
+
+// CountMatched returns how many rows q matches on any GraphQueryer, using
+// the backend's [MatchedCounter] when it has one and GraphCount's matched
+// half otherwise. OrderBy/Limit/Offset on q are ignored, as GraphCount does.
+func CountMatched(ctx context.Context, gq GraphQueryer, q GraphQuery) (int, error) {
+	if mc, ok := gq.(MatchedCounter); ok {
+		return mc.CountMatched(ctx, q)
+	}
+	matched, _, err := gq.GraphCount(ctx, q)
+	return matched, err
 }
 
 // GraphQueryHeaders runs q as a content-free query on any GraphQueryer.

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -94,9 +94,6 @@ type OrderSpec struct {
 	Descending bool
 }
 
-// GraphBranch is one arm of [GraphQuery.Any]: a relation predicate and the
-// faces it grants. A nil FaceIn grants every face; a nil HasInbound holds for
-// every entity of the type (the branch is then only a face set).
 // GraphHeaderQueryer is the content-free projection of [GraphQueryer]:
 // the same predicate evaluation, yielding [EntityHeader] rows without the
 // markdown body. OPTIONAL — type-asserted like [HeaderReader], with
@@ -153,6 +150,9 @@ func GraphQueryHeaders(ctx context.Context, gq GraphQueryer, q GraphQuery) iter.
 	}
 }
 
+// GraphBranch is one arm of [GraphQuery.Any]: a relation predicate and the
+// faces it grants. A nil FaceIn grants every face; a nil HasInbound holds for
+// every entity of the type (the branch is then only a face set).
 type GraphBranch struct {
 	HasInbound *RelationPredicate
 	FaceIn     []entity.Face

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -13,8 +13,10 @@ package graphquerynaive
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -55,6 +57,8 @@ func Run(ctx context.Context, r Reader, q store.GraphQuery) iter.Seq2[*entity.En
 			yield(nil, err)
 			return
 		}
+		paged := len(q.OrderBy) > 0 || q.Limit > 0 || q.Offset > 0
+		var matched []*entity.Entity
 		for _, e := range candidates {
 			ok, err := matches(ctx, r, e, q)
 			if err != nil {
@@ -63,13 +67,76 @@ func Run(ctx context.Context, r Reader, q store.GraphQuery) iter.Seq2[*entity.En
 				}
 				continue
 			}
-			if ok {
+			if !ok {
+				continue
+			}
+			if !paged {
 				if !yield(e, nil) {
 					return
 				}
+				continue
+			}
+			matched = append(matched, e)
+		}
+		if !paged {
+			return
+		}
+		// Ordering and paging apply to the matched set as a whole, so they
+		// wait until every candidate has been judged.
+		Order(matched, q.OrderBy)
+		for _, e := range Page(matched, q.Offset, q.Limit) {
+			if !yield(e, nil) {
+				return
 			}
 		}
 	}
+}
+
+// Order sorts rows in place by specs with GraphQuery.OrderBy's semantics:
+// byte-wise on each property's string form, rows missing the property last
+// in either direction, id ascending as the final tiebreak. A stable sort,
+// so equal keys keep store order.
+func Order(rows []*entity.Entity, specs []store.OrderSpec) {
+	if len(specs) == 0 {
+		return
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		for _, spec := range specs {
+			vi, oki := rows[i].Properties[spec.Property]
+			vj, okj := rows[j].Properties[spec.Property]
+			if oki != okj {
+				return oki // the row that HAS the property sorts first
+			}
+			if !oki {
+				continue
+			}
+			si, sj := fmt.Sprint(vi), fmt.Sprint(vj)
+			if si == sj {
+				continue
+			}
+			if spec.Descending {
+				return si > sj
+			}
+			return si < sj
+		}
+		return rows[i].ID < rows[j].ID
+	})
+}
+
+// Page returns the window rows[offset : offset+limit] (limit 0 = to the
+// end), clamped to the slice.
+func Page[T any](rows []T, offset, limit int) []T {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(rows) {
+		return nil
+	}
+	end := len(rows)
+	if limit > 0 && offset+limit < end {
+		end = offset + limit
+	}
+	return rows[offset:end]
 }
 
 // Count returns (matched, total) for q against r.

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -93,9 +93,10 @@ func Run(ctx context.Context, r Reader, q store.GraphQuery) iter.Seq2[*entity.En
 }
 
 // Order sorts rows in place by specs with GraphQuery.OrderBy's semantics:
-// byte-wise on each property's string form, rows missing the property last
-// in either direction, id ascending as the final tiebreak. A stable sort,
-// so equal keys keep store order.
+// byte-wise on each property's string form, a row missing the property
+// sorting as the largest value (last ascending, first descending — SQL's
+// default null placement), id ascending as the final tiebreak. A stable
+// sort, so equal keys keep store order.
 func Order(rows []*entity.Entity, specs []store.OrderSpec) {
 	if len(specs) == 0 {
 		return
@@ -105,7 +106,8 @@ func Order(rows []*entity.Entity, specs []store.OrderSpec) {
 			vi, oki := rows[i].Properties[spec.Property]
 			vj, okj := rows[j].Properties[spec.Property]
 			if oki != okj {
-				return oki // the row that HAS the property sorts first
+				// The present value is smaller than the absent one.
+				return oki != spec.Descending
 			}
 			if !oki {
 				continue

--- a/internal/store/graphquerynaive/naive.go
+++ b/internal/store/graphquerynaive/naive.go
@@ -103,8 +103,8 @@ func Order(rows []*entity.Entity, specs []store.OrderSpec) {
 	}
 	sort.SliceStable(rows, func(i, j int) bool {
 		for _, spec := range specs {
-			vi, oki := rows[i].Properties[spec.Property]
-			vj, okj := rows[j].Properties[spec.Property]
+			vi, oki := sortValue(rows[i], spec.Property)
+			vj, okj := sortValue(rows[j], spec.Property)
 			if oki != okj {
 				// The present value is smaller than the absent one.
 				return oki != spec.Descending
@@ -123,6 +123,18 @@ func Order(rows []*entity.Entity, specs []store.OrderSpec) {
 		}
 		return rows[i].ID < rows[j].ID
 	})
+}
+
+// sortValue reads a sort key the way SQL's `->>` does: a key that is
+// missing OR holds JSON null is "no value" (SQL NULL, the largest), never
+// the text "<nil>". Without this a null-valued property sorted between
+// dates and absent rows in Go while PostgreSQL put it last.
+func sortValue(e *entity.Entity, property string) (any, bool) {
+	v, ok := e.Properties[property]
+	if !ok || v == nil {
+		return nil, false
+	}
+	return v, true
 }
 
 // Page returns the window rows[offset : offset+limit] (limit 0 = to the

--- a/internal/store/memstore/memstore.go
+++ b/internal/store/memstore/memstore.go
@@ -911,10 +911,11 @@ func (m *MemStore) GetRelation(_ context.Context, from, relType, to string) (*en
 
 func (m *MemStore) ListRelations(_ context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
 	m.mu.RLock()
+	match := storeutil.NewRelationMatcher(q)
 	snapshot := make([]*entity.Relation, 0)
 	for _, key := range m.relationOrder {
 		r := m.relations[key]
-		if !matchRelation(r, q) {
+		if !match(r) {
 			continue
 		}
 		snapshot = append(snapshot, r.Clone())
@@ -939,8 +940,9 @@ func (m *MemStore) ListRelationsPage(_ context.Context, q store.RelationQuery) (
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	match := storeutil.NewRelationMatcher(q)
 	keys := storeutil.PaginateSortedKeys(m.relationOrder, cursorKey, q.Limit, func(key string) bool {
-		return matchRelation(m.relations[key], q)
+		return match(m.relations[key])
 	})
 
 	items := make([]*entity.Relation, 0, len(keys.Keys))
@@ -952,15 +954,14 @@ func (m *MemStore) ListRelationsPage(_ context.Context, q store.RelationQuery) (
 	return store.Page[*entity.Relation]{Items: items, NextCursor: keys.NextCursor}, nil
 }
 
-var matchRelation = storeutil.MatchRelation
-
 func (m *MemStore) CountRelations(_ context.Context, q store.RelationQuery) (int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	match := storeutil.NewRelationMatcher(q)
 	count := 0
 	for _, key := range m.relationOrder {
-		if matchRelation(m.relations[key], q) {
+		if match(m.relations[key]) {
 			count++
 		}
 	}

--- a/internal/store/pgstore/derivedschema.go
+++ b/internal/store/pgstore/derivedschema.go
@@ -63,6 +63,8 @@ const derivedUniquePrefix = "rela_derived_uniq__"
 // derivedQueryPrefix is owned exclusively by the static-query index rule.
 const derivedQueryPrefix = "rela_derived_query__"
 
+const derivedListPrefix = "rela_derived_list__"
+
 // uniqueIndexName is the deterministic index name for a (type, property) unique
 // rule. Deterministic across processes and versions (no per-run entropy) so the
 // drop side of reconcile is safe: an index whose name is not recomputed from the
@@ -73,6 +75,43 @@ const derivedQueryPrefix = "rela_derived_query__"
 func uniqueIndexName(entityType, property string) string {
 	sum := sha256.Sum256([]byte(entityType + "\x00" + property))
 	return derivedUniquePrefix + hex.EncodeToString(sum[:16])
+}
+
+// listIndexName hashes the whole list shape: filters, a separator that no
+// property name can contain, then the ordered sort keys — so the same keys
+// in a different role or order name a different index.
+func listIndexName(spec store.DerivedObjectSpec) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(spec.Type))
+	for _, property := range spec.Properties {
+		_, _ = h.Write([]byte{'\x00'})
+		_, _ = h.Write([]byte(property))
+	}
+	_, _ = h.Write([]byte{'\x01'})
+	for _, property := range spec.OrderBy {
+		_, _ = h.Write([]byte{'\x00'})
+		_, _ = h.Write([]byte(property))
+	}
+	return derivedListPrefix + hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+// createListIndexDDL is the shape a pushed list page (listpushdown.go)
+// scans: type first (a parameter in the query, so it must be a column, not
+// a partial-index guard), the equality-filtered properties, the sort keys
+// under the collation the page orders by, and id as the tiebreak; partial on
+// the default face, which every list page filters on literally.
+func createListIndexDDL(name string, spec store.DerivedObjectSpec) string {
+	columns := make([]string, 0, 2+len(spec.Properties)+len(spec.OrderBy))
+	columns = append(columns, "type")
+	for _, property := range spec.Properties {
+		columns = append(columns, "(properties->>"+quoteLiteral(property)+")")
+	}
+	for _, property := range spec.OrderBy {
+		columns = append(columns, "((properties->>"+quoteLiteral(property)+`) COLLATE "C")`)
+	}
+	columns = append(columns, "id")
+	return "CREATE INDEX IF NOT EXISTS " + quoteIdent(name) + " ON entities (" +
+		strings.Join(columns, ", ") + ") WHERE face = ''"
 }
 
 func queryIndexName(entityType string, properties []string) string {
@@ -211,7 +250,82 @@ func (s *Store) Reconcile(
 	if err != nil {
 		return nil, err
 	}
-	return append(outcomes, queryOutcomes...), nil
+	outcomes = append(outcomes, queryOutcomes...)
+	listOutcomes, err := reconcileListIndexes(ctx, conn, desired, opts)
+	if err != nil {
+		return nil, err
+	}
+	return append(outcomes, listOutcomes...), nil
+}
+
+// reconcileListIndexes is reconcileQueryIndexes for [store.DerivedListIndex]
+// specs, under its own name prefix so the two families never drop each
+// other's indexes.
+func reconcileListIndexes(
+	ctx context.Context, conn *pgxpool.Conn, desired []store.DerivedObjectSpec, opts store.ReconcileOptions,
+) ([]store.DerivedObjectOutcome, error) {
+	desiredByName := make(map[string]store.DerivedObjectSpec)
+	var outcomes []store.DerivedObjectOutcome
+	for _, spec := range desired {
+		if spec.Kind != store.DerivedListIndex {
+			continue
+		}
+		if !safeDDLName(spec.Type) || len(spec.OrderBy) == 0 {
+			outcomes = append(outcomes, unenforced(spec, "invalid list index shape"))
+			continue
+		}
+		valid := true
+		for _, property := range append(append([]string(nil), spec.Properties...), spec.OrderBy...) {
+			if !safeDDLName(property) {
+				valid = false
+				break
+			}
+		}
+		if !valid {
+			outcomes = append(outcomes, unenforced(spec, "unsafe property name for DDL"))
+			continue
+		}
+		desiredByName[listIndexName(spec)] = spec
+	}
+
+	actual, err := listOwnedIndexes(ctx, conn, derivedListPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: reconcile: list list-indexes: %w", err)
+	}
+	for name := range actual {
+		if _, ok := desiredByName[name]; ok {
+			continue
+		}
+		out := store.DerivedObjectOutcome{
+			Spec: store.DerivedObjectSpec{Kind: store.DerivedListIndex}, State: store.DerivedDropped,
+			Reason: "index " + name + " no longer declared", WouldChange: opts.DryRun,
+		}
+		if !opts.DryRun {
+			if _, dropErr := conn.Exec(ctx, `DROP INDEX IF EXISTS `+quoteIdent(name)); dropErr != nil {
+				return nil, fmt.Errorf("pgstore: reconcile: drop %s: %w", name, dropErr)
+			}
+		}
+		outcomes = append(outcomes, out)
+	}
+	for _, name := range sortedNames(desiredByName) {
+		spec := desiredByName[name]
+		if _, ok := actual[name]; ok {
+			outcomes = append(outcomes, store.DerivedObjectOutcome{Spec: spec, State: store.DerivedEnforced})
+			continue
+		}
+		if opts.DryRun {
+			outcomes = append(outcomes, store.DerivedObjectOutcome{
+				Spec: spec, State: store.DerivedCreated, WouldChange: true,
+			})
+			continue
+		}
+		if _, createErr := conn.Exec(ctx, createListIndexDDL(name, spec)); createErr != nil {
+			outcomes = append(outcomes, unenforced(spec, "index could not be created: "+createErr.Error()))
+			continue
+		}
+		outcomes = append(outcomes, store.DerivedObjectOutcome{Spec: spec, State: store.DerivedCreated})
+	}
+	return outcomes, nil
 }
 
 func reconcileQueryIndexes(

--- a/internal/store/pgstore/derivedschema_unit_test.go
+++ b/internal/store/pgstore/derivedschema_unit_test.go
@@ -123,3 +123,33 @@ func TestMapUniqueViolation(t *testing.T) {
 		}
 	})
 }
+
+// A list index names the whole shape — filters, then sort keys in order — and
+// its DDL is the pushed page's scan: type, filters, sort keys under COLLATE
+// "C", id, partial on the default face (TKT-1U8XYN).
+func TestListIndexNameAndDDL(t *testing.T) {
+	a := store.DerivedObjectSpec{Kind: store.DerivedListIndex, Type: "task", Properties: []string{"status"}, OrderBy: []string{"due"}}
+	b := store.DerivedObjectSpec{Kind: store.DerivedListIndex, Type: "task", Properties: []string{"due"}, OrderBy: []string{"status"}}
+	c := store.DerivedObjectSpec{Kind: store.DerivedListIndex, Type: "task", OrderBy: []string{"due", "status"}}
+	d := store.DerivedObjectSpec{Kind: store.DerivedListIndex, Type: "task", OrderBy: []string{"status", "due"}}
+	names := map[string]bool{}
+	for _, spec := range []store.DerivedObjectSpec{a, b, c, d} {
+		n := listIndexName(spec)
+		if !strings.HasPrefix(n, derivedListPrefix) || len(n) > 63 {
+			t.Errorf("name %q: bad prefix or length", n)
+		}
+		if names[n] {
+			t.Errorf("name %q collides across shapes", n)
+		}
+		names[n] = true
+	}
+	again := store.DerivedObjectSpec{Kind: store.DerivedListIndex, Type: "task", Properties: []string{"status"}, OrderBy: []string{"due"}}
+	if listIndexName(a) != listIndexName(again) {
+		t.Error("name is not deterministic across equal specs")
+	}
+	ddl := createListIndexDDL("ix", a)
+	want := `CREATE INDEX IF NOT EXISTS "ix" ON entities (type, (properties->>'status'), ((properties->>'due') COLLATE "C"), id) WHERE face = ''`
+	if ddl != want {
+		t.Errorf("DDL = %s\nwant %s", ddl, want)
+	}
+}

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1205,15 +1206,31 @@ func stringifyJSONValue(raw []byte) string {
 // against. It mirrors search.MatchText's field selection exactly: entity ID,
 // content, and STRING-valued properties only (non-string props are excluded).
 func entitySearchText(e *entity.Entity) string {
+	// Order matters (TKT-1U8XYN): id, then string properties in key order,
+	// then the body. Ranking compares the query against the first
+	// searchRankPrefix bytes, so the identity and title-like properties
+	// decide relevance and the body only decides whether the row matches.
+	// Key order keeps the column deterministic; migration 0014 composes
+	// existing rows the same way.
 	var b strings.Builder
 	b.WriteString(strings.ToLower(e.ID))
 	b.WriteByte('\n')
-	b.WriteString(strings.ToLower(e.Content))
-	for _, v := range e.Properties {
+	keys := make([]string, 0, len(e.Properties))
+	strs := make(map[string]string, len(e.Properties))
+	for k, v := range e.Properties {
 		if str, ok := v.(string); ok {
-			b.WriteByte('\n')
-			b.WriteString(strings.ToLower(str))
+			keys = append(keys, k)
+			strs[k] = str
 		}
 	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(strings.ToLower(strs[k]))
+	}
+	b.WriteByte('\n')
+	b.WriteString(strings.ToLower(e.Content))
 	return b.String()
 }

--- a/internal/store/pgstore/entity.go
+++ b/internal/store/pgstore/entity.go
@@ -197,6 +197,7 @@ func (s *Store) CountEntities(ctx context.Context, q store.EntityQuery) (int, er
 // the publication bit, so an unscoped tally would tell a published-world
 // surface how many unpublished drafts exist.
 func buildEntityCountSQL(q store.EntityQuery) (sql string, args []any) {
+	q.World = effectiveWorld(q.World, q.Type)
 	if q.World.IsDefaultWorld() {
 		where, wargs := entityWhere(q, "")
 		return "SELECT count(*) FROM entities" + where, wargs
@@ -998,6 +999,7 @@ func buildEntityHeaderListSQL(q store.EntityQuery, keysetAfter string) (sql stri
 // land mid-family and resolve a prime from a partial view, which is the
 // wrong-prime hazard storeutil.PaginateWorldPrimes exists to avoid.
 func buildEntitySelectSQL(q store.EntityQuery, keysetAfter, columns string) (sql string, args []any) {
+	q.World = effectiveWorld(q.World, q.Type)
 	if q.World.IsDefaultWorld() {
 		where, wargs := entityWhere(q, keysetAfter)
 		return `SELECT ` + columns + ` FROM entities` + where + ` ORDER BY id ASC, face ASC`, wargs

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -95,6 +95,21 @@ func (s *Store) GraphQueryHeaders(ctx context.Context, q store.GraphQuery) iter.
 	}
 }
 
+// CountMatched implements store.MatchedCounter: GraphCount's first statement
+// alone. A list page needs only the scoped count, and the second statement
+// GraphCount would run — the type's world-wide total — is the expensive one.
+func (s *Store) CountMatched(ctx context.Context, q store.GraphQuery) (int, error) {
+	if err := checkGraphQueryScope(q); err != nil {
+		return 0, err
+	}
+	matchedSQL, matchedArgs := buildGraphQuerySQL(q, true)
+	var matched int
+	if err := s.db.QueryRow(ctx, matchedSQL, matchedArgs...).Scan(&matched); err != nil {
+		return 0, fmt.Errorf("pgstore: graph count (matched): %w", err)
+	}
+	return matched, nil
+}
+
 func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
 	if scopeErr := checkGraphQueryScope(q); scopeErr != nil {
 		return 0, 0, scopeErr
@@ -122,7 +137,7 @@ func buildGraphTotalSQL(q store.GraphQuery) (sqlText string, args []any) {
 	typeArg := b.arg(q.EntityType)
 	scope, _, _ := graphWorldScope(b, q)
 	agg := "count(*)"
-	if !q.World.IsDefaultWorld() {
+	if !effectiveWorld(q.World, q.EntityType).IsDefaultWorld() {
 		agg = "count(DISTINCT e.id)"
 	}
 	return "SELECT " + agg + " FROM entities e WHERE e.type = " + typeArg + " AND " + scope, b.args
@@ -394,7 +409,7 @@ func buildGraphQuerySQLSelect(q store.GraphQuery, sel graphSelect) (sqlText stri
 		// coordinates. count(DISTINCT e.id) is exact here because the
 		// world admits at most one prime per id.
 		selectList = "count(*)"
-		if !q.World.IsDefaultWorld() {
+		if !effectiveWorld(q.World, q.EntityType).IsDefaultWorld() {
 			selectList = "count(DISTINCT e.id)"
 		}
 		orderBy = ""
@@ -435,8 +450,11 @@ func buildGraphQuerySQLSelect(q store.GraphQuery, sel graphSelect) (sqlText stri
 	// resolved primes in an outer query; a default-world query pages
 	// directly, its plain id ordering replaced. Either way the sort is
 	// byte-wise on the property's text form (COLLATE "C" — the Go
-	// comparator's semantics), NULLS LAST in both directions, id ascending
-	// as the tiebreak.
+	// comparator's semantics) with PostgreSQL's default null placement,
+	// which treats an absent value as the largest: last ascending, first
+	// descending. That default is deliberate — it is what lets one
+	// expression index serve both directions (a backward scan of an ASC
+	// index is exactly DESC NULLS FIRST) — and the Go comparators mirror it.
 	inner := sb.String()
 	if distinctOn != "" {
 		inner = "SELECT * FROM (" + inner + ") e"
@@ -451,7 +469,7 @@ func buildGraphQuerySQLSelect(q store.GraphQuery, sel graphSelect) (sqlText stri
 		if spec.Descending {
 			dir = " DESC"
 		}
-		page.WriteString("(e.properties ->> " + b.arg(spec.Property) + `) COLLATE "C"` + dir + " NULLS LAST, ")
+		page.WriteString("(e.properties ->> " + b.arg(spec.Property) + `) COLLATE "C"` + dir + ", ")
 	}
 	page.WriteString("e.id ASC")
 	if q.Limit > 0 {
@@ -598,7 +616,7 @@ func cappedDepth(d int) int {
 // filter cannot be applied at one call site and forgotten at another — all
 // three graph paths go through here (TKT-O7R2A1).
 func graphWorldScope(b *sqlBuilder, q store.GraphQuery) (where, distinctOn, rankOrder string) {
-	w := q.World
+	w := effectiveWorld(q.World, q.EntityType)
 	faceIn := func(base string) string {
 		if len(q.FaceIn) == 0 {
 			return base

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -56,11 +56,21 @@ func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*e
 	}
 }
 
-// GraphCount runs the predicate query as `SELECT count(*)` and a
-// separate unconditional count of entities of the type. Two
-// round-trips beats one COUNT FILTER because both rely on the same
-// recursive CTE shape — duplicating the WITH RECURSIVE inside a
-// single FILTER expression saves nothing.
+// CountMatched implements store.MatchedCounter: GraphCount's first statement
+// alone. A list page needs only the scoped count, and the second statement
+// GraphCount would run — the type's world-wide total — is the expensive one.
+func (s *Store) CountMatched(ctx context.Context, q store.GraphQuery) (int, error) {
+	if err := checkGraphQueryScope(q); err != nil {
+		return 0, err
+	}
+	matchedSQL, matchedArgs := buildGraphQuerySQL(q, true)
+	var matched int
+	if err := s.db.QueryRow(ctx, matchedSQL, matchedArgs...).Scan(&matched); err != nil {
+		return 0, fmt.Errorf("pgstore: graph count (matched): %w", err)
+	}
+	return matched, nil
+}
+
 // GraphQueryHeaders implements store.GraphHeaderQueryer: GraphQuery's
 // predicate evaluation with the content column projected away, so a list
 // page's filter/sort/paginate pass over a whole type never transfers the
@@ -95,21 +105,11 @@ func (s *Store) GraphQueryHeaders(ctx context.Context, q store.GraphQuery) iter.
 	}
 }
 
-// CountMatched implements store.MatchedCounter: GraphCount's first statement
-// alone. A list page needs only the scoped count, and the second statement
-// GraphCount would run — the type's world-wide total — is the expensive one.
-func (s *Store) CountMatched(ctx context.Context, q store.GraphQuery) (int, error) {
-	if err := checkGraphQueryScope(q); err != nil {
-		return 0, err
-	}
-	matchedSQL, matchedArgs := buildGraphQuerySQL(q, true)
-	var matched int
-	if err := s.db.QueryRow(ctx, matchedSQL, matchedArgs...).Scan(&matched); err != nil {
-		return 0, fmt.Errorf("pgstore: graph count (matched): %w", err)
-	}
-	return matched, nil
-}
-
+// GraphCount runs the predicate query as `SELECT count(*)` and a
+// separate unconditional count of entities of the type. Two
+// round-trips beats one COUNT FILTER because both rely on the same
+// recursive CTE shape — duplicating the WITH RECURSIVE inside a
+// single FILTER expression saves nothing.
 func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
 	if scopeErr := checkGraphQueryScope(q); scopeErr != nil {
 		return 0, 0, scopeErr
@@ -455,6 +455,13 @@ func buildGraphQuerySQLSelect(q store.GraphQuery, sel graphSelect) (sqlText stri
 	// descending. That default is deliberate — it is what lets one
 	// expression index serve both directions (a backward scan of an ASC
 	// index is exactly DESC NULLS FIRST) — and the Go comparators mirror it.
+	// graphWorldScope returns distinctOn and rankOrder as a pair: both empty
+	// (default world; the plain id ORDER BY is ours to replace) or both set
+	// (world; the DISTINCT ON owns its ORDER BY, so we wrap). A one-sided
+	// return would corrupt the SQL silently, hence the guard.
+	if (distinctOn == "") != (rankOrder == "") {
+		panic("pgstore: graphWorldScope returned DISTINCT ON without its ORDER BY, or vice versa")
+	}
 	inner := sb.String()
 	if distinctOn != "" {
 		inner = "SELECT * FROM (" + inner + ") e"

--- a/internal/store/pgstore/graphquery.go
+++ b/internal/store/pgstore/graphquery.go
@@ -61,6 +61,40 @@ func (s *Store) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*e
 // round-trips beats one COUNT FILTER because both rely on the same
 // recursive CTE shape — duplicating the WITH RECURSIVE inside a
 // single FILTER expression saves nothing.
+// GraphQueryHeaders implements store.GraphHeaderQueryer: GraphQuery's
+// predicate evaluation with the content column projected away, so a list
+// page's filter/sort/paginate pass over a whole type never transfers the
+// bodies it will not render (TKT-1U8XYN).
+func (s *Store) GraphQueryHeaders(ctx context.Context, q store.GraphQuery) iter.Seq2[store.EntityHeader, error] {
+	if err := checkGraphQueryScope(q); err != nil {
+		return func(yield func(store.EntityHeader, error) bool) { yield(store.EntityHeader{}, err) }
+	}
+	sqlText, args := buildGraphQuerySQLSelect(q, graphSelectHeaders)
+	return func(yield func(store.EntityHeader, error) bool) {
+		rows, err := s.db.Query(ctx, sqlText, args...)
+		if err != nil {
+			yield(store.EntityHeader{}, fmt.Errorf("pgstore: graph query headers: %w", err))
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			h, scanErr := scanEntityHeader(rows)
+			if scanErr != nil {
+				if !yield(store.EntityHeader{}, scanErr) {
+					return
+				}
+				continue
+			}
+			if !yield(h, nil) {
+				return
+			}
+		}
+		if err := rows.Err(); err != nil {
+			yield(store.EntityHeader{}, err)
+		}
+	}
+}
+
 func (s *Store) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
 	if scopeErr := checkGraphQueryScope(q); scopeErr != nil {
 		return 0, 0, scopeErr
@@ -315,6 +349,31 @@ func equalsCond(b *sqlBuilder, txt, jsn, value string) string {
 // when BuildGraphQuerySQLForTest is invoked from tests — the
 // builder treats all input the same way.
 func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, args []any) {
+	if countOnly {
+		return buildGraphQuerySQLSelect(q, graphSelectCount)
+	}
+	return buildGraphQuerySQLSelect(q, graphSelectRows)
+}
+
+// graphSelect chooses what a graph query projects: whole rows, content-free
+// header rows, or a count. The predicate evaluation is identical across the
+// three — only the SELECT list and ordering differ.
+type graphSelect int
+
+const (
+	graphSelectRows graphSelect = iota
+	graphSelectHeaders
+	graphSelectCount
+)
+
+// graphSelectLists are the column lists for the row projections; scanEntity
+// and scanEntityHeader expect exactly these columns in this order.
+var graphSelectLists = map[graphSelect]string{
+	graphSelectRows:    "e.id, e.type, e.face, e.properties, e.content, e.updated_at",
+	graphSelectHeaders: "e.id, e.type, e.face, e.properties, e.updated_at",
+}
+
+func buildGraphQuerySQLSelect(q store.GraphQuery, sel graphSelect) (sqlText string, args []any) {
 	b := &sqlBuilder{}
 	// $1 is always q.EntityType.
 	typeArg := b.arg(q.EntityType)
@@ -323,9 +382,10 @@ func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, arg
 
 	// Branch the SELECT list + ORDER BY: count queries skip column
 	// fetching and ordering; row queries return the standard entity
-	// columns and stable id-ascending order. The rest of the query
-	// (WITH, FROM, WHERE, EXISTS chain) is identical.
-	selectList := "e.id, e.type, e.face, e.properties, e.content, e.updated_at"
+	// columns (or the header subset) and stable id-ascending order. The
+	// rest of the query (WITH, FROM, WHERE, EXISTS chain) is identical.
+	countOnly := sel == graphSelectCount
+	selectList := graphSelectLists[sel]
 	orderBy := " ORDER BY e.id"
 	if countOnly {
 		// A world-scoped count must count PRIMES: DISTINCT ON cannot be
@@ -367,7 +427,40 @@ func buildGraphQuerySQL(q store.GraphQuery, countOnly bool) (sqlText string, arg
 	sb.WriteString(orderBy)
 	sb.WriteString(rankOrder)
 
-	return sb.String(), b.args
+	if countOnly || (len(q.OrderBy) == 0 && q.Limit == 0 && q.Offset == 0) {
+		return sb.String(), b.args
+	}
+	// Ordering and paging (TKT-1U8XYN). A world query's DISTINCT ON owns its
+	// ORDER BY (it must lead with e.id), so the page is taken over the
+	// resolved primes in an outer query; a default-world query pages
+	// directly, its plain id ordering replaced. Either way the sort is
+	// byte-wise on the property's text form (COLLATE "C" — the Go
+	// comparator's semantics), NULLS LAST in both directions, id ascending
+	// as the tiebreak.
+	inner := sb.String()
+	if distinctOn != "" {
+		inner = "SELECT * FROM (" + inner + ") e"
+	} else {
+		inner = strings.TrimSuffix(inner, orderBy)
+	}
+	var page strings.Builder
+	page.WriteString(inner)
+	page.WriteString(" ORDER BY ")
+	for _, spec := range q.OrderBy {
+		dir := " ASC"
+		if spec.Descending {
+			dir = " DESC"
+		}
+		page.WriteString("(e.properties ->> " + b.arg(spec.Property) + `) COLLATE "C"` + dir + " NULLS LAST, ")
+	}
+	page.WriteString("e.id ASC")
+	if q.Limit > 0 {
+		page.WriteString(" LIMIT " + b.arg(q.Limit))
+	}
+	if q.Offset > 0 {
+		page.WriteString(" OFFSET " + b.arg(q.Offset))
+	}
+	return page.String(), b.args
 }
 
 // buildPredicateSQL emits (CTE definitions, EXISTS clause) for one

--- a/internal/store/pgstore/graphquery_explain_test.go
+++ b/internal/store/pgstore/graphquery_explain_test.go
@@ -139,3 +139,41 @@ func explainGraphQuery(t *testing.T, pool *pgxpool.Pool, q store.GraphQuery) str
 	require.NoError(t, rows.Err())
 	return strings.Join(lines, "\n")
 }
+
+// A pushed list page — filter on one property, order by another, LIMIT —
+// scans the derived list index instead of sorting the type (TKT-1U8XYN).
+func TestGraphQueryExplainPagedListUsesDerivedListIndex(t *testing.T) {
+	const n = 5000
+	pool := newScopedPool(t)
+	s, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	spec := []store.DerivedObjectSpec{{
+		Kind: store.DerivedListIndex, Type: "task", Properties: []string{"status"}, OrderBy: []string{"due"},
+	}}
+	_, err = s.Reconcile(ctx, spec, store.ReconcileOptions{})
+	require.NoError(t, err)
+
+	for i := range n {
+		e := entity.New(fmt.Sprintf("TASK-%06d", i), "task")
+		e.Properties["status"] = []string{"open", "done"}[i%2]
+		e.Properties["due"] = fmt.Sprintf("2026-%02d-%02d", 1+i%12, 1+i%28)
+		require.NoError(t, s.CreateEntity(ctx, e))
+	}
+	_, err = pool.Exec(ctx, "ANALYZE entities")
+	require.NoError(t, err)
+
+	plan := explainGraphQuery(t, pool, store.GraphQuery{
+		EntityType: "task",
+		Props:      []store.PropPredicate{{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true}},
+		OrderBy:    []store.OrderSpec{{Property: "due"}},
+		Limit:      25,
+	})
+	t.Logf("plan:\n%s", plan)
+	if !strings.Contains(plan, "rela_derived_list__") {
+		t.Fatalf("derived list index is not used:\n%s", plan)
+	}
+	if strings.Contains(plan, "Sort") {
+		t.Fatalf("page still sorts instead of walking the index:\n%s", plan)
+	}
+}

--- a/internal/store/pgstore/migrations/0014_read_indexes.sql
+++ b/internal/store/pgstore/migrations/0014_read_indexes.sql
@@ -1,0 +1,43 @@
+-- pgstore schema, version 14: read-path indexes and a search ranking that
+-- scales (TKT-1U8XYN).
+--
+-- entities_type_id_idx: the default page of a type ("this type, by id,
+-- rows N..M") is `WHERE face = '' AND type = $1 ORDER BY id LIMIT k`. The
+-- primary key (id, face) cannot serve that with a type filter; (type)
+-- alone leaves a sort over the type. A partial (type, id) index on the
+-- default face makes the page an index range scan. Kanban boards fetch
+-- exactly this shape, 100 rows at a time.
+--
+-- entities_id_prefix_idx: HighestID (sequential id allocation on every
+-- create) runs `WHERE id LIKE 'PFX-%' AND face = ''`. The unique
+-- (lower(id), face) index cannot serve a prefix pattern; text_pattern_ops
+-- can, turning a per-create scan of the table into a range scan of one
+-- prefix.
+--
+-- entities_search_tsv_idx is dropped: nothing has ever queried it. Search
+-- is a trigram LIKE over search_text (entities_search_trgm_idx) ranked by
+-- similarity — see search.go — so the tsvector index was pure write
+-- amplification on every entity write (TKT-ZZL53L).
+--
+-- search_text is rebuilt with id, then string properties, then content,
+-- so that the first kilobyte is the identity and the title rather than the
+-- opening of the body. The store composes it that way from now on
+-- (entitySearchText); this brings existing rows in line. Ranking uses that
+-- prefix: similarity over a whole 5 KB body per candidate row cost seconds
+-- on a common word, and title similarity is what a reader means anyway.
+-- lower() here vs strings.ToLower in Go can differ on exotic Unicode; the
+-- next write of a row recomposes it in Go, and the mismatch could only
+-- ever affect matching on such characters within a body.
+
+CREATE INDEX IF NOT EXISTS entities_type_id_idx ON entities (type, id) WHERE face = '';
+
+CREATE INDEX IF NOT EXISTS entities_id_prefix_idx ON entities (id text_pattern_ops) WHERE face = '';
+
+DROP INDEX IF EXISTS entities_search_tsv_idx;
+
+UPDATE entities SET search_text =
+    lower(id) || E'\n' ||
+    COALESCE((SELECT string_agg(lower(p.value), E'\n' ORDER BY p.key)
+              FROM jsonb_each_text(properties) p
+              WHERE jsonb_typeof(properties -> p.key) = 'string'), '') || E'\n' ||
+    lower(content);

--- a/internal/store/pgstore/migrations/0014_read_indexes.sql
+++ b/internal/store/pgstore/migrations/0014_read_indexes.sql
@@ -35,9 +35,19 @@ CREATE INDEX IF NOT EXISTS entities_id_prefix_idx ON entities (id text_pattern_o
 
 DROP INDEX IF EXISTS entities_search_tsv_idx;
 
-UPDATE entities SET search_text =
-    lower(id) || E'\n' ||
-    COALESCE((SELECT string_agg(lower(p.value), E'\n' ORDER BY p.key)
-              FROM jsonb_each_text(properties) p
-              WHERE jsonb_typeof(properties -> p.key) = 'string'), '') || E'\n' ||
-    lower(content);
+-- One-time rewrite of every entity row (and of the trigram index behind it),
+-- inside the migration transaction: expect the first start after upgrading
+-- to pause for a time proportional to the table — seconds at 20k rows. The
+-- IS DISTINCT FROM guard makes a re-run touch only rows that still differ.
+UPDATE entities SET search_text = composed.search_text
+FROM (
+    SELECT id, face,
+           lower(id) || E'\n' ||
+           COALESCE((SELECT string_agg(lower(p.value), E'\n' ORDER BY p.key)
+                     FROM jsonb_each_text(properties) p
+                     WHERE jsonb_typeof(properties -> p.key) = 'string'), '') || E'\n' ||
+           lower(content) AS search_text
+    FROM entities
+) composed
+WHERE entities.id = composed.id AND entities.face = composed.face
+  AND entities.search_text IS DISTINCT FROM composed.search_text;

--- a/internal/store/pgstore/open.go
+++ b/internal/store/pgstore/open.go
@@ -27,11 +27,10 @@ func Open(ctx context.Context, dsn string) (store.Store, search.Searcher, io.Clo
 		// ParseConfig parses (not connects); pgx redacts the password in errors.
 		return nil, nil, nil, fmt.Errorf("parse database DSN: %w", err)
 	}
-	// Attach the query tracer only when slog Debug is enabled. Avoids
-	// the per-query context-value alloc in production where Debug is off.
-	if debugEnabled(ctx) {
-		cfg.ConnConfig.Tracer = debugQueryTracer{}
-	}
+	// The tracer is always attached; it decides per statement whether to
+	// account (stats on the context) or log (Debug enabled) and otherwise
+	// costs one context lookup. See queryTracer.
+	cfg.ConnConfig.Tracer = queryTracer{}
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("connect to database: %w", err)

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -122,8 +122,14 @@ type DBTX interface {
 // mandated store.Store interface on the same terms. Required-interface
 // exception, not accreted API.)
 //
-//plimsoll:max-exported-methods=42
-//plimsoll:max-methods=52
+// (+2 exported, TKT-1U8XYN: GraphQueryHeaders and CountMatched are OPTIONAL
+// store capabilities — store.GraphHeaderQueryer, store.MatchedCounter — that
+// consumers type-assert off the store handle, exactly as HeaderReader is.
+// They have to live on this type to be discoverable that way; a second
+// type would not be found by the assertion.)
+//
+//plimsoll:max-exported-methods=44
+//plimsoll:max-methods=54
 type Store struct {
 	db        DBTX
 	observers []store.EntityObserver // notified synchronously after committed entity writes

--- a/internal/store/pgstore/relation.go
+++ b/internal/store/pgstore/relation.go
@@ -350,6 +350,21 @@ func relationWhere(q store.RelationQuery, keysetAfter string) (where string, arg
 			conds = append(conds, fmt.Sprintf("(from_id = $%d OR to_id = $%d)", len(args), len(args)))
 		}
 	}
+	if q.EntityIDs != nil {
+		// The explicit ::text[] cast keeps an EMPTY slice a valid, never-
+		// matching predicate rather than an "unknown array type" error, so
+		// nil-vs-empty keeps its documented meaning.
+		switch q.Direction {
+		case store.DirectionOutgoing:
+			add("from_id = ANY($%d::text[])", q.EntityIDs)
+		case store.DirectionIncoming:
+			add("to_id = ANY($%d::text[])", q.EntityIDs)
+		default: // DirectionBoth
+			args = append(args, q.EntityIDs)
+			conds = append(conds, fmt.Sprintf("(from_id = ANY($%d::text[]) OR to_id = ANY($%d::text[]))",
+				len(args), len(args)))
+		}
+	}
 	if keysetAfter != "" {
 		// An unparseable cursor genuinely RESTARTS (condition omitted):
 		// comparing against garbage would silently skip rows — see the

--- a/internal/store/pgstore/search.go
+++ b/internal/store/pgstore/search.go
@@ -177,13 +177,29 @@ func buildSearchSQL(needle string, limit int, w store.WorldScope) (sqlText strin
 		sqlText += ` ORDER BY id ASC`
 	} else {
 		args = append(args, needle)
-		sqlText += ` ORDER BY similarity(search_text, $` + strconv.Itoa(len(args)) + `) DESC, id ASC`
+		sqlText += ` ORDER BY ` + rankExpr("search_text", len(args)) + ` DESC, id ASC`
 	}
 	if limit > 0 {
 		args = append(args, limit)
 		sqlText += ` LIMIT $` + strconv.Itoa(len(args))
 	}
 	return sqlText, args
+}
+
+// searchRankPrefix is how much of search_text similarity ranking looks at:
+// the id and the string properties (title first among them alphabetically
+// in most schemas) that lead the column, not the body behind them. A
+// trigram similarity over every candidate's whole body cost seconds on a
+// common word at 20k rows (TKT-1U8XYN); a reader searching "telemetry"
+// wants the entities ABOUT telemetry ranked first, which is what the
+// prefix says, and every row that mentions it still matches — matching
+// is the LIKE over the whole column, ranking is this prefix.
+const searchRankPrefix = 1024
+
+// rankExpr is the ranking expression both search builders order by; they
+// must agree (see buildVisibleSearchSQL's ordered-subsequence contract).
+func rankExpr(col string, needleArg int) string {
+	return `similarity(left(` + col + `, ` + strconv.Itoa(searchRankPrefix) + `), $` + strconv.Itoa(needleArg) + `)`
 }
 
 // Close releases backend resources. The handle is owned by the wiring layer,

--- a/internal/store/pgstore/search_test.go
+++ b/internal/store/pgstore/search_test.go
@@ -2,6 +2,7 @@ package pgstore_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,4 +55,60 @@ func searchIDs(t *testing.T, b *pgstore.SearchBackend, text string) []string {
 		ids = append(ids, f.ID)
 	}
 	return ids
+}
+
+// Ranking looks at the identity/title prefix of search_text, not the body:
+// an entity whose TITLE carries the word outranks one that only mentions it
+// deep in a long body, and the body-only entity still matches (TKT-1U8XYN).
+func TestSearch_RanksTitleMatchAboveBodyMention(t *testing.T) {
+	pool := newScopedPool(t)
+	backend := pgstore.NewSearchBackend(pool)
+	st, err := pgstore.New(pool, pgstore.WithObserver(backend))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	body := entity.New("N-1", "note")
+	body.SetString("title", "Quarterly review")
+	body.Content = strings.Repeat("filler words about nothing in particular. ", 60) + "telemetry appears here at the end"
+	require.NoError(t, st.CreateEntity(ctx, body))
+	title := entity.New("N-2", "note")
+	title.SetString("title", "Telemetry rollout")
+	title.Content = strings.Repeat("unrelated prose. ", 80)
+	require.NoError(t, st.CreateEntity(ctx, title))
+
+	faces, err := backend.Search("telemetry", 10, store.DefaultWorld())
+	require.NoError(t, err)
+	ids := make([]string, 0, len(faces))
+	for _, f := range faces {
+		ids = append(ids, f.ID)
+	}
+	require.Equal(t, []string{"N-2", "N-1"}, ids)
+}
+
+// Migration 0014 rebuilds search_text in SQL for rows written before the
+// column's composition changed; it must produce what the store now writes.
+func TestMigration0014_SearchTextRebuildMatchesStore(t *testing.T) {
+	pool := newScopedPool(t)
+	st, err := pgstore.New(pool)
+	require.NoError(t, err)
+	ctx := context.Background()
+	e := entity.New("Mixed-Case-9", "note")
+	e.SetString("title", "Zebra Crossing")
+	e.SetString("owner", "Alice")
+	e.Properties["count"] = 3
+	e.Content = "Body Text\nsecond line"
+	require.NoError(t, st.CreateEntity(ctx, e))
+
+	var written string
+	require.NoError(t, pool.QueryRow(ctx, `SELECT search_text FROM entities WHERE id = 'Mixed-Case-9'`).Scan(&written))
+	_, err = pool.Exec(ctx, `UPDATE entities SET search_text =
+		lower(id) || E'\n' ||
+		COALESCE((SELECT string_agg(lower(p.value), E'\n' ORDER BY p.key)
+		          FROM jsonb_each_text(properties) p
+		          WHERE jsonb_typeof(properties -> p.key) = 'string'), '') || E'\n' ||
+		lower(content)`)
+	require.NoError(t, err)
+	var rebuilt string
+	require.NoError(t, pool.QueryRow(ctx, `SELECT search_text FROM entities WHERE id = 'Mixed-Case-9'`).Scan(&rebuilt))
+	require.Equal(t, written, rebuilt)
 }

--- a/internal/store/pgstore/status_test.go
+++ b/internal/store/pgstore/status_test.go
@@ -33,8 +33,8 @@ func TestStatusFreshSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, current, "un-migrated schema is version 0")
 	// target is the highest embedded migration version — bump this when a new
-	// migration is added (0013_write_origin.sql took it from 12 to 13).
-	require.Equal(t, 13, target, "binary embeds migrations through 0013")
+	// migration is added (0014_read_indexes.sql took it from 13 to 14).
+	require.Equal(t, 14, target, "binary embeds migrations through 0014")
 }
 
 // TestStatusAfterMigrate verifies Status reports current==target once Migrate

--- a/internal/store/pgstore/tracer.go
+++ b/internal/store/pgstore/tracer.go
@@ -6,55 +6,86 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// debugQueryTracer is a [pgx.QueryTracer] that logs every SQL query
-// at slog.Debug level with the SQL text, arguments, and execution
-// duration. It is attached when slog's default handler is enabled at
-// Debug level; at higher levels it is omitted, so production
-// deployments pay no per-query overhead.
+// queryTracer is the [pgx.QueryTracer] attached to every pool Open builds.
+// It does two independent things per statement, each opt-in by the caller's
+// context or logger rather than by pool configuration:
 //
-// Logging at Debug rather than Info is deliberate: query traffic is
-// chatty (one log line per query, every query, for the lifetime of
-// the process). Operators flip slog to Debug only when they need it
-// — typically to diagnose a misbehaving query plan or unexpected
-// query count from a higher layer.
-type debugQueryTracer struct{}
+//   - Accounting: when the query's context carries a [store.QueryStats]
+//     (a request middleware installs one), the statement's count and
+//     duration are recorded there. This is how "how many queries did this
+//     request issue?" is answered without touching the ~60 call sites that
+//     run SQL.
+//   - Logging: when slog's default handler is enabled at Debug, one
+//     record per statement with SQL text, arguments, duration and row count.
+//     Debug rather than Info is deliberate: query traffic is chatty, and
+//     operators flip to Debug only when diagnosing a plan or an unexpected
+//     query count.
+//
+// When neither applies — production with Debug off and no stats on the
+// context — TraceQueryStart returns the context unchanged, so the per-query
+// overhead is one context lookup and one level check, no allocation. That
+// is why the tracer can be attached unconditionally: the earlier design
+// attached it only when Debug was on at Open time, which made stats
+// impossible and froze the logging decision at startup.
+//
+// Transactions are covered too: a [Store.Tx] view runs on a pgx.Tx from the
+// same pool, and pgx traces BEGIN/COMMIT and every statement inside through
+// the same connection-level tracer.
+type queryTracer struct{}
 
 type tracerCtxKey struct{}
 
 type tracerCtxVal struct {
 	start time.Time
+	stats *store.QueryStats // nil when the context carries none
+	debug bool
 	sql   string
 	args  []any
 }
 
-// TraceQueryStart records the query parameters on the context for
-// TraceQueryEnd to read. The data is intentionally NOT logged here
-// — slog the whole event once with timing, not twice.
-func (debugQueryTracer) TraceQueryStart(
+// TraceQueryStart decides what, if anything, this statement will report and
+// parks that decision on the context for TraceQueryEnd. Nothing is logged
+// here — one record per statement, emitted once with its timing.
+func (queryTracer) TraceQueryStart(
 	ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData,
 ) context.Context {
-	return context.WithValue(ctx, tracerCtxKey{}, &tracerCtxVal{
-		start: time.Now(),
-		sql:   data.SQL,
-		args:  data.Args,
-	})
+	stats := store.QueryStatsFrom(ctx)
+	debug := slog.Default().Enabled(ctx, slog.LevelDebug)
+	if stats == nil && !debug {
+		return ctx
+	}
+	v := &tracerCtxVal{start: time.Now(), stats: stats, debug: debug}
+	if debug {
+		v.sql = data.SQL
+		v.args = data.Args
+	}
+	return context.WithValue(ctx, tracerCtxKey{}, v)
 }
 
-// TraceQueryEnd emits one slog.Debug record per query. The
-// `duration_us` field is a microseconds integer (jq-friendly,
-// avoids the floating-point printing variance of time.Duration's
-// String).
-func (debugQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+// TraceQueryEnd records the statement against the context's stats and, at
+// Debug, emits one slog record. The `duration_us` field is a microseconds
+// integer (jq-friendly, avoids the floating-point printing variance of
+// time.Duration's String).
+func (queryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
 	v, ok := ctx.Value(tracerCtxKey{}).(*tracerCtxVal)
 	if !ok {
+		return
+	}
+	elapsed := time.Since(v.start)
+	if v.stats != nil {
+		v.stats.Record(elapsed)
+	}
+	if !v.debug {
 		return
 	}
 	attrs := []any{
 		"sql", v.sql,
 		"args", v.args,
-		"duration_us", time.Since(v.start).Microseconds(),
+		"duration_us", elapsed.Microseconds(),
 	}
 	if data.Err != nil {
 		attrs = append(attrs, "error", data.Err.Error())
@@ -67,13 +98,4 @@ func (debugQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx
 		}
 	}
 	slog.Debug("pgstore: query", attrs...)
-}
-
-// debugEnabled reports whether slog's default logger will emit Debug
-// records for ctx. Used by Open to decide whether to attach the
-// tracer at all — the tracer's overhead is the context value alloc
-// per query, trivial in isolation but multiplied by every query in
-// the system.
-func debugEnabled(ctx context.Context) bool {
-	return slog.Default().Enabled(ctx, slog.LevelDebug)
 }

--- a/internal/store/pgstore/tracer_pool_test.go
+++ b/internal/store/pgstore/tracer_pool_test.go
@@ -10,29 +10,53 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Sourcehaven-BV/rela/internal/store/pgstore"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// TestDebugQueryTracer_FromPoolEmits proves the env-driven path:
-// when slog Debug is enabled BEFORE pgstore.Open, the pool gets the
-// tracer attached and queries emit log records. Without this, the
-// debugEnabled() check could be wired wrong and we'd ship a tracer
-// that nobody ever sees.
-func TestDebugQueryTracer_FromPoolEmits(t *testing.T) {
+// TestQueryTracer_FromPoolEmits proves the pool path: the tracer Open
+// attaches sees every statement, and with slog Debug enabled queries emit
+// log records. Without this, the tracer could be wired wrong and we'd ship
+// one that nobody ever sees.
+func TestQueryTracer_FromPoolEmits(t *testing.T) {
 	var buf bytes.Buffer
 	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	prev := slog.Default()
 	slog.SetDefault(slog.New(h))
 	t.Cleanup(func() { slog.SetDefault(prev) })
 
-	st, _, closer, err := pgstore.Open(context.Background(), testDSN(t))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = closer.Close() })
+	st := openWriter(t, freshFeedSchema(t))
 
 	// Drive one query through the store. The exact query doesn't
 	// matter; we only need a pgx round-trip so the tracer fires.
 	_, _ = st.GetEntity(context.Background(), "nonexistent")
 
 	require.Contains(t, buf.String(), "pgstore: query",
-		"Open with Debug enabled should attach the tracer and queries should emit")
+		"Open should attach the tracer and queries should emit at Debug")
+}
+
+// TestQueryTracer_FromPoolRecordsStats proves per-request accounting
+// end-to-end: a context carrying store.QueryStats sees exactly the
+// statements the store issued, including those inside a Tx (pgx traces
+// BEGIN/COMMIT through the same connection tracer, so a transaction costs
+// more than its body — that is the honest number).
+func TestQueryTracer_FromPoolRecordsStats(t *testing.T) {
+	st := openWriter(t, freshFeedSchema(t))
+
+	ctx, stats := store.WithQueryStats(context.Background())
+	_, _ = st.GetEntity(ctx, "nonexistent")
+	require.EqualValues(t, 1, stats.Queries(), "GetEntity is one round-trip")
+	require.Positive(t, stats.Duration().Nanoseconds())
+
+	before := stats.Queries()
+	require.NoError(t, st.Tx(ctx, func(view store.Store) error {
+		_, _ = view.GetEntity(ctx, "nonexistent")
+		return nil
+	}))
+	require.Greater(t, stats.Queries(), before+1,
+		"a Tx must account its body AND the transaction statements around it")
+
+	// A context without stats must not disturb another request's counters.
+	after := stats.Queries()
+	_, _ = st.GetEntity(context.Background(), "nonexistent")
+	require.Equal(t, after, stats.Queries())
 }

--- a/internal/store/pgstore/tracer_test.go
+++ b/internal/store/pgstore/tracer_test.go
@@ -7,24 +7,27 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
-// TestDebugQueryTracer_LogsAtDebugLevel exercises the tracer
-// directly (without a real pgx connection) to confirm:
+// TestQueryTracer_LogsAtDebugLevel exercises the tracer directly (without
+// a real pgx connection) to confirm:
 //
 //   - At slog.Debug it emits one record per (Start, End) pair.
-//   - At slog.Info it emits nothing — the per-query overhead is
-//     limited to the (cheap) context value alloc.
+//   - At slog.Info it emits nothing and, with no stats on the context,
+//     returns the context UNCHANGED — the production no-alloc guarantee.
 //   - The emitted record carries the SQL text and a non-negative
 //     duration_us.
 //
 // The full integration (pool → query → tracer) is covered by
-// TestDebugQueryTracer_FromPoolEmits in tracer_pool_test.go.
-func TestDebugQueryTracer_LogsAtDebugLevel(t *testing.T) {
+// TestQueryTracer_FromPoolEmits in tracer_pool_test.go.
+func TestQueryTracer_LogsAtDebugLevel(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		level    slog.Level
@@ -38,8 +41,9 @@ func TestDebugQueryTracer_LogsAtDebugLevel(t *testing.T) {
 			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: tc.level})
 			t.Cleanup(swapDefaultLogger(slog.New(h)))
 
-			tr := debugQueryTracer{}
-			ctx := tr.TraceQueryStart(context.Background(), nil, pgx.TraceQueryStartData{
+			tr := queryTracer{}
+			base := context.Background()
+			ctx := tr.TraceQueryStart(base, nil, pgx.TraceQueryStartData{
 				SQL:  "SELECT 1",
 				Args: []any{42},
 			})
@@ -54,9 +58,32 @@ func TestDebugQueryTracer_LogsAtDebugLevel(t *testing.T) {
 				require.Contains(t, out, "duration_us=")
 			} else {
 				require.Empty(t, out, "Info level should not emit Debug traces")
+				require.Equal(t, base, ctx,
+					"with Debug off and no stats the tracer must not allocate a derived context")
 			}
 		})
 	}
+}
+
+// TestQueryTracer_RecordsIntoContextStats: a context carrying
+// store.QueryStats is accounted regardless of log level, and an errored
+// statement still counts — a failed round-trip is still a round-trip.
+func TestQueryTracer_RecordsIntoContextStats(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	t.Cleanup(swapDefaultLogger(slog.New(h)))
+
+	tr := queryTracer{}
+	ctx, stats := store.WithQueryStats(context.Background())
+
+	for i, err := range []error{nil, context.DeadlineExceeded} {
+		qctx := tr.TraceQueryStart(ctx, nil, pgx.TraceQueryStartData{SQL: "SELECT 1"})
+		time.Sleep(time.Millisecond)
+		tr.TraceQueryEnd(qctx, nil, pgx.TraceQueryEndData{Err: err})
+		require.EqualValues(t, i+1, stats.Queries())
+	}
+	require.Greater(t, stats.Duration(), time.Duration(0))
+	require.Empty(t, buf.String(), "accounting must not log at Info")
 }
 
 // swapDefaultLogger replaces slog.Default and returns a closer that

--- a/internal/store/pgstore/userstate.go
+++ b/internal/store/pgstore/userstate.go
@@ -155,6 +155,87 @@ func (s *UserStateStore) MutedSources(ctx context.Context, user string) ([]strin
 	return out, nil
 }
 
+// SnoozedUntilMany reads every live snooze for the keys in one statement:
+// the keys are shipped as parallel arrays and joined by ordinal, which keeps
+// (user, source, entity, variant) tuples intact without a VALUES list of
+// variable width.
+func (s *UserStateStore) SnoozedUntilMany(
+	ctx context.Context, keys []userstate.Key, now time.Time,
+) (map[userstate.Key]time.Time, error) {
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	out := make(map[userstate.Key]time.Time, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	users, sources, entities, variants := splitKeys(keys)
+	const q = `
+		SELECT s.user_id, s.source, s.entity_id, s.variant, s.until
+		FROM next_action_snoozes s
+		JOIN unnest($1::text[], $2::text[], $3::text[], $4::text[]) AS k(user_id, source, entity_id, variant)
+		  ON s.user_id = k.user_id AND s.source = k.source AND s.entity_id = k.entity_id AND s.variant = k.variant
+		WHERE s.until > $5`
+	rows, err := s.db.Query(ctx, q, users, sources, entities, variants, now)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: snooze batch lookup: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var k userstate.Key
+		var until time.Time
+		if err := rows.Scan(&k.User, &k.Source, &k.EntityID, &k.Variant, &until); err != nil {
+			return nil, err
+		}
+		out[k] = until
+	}
+	return out, rows.Err()
+}
+
+// LastShownMany is LastShown for a batch, in one statement (see
+// SnoozedUntilMany for the key transport).
+func (s *UserStateStore) LastShownMany(
+	ctx context.Context, keys []userstate.Key,
+) (map[userstate.Key]time.Time, error) {
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	out := make(map[userstate.Key]time.Time, len(keys))
+	if len(keys) == 0 {
+		return out, nil
+	}
+	users, sources, entities, variants := splitKeys(keys)
+	const q = `
+		SELECT s.user_id, s.source, s.entity_id, s.variant, s.shown_at
+		FROM next_action_shown s
+		JOIN unnest($1::text[], $2::text[], $3::text[], $4::text[]) AS k(user_id, source, entity_id, variant)
+		  ON s.user_id = k.user_id AND s.source = k.source AND s.entity_id = k.entity_id AND s.variant = k.variant`
+	rows, err := s.db.Query(ctx, q, users, sources, entities, variants)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: last-shown batch lookup: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var k userstate.Key
+		var at time.Time
+		if err := rows.Scan(&k.User, &k.Source, &k.EntityID, &k.Variant, &at); err != nil {
+			return nil, err
+		}
+		out[k] = at
+	}
+	return out, rows.Err()
+}
+
+func splitKeys(keys []userstate.Key) (users, sources, entities, variants []string) {
+	for _, k := range keys {
+		users = append(users, k.User)
+		sources = append(sources, k.Source)
+		entities = append(entities, k.EntityID)
+		variants = append(variants, k.Variant)
+	}
+	return users, sources, entities, variants
+}
+
 func (s *UserStateStore) LastShown(ctx context.Context, key userstate.Key) (time.Time, bool, error) {
 	if s.closed {
 		return time.Time{}, false, userstate.ErrClosed

--- a/internal/store/pgstore/visiblesearch.go
+++ b/internal/store/pgstore/visiblesearch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -277,7 +278,8 @@ func buildVisibleSearchSQL(
 	if q.Text != "" {
 		needle := strings.ToLower(q.Text)
 		sb.WriteString(" AND e.search_text LIKE '%' || " + b.arg(escapeLike(needle)) + ` || '%' ESCAPE '\'`)
-		orderBy = " ORDER BY similarity(e.search_text, " + b.arg(needle) + ") DESC, e.id ASC"
+		orderBy = " ORDER BY similarity(left(e.search_text, " + strconv.Itoa(searchRankPrefix) + "), " +
+			b.arg(needle) + ") DESC, e.id ASC"
 	}
 	if len(q.Types) > 0 {
 		sb.WriteString(" AND e.type = ANY(" + b.arg(q.Types) + ")")

--- a/internal/store/pgstore/world.go
+++ b/internal/store/pgstore/world.go
@@ -45,6 +45,22 @@ import (
 // rewriting generated SQL with ReplaceAll would corrupt any column whose
 // name merely CONTAINS "face" — from_face is one — and would break
 // silently the moment this function emits a new column.
+// effectiveWorld collapses a world to the default world for a query bound
+// to ONE entity type the world does not scope (TKT-1U8XYN). For such a type
+// the world's candidate predicate reduces to `face = ”` and its rank to a
+// constant, so the DISTINCT ON + CASE machinery would only cost — every
+// row of a faceless type is its own prime. The result is byte-identical;
+// the plan is an index scan instead of a sort over the whole type.
+func effectiveWorld(w store.WorldScope, entityType string) store.WorldScope {
+	if entityType == "" || w.IsDefaultWorld() {
+		return w
+	}
+	if _, scoped := w.For(entityType); scoped {
+		return w
+	}
+	return store.DefaultWorld()
+}
+
 func worldSQL(w store.WorldScope, alias string, args *[]any) (rank, candidate string) {
 	col := func(name string) string {
 		if alias == "" {

--- a/internal/store/pgstore/world.go
+++ b/internal/store/pgstore/world.go
@@ -45,12 +45,7 @@ import (
 // rewriting generated SQL with ReplaceAll would corrupt any column whose
 // name merely CONTAINS "face" — from_face is one — and would break
 // silently the moment this function emits a new column.
-// effectiveWorld collapses a world to the default world for a query bound
-// to ONE entity type the world does not scope (TKT-1U8XYN). For such a type
-// the world's candidate predicate reduces to `face = ”` and its rank to a
-// constant, so the DISTINCT ON + CASE machinery would only cost — every
-// row of a faceless type is its own prime. The result is byte-identical;
-// the plan is an index scan instead of a sort over the whole type.
+
 func effectiveWorld(w store.WorldScope, entityType string) store.WorldScope {
 	if entityType == "" || w.IsDefaultWorld() {
 		return w
@@ -61,6 +56,12 @@ func effectiveWorld(w store.WorldScope, entityType string) store.WorldScope {
 	return store.DefaultWorld()
 }
 
+// effectiveWorld collapses a world to the default world for a query bound
+// to ONE entity type the world does not scope (TKT-1U8XYN). For such a type
+// the world's candidate predicate reduces to `face = ”` and its rank to a
+// constant, so the DISTINCT ON + CASE machinery would only cost — every
+// row of a faceless type is its own prime. The result is byte-identical;
+// the plan is an index scan instead of a sort over the whole type.
 func worldSQL(w store.WorldScope, alias string, args *[]any) (rank, candidate string) {
 	col := func(name string) string {
 		if alias == "" {

--- a/internal/store/querystats.go
+++ b/internal/store/querystats.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
+
+// QueryStats accumulates the storage work performed on behalf of one
+// operation — typically one HTTP request. A backend that talks to an
+// external database records every statement it issues against the stats
+// found on the context; the fs and memory backends record nothing, which is
+// honest: they have no per-statement cost to report.
+//
+// The value is meant to answer "how many round-trips did this request cost,
+// and how long did the database spend on them?", the two numbers that make
+// an N+1 pattern visible before it becomes a latency complaint. It is NOT a
+// tracing facility — no per-statement detail is kept, so the memory cost is
+// two counters regardless of how many statements run.
+//
+// Safe for concurrent use: a request that fans out to goroutines sharing its
+// context accumulates into the same counters.
+type QueryStats struct {
+	queries atomic.Int64
+	nanos   atomic.Int64
+}
+
+// Record adds one statement of the given duration.
+func (s *QueryStats) Record(d time.Duration) {
+	s.queries.Add(1)
+	s.nanos.Add(int64(d))
+}
+
+// Queries returns the number of statements recorded so far.
+func (s *QueryStats) Queries() int64 { return s.queries.Load() }
+
+// Duration returns the summed statement durations recorded so far. It is
+// database time, not wall time: statements issued concurrently overlap, and
+// time spent in Go between statements is not included.
+func (s *QueryStats) Duration() time.Duration { return time.Duration(s.nanos.Load()) }
+
+type queryStatsKey struct{}
+
+// WithQueryStats attaches a fresh QueryStats to ctx and returns both. The
+// caller that starts an operation (a request middleware, a job runner) owns
+// the returned stats and reads them when the operation ends.
+func WithQueryStats(ctx context.Context) (context.Context, *QueryStats) {
+	s := &QueryStats{}
+	return context.WithValue(ctx, queryStatsKey{}, s), s
+}
+
+// QueryStatsFrom returns the QueryStats attached to ctx.
+//
+// Nil: returned when the context carries none — a backend records against it
+// only when non-nil, so an operation that never asked for stats costs nothing
+// beyond this lookup.
+func QueryStatsFrom(ctx context.Context) *QueryStats {
+	s, _ := ctx.Value(queryStatsKey{}).(*QueryStats)
+	return s
+}

--- a/internal/store/querystats_test.go
+++ b/internal/store/querystats_test.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestQueryStats_AbsentIsNil(t *testing.T) {
+	if got := QueryStatsFrom(context.Background()); got != nil {
+		t.Fatalf("QueryStatsFrom on a bare context = %v, want nil", got)
+	}
+}
+
+func TestQueryStats_RecordsCountAndDuration(t *testing.T) {
+	ctx, stats := WithQueryStats(context.Background())
+	if QueryStatsFrom(ctx) != stats {
+		t.Fatal("QueryStatsFrom should return the value WithQueryStats attached")
+	}
+	stats.Record(3 * time.Millisecond)
+	stats.Record(2 * time.Millisecond)
+	if got := stats.Queries(); got != 2 {
+		t.Errorf("Queries = %d, want 2", got)
+	}
+	if got := stats.Duration(); got != 5*time.Millisecond {
+		t.Errorf("Duration = %v, want 5ms", got)
+	}
+}
+
+func TestQueryStats_ConcurrentRecordIsExact(t *testing.T) {
+	_, stats := WithQueryStats(context.Background())
+	const workers, perWorker = 8, 1000
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for range perWorker {
+				stats.Record(time.Microsecond)
+			}
+		})
+	}
+	wg.Wait()
+	if got := stats.Queries(); got != workers*perWorker {
+		t.Errorf("Queries = %d, want %d", got, workers*perWorker)
+	}
+	if got := stats.Duration(); got != workers*perWorker*time.Microsecond {
+		t.Errorf("Duration = %v, want %v", got, workers*perWorker*time.Microsecond)
+	}
+}
+
+func TestQueryStats_ChildContextSharesParentStats(t *testing.T) {
+	ctx, stats := WithQueryStats(context.Background())
+	child, cancel := context.WithCancel(ctx)
+	defer cancel()
+	QueryStatsFrom(child).Record(time.Millisecond)
+	if got := stats.Queries(); got != 1 {
+		t.Errorf("a derived context must record into the same stats; Queries = %d", got)
+	}
+}

--- a/internal/store/sqlitestore/relation.go
+++ b/internal/store/sqlitestore/relation.go
@@ -120,6 +120,29 @@ func buildRelationQueryFrom(q store.RelationQuery, cursorKey string) (sqlText st
 			args = append(args, q.EntityID, q.EntityID)
 		}
 	}
+	if q.EntityIDs != nil {
+		// SQLite has no array parameters: expand to a placeholder list. An
+		// empty slice becomes a constant-false predicate so nil-vs-empty
+		// keeps its documented meaning (nil = unfiltered, empty = nothing).
+		in := "(NULL)"
+		if len(q.EntityIDs) > 0 {
+			in = "(" + strings.TrimSuffix(strings.Repeat("?,", len(q.EntityIDs)), ",") + ")"
+		}
+		for _, id := range q.EntityIDs {
+			args = append(args, id)
+		}
+		switch q.Direction {
+		case store.DirectionOutgoing:
+			conds = append(conds, "from_id IN "+in)
+		case store.DirectionIncoming:
+			conds = append(conds, "to_id IN "+in)
+		default:
+			for _, id := range q.EntityIDs {
+				args = append(args, id)
+			}
+			conds = append(conds, "(from_id IN "+in+" OR to_id IN "+in+")")
+		}
+	}
 
 	sqlText = `SELECT ` + relationColumns + ` FROM relations`
 	if len(conds) > 0 {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -421,8 +421,17 @@ type RelationQuery struct {
 	Type      string    // filter by relation type
 	EntityID  string    // filter by either endpoint (From OR To)
 	Direction Direction // outgoing, incoming, or both
-	Cursor    string    // pagination cursor from a previous page (empty = start); ignored by ListRelations
-	Limit     int       // max relations per page (0 = no limit); ignored by ListRelations
+
+	// EntityIDs is the plural of EntityID: the edge's endpoint (per
+	// Direction, exactly as for EntityID) must be one of these ids. It
+	// exists so a page of rows loads its edges in ONE query instead of one
+	// per row (TKT-1U8XYN); it composes with Type and FromFace like EntityID
+	// does. Nil means unfiltered; an empty, non-nil slice matches nothing —
+	// a caller that computed "no ids" must get no edges, not all of them.
+	// When both EntityID and EntityIDs are set an edge must satisfy both.
+	EntityIDs []string
+	Cursor    string // pagination cursor from a previous page (empty = start); ignored by ListRelations
+	Limit     int    // max relations per page (0 = no limit); ignored by ListRelations
 
 	// FromFace filters on the state-specific tail of an edge
 	// (TKT-DOFYR1). nil — the zero value — leaves the tail UNFILTERED:

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -560,6 +560,13 @@ type EntityHeader struct {
 	// header read reports redaction exactly like a gated entity read —
 	// a header must never look MORE complete than the entity it projects.
 	Redacted []string
+
+	// Inaccessible mirrors [entity.Entity.Inaccessible]: the fields a
+	// storage-level failure (an undecryptable git-crypt file) withheld. A
+	// list rendered from headers must show the same lock a list rendered
+	// from entities did (TKT-1U8XYN); dropping it here silently un-locked
+	// every cell of an encrypted row.
+	Inaccessible []entity.InaccessibleField
 }
 
 // HeaderReader lists entities without their body content.
@@ -586,12 +593,13 @@ type HeaderReader interface {
 // avoid one. Do not mutate a header's Properties.
 func HeaderOf(e *entity.Entity) EntityHeader {
 	return EntityHeader{
-		ID:         e.ID,
-		Type:       e.Type,
-		Face:       e.Face,
-		Properties: e.Properties,
-		UpdatedAt:  e.UpdatedAt,
-		Redacted:   e.Redacted,
+		ID:           e.ID,
+		Type:         e.Type,
+		Face:         e.Face,
+		Properties:   e.Properties,
+		UpdatedAt:    e.UpdatedAt,
+		Redacted:     e.Redacted,
+		Inaccessible: e.Inaccessible,
 	}
 }
 

--- a/internal/store/storetest/counting.go
+++ b/internal/store/storetest/counting.go
@@ -1,0 +1,187 @@
+package storetest
+
+import (
+	"context"
+	"iter"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// Counting decorates a store.Store and counts every read call by method
+// name, so a test can pin how many store round-trips an operation costs —
+// the backend-agnostic twin of the SQL accounting a postgres request gets
+// through store.QueryStats (TKT-1U8XYN). An N+1 in a handler is N store
+// calls whatever the backend, which is why this counts calls, not SQL.
+//
+// Reads are counted; writes pass through uncounted (a test seeds through
+// the same handle, and seeding is not the thing under measurement). The
+// optional capabilities a consumer type-asserts are forwarded: the header
+// reader (counted), and the transaction view (its reads counted too).
+type Counting struct {
+	store.Store
+
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+// NewCounting wraps s.
+func NewCounting(s store.Store) *Counting {
+	return &Counting{Store: s, calls: map[string]int{}}
+}
+
+func (c *Counting) hit(method string) {
+	c.mu.Lock()
+	c.calls[method]++
+	c.mu.Unlock()
+}
+
+// Reset clears the counters.
+func (c *Counting) Reset() {
+	c.mu.Lock()
+	c.calls = map[string]int{}
+	c.mu.Unlock()
+}
+
+// Reads returns the total number of read calls since the last Reset.
+func (c *Counting) Reads() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, v := range c.calls {
+		n += v
+	}
+	return n
+}
+
+// Calls returns a copy of the per-method counters.
+func (c *Counting) Calls() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]int, len(c.calls))
+	for k, v := range c.calls {
+		out[k] = v
+	}
+	return out
+}
+
+// String renders the counters as "Method=n Method=n", sorted, for test
+// failure messages.
+func (c *Counting) String() string {
+	calls := c.Calls()
+	keys := make([]string, 0, len(calls))
+	for k := range calls {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(itoa(calls[k]))
+	}
+	return b.String()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var d []byte
+	for n > 0 {
+		d = append([]byte{byte('0' + n%10)}, d...)
+		n /= 10
+	}
+	return string(d)
+}
+
+func (c *Counting) GetEntity(ctx context.Context, id string) (*entity.Entity, error) {
+	c.hit("GetEntity")
+	return c.Store.GetEntity(ctx, id)
+}
+
+func (c *Counting) GetEntityState(ctx context.Context, id string, face entity.Face) (*entity.Entity, error) {
+	c.hit("GetEntityState")
+	return c.Store.GetEntityState(ctx, id, face)
+}
+
+func (c *Counting) ListEntities(ctx context.Context, q store.EntityQuery) iter.Seq2[*entity.Entity, error] {
+	c.hit("ListEntities")
+	return c.Store.ListEntities(ctx, q)
+}
+
+func (c *Counting) ListEntitiesPage(ctx context.Context, q store.EntityQuery) (store.Page[*entity.Entity], error) {
+	c.hit("ListEntitiesPage")
+	return c.Store.ListEntitiesPage(ctx, q)
+}
+
+func (c *Counting) CountEntities(ctx context.Context, q store.EntityQuery) (int, error) {
+	c.hit("CountEntities")
+	return c.Store.CountEntities(ctx, q)
+}
+
+func (c *Counting) HighestID(ctx context.Context, prefix string) (int, error) {
+	c.hit("HighestID")
+	return c.Store.HighestID(ctx, prefix)
+}
+
+func (c *Counting) PropertyValues(ctx context.Context, property string, limit int) ([]string, error) {
+	c.hit("PropertyValues")
+	return c.Store.PropertyValues(ctx, property, limit)
+}
+
+func (c *Counting) GetRelation(ctx context.Context, from, relType, to string) (*entity.Relation, error) {
+	c.hit("GetRelation")
+	return c.Store.GetRelation(ctx, from, relType, to)
+}
+
+func (c *Counting) ListRelations(ctx context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
+	c.hit("ListRelations")
+	return c.Store.ListRelations(ctx, q)
+}
+
+func (c *Counting) ListRelationsPage(ctx context.Context, q store.RelationQuery) (store.Page[*entity.Relation], error) {
+	c.hit("ListRelationsPage")
+	return c.Store.ListRelationsPage(ctx, q)
+}
+
+func (c *Counting) CountRelations(ctx context.Context, q store.RelationQuery) (int, error) {
+	c.hit("CountRelations")
+	return c.Store.CountRelations(ctx, q)
+}
+
+func (c *Counting) GraphQuery(ctx context.Context, q store.GraphQuery) iter.Seq2[*entity.Entity, error] {
+	c.hit("GraphQuery")
+	return c.Store.GraphQuery(ctx, q)
+}
+
+func (c *Counting) GraphCount(ctx context.Context, q store.GraphQuery) (matched, total int, err error) {
+	c.hit("GraphCount")
+	return c.Store.GraphCount(ctx, q)
+}
+
+func (c *Counting) MatchingIDs(ctx context.Context, q store.GraphQuery, ids []string) (map[string]bool, error) {
+	c.hit("MatchingIDs")
+	return c.Store.MatchingIDs(ctx, q, ids)
+}
+
+// ListEntityHeaders forwards to the wrapped store's header reader, or to
+// the generic projection when it has none — either way it is counted as
+// one read.
+func (c *Counting) ListEntityHeaders(ctx context.Context, q store.EntityQuery) iter.Seq2[store.EntityHeader, error] {
+	c.hit("ListEntityHeaders")
+	return store.ListEntityHeaders(ctx, c.Store, q)
+}
+
+// Tx forwards the transaction, wrapping the view so reads inside it count.
+func (c *Counting) Tx(ctx context.Context, fn func(store.Store) error) error {
+	return c.Store.Tx(ctx, func(view store.Store) error {
+		return fn(&Counting{Store: view, calls: c.calls})
+	})
+}

--- a/internal/store/storetest/counting.go
+++ b/internal/store/storetest/counting.go
@@ -3,6 +3,7 @@ package storetest
 import (
 	"context"
 	"iter"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -62,9 +63,7 @@ func (c *Counting) Calls() map[string]int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	out := make(map[string]int, len(c.calls))
-	for k, v := range c.calls {
-		out[k] = v
-	}
+	maps.Copy(out, c.calls)
 	return out
 }
 

--- a/internal/store/storetest/graphquery.go
+++ b/internal/store/storetest/graphquery.go
@@ -2,7 +2,9 @@ package storetest
 
 import (
 	"context"
+	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -614,6 +616,140 @@ func seedEntityWithProps(t *testing.T, s store.Store, typ, id string, props map[
 }
 
 // mustRel creates a relation; fails the test on error.
+// RunGraphPagingTests pins GraphQuery.OrderBy/Limit/Offset (TKT-1U8XYN):
+// byte-wise ordering on the property's string form, rows without the
+// property last in either direction, id as tiebreak; a Limit/Offset window
+// equal to slicing the full ordered result; GraphCount unaffected by paging;
+// headers paging identically.
+func RunGraphPagingTests(t *testing.T, f Factory) {
+	seed := func(t *testing.T, s store.Store) {
+		t.Helper()
+		// due values chosen so byte order != insertion order, with two
+		// rows sharing a value (tiebreak) and two rows without one.
+		dues := []string{"2026-03-01", "", "2026-01-15", "2026-03-01", "", "2025-12-31"}
+		for i, due := range dues {
+			e := entity.New(fmt.Sprintf("T-%d", i), "ticket")
+			e.SetString("title", fmt.Sprintf("Ticket %d", i))
+			e.SetString("status", []string{"open", "done"}[i%2])
+			if due != "" {
+				e.SetString("due", due)
+			}
+			require.NoError(t, s.CreateEntity(ctx(), e))
+		}
+	}
+	ids := func(t *testing.T, s store.Store, q store.GraphQuery) []string {
+		t.Helper()
+		var out []string
+		for e, err := range s.GraphQuery(ctx(), q) {
+			require.NoError(t, err)
+			out = append(out, e.ID)
+		}
+		return out
+	}
+
+	t.Run("OrderMissingLastTiebreakID", func(t *testing.T) {
+		s := f(t)
+		seed(t, s)
+		asc := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: []store.OrderSpec{{Property: "due"}}})
+		require.Equal(t, []string{"T-5", "T-2", "T-0", "T-3", "T-1", "T-4"}, asc)
+		desc := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: []store.OrderSpec{{Property: "due", Descending: true}}})
+		require.Equal(t, []string{"T-0", "T-3", "T-2", "T-5", "T-1", "T-4"}, desc)
+	})
+
+	t.Run("WindowEqualsSlice", func(t *testing.T) {
+		s := f(t)
+		seed(t, s)
+		order := []store.OrderSpec{{Property: "due"}}
+		full := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: order})
+		for _, w := range []struct{ off, lim int }{{0, 2}, {2, 2}, {4, 10}, {6, 2}, {1, 0}} {
+			got := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: order, Offset: w.off, Limit: w.lim})
+			end := len(full)
+			if w.lim > 0 && w.off+w.lim < end {
+				end = w.off + w.lim
+			}
+			var want []string
+			if w.off < len(full) {
+				want = full[w.off:end]
+			}
+			require.Equal(t, want, got, "offset %d limit %d", w.off, w.lim)
+		}
+	})
+
+	t.Run("CountIgnoresPaging", func(t *testing.T) {
+		s := f(t)
+		seed(t, s)
+		q := store.GraphQuery{
+			EntityType: "ticket",
+			Props:      []store.PropPredicate{{Property: "status", Op: store.PropEqual, Value: "open"}},
+			OrderBy:    []store.OrderSpec{{Property: "due"}}, Limit: 1, Offset: 1,
+		}
+		matched, _, err := s.GraphCount(ctx(), q)
+		require.NoError(t, err)
+		require.Equal(t, 3, matched)
+		require.Len(t, ids(t, s, q), 1)
+	})
+
+	t.Run("HeadersPageTheSame", func(t *testing.T) {
+		s := f(t)
+		seed(t, s)
+		q := store.GraphQuery{EntityType: "ticket", OrderBy: []store.OrderSpec{{Property: "due", Descending: true}}, Limit: 3}
+		want := ids(t, s, q)
+		var got []string
+		for h, err := range store.GraphQueryHeaders(ctx(), s, q) {
+			require.NoError(t, err)
+			got = append(got, h.ID)
+		}
+		require.Equal(t, want, got)
+	})
+}
+
+// RunGraphHeaderTests pins the content-free projection of GraphQuery
+// (TKT-1U8XYN): for a type-plus-property query and a relation-predicate
+// query, store.GraphQueryHeaders yields exactly HeaderOf(row) for every row
+// GraphQuery yields, in the same order — whether the backend implements
+// store.GraphHeaderQueryer natively or through the generic fallback.
+func RunGraphHeaderTests(t *testing.T, f Factory) {
+	t.Run("HeadersMatchRows", func(t *testing.T) {
+		s := f(t)
+		for i := range 6 {
+			e := entity.New(fmt.Sprintf("T-%d", i), "ticket")
+			e.SetString("title", fmt.Sprintf("Ticket %d", i))
+			e.SetString("status", []string{"open", "done"}[i%2])
+			e.Content = strings.Repeat("body ", 50)
+			require.NoError(t, s.CreateEntity(ctx(), e))
+		}
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("F-1", "feature")))
+		mustRel(t, s, "T-1", "implements", "F-1")
+		mustRel(t, s, "T-3", "implements", "F-1")
+
+		queries := []store.GraphQuery{
+			{EntityType: "ticket"},
+			{EntityType: "ticket", Props: []store.PropPredicate{{Property: "status", Op: store.PropEqual, Value: "open"}}},
+			{EntityType: "ticket", HasOutbound: &store.RelationPredicate{OfTypes: []string{"implements"}}},
+		}
+		for i, q := range queries {
+			var want []store.EntityHeader
+			for e, err := range s.GraphQuery(ctx(), q) {
+				require.NoError(t, err)
+				want = append(want, store.HeaderOf(e))
+			}
+			var got []store.EntityHeader
+			for h, err := range store.GraphQueryHeaders(ctx(), s, q) {
+				require.NoError(t, err)
+				got = append(got, h)
+			}
+			require.NotEmpty(t, want, "query %d matched nothing; fixture is wrong", i)
+			require.Len(t, got, len(want), "query %d", i)
+			for j := range want {
+				require.Equal(t, want[j].ID, got[j].ID, "query %d row %d", i, j)
+				require.Equal(t, want[j].Type, got[j].Type)
+				require.Equal(t, want[j].Face, got[j].Face)
+				require.Equal(t, want[j].Properties, got[j].Properties)
+			}
+		}
+	})
+}
+
 func mustRel(t *testing.T, s store.Store, from, relType, to string) {
 	t.Helper()
 	_, err := s.CreateRelation(ctx(), from, relType, to, nil)

--- a/internal/store/storetest/graphquery.go
+++ b/internal/store/storetest/graphquery.go
@@ -615,7 +615,6 @@ func seedEntityWithProps(t *testing.T, s store.Store, typ, id string, props map[
 	require.NoError(t, s.CreateEntity(ctx(), e), "create %s/%s", typ, id)
 }
 
-// mustRel creates a relation; fails the test on error.
 // RunGraphPagingTests pins GraphQuery.OrderBy/Limit/Offset (TKT-1U8XYN):
 // byte-wise ordering on the property's string form, a row without the
 // property sorting as the largest value, id as tiebreak; a Limit/Offset window
@@ -625,13 +624,19 @@ func RunGraphPagingTests(t *testing.T, f Factory) {
 	seed := func(t *testing.T, s store.Store) {
 		t.Helper()
 		// due values chosen so byte order != insertion order, with two
-		// rows sharing a value (tiebreak) and two rows without one.
-		dues := []string{"2026-03-01", "", "2026-01-15", "2026-03-01", "", "2025-12-31"}
+		// rows sharing a value (tiebreak), two rows without the key, and one
+		// row holding a JSON null — which must sort with the absent rows, as
+		// SQL's `->>` yields NULL for it.
+		dues := []string{"2026-03-01", "", "2026-01-15", "2026-03-01", "", "2025-12-31", "null"}
 		for i, due := range dues {
 			e := entity.New(fmt.Sprintf("T-%d", i), "ticket")
 			e.SetString("title", fmt.Sprintf("Ticket %d", i))
 			e.SetString("status", []string{"open", "done"}[i%2])
-			if due != "" {
+			switch due {
+			case "":
+			case "null":
+				e.Properties["due"] = nil
+			default:
 				e.SetString("due", due)
 			}
 			require.NoError(t, s.CreateEntity(ctx(), e))
@@ -651,11 +656,11 @@ func RunGraphPagingTests(t *testing.T, f Factory) {
 		s := f(t)
 		seed(t, s)
 		asc := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: []store.OrderSpec{{Property: "due"}}})
-		require.Equal(t, []string{"T-5", "T-2", "T-0", "T-3", "T-1", "T-4"}, asc)
+		require.Equal(t, []string{"T-5", "T-2", "T-0", "T-3", "T-1", "T-4", "T-6"}, asc)
 		// Descending: the absent value is the largest, so the rows without
 		// `due` lead (SQL's default null placement; one index, both ways).
 		desc := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: []store.OrderSpec{{Property: "due", Descending: true}}})
-		require.Equal(t, []string{"T-1", "T-4", "T-0", "T-3", "T-2", "T-5"}, desc)
+		require.Equal(t, []string{"T-1", "T-4", "T-6", "T-0", "T-3", "T-2", "T-5"}, desc)
 	})
 
 	t.Run("WindowEqualsSlice", func(t *testing.T) {
@@ -687,7 +692,7 @@ func RunGraphPagingTests(t *testing.T, f Factory) {
 		}
 		matched, _, err := s.GraphCount(ctx(), q)
 		require.NoError(t, err)
-		require.Equal(t, 3, matched)
+		require.Equal(t, 4, matched)
 		require.Len(t, ids(t, s, q), 1)
 	})
 
@@ -768,6 +773,7 @@ func RunGraphHeaderTests(t *testing.T, f Factory) {
 	})
 }
 
+// mustRel creates a relation; fails the test on error.
 func mustRel(t *testing.T, s store.Store, from, relType, to string) {
 	t.Helper()
 	_, err := s.CreateRelation(ctx(), from, relType, to, nil)

--- a/internal/store/storetest/graphquery.go
+++ b/internal/store/storetest/graphquery.go
@@ -617,8 +617,8 @@ func seedEntityWithProps(t *testing.T, s store.Store, typ, id string, props map[
 
 // mustRel creates a relation; fails the test on error.
 // RunGraphPagingTests pins GraphQuery.OrderBy/Limit/Offset (TKT-1U8XYN):
-// byte-wise ordering on the property's string form, rows without the
-// property last in either direction, id as tiebreak; a Limit/Offset window
+// byte-wise ordering on the property's string form, a row without the
+// property sorting as the largest value, id as tiebreak; a Limit/Offset window
 // equal to slicing the full ordered result; GraphCount unaffected by paging;
 // headers paging identically.
 func RunGraphPagingTests(t *testing.T, f Factory) {
@@ -652,8 +652,10 @@ func RunGraphPagingTests(t *testing.T, f Factory) {
 		seed(t, s)
 		asc := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: []store.OrderSpec{{Property: "due"}}})
 		require.Equal(t, []string{"T-5", "T-2", "T-0", "T-3", "T-1", "T-4"}, asc)
+		// Descending: the absent value is the largest, so the rows without
+		// `due` lead (SQL's default null placement; one index, both ways).
 		desc := ids(t, s, store.GraphQuery{EntityType: "ticket", OrderBy: []store.OrderSpec{{Property: "due", Descending: true}}})
-		require.Equal(t, []string{"T-0", "T-3", "T-2", "T-5", "T-1", "T-4"}, desc)
+		require.Equal(t, []string{"T-1", "T-4", "T-0", "T-3", "T-2", "T-5"}, desc)
 	})
 
 	t.Run("WindowEqualsSlice", func(t *testing.T) {
@@ -687,6 +689,22 @@ func RunGraphPagingTests(t *testing.T, f Factory) {
 		require.NoError(t, err)
 		require.Equal(t, 3, matched)
 		require.Len(t, ids(t, s, q), 1)
+	})
+
+	t.Run("CountMatchedEqualsGraphCountMatched", func(t *testing.T) {
+		s := f(t)
+		seed(t, s)
+		q := store.GraphQuery{
+			EntityType: "ticket",
+			Props:      []store.PropPredicate{{Property: "status", Op: store.PropEqual, Value: "done"}},
+			OrderBy:    []store.OrderSpec{{Property: "due"}}, Limit: 1,
+		}
+		matched, _, err := s.GraphCount(ctx(), q)
+		require.NoError(t, err)
+		got, err := store.CountMatched(ctx(), s, q)
+		require.NoError(t, err)
+		require.Equal(t, matched, got)
+		require.Equal(t, 3, got, "T-1, T-3, T-5 are done")
 	})
 
 	t.Run("HeadersPageTheSame", func(t *testing.T) {

--- a/internal/store/storetest/relation.go
+++ b/internal/store/storetest/relation.go
@@ -239,6 +239,81 @@ func RunRelationTests(t *testing.T, f Factory) {
 		assert.Empty(t, keys)
 	})
 
+	// EntityIDs is the plural of EntityID under the same Direction/FromFace
+	// semantics (TKT-1U8XYN): the batch must equal the union of the scalar
+	// calls, nil must mean unfiltered and empty must mean nothing.
+	t.Run("ListEntityIDsBatchEqualsUnionOfScalarCalls", func(t *testing.T) {
+		s := f(t)
+		for _, id := range []string{"A", "B", "C", "D"} {
+			require.NoError(t, s.CreateEntity(ctx(), entity.New(id, "node")))
+		}
+		for _, r := range [][3]string{{"A", "links", "B"}, {"B", "links", "C"}, {"C", "links", "D"}, {"D", "other", "A"}} {
+			_, err := s.CreateRelation(ctx(), r[0], r[1], r[2], nil)
+			require.NoError(t, err)
+		}
+		keys := func(q store.RelationQuery) map[string]bool {
+			out := map[string]bool{}
+			for r, err := range s.ListRelations(ctx(), q) {
+				require.NoError(t, err)
+				out[r.Key()] = true
+			}
+			return out
+		}
+		for _, dir := range []store.Direction{store.DirectionOutgoing, store.DirectionIncoming, store.DirectionBoth} {
+			for _, relType := range []string{"", "links"} {
+				want := map[string]bool{}
+				for _, id := range []string{"A", "C"} {
+					for k := range keys(store.RelationQuery{EntityID: id, Direction: dir, Type: relType}) {
+						want[k] = true
+					}
+				}
+				got := keys(store.RelationQuery{EntityIDs: []string{"A", "C"}, Direction: dir, Type: relType})
+				require.Equal(t, want, got, "direction %v type %q", dir, relType)
+			}
+		}
+		// Duplicated and unknown ids are harmless.
+		require.Len(t, keys(store.RelationQuery{EntityIDs: []string{"A", "A", "nope"}, Direction: store.DirectionOutgoing}), 1)
+	})
+
+	t.Run("ListEntityIDsNilIsUnfilteredEmptyIsNothing", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("A", "node")))
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("B", "node")))
+		_, err := s.CreateRelation(ctx(), "A", "links", "B", nil)
+		require.NoError(t, err)
+		count := func(q store.RelationQuery) int {
+			n := 0
+			for _, err := range s.ListRelations(ctx(), q) {
+				require.NoError(t, err)
+				n++
+			}
+			return n
+		}
+		require.Equal(t, 1, count(store.RelationQuery{EntityIDs: nil}), "nil EntityIDs must not filter")
+		require.Equal(t, 0, count(store.RelationQuery{EntityIDs: []string{}}), "empty EntityIDs must match nothing")
+		for _, dir := range []store.Direction{store.DirectionOutgoing, store.DirectionIncoming, store.DirectionBoth} {
+			c, err := s.CountRelations(ctx(), store.RelationQuery{EntityIDs: []string{}, Direction: dir})
+			require.NoError(t, err)
+			require.Equal(t, 0, c)
+		}
+	})
+
+	t.Run("ListEntityIDsComposesWithEntityID", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("A", "node")))
+		require.NoError(t, s.CreateEntity(ctx(), entity.New("B", "node")))
+		_, err := s.CreateRelation(ctx(), "A", "links", "B", nil)
+		require.NoError(t, err)
+		n := 0
+		for _, err := range s.ListRelations(ctx(), store.RelationQuery{
+			EntityID: "B", EntityIDs: []string{"A"}, Direction: store.DirectionOutgoing,
+		}) {
+			require.NoError(t, err)
+			n++
+		}
+		require.Equal(t, 0, n, "both filters apply: B is not a source in the batch")
+	})
+
 	t.Run("CreateRejectsEmptyFrom", func(t *testing.T) {
 		s := f(t)
 		require.NoError(t, s.CreateEntity(ctx(), entity.New("B", "req")))

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -173,6 +173,8 @@ func RunAll(t *testing.T, f Factory, sf SearchFactory, vsf VisibleSearchFactory,
 	t.Run("Relation", func(t *testing.T) { RunRelationTests(t, f) })
 	t.Run("Query", func(t *testing.T) { RunQueryTests(t, f) })
 	t.Run("GraphQuery", func(t *testing.T) { RunGraphQueryTests(t, f) })
+	t.Run("GraphHeaders", func(t *testing.T) { RunGraphHeaderTests(t, f) })
+	t.Run("GraphPaging", func(t *testing.T) { RunGraphPagingTests(t, f) })
 	t.Run("Pagination", func(t *testing.T) { RunPaginationTests(t, f) })
 	if sf != nil {
 		t.Run("Search", func(t *testing.T) { RunSearchTests(t, sf) })

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -308,6 +308,24 @@ func StateTypeMismatchError(id string, p entity.Face, got, want string) error {
 // which is today's behavior for faceless projects; non-nil matches
 // by equality only (the store never inspects face contents).
 func MatchRelation(r *entity.Relation, q store.RelationQuery) bool {
+	return NewRelationMatcher(q)(r)
+}
+
+// NewRelationMatcher compiles q once — the EntityIDs set in particular —
+// into a predicate for a scan. A loop over N relations must use this rather
+// than [MatchRelation], which would rebuild the batch set per row.
+func NewRelationMatcher(q store.RelationQuery) func(*entity.Relation) bool {
+	var set map[string]struct{}
+	if q.EntityIDs != nil {
+		set = make(map[string]struct{}, len(q.EntityIDs))
+		for _, id := range q.EntityIDs {
+			set[id] = struct{}{}
+		}
+	}
+	return func(r *entity.Relation) bool { return matchRelation(r, q, set) }
+}
+
+func matchRelation(r *entity.Relation, q store.RelationQuery, set map[string]struct{}) bool {
 	if q.Type != "" && r.Type != q.Type {
 		return false
 	}
@@ -324,10 +342,6 @@ func MatchRelation(r *entity.Relation, q store.RelationQuery) bool {
 		return false
 	}
 	if q.EntityIDs != nil {
-		set := make(map[string]struct{}, len(q.EntityIDs))
-		for _, id := range q.EntityIDs {
-			set[id] = struct{}{}
-		}
 		if !endpointMatches(r, q.Direction, func(id string) bool { _, ok := set[id]; return ok }) {
 			return false
 		}

--- a/internal/store/storeutil/storeutil.go
+++ b/internal/store/storeutil/storeutil.go
@@ -320,23 +320,33 @@ func MatchRelation(r *entity.Relation, q store.RelationQuery) bool {
 	if q.To != "" && r.To != q.To {
 		return false
 	}
-	if q.EntityID != "" {
-		switch q.Direction {
-		case store.DirectionOutgoing:
-			if r.From != q.EntityID {
-				return false
-			}
-		case store.DirectionIncoming:
-			if r.To != q.EntityID {
-				return false
-			}
-		default: // DirectionBoth
-			if r.From != q.EntityID && r.To != q.EntityID {
-				return false
-			}
+	if q.EntityID != "" && !endpointMatches(r, q.Direction, func(id string) bool { return id == q.EntityID }) {
+		return false
+	}
+	if q.EntityIDs != nil {
+		set := make(map[string]struct{}, len(q.EntityIDs))
+		for _, id := range q.EntityIDs {
+			set[id] = struct{}{}
+		}
+		if !endpointMatches(r, q.Direction, func(id string) bool { _, ok := set[id]; return ok }) {
+			return false
 		}
 	}
 	return true
+}
+
+// endpointMatches reports whether the endpoint(s) Direction selects on r
+// satisfy want: the source for outgoing, the target for incoming, either
+// for both.
+func endpointMatches(r *entity.Relation, dir store.Direction, want func(id string) bool) bool {
+	switch dir {
+	case store.DirectionOutgoing:
+		return want(r.From)
+	case store.DirectionIncoming:
+		return want(r.To)
+	default: // DirectionBoth
+		return want(r.From) || want(r.To)
+	}
 }
 
 // ValidateEntityQuery rejects a query whose fields contradict each

--- a/internal/userstate/kvuserstate/kv.go
+++ b/internal/userstate/kvuserstate/kv.go
@@ -177,6 +177,46 @@ func (s *Store) SnoozedUntil(
 	return until, true, nil
 }
 
+func (s *Store) SnoozedUntilMany(
+	ctx context.Context, keys []userstate.Key, now time.Time,
+) (map[userstate.Key]time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[userstate.Key]time.Time, len(keys))
+	for _, k := range keys {
+		if until, ok := doc.Snoozes[keyString(k)]; ok && now.Before(until) {
+			out[k] = until
+		}
+	}
+	return out, nil
+}
+
+func (s *Store) LastShownMany(ctx context.Context, keys []userstate.Key) (map[userstate.Key]time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	doc, err := s.load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[userstate.Key]time.Time, len(keys))
+	for _, k := range keys {
+		if at, ok := doc.Shown[keyString(k)]; ok {
+			out[k] = at
+		}
+	}
+	return out, nil
+}
+
 func (s *Store) SetSnooze(ctx context.Context, key userstate.Key, until time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/userstate/memuserstate/mem.go
+++ b/internal/userstate/memuserstate/mem.go
@@ -57,6 +57,38 @@ func (s *Store) SnoozedUntil(
 	return until, true, nil
 }
 
+func (s *Store) SnoozedUntilMany(
+	_ context.Context, keys []userstate.Key, now time.Time,
+) (map[userstate.Key]time.Time, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	out := make(map[userstate.Key]time.Time, len(keys))
+	for _, k := range keys {
+		if until, ok := s.snoozes[k]; ok && now.Before(until) {
+			out[k] = until
+		}
+	}
+	return out, nil
+}
+
+func (s *Store) LastShownMany(_ context.Context, keys []userstate.Key) (map[userstate.Key]time.Time, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, userstate.ErrClosed
+	}
+	out := make(map[userstate.Key]time.Time, len(keys))
+	for _, k := range keys {
+		if at, ok := s.shown[k]; ok {
+			out[k] = at
+		}
+	}
+	return out, nil
+}
+
 func (s *Store) SetSnooze(_ context.Context, key userstate.Key, until time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/userstate/userstate.go
+++ b/internal/userstate/userstate.go
@@ -99,6 +99,15 @@ type Store interface {
 	// it ever was. Drives cooldown.
 	LastShown(ctx context.Context, key Key) (at time.Time, ok bool, err error)
 
+	// SnoozedUntilMany is SnoozedUntil for a batch: the live snooze deadline
+	// per key that has one, in one round-trip (TKT-1U8XYN — the next-action
+	// engine judges every candidate of a source and paid two lookups each).
+	// A key with no live snooze is absent from the result.
+	SnoozedUntilMany(ctx context.Context, keys []Key, now time.Time) (map[Key]time.Time, error)
+
+	// LastShownMany is LastShown for a batch; keys never shown are absent.
+	LastShownMany(ctx context.Context, keys []Key) (map[Key]time.Time, error)
+
 	// MarkShown records that the suggestion was surfaced at `at`.
 	MarkShown(ctx context.Context, key Key, at time.Time) error
 

--- a/internal/userstate/userstatetest/userstatetest.go
+++ b/internal/userstate/userstatetest/userstatetest.go
@@ -52,9 +52,65 @@ func RunAll(t *testing.T, f Factory) {
 	t.Run("Snooze", func(t *testing.T) { RunSnoozeTests(t, f) })
 	t.Run("Mute", func(t *testing.T) { RunMuteTests(t, f) })
 	t.Run("Shown", func(t *testing.T) { RunShownTests(t, f) })
+	t.Run("Batch", func(t *testing.T) { RunBatchTests(t, f) })
 	t.Run("Prune", func(t *testing.T) { RunPruneTests(t, f) })
 	t.Run("Isolation", func(t *testing.T) { RunIsolationTests(t, f) })
 	t.Run("Closed", func(t *testing.T) { RunClosedTests(t, f) })
+}
+
+// RunBatchTests pins SnoozedUntilMany / LastShownMany (TKT-1U8XYN): each
+// equals the per-key call for every key, absent keys are absent, an empty
+// batch is an empty map, and expiry is judged the same way.
+func RunBatchTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("empty batch", func(t *testing.T) {
+		s := f(t)
+		got, err := s.SnoozedUntilMany(ctx, nil, base)
+		require.NoError(t, err)
+		require.Empty(t, got)
+		shown, err := s.LastShownMany(ctx, nil)
+		require.NoError(t, err)
+		require.Empty(t, shown)
+	})
+
+	t.Run("matches the per-key calls", func(t *testing.T) {
+		s := f(t)
+		live, expired, shownK, never := key("alice", "stale", "T-1"), key("alice", "stale", "T-2"),
+			key("alice", "stale", "T-3"), key("bob", "stale", "T-1")
+		require.NoError(t, s.SetSnooze(ctx, live, base.Add(oneDay)))
+		require.NoError(t, s.SetSnooze(ctx, expired, base.Add(-oneHourSpan)))
+		require.NoError(t, s.MarkShown(ctx, shownK, base))
+		require.NoError(t, s.MarkShown(ctx, live, base.Add(-oneDay)))
+		keys := []userstate.Key{live, expired, shownK, never}
+
+		snoozes, err := s.SnoozedUntilMany(ctx, keys, base)
+		require.NoError(t, err)
+		for _, k := range keys {
+			until, ok, kerr := s.SnoozedUntil(ctx, k, base)
+			require.NoError(t, kerr)
+			got, present := snoozes[k]
+			require.Equal(t, ok, present, "snooze presence for %+v", k)
+			if ok {
+				require.True(t, until.Equal(got))
+			}
+		}
+		require.Len(t, snoozes, 1)
+
+		shown, err := s.LastShownMany(ctx, keys)
+		require.NoError(t, err)
+		for _, k := range keys {
+			at, ok, kerr := s.LastShown(ctx, k)
+			require.NoError(t, kerr)
+			got, present := shown[k]
+			require.Equal(t, ok, present, "shown presence for %+v", k)
+			if ok {
+				require.True(t, at.Equal(got))
+			}
+		}
+		require.Len(t, shown, 2)
+	})
 }
 
 // RunSnoozeTests pins snooze semantics, including the boundary condition and

--- a/internal/worldreader/relations.go
+++ b/internal/worldreader/relations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"slices"
 
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -121,6 +122,87 @@ func (rr *RelationReader) Neighbors(
 		}
 	}); err != nil {
 		return nil, err
+	}
+	return out, nil
+}
+
+// NeighborsForPage is [RelationReader.Neighbors] for a whole page of
+// resolved rows in ONE identity query plus one content query per distinct
+// face on the page, instead of two queries per row (TKT-1U8XYN). The result
+// is index-aligned with rows: rows[i]'s edges are out[i], in the same order
+// Neighbors would return them (identity edges, then content edges, each in
+// store order), and a row the world excludes keeps a nil entry.
+//
+// The per-row contract is preserved exactly: a content edge counts for a row
+// only when the edge's tail face IS that row's face, so an edge between two
+// page rows resolved at different faces lands on the row whose face it
+// carries and not on the other — precisely what the per-row content query
+// (`FromFace = prime`) did.
+func (rr *RelationReader) NeighborsForPage(
+	ctx context.Context, rows []Resolved, dir store.Direction,
+) ([][]*entity.Relation, error) {
+	out := make([][]*entity.Relation, len(rows))
+	rowIdx := make(map[string]int, len(rows))
+	ids := make([]string, 0, len(rows))
+	byFace := make(map[entity.Face][]string)
+	for i, res := range rows {
+		if !res.Found || res.Entity == nil {
+			continue
+		}
+		id := res.Entity.ID
+		rowIdx[id] = i
+		ids = append(ids, id)
+		byFace[res.Face] = append(byFace[res.Face], id)
+	}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	// assign hands rel to the row(s) at its selected endpoint(s); face, when
+	// non-nil, restricts that to rows resolved at exactly that face.
+	assign := func(rel *entity.Relation, face *entity.Face) {
+		give := func(id string) {
+			i, ok := rowIdx[id]
+			if !ok || (face != nil && rows[i].Face != *face) {
+				return
+			}
+			out[i] = append(out[i], rel)
+		}
+		switch dir {
+		case store.DirectionOutgoing:
+			give(rel.From)
+		case store.DirectionIncoming:
+			give(rel.To)
+		default:
+			give(rel.From)
+			if rel.To != rel.From {
+				give(rel.To)
+			}
+		}
+	}
+
+	identityQ := store.RelationQuery{Direction: dir, FromFace: nil, EntityIDs: ids}
+	if err := collect(rr.lister.ListRelations(ctx, identityQ), func(rel *entity.Relation) {
+		if !rr.classes.IsContentScoped(rel.Type) {
+			assign(rel, nil)
+		}
+	}); err != nil {
+		return nil, err
+	}
+	faces := make([]entity.Face, 0, len(byFace))
+	for f := range byFace {
+		faces = append(faces, f)
+	}
+	slices.Sort(faces)
+	for _, f := range faces {
+		face := f
+		contentQ := store.RelationQuery{Direction: dir, FromFace: &face, EntityIDs: byFace[f]}
+		if err := collect(rr.lister.ListRelations(ctx, contentQ), func(rel *entity.Relation) {
+			if rr.classes.IsContentScoped(rel.Type) {
+				assign(rel, &face)
+			}
+		}); err != nil {
+			return nil, err
+		}
 	}
 	return out, nil
 }

--- a/internal/worldreader/relations_page_test.go
+++ b/internal/worldreader/relations_page_test.go
@@ -1,0 +1,104 @@
+package worldreader_test
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/storeutil"
+	"github.com/Sourcehaven-BV/rela/internal/worldreader"
+)
+
+// filteringLister answers a RelationQuery the way a store would — by
+// matching — so the batched and per-row paths can be compared on the
+// same edge set.
+type filteringLister struct {
+	rels    []*entity.Relation
+	queries int
+}
+
+func (l *filteringLister) ListRelations(_ context.Context, q store.RelationQuery) iter.Seq2[*entity.Relation, error] {
+	l.queries++
+	match := storeutil.NewRelationMatcher(q)
+	return func(yield func(*entity.Relation, error) bool) {
+		for _, rel := range l.rels {
+			if match(rel) && !yield(rel, nil) {
+				return
+			}
+		}
+	}
+}
+
+func face(t *testing.T, s string) entity.Face {
+	t.Helper()
+	f, err := entity.ParseFace(s)
+	require.NoError(t, err)
+	return f
+}
+
+// NeighborsForPage must equal Neighbors row by row — same edges, same order —
+// while issuing one identity query plus one content query per distinct face
+// on the page (TKT-1U8XYN).
+func TestNeighborsForPage_EqualsPerRowNeighbors(t *testing.T) {
+	published, nl := face(t, "published"), face(t, "nl")
+	rel := func(from string, tail entity.Face, typ, to string) *entity.Relation {
+		return &entity.Relation{From: from, FromFace: tail, Type: typ, To: to}
+	}
+	edges := []*entity.Relation{
+		rel("POL-1", "", "owned-by", "TEAM-1"),         // identity, default tail
+		rel("POL-1", published, "implements", "CTL-1"), // content, published tail
+		rel("POL-1", "", "implements", "CTL-2"),        // content, draft tail (not POL-1's face on this page)
+		rel("POL-2", "", "implements", "CTL-3"),        // content, default tail — POL-2's face
+		rel("POL-2", "", "owned-by", "TEAM-2"),         // identity
+		rel("DOC-1", nl, "references", "POL-1"),        // content from DOC-1's nl face to a page row
+		rel("DOC-1", "", "references", "POL-2"),        // content from DOC-1's en face — not its face here
+		rel("POL-2", published, "implements", "POL-1"), // content edge between two rows, published tail
+		rel("X-9", "", "owned-by", "POL-1"),            // identity, incoming to a row
+	}
+	classes := contentTypes{"implements": true, "references": true}
+	rows := []worldreader.Resolved{
+		{Entity: &entity.Entity{ID: "POL-1", Type: "policy", Face: published}, Face: published, Found: true},
+		{Entity: &entity.Entity{ID: "POL-2", Type: "policy"}, Face: "", Found: true},
+		{Entity: &entity.Entity{ID: "DOC-1", Type: "document", Face: nl}, Face: nl, Found: true},
+		{Found: false}, // excluded by the world: no edges
+	}
+	for _, dir := range []store.Direction{store.DirectionBoth, store.DirectionOutgoing, store.DirectionIncoming} {
+		lister := &filteringLister{rels: edges}
+		rr, err := worldreader.NewRelationReader(lister, classes)
+		require.NoError(t, err)
+
+		got, err := rr.NeighborsForPage(context.Background(), rows, dir)
+		require.NoError(t, err)
+		require.Len(t, got, len(rows))
+		// identity query + one content query per distinct face (published, "", nl)
+		require.Equal(t, 4, lister.queries, "direction %v", dir)
+
+		for i, res := range rows {
+			want, err := rr.Neighbors(context.Background(), res, dir)
+			require.NoError(t, err)
+			require.Equal(t, keys(want), keys(got[i]), "direction %v row %d", dir, i)
+		}
+	}
+}
+
+func TestNeighborsForPage_EmptyPage(t *testing.T) {
+	lister := &filteringLister{}
+	rr, err := worldreader.NewRelationReader(lister, contentTypes{})
+	require.NoError(t, err)
+	got, err := rr.NeighborsForPage(context.Background(), nil, store.DirectionBoth)
+	require.NoError(t, err)
+	require.Empty(t, got)
+	require.Zero(t, lister.queries, "nothing to ask for")
+}
+
+func keys(rels []*entity.Relation) []string {
+	out := make([]string, 0, len(rels))
+	for _, r := range rels {
+		out = append(out, r.Key())
+	}
+	return out
+}

--- a/prototypes/perf/project/acl.yaml
+++ b/prototypes/perf/project/acl.yaml
@@ -1,0 +1,68 @@
+description: >
+  Three roles resolved through the graph: the request's email is looked up
+  on person.email, and the person's `member-of` team decides the role. A
+  handful of direct assignments exist for principals that are not in the
+  graph (break-glass and the demo accounts).
+
+user_entity_type: person
+principal_property: email
+membership_relation: member-of
+
+role_relations:
+  member-of:
+    requires_permission: manage-roles
+
+roles:
+  reader:
+    description: >
+      Reads the published portfolio and ISMS. No editorial world, no risks,
+      no people — and policies only through their published face.
+    read:
+      - project
+      - task
+      - control
+      - team
+      - document
+      - policy@published
+      - "world:published"
+      - "world:site-nl"
+
+  editor:
+    description: >
+      Works on the portfolio and on drafts. Sees people but not what they
+      earn: `visible:` is closed-world, so salary is redacted by omission.
+    read: ["*", "world:published", "world:editorial", "world:site-nl"]
+    create: [task, project, document, policy, risk, control]
+    update: [task, project, document, policy, risk, control]
+    delete: [task, document]
+    visible:
+      person:
+        - field: title
+        - field: email
+        - field: role_title
+        - field: started
+
+  manager:
+    description: >
+      Everything, including publishing policies and conferring roles.
+    read: ["*", "world:published", "world:editorial", "world:site-nl"]
+    create: ["*"]
+    update: ["*"]
+    delete: ["*"]
+    permissions: [manage-roles, publish-policy]
+
+# Team ids are stable (the seeder mints them by name), so a team is the unit
+# of assignment: everyone `member-of` the team holds the role.
+assignments:
+  TEAM-leadership: manager
+  TEAM-security: manager
+  TEAM-engineering-1: editor
+  TEAM-engineering-2: editor
+  TEAM-engineering-3: editor
+  TEAM-operations-1: editor
+  TEAM-operations-2: editor
+  TEAM-finance: reader
+  # Demo principals that exist as persons in the graph, one per role.
+  alice@perf.example: manager
+  bob@perf.example: editor
+  carol@perf.example: reader

--- a/prototypes/perf/project/acl.yaml
+++ b/prototypes/perf/project/acl.yaml
@@ -1,22 +1,17 @@
 description: >
-  Three roles resolved through the graph: the request's email is looked up
-  on person.email, and the person's `member-of` team decides the role. A
-  handful of direct assignments exist for principals that are not in the
-  graph (break-glass and the demo accounts).
+  Three roles resolved through the graph: the request's email is looked up on person.email, and the person's `member-of` team decides the role. A handful of direct assignments exist for principals that are not in the graph (break-glass and the demo accounts).
 
 user_entity_type: person
 principal_property: email
 membership_relation: member-of
-
 role_relations:
   member-of:
     requires_permission: manage-roles
-
 roles:
   reader:
     description: >
-      Reads the published portfolio and ISMS. No editorial world, no risks,
-      no people — and policies only through their published face.
+      Reads the published portfolio and ISMS. No editorial world, no risks, no people — and policies only through their published face.
+
     read:
       - project
       - task
@@ -26,11 +21,10 @@ roles:
       - policy@published
       - "world:published"
       - "world:site-nl"
-
   editor:
     description: >
-      Works on the portfolio and on drafts. Sees people but not what they
-      earn: `visible:` is closed-world, so salary is redacted by omission.
+      Works on the portfolio and on drafts. Sees people but not what they earn: `visible:` is closed-world, so salary is redacted by omission.
+
     read: ["*", "world:published", "world:editorial", "world:site-nl"]
     create: [task, project, document, policy, risk, control]
     update: [task, project, document, policy, risk, control]
@@ -41,16 +35,20 @@ roles:
         - field: email
         - field: role_title
         - field: started
-
   manager:
     description: >
       Everything, including publishing policies and conferring roles.
+
     read: ["*", "world:published", "world:editorial", "world:site-nl"]
     create: ["*"]
     update: ["*"]
     delete: ["*"]
     permissions: [manage-roles, publish-policy]
-
+  # Added by migration: lets scheduled tasks read. Narrow or
+  # remove this once each job has a run_as identity of its own.
+  scheduler-system:
+    read:
+      - "*"
 # Team ids are stable (the seeder mints them by name), so a team is the unit
 # of assignment: everyone `member-of` the team holds the role.
 assignments:
@@ -66,3 +64,4 @@ assignments:
   alice@perf.example: manager
   bob@perf.example: editor
   carol@perf.example: reader
+  system:scheduler: scheduler-system

--- a/prototypes/perf/project/data-entry.yaml
+++ b/prototypes/perf/project/data-entry.yaml
@@ -1,0 +1,386 @@
+version: "1.0"
+
+app:
+  name: "Perf portfolio"
+  description: "ISMS + delivery portfolio at scale, for measuring read paths"
+  default_world: published
+
+styles:
+  task_status:
+    todo: gray
+    doing: blue
+    review: orange
+    done: green
+  priority:
+    low: gray
+    medium: blue
+    high: orange
+    critical: red
+  risk_level:
+    low: green
+    medium: orange
+    high: red
+
+lists:
+  tasks:
+    entity_type: task
+    title: "Tasks"
+    description: "Every task, with its assignee and project resolved per row"
+    create_form: new_task
+    edit_form: edit_task
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: status, sortable: true }
+      - { property: priority, sortable: true }
+      - { property: due, sortable: true }
+      - { relation: assigned-to, label: "Assignee" }
+      - { relation: contains, direction: incoming, label: "Part of" }
+    filter_controls:
+      - { property: status, widget: multi-select }
+      - { property: priority, widget: select }
+      - { relation: assigned-to, label: "Assignee" }
+    sort:
+      - { property: due, direction: asc }
+
+  open_tasks:
+    entity_type: task
+    title: "Open tasks"
+    description: "Static filter on status, sorted by priority"
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: priority, sortable: true }
+      - { property: due, sortable: true }
+      - { relation: assigned-to, label: "Assignee" }
+    filters:
+      - { property: status, operator: "!=", value: done }
+    sort:
+      - { property: priority, direction: desc }
+      - { property: due, direction: asc }
+
+  projects:
+    entity_type: project
+    title: "Projects"
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: status, sortable: true }
+      - { property: planned_start, sortable: true }
+      - { property: planned_end, sortable: true }
+      - { relation: leads, direction: incoming, label: "Lead" }
+      - { relation: owns, direction: incoming, label: "Owner" }
+    filter_controls:
+      - { property: status, widget: multi-select }
+
+  people:
+    entity_type: person
+    title: "People"
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: role_title, sortable: true }
+      - { property: salary, sortable: true }
+      - { relation: member-of, label: "Team" }
+    filter_controls:
+      - { relation: member-of, label: "Team" }
+
+  policies:
+    entity_type: policy
+    title: "Policies"
+    description: "Shown at the face the world resolves"
+    create_form: new_policy
+    create_world: editorial
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: status, sortable: true }
+      - { property: owner, sortable: true }
+      - { relation: implements, label: "Controls" }
+    filter_controls:
+      - { property: status, widget: multi-select }
+
+  documents:
+    entity_type: document
+    title: "Documents"
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: category, sortable: true }
+      - { relation: references, label: "References" }
+    filter_controls:
+      - { property: category, widget: select }
+
+  risks:
+    entity_type: risk
+    title: "Risks"
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: level, sortable: true }
+      - { property: status, sortable: true }
+      - { relation: mitigates, direction: incoming, label: "Mitigated by" }
+    filter_controls:
+      - { property: level, widget: multi-select }
+      - { property: status, widget: multi-select }
+
+  controls:
+    entity_type: control
+    title: "Controls"
+    columns:
+      - { property: title, sortable: true, link: detail }
+      - { property: family, sortable: true }
+      - { property: status, sortable: true }
+      - { relation: implements, direction: incoming, label: "Policies" }
+
+forms:
+  new_task:
+    entity_type: task
+    title: "New task"
+    body: true
+    fields:
+      - { property: title }
+      - { property: status }
+      - { property: priority }
+      - { property: start }
+      - { property: due }
+      - { property: estimate }
+    relations:
+      - { relation: assigned-to, direction: outgoing, widget: select, label: "Assignee" }
+      - { relation: contains, direction: incoming, widget: select, label: "Part of" }
+  edit_task:
+    entity_type: task
+    title: "Edit task"
+    body: true
+    fields:
+      - { property: title }
+      - { property: status }
+      - { property: priority }
+      - { property: start }
+      - { property: due }
+      - { property: estimate }
+    relations:
+      - { relation: assigned-to, direction: outgoing, widget: select, label: "Assignee" }
+      - { relation: depends-on, direction: outgoing, widget: multi-select, label: "Depends on" }
+  new_policy:
+    entity_type: policy
+    title: "New policy"
+    body: true
+    fields:
+      - { property: title }
+      - { property: status }
+      - { property: owner }
+      - { property: version }
+    relations:
+      - { relation: implements, direction: outgoing, widget: multi-select, label: "Implements" }
+      - { relation: owned-by, direction: outgoing, widget: select, label: "Owned by" }
+
+views:
+  project_detail:
+    title: "Project"
+    entry: { type: project }
+    traverse:
+      - { from: entry, follow: contains, collect_as: children }
+      - { from: entry, follow: contains, recursive: true, max_depth: 4, collect_as: all_work }
+      - { from: entry, follow_incoming: leads, collect_as: leads }
+      - { from: entry, follow_incoming: owns, collect_as: owners }
+      - { from: all_work, follow: assigned-to, collect_as: staff }
+    sections:
+      - { heading: "Project", source: entry, display: properties,
+          fields: [ { property: status }, { property: planned_start }, { property: planned_end }, { property: target_date }, { property: budget } ] }
+      - { source: entry, display: content }
+      - heading: "Lead"
+        source: leads
+        display: list
+        fields: [ { property: title }, { property: role_title } ]
+      - heading: "Work"
+        source: children
+        display: table
+        columns:
+          - { property: title, link: true }
+          - { property: status }
+          - { property: priority }
+          - { property: due }
+          - { relation: assigned-to, label: "Assignee" }
+          - { relation: depends-on, label: "Depends on" }
+        empty_message: "No work planned"
+      - heading: "Everyone involved"
+        source: staff
+        display: table
+        columns:
+          - { property: title, link: true }
+          - { property: role_title }
+          - { relation: member-of, label: "Team" }
+
+  task_detail:
+    title: "Task"
+    entry: { type: task }
+    traverse:
+      - { from: entry, follow_incoming: contains, collect_as: parent }
+      - { from: entry, follow: contains, collect_as: subtasks }
+      - { from: entry, follow: depends-on, collect_as: dependencies }
+      - { from: entry, follow_incoming: depends-on, collect_as: dependents }
+      - { from: entry, follow: assigned-to, collect_as: assignee }
+    sections:
+      - { heading: "Task", source: entry, display: properties,
+          fields: [ { property: status }, { property: priority }, { property: start }, { property: due }, { property: estimate } ] }
+      - { source: entry, display: content }
+      - { heading: "Assignee", source: assignee, display: list, fields: [ { property: title }, { property: role_title } ] }
+      - { heading: "Part of", source: parent, display: list, fields: [ { property: title }, { property: status } ], link: true }
+      - heading: "Subtasks"
+        source: subtasks
+        display: table
+        columns: [ { property: title, link: true }, { property: status }, { relation: assigned-to, label: "Assignee" } ]
+      - heading: "Depends on"
+        source: dependencies
+        display: table
+        columns: [ { property: title, link: true }, { property: status }, { property: due }, { relation: assigned-to, label: "Assignee" } ]
+      - heading: "Blocks"
+        source: dependents
+        display: table
+        columns: [ { property: title, link: true }, { property: status }, { property: due } ]
+
+  policy_detail:
+    title: "Policy"
+    entry: { type: policy }
+    traverse:
+      - { from: entry, follow: implements, collect_as: controls }
+      - { from: controls, follow: mitigates, collect_as: risks }
+      - { from: entry, follow: owned-by, collect_as: owner }
+      - { from: entry, follow_incoming: references, collect_as: cited_by }
+    sections:
+      - { heading: "Policy", source: entry, display: properties,
+          fields: [ { property: status }, { property: owner }, { property: version } ] }
+      - { source: entry, display: content }
+      - { heading: "Owned by", source: owner, display: list, fields: [ { property: title } ] }
+      - heading: "Implements"
+        source: controls
+        display: table
+        columns: [ { property: title, link: true }, { property: family }, { property: status }, { relation: mitigates, label: "Mitigates" } ]
+      - heading: "Risks addressed"
+        source: risks
+        display: table
+        columns: [ { property: title, link: true }, { property: level }, { property: status } ]
+      - heading: "Cited by"
+        source: cited_by
+        display: table
+        columns: [ { property: title, link: true }, { property: category } ]
+
+  person_detail:
+    title: "Person"
+    entry: { type: person }
+    traverse:
+      - { from: entry, follow: member-of, collect_as: team }
+      - { from: entry, follow_incoming: assigned-to, collect_as: tasks }
+      - { from: entry, follow: leads, collect_as: projects }
+    sections:
+      - { heading: "Person", source: entry, display: properties,
+          fields: [ { property: email }, { property: role_title }, { property: salary }, { property: started } ] }
+      - { heading: "Team", source: team, display: list, fields: [ { property: title }, { property: department } ] }
+      - heading: "Assigned work"
+        source: tasks
+        display: table
+        columns: [ { property: title, link: true }, { property: status }, { property: priority }, { property: due }, { relation: contains, direction: incoming, label: "Part of" } ]
+      - heading: "Leads"
+        source: projects
+        display: table
+        columns: [ { property: title, link: true }, { property: status } ]
+
+entity_views:
+  project: { detail_view: project_detail }
+  task:    { detail_view: task_detail }
+  policy:  { detail_view: policy_detail }
+  person:  { detail_view: person_detail }
+
+kanbans:
+  task_board:
+    entity_type: task
+    title: "Task board"
+    column_property: status
+    columns:
+      - { value: todo, label: "To do" }
+      - { value: doing, label: "Doing" }
+      - { value: review, label: "Review" }
+      - { value: done, label: "Done" }
+    card:
+      title: title
+      fields:
+        - { property: priority }
+        - { property: due }
+    filter_controls:
+      - { property: priority, widget: multi-select }
+      - { relation: assigned-to, label: "Assignee" }
+
+  policy_pipeline:
+    entity_type: policy
+    title: "Policy pipeline"
+    column_property: status
+    columns:
+      - { value: to-do, label: "To do" }
+      - { value: doing, label: "Doing" }
+      - { value: done, label: "Done" }
+    card:
+      title: title
+      fields:
+        - { property: owner }
+
+dashboard:
+  title: "Portfolio"
+  description: "Counts and breakdowns over the whole graph"
+  cards:
+    - { title: "Tasks", query: "type:task", display: count }
+    - { title: "Open tasks", query: "type:task prop:status!=done", display: count }
+    - { title: "Tasks by status", query: "type:task", display: breakdown, group_by: status }
+    - { title: "Tasks by priority", query: "type:task", display: breakdown, group_by: priority }
+    - { title: "Projects by status", query: "type:project", display: breakdown, group_by: status }
+    - { title: "Risks by level", query: "type:risk", display: breakdown, group_by: level }
+    - { title: "Open risks", query: "type:risk prop:status=open", display: count }
+    - title: "Critical work"
+      query: "type:task prop:priority=critical prop:status!=done"
+      display: table
+      columns: [ { property: title, link: true }, { property: due } ]
+      sort: [ { property: due, direction: asc } ]
+      limit: 8
+    - { title: "Policies", query: "type:policy", display: breakdown, group_by: status }
+
+gantts:
+  delivery:
+    title: "Delivery plan"
+    hierarchy: [contains]
+    default_depth: 2
+    sources:
+      project: { start: planned_start, end: planned_end, committed: target_date }
+      task:    { start: start, end: due }
+    tooltip:
+      fields:
+        - { property: status }
+        - { property: priority }
+
+next_action_bands:
+  - { id: overdue, label: "Overdue", prominence: banner }
+  - { id: upkeep, label: "Upkeep", prominence: notice }
+
+next_actions:
+  overdue-critical:
+    band: overdue
+    query: "type:task prop:priority=critical prop:status!=done prop:due<2026-06-01"
+    suggest: "{title} is critical and past due."
+    cooldown: 1h
+    actions:
+      - { navigate: "/entity/task/{id}", label: "Open" }
+      - { snooze: ["1d"] }
+  finished-draft:
+    band: upkeep
+    source_world: editorial
+    query: "type:policy prop:status=done"
+    suggest: "The draft of {title} is done. Publish it?"
+    cooldown: 1h
+    actions:
+      - { navigate: "/entity/policy/{id}?world=editorial", label: "Open the draft" }
+      - { snooze: ["1d"] }
+
+navigation:
+  - { label: "Tasks", list: tasks }
+  - { label: "Open tasks", list: open_tasks }
+  - { label: "Task board", kanban: task_board }
+  - { label: "Projects", list: projects }
+  - { label: "Delivery", gantt: delivery }
+  - { label: "People", list: people }
+  - { label: "Policies", list: policies }
+  - { label: "Pipeline", kanban: policy_pipeline }
+  - { label: "Documents", list: documents }
+  - { label: "Risks", list: risks }
+  - { label: "Controls", list: controls }

--- a/prototypes/perf/project/data-entry.yaml
+++ b/prototypes/perf/project/data-entry.yaml
@@ -1,10 +1,8 @@
 version: "1.0"
-
 app:
   name: "Perf portfolio"
   description: "ISMS + delivery portfolio at scale, for measuring read paths"
   default_world: published
-
 styles:
   task_status:
     todo: gray
@@ -20,7 +18,6 @@ styles:
     low: green
     medium: orange
     high: red
-
 lists:
   tasks:
     entity_type: task
@@ -29,58 +26,54 @@ lists:
     create_form: new_task
     edit_form: edit_task
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: status, sortable: true }
-      - { property: priority, sortable: true }
-      - { property: due, sortable: true }
-      - { relation: assigned-to, label: "Assignee" }
-      - { relation: contains, direction: incoming, label: "Part of" }
+      - {property: title, sortable: true, link: detail}
+      - {property: status, sortable: true}
+      - {property: priority, sortable: true}
+      - {property: due, sortable: true}
+      - {relation: assigned-to, label: "Assignee", direction: outgoing}
+      - {relation: contains, direction: incoming, label: "Part of"}
     filter_controls:
-      - { property: status, widget: multi-select }
-      - { property: priority, widget: select }
-      - { relation: assigned-to, label: "Assignee" }
+      - {property: status, widget: multi-select}
+      - {property: priority, widget: select}
+      - {relation: assigned-to, label: "Assignee", direction: outgoing}
     sort:
-      - { property: due, direction: asc }
-
+      - {property: due, direction: asc}
   open_tasks:
     entity_type: task
     title: "Open tasks"
     description: "Static filter on status, sorted by priority"
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: priority, sortable: true }
-      - { property: due, sortable: true }
-      - { relation: assigned-to, label: "Assignee" }
+      - {property: title, sortable: true, link: detail}
+      - {property: priority, sortable: true}
+      - {property: due, sortable: true}
+      - {relation: assigned-to, label: "Assignee", direction: outgoing}
     filters:
-      - { property: status, operator: "!=", value: done }
+      - {property: status, operator: "!=", value: done}
     sort:
-      - { property: priority, direction: desc }
-      - { property: due, direction: asc }
-
+      - {property: priority, direction: desc}
+      - {property: due, direction: asc}
   projects:
     entity_type: project
     title: "Projects"
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: status, sortable: true }
-      - { property: planned_start, sortable: true }
-      - { property: planned_end, sortable: true }
-      - { relation: leads, direction: incoming, label: "Lead" }
-      - { relation: owns, direction: incoming, label: "Owner" }
+      - {property: title, sortable: true, link: detail}
+      - {property: status, sortable: true}
+      - {property: planned_start, sortable: true}
+      - {property: planned_end, sortable: true}
+      - {relation: leads, direction: incoming, label: "Lead"}
+      - {relation: owns, direction: incoming, label: "Owner"}
     filter_controls:
-      - { property: status, widget: multi-select }
-
+      - {property: status, widget: multi-select}
   people:
     entity_type: person
     title: "People"
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: role_title, sortable: true }
-      - { property: salary, sortable: true }
-      - { relation: member-of, label: "Team" }
+      - {property: title, sortable: true, link: detail}
+      - {property: role_title, sortable: true}
+      - {property: salary, sortable: true}
+      - {relation: member-of, label: "Team", direction: outgoing}
     filter_controls:
-      - { relation: member-of, label: "Team" }
-
+      - {relation: member-of, label: "Team", direction: outgoing}
   policies:
     entity_type: policy
     title: "Policies"
@@ -88,271 +81,247 @@ lists:
     create_form: new_policy
     create_world: editorial
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: status, sortable: true }
-      - { property: owner, sortable: true }
-      - { relation: implements, label: "Controls" }
+      - {property: title, sortable: true, link: detail}
+      - {property: status, sortable: true}
+      - {property: owner, sortable: true}
+      - {relation: implements, label: "Controls", direction: outgoing}
     filter_controls:
-      - { property: status, widget: multi-select }
-
+      - {property: status, widget: multi-select}
   documents:
     entity_type: document
     title: "Documents"
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: category, sortable: true }
-      - { relation: references, label: "References" }
+      - {property: title, sortable: true, link: detail}
+      - {property: category, sortable: true}
+      - {relation: references, label: "References", direction: outgoing}
     filter_controls:
-      - { property: category, widget: select }
-
+      - {property: category, widget: select}
   risks:
     entity_type: risk
     title: "Risks"
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: level, sortable: true }
-      - { property: status, sortable: true }
-      - { relation: mitigates, direction: incoming, label: "Mitigated by" }
+      - {property: title, sortable: true, link: detail}
+      - {property: level, sortable: true}
+      - {property: status, sortable: true}
+      - {relation: mitigates, direction: incoming, label: "Mitigated by"}
     filter_controls:
-      - { property: level, widget: multi-select }
-      - { property: status, widget: multi-select }
-
+      - {property: level, widget: multi-select}
+      - {property: status, widget: multi-select}
   controls:
     entity_type: control
     title: "Controls"
     columns:
-      - { property: title, sortable: true, link: detail }
-      - { property: family, sortable: true }
-      - { property: status, sortable: true }
-      - { relation: implements, direction: incoming, label: "Policies" }
-
+      - {property: title, sortable: true, link: detail}
+      - {property: family, sortable: true}
+      - {property: status, sortable: true}
+      - {relation: implements, direction: incoming, label: "Policies"}
 forms:
   new_task:
     entity_type: task
     title: "New task"
     body: true
     fields:
-      - { property: title }
-      - { property: status }
-      - { property: priority }
-      - { property: start }
-      - { property: due }
-      - { property: estimate }
+      - {property: title}
+      - {property: status}
+      - {property: priority}
+      - {property: start}
+      - {property: due}
+      - {property: estimate}
     relations:
-      - { relation: assigned-to, direction: outgoing, widget: select, label: "Assignee" }
-      - { relation: contains, direction: incoming, widget: select, label: "Part of" }
+      - {relation: assigned-to, direction: outgoing, label: "Assignee"}
+      - {relation: contains, direction: incoming, label: "Part of"}
   edit_task:
     entity_type: task
     title: "Edit task"
     body: true
     fields:
-      - { property: title }
-      - { property: status }
-      - { property: priority }
-      - { property: start }
-      - { property: due }
-      - { property: estimate }
+      - {property: title}
+      - {property: status}
+      - {property: priority}
+      - {property: start}
+      - {property: due}
+      - {property: estimate}
     relations:
-      - { relation: assigned-to, direction: outgoing, widget: select, label: "Assignee" }
-      - { relation: depends-on, direction: outgoing, widget: multi-select, label: "Depends on" }
+      - {relation: assigned-to, direction: outgoing, label: "Assignee"}
+      - {relation: depends-on, direction: outgoing, widget: multi-select, label: "Depends on"}
   new_policy:
     entity_type: policy
     title: "New policy"
     body: true
     fields:
-      - { property: title }
-      - { property: status }
-      - { property: owner }
-      - { property: version }
+      - {property: title}
+      - {property: status}
+      - {property: owner}
+      - {property: version}
     relations:
-      - { relation: implements, direction: outgoing, widget: multi-select, label: "Implements" }
-      - { relation: owned-by, direction: outgoing, widget: select, label: "Owned by" }
-
+      - {relation: implements, direction: outgoing, widget: multi-select, label: "Implements"}
+      - {relation: owned-by, direction: outgoing, label: "Owned by"}
 views:
-  project_detail:
+  project:
     title: "Project"
-    entry: { type: project }
+    entry: {type: project}
     traverse:
-      - { from: entry, follow: contains, collect_as: children }
-      - { from: entry, follow: contains, recursive: true, max_depth: 4, collect_as: all_work }
-      - { from: entry, follow_incoming: leads, collect_as: leads }
-      - { from: entry, follow_incoming: owns, collect_as: owners }
-      - { from: all_work, follow: assigned-to, collect_as: staff }
+      - {from: entry, follow: contains, collect_as: children}
+      - {from: entry, follow: contains, recursive: true, max_depth: 4, collect_as: all_work}
+      - {from: entry, follow_incoming: leads, collect_as: leads}
+      - {from: entry, follow_incoming: owns, collect_as: owners}
+      - {from: all_work, follow: assigned-to, collect_as: staff}
     sections:
-      - { heading: "Project", source: entry, display: properties,
-          fields: [ { property: status }, { property: planned_start }, { property: planned_end }, { property: target_date }, { property: budget } ] }
-      - { source: entry, display: content }
+      - {heading: "Project", source: entry, display: properties, fields: [{property: status}, {property: planned_start}, {property: planned_end}, {property: target_date}, {property: budget}]}
+      - {source: entry, display: content}
       - heading: "Lead"
         source: leads
         display: list
-        fields: [ { property: title }, { property: role_title } ]
+        fields: [{property: title}, {property: role_title}]
       - heading: "Work"
         source: children
         display: table
         columns:
-          - { property: title, link: true }
-          - { property: status }
-          - { property: priority }
-          - { property: due }
-          - { relation: assigned-to, label: "Assignee" }
-          - { relation: depends-on, label: "Depends on" }
+          - {property: title, link: detail}
+          - {property: status}
+          - {property: priority}
+          - {property: due}
+          - {relation: assigned-to, label: "Assignee"}
+          - {relation: depends-on, direction: outgoing, label: "Depends on"}
         empty_message: "No work planned"
       - heading: "Everyone involved"
         source: staff
         display: table
         columns:
-          - { property: title, link: true }
-          - { property: role_title }
-          - { relation: member-of, label: "Team" }
-
-  task_detail:
+          - {property: title, link: detail}
+          - {property: role_title}
+          - {relation: member-of, label: "Team"}
+  task:
     title: "Task"
-    entry: { type: task }
+    entry: {type: task}
     traverse:
-      - { from: entry, follow_incoming: contains, collect_as: parent }
-      - { from: entry, follow: contains, collect_as: subtasks }
-      - { from: entry, follow: depends-on, collect_as: dependencies }
-      - { from: entry, follow_incoming: depends-on, collect_as: dependents }
-      - { from: entry, follow: assigned-to, collect_as: assignee }
+      - {from: entry, follow_incoming: contains, collect_as: parent}
+      - {from: entry, follow: contains, collect_as: subtasks}
+      - {from: entry, follow: depends-on, collect_as: dependencies}
+      - {from: entry, follow_incoming: depends-on, collect_as: dependents}
+      - {from: entry, follow: assigned-to, collect_as: assignee}
     sections:
-      - { heading: "Task", source: entry, display: properties,
-          fields: [ { property: status }, { property: priority }, { property: start }, { property: due }, { property: estimate } ] }
-      - { source: entry, display: content }
-      - { heading: "Assignee", source: assignee, display: list, fields: [ { property: title }, { property: role_title } ] }
-      - { heading: "Part of", source: parent, display: list, fields: [ { property: title }, { property: status } ], link: true }
+      - {heading: "Task", source: entry, display: properties, fields: [{property: status}, {property: priority}, {property: start}, {property: due}, {property: estimate}]}
+      - {source: entry, display: content}
+      - {heading: "Assignee", source: assignee, display: list, fields: [{property: title}, {property: role_title}]}
+      - {heading: "Part of", source: parent, display: list, fields: [{property: title}, {property: status}], link: detail}
       - heading: "Subtasks"
         source: subtasks
         display: table
-        columns: [ { property: title, link: true }, { property: status }, { relation: assigned-to, label: "Assignee" } ]
+        columns: [{property: title, link: detail}, {property: status}, {relation: assigned-to, label: "Assignee"}]
       - heading: "Depends on"
         source: dependencies
         display: table
-        columns: [ { property: title, link: true }, { property: status }, { property: due }, { relation: assigned-to, label: "Assignee" } ]
+        columns: [{property: title, link: detail}, {property: status}, {property: due}, {relation: assigned-to, label: "Assignee"}]
       - heading: "Blocks"
         source: dependents
         display: table
-        columns: [ { property: title, link: true }, { property: status }, { property: due } ]
-
-  policy_detail:
+        columns: [{property: title, link: detail}, {property: status}, {property: due}]
+  policy:
     title: "Policy"
-    entry: { type: policy }
+    entry: {type: policy}
     traverse:
-      - { from: entry, follow: implements, collect_as: controls }
-      - { from: controls, follow: mitigates, collect_as: risks }
-      - { from: entry, follow: owned-by, collect_as: owner }
-      - { from: entry, follow_incoming: references, collect_as: cited_by }
+      - {from: entry, follow: implements, collect_as: controls}
+      - {from: controls, follow: mitigates, collect_as: risks}
+      - {from: entry, follow: owned-by, collect_as: owner}
+      - {from: entry, follow_incoming: references, collect_as: cited_by}
     sections:
-      - { heading: "Policy", source: entry, display: properties,
-          fields: [ { property: status }, { property: owner }, { property: version } ] }
-      - { source: entry, display: content }
-      - { heading: "Owned by", source: owner, display: list, fields: [ { property: title } ] }
+      - {heading: "Policy", source: entry, display: properties, fields: [{property: status}, {property: owner}, {property: version}]}
+      - {source: entry, display: content}
+      - {heading: "Owned by", source: owner, display: list, fields: [{property: title}]}
       - heading: "Implements"
         source: controls
         display: table
-        columns: [ { property: title, link: true }, { property: family }, { property: status }, { relation: mitigates, label: "Mitigates" } ]
+        columns: [{property: title, link: detail}, {property: family}, {property: status}, {relation: mitigates, label: "Mitigates"}]
       - heading: "Risks addressed"
         source: risks
         display: table
-        columns: [ { property: title, link: true }, { property: level }, { property: status } ]
+        columns: [{property: title, link: detail}, {property: level}, {property: status}]
       - heading: "Cited by"
         source: cited_by
         display: table
-        columns: [ { property: title, link: true }, { property: category } ]
-
-  person_detail:
+        columns: [{property: title, link: detail}, {property: category}]
+  person:
     title: "Person"
-    entry: { type: person }
+    entry: {type: person}
     traverse:
-      - { from: entry, follow: member-of, collect_as: team }
-      - { from: entry, follow_incoming: assigned-to, collect_as: tasks }
-      - { from: entry, follow: leads, collect_as: projects }
+      - {from: entry, follow: member-of, collect_as: team}
+      - {from: entry, follow_incoming: assigned-to, collect_as: tasks}
+      - {from: entry, follow: leads, collect_as: projects}
     sections:
-      - { heading: "Person", source: entry, display: properties,
-          fields: [ { property: email }, { property: role_title }, { property: salary }, { property: started } ] }
-      - { heading: "Team", source: team, display: list, fields: [ { property: title }, { property: department } ] }
+      - {heading: "Person", source: entry, display: properties, fields: [{property: email}, {property: role_title}, {property: salary}, {property: started}]}
+      - {heading: "Team", source: team, display: list, fields: [{property: title}, {property: department}]}
       - heading: "Assigned work"
         source: tasks
         display: table
-        columns: [ { property: title, link: true }, { property: status }, { property: priority }, { property: due }, { relation: contains, direction: incoming, label: "Part of" } ]
+        columns: [{property: title, link: detail}, {property: status}, {property: priority}, {property: due}, {relation: contains, direction: incoming, label: "Part of"}]
       - heading: "Leads"
         source: projects
         display: table
-        columns: [ { property: title, link: true }, { property: status } ]
-
-entity_views:
-  project: { detail_view: project_detail }
-  task:    { detail_view: task_detail }
-  policy:  { detail_view: policy_detail }
-  person:  { detail_view: person_detail }
-
+        columns: [{property: title, link: detail}, {property: status}]
 kanbans:
   task_board:
     entity_type: task
     title: "Task board"
     column_property: status
     columns:
-      - { value: todo, label: "To do" }
-      - { value: doing, label: "Doing" }
-      - { value: review, label: "Review" }
-      - { value: done, label: "Done" }
+      - {value: todo, label: "To do"}
+      - {value: doing, label: "Doing"}
+      - {value: review, label: "Review"}
+      - {value: done, label: "Done"}
     card:
       title: title
       fields:
-        - { property: priority }
-        - { property: due }
+        - {property: priority}
+        - {property: due}
     filter_controls:
-      - { property: priority, widget: multi-select }
-      - { relation: assigned-to, label: "Assignee" }
-
+      - {property: priority, widget: multi-select}
+      - {relation: assigned-to, label: "Assignee", direction: outgoing}
   policy_pipeline:
     entity_type: policy
     title: "Policy pipeline"
     column_property: status
     columns:
-      - { value: to-do, label: "To do" }
-      - { value: doing, label: "Doing" }
-      - { value: done, label: "Done" }
+      - {value: to-do, label: "To do"}
+      - {value: doing, label: "Doing"}
+      - {value: done, label: "Done"}
     card:
       title: title
       fields:
-        - { property: owner }
-
+        - {property: owner}
 dashboard:
   title: "Portfolio"
   description: "Counts and breakdowns over the whole graph"
   cards:
-    - { title: "Tasks", query: "type:task", display: count }
-    - { title: "Open tasks", query: "type:task prop:status!=done", display: count }
-    - { title: "Tasks by status", query: "type:task", display: breakdown, group_by: status }
-    - { title: "Tasks by priority", query: "type:task", display: breakdown, group_by: priority }
-    - { title: "Projects by status", query: "type:project", display: breakdown, group_by: status }
-    - { title: "Risks by level", query: "type:risk", display: breakdown, group_by: level }
-    - { title: "Open risks", query: "type:risk prop:status=open", display: count }
+    - {title: "Tasks", query: "type:task", display: count}
+    - {title: "Open tasks", query: "type:task prop:status!=done", display: count}
+    - {title: "Tasks by status", query: "type:task", display: breakdown, group_by: status}
+    - {title: "Tasks by priority", query: "type:task", display: breakdown, group_by: priority}
+    - {title: "Projects by status", query: "type:project", display: breakdown, group_by: status}
+    - {title: "Risks by level", query: "type:risk", display: breakdown, group_by: level}
+    - {title: "Open risks", query: "type:risk prop:status=open", display: count}
     - title: "Critical work"
       query: "type:task prop:priority=critical prop:status!=done"
       display: table
-      columns: [ { property: title, link: true }, { property: due } ]
-      sort: [ { property: due, direction: asc } ]
+      columns: [{property: title, link: detail}, {property: due}]
+      sort: [{property: due, direction: asc}]
       limit: 8
-    - { title: "Policies", query: "type:policy", display: breakdown, group_by: status }
-
+    - {title: "Policies", query: "type:policy", display: breakdown, group_by: status}
 gantts:
   delivery:
     title: "Delivery plan"
     hierarchy: [contains]
     default_depth: 2
     sources:
-      project: { start: planned_start, end: planned_end, committed: target_date }
-      task:    { start: start, end: due }
+      project: {start: planned_start, end: planned_end, committed: target_date}
+      task: {start: start, end: due}
     tooltip:
       fields:
-        - { property: status }
-        - { property: priority }
-
+        - {property: status}
+        - {property: priority}
 next_action_bands:
-  - { id: overdue, label: "Overdue", prominence: banner }
-  - { id: upkeep, label: "Upkeep", prominence: notice }
-
+  - {id: overdue, label: "Overdue", prominence: banner}
+  - {id: upkeep, label: "Upkeep", prominence: notice}
 next_actions:
   overdue-critical:
     band: overdue
@@ -360,8 +329,8 @@ next_actions:
     suggest: "{title} is critical and past due."
     cooldown: 1h
     actions:
-      - { navigate: "/entity/task/{id}", label: "Open" }
-      - { snooze: ["1d"] }
+      - {navigate: "/entity/task/{id}", label: "Open"}
+      - {snooze: ["1d"]}
   finished-draft:
     band: upkeep
     source_world: editorial
@@ -369,18 +338,17 @@ next_actions:
     suggest: "The draft of {title} is done. Publish it?"
     cooldown: 1h
     actions:
-      - { navigate: "/entity/policy/{id}?world=editorial", label: "Open the draft" }
-      - { snooze: ["1d"] }
-
+      - {navigate: "/entity/policy/{id}?world=editorial", label: "Open the draft"}
+      - {snooze: ["1d"]}
 navigation:
-  - { label: "Tasks", list: tasks }
-  - { label: "Open tasks", list: open_tasks }
-  - { label: "Task board", kanban: task_board }
-  - { label: "Projects", list: projects }
-  - { label: "Delivery", gantt: delivery }
-  - { label: "People", list: people }
-  - { label: "Policies", list: policies }
-  - { label: "Pipeline", kanban: policy_pipeline }
-  - { label: "Documents", list: documents }
-  - { label: "Risks", list: risks }
-  - { label: "Controls", list: controls }
+  - {label: "Tasks", list: tasks}
+  - {label: "Open tasks", list: open_tasks}
+  - {label: "Task board", kanban: task_board}
+  - {label: "Projects", list: projects}
+  - {label: "Delivery", gantt: delivery}
+  - {label: "People", list: people}
+  - {label: "Policies", list: policies}
+  - {label: "Pipeline", kanban: policy_pipeline}
+  - {label: "Documents", list: documents}
+  - {label: "Risks", list: risks}
+  - {label: "Controls", list: controls}

--- a/prototypes/perf/project/schema.yaml
+++ b/prototypes/perf/project/schema.yaml
@@ -1,0 +1,221 @@
+version: "1.0"
+
+description: >
+  Performance demo: an ISMS plus a delivery portfolio, sized by `rela dev
+  seed`. Every read shape the data-entry app has is exercised here at scale —
+  lists with relation columns and relation filters, views with table sections,
+  kanbans, a dashboard, a gantt, next actions — under an ACL with group
+  membership, field redaction, and two content-state axes (policy
+  draft/published, document en/nl) served through worlds.
+
+entities:
+  team:
+    label: Team
+    id_prefix: TEAM
+    id_type: manual
+    properties:
+      title:      { type: string, required: true }
+      department: { type: department, required: true }
+
+  person:
+    label: Person
+    label_plural: People
+    id_prefix: PERS
+    id_type: manual
+    properties:
+      title:      { type: string, required: true }
+      # The principal is resolved to a person by email (acl.yaml
+      # `principal_property`), which requires the property to be unique. The
+      # seeder generates emails by construction, so no two collide.
+      email:      { type: string, required: true, unique: true }
+      role_title: { type: string }
+      # Redacted for every role but manager (acl.yaml `visible:`).
+      salary:     { type: integer }
+      started:    { type: date }
+
+  project:
+    label: Project
+    id_prefix: PRJ
+    id_type: manual
+    properties:
+      title:         { type: string, required: true }
+      status:        { type: project_status, required: true }
+      planned_start: { type: date }
+      planned_end:   { type: date }
+      target_date:   { type: date }
+      budget:        { type: integer }
+
+  task:
+    label: Task
+    id_prefix: TSK
+    id_type: manual
+    default_sort:
+      - property: due
+    properties:
+      title:    { type: string, required: true }
+      status:   { type: task_status, required: true }
+      priority: { type: priority, required: true }
+      start:    { type: date }
+      due:      { type: date }
+      estimate: { type: integer }
+
+  control:
+    label: Control
+    id_prefix: CTL
+    id_type: manual
+    properties:
+      title:  { type: string, required: true }
+      family: { type: control_family, required: true }
+      status: { type: control_status, required: true }
+
+  risk:
+    label: Risk
+    id_prefix: RSK
+    id_type: manual
+    properties:
+      title:      { type: string, required: true }
+      level:      { type: risk_level, required: true }
+      likelihood: { type: integer }
+      impact:     { type: integer }
+      status:     { type: risk_status, required: true }
+
+  policy:
+    label: Policy
+    id_prefix: POL
+    id_type: manual
+    # Editorial axis: a bare id addresses the draft; publishing creates the
+    # published face (see `copies:`).
+    bare_face: draft
+    faces:
+      draft:     { label: "Draft" }
+      published: { label: "Published" }
+    properties:
+      title:   { type: string, required: true }
+      status:  { type: policy_status, required: true }
+      owner:   { type: string }
+      version: { type: string }
+
+  document:
+    label: Document
+    id_prefix: DOC
+    id_type: manual
+    # Language axis: English is what a bare id addresses; Dutch is a peer.
+    bare_face: en
+    faces:
+      en: { label: "English" }
+      nl: { label: "Nederlands" }
+    properties:
+      title:    { type: string, required: true }
+      category: { type: doc_category, required: true }
+
+types:
+  department:
+    values: [engineering, security, operations, finance, leadership]
+  project_status:
+    values: [proposed, active, on-hold, done]
+    initial: proposed
+    transitions:
+      - { from: proposed, to: active, label: "start" }
+      - { from: active, to: on-hold, label: "pause" }
+      - { from: on-hold, to: active, label: "resume" }
+      - { from: active, to: done, label: "finish" }
+  task_status:
+    values: [todo, doing, review, done]
+    initial: todo
+    transitions:
+      - { from: todo, to: doing, label: "start" }
+      - { from: doing, to: review, label: "submit" }
+      - { from: review, to: doing, label: "rework" }
+      - { from: review, to: done, label: "accept" }
+  priority:
+    values: [low, medium, high, critical]
+  control_family:
+    values: [organizational, people, physical, technological]
+  control_status:
+    values: [missing, partial, implemented]
+  risk_level:
+    values: [low, medium, high]
+  risk_status:
+    values: [open, mitigated, accepted]
+    initial: open
+    transitions:
+      - { from: open, to: mitigated, label: "mitigate" }
+      - { from: open, to: accepted, label: "accept" }
+  policy_status:
+    values: [to-do, doing, done]
+    initial: to-do
+    transitions:
+      - { from: to-do, to: doing, label: "start" }
+      - { from: doing, to: done, label: "finish" }
+  doc_category:
+    values: [guide, runbook, reference, decision]
+
+relations:
+  member-of:
+    description: A person belongs to a team. Walked by the ACL for group roles.
+    from: [person]
+    to: [team]
+  leads:
+    description: A person leads a project.
+    from: [person]
+    to: [project]
+  owns:
+    description: A team owns a project.
+    from: [team]
+    to: [project]
+  contains:
+    description: Work breakdown, traversed by the gantt. Self-referential so subprojects and subtasks nest.
+    from: [project, task]
+    to: [project, task]
+  assigned-to:
+    description: A task is assigned to a person.
+    from: [task]
+    to: [person]
+  depends-on:
+    description: A task depends on another task.
+    from: [task]
+    to: [task]
+  mitigates:
+    description: A control mitigates a risk.
+    from: [control]
+    to: [risk]
+  implements:
+    description: A policy implements a control. Content-scoped, so a draft may implement a different set than the published face.
+    from: [policy]
+    to: [control]
+    scope: content
+  owned-by:
+    description: A policy is owned by a team. Identity-scoped, shared by every face.
+    from: [policy]
+    to: [team]
+    scope: identity
+  references:
+    description: A document references a policy or control. Content-scoped, so a translation may cite differently.
+    from: [document]
+    to: [policy, control]
+    scope: content
+
+worlds:
+  published:
+    select: published
+    # Documents have no `published` face; English is their published form.
+    overrides:
+      document: [en]
+    otherwise: exclude
+    banner: "Published — what readers see"
+  editorial:
+    select: [draft, published]
+    otherwise: default
+    banner: "Editorial — drafts included"
+  site-nl:
+    select: [nl, en]
+    otherwise: default
+
+copies:
+  publish:
+    from: policy@draft
+    to: policy@published
+    label: Publish
+    fields: all
+    guard:
+      permission: publish-policy

--- a/tickets/entities/docs-checklists/DOCS-CF2ZL2.md
+++ b/tickets/entities/docs-checklists/DOCS-CF2ZL2.md
@@ -1,0 +1,61 @@
+---
+id: DOCS-CF2ZL2
+type: docs-checklist
+title: 'Docs: PostgreSQL read-path performance audit (query accounting, perf seed, batching, pushdown, indexes)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported functions/types have godoc
+- [x] Non-obvious decisions explained in comments
+- [x] Package docs updated if package purpose changed
+
+New exported API carries godoc that says why it exists, not just what it does:
+`store.QueryStats` (why two counters and nothing per statement),
+`store.RelationQuery.EntityIDs` (nil vs empty, composition with Direction and
+FromFace), `store.GraphHeaderQueryer` / `GraphQueryHeaders`,
+`store.MatchedCounter` / `CountMatched` (why the unscoped total is never
+exposed), `store.GraphQuery.OrderBy/Limit/Offset` and `OrderSpec` (absent value
+sorts as largest, and why that asymmetry lets one index serve both directions),
+`store.DerivedListIndex` and `DerivedObjectSpec.OrderBy`,
+`worldreader.RelationReader.NeighborsForPage`,
+`userstate.Store.SnoozedUntilMany` / `LastShownMany`, `queryplan.StringShaped`,
+`acl.PrincipalStore`, `storetest.Counting`, the whole `perfseed` package
+(package doc explains why a generator, determinism, and the raw-store
+obligations).
+
+Decisions documented where someone would otherwise undo them:
+`pgstore/tracer.go` (always attached; no allocation when nothing applies),
+`dataentry/requeststats.go` (Debug gate is a security property),
+`dataentry/rowcontent.go` (file comment: where content-free entities may and may
+not travel), `dataentry/listpushdown.go` (eligibility is what makes the two
+paths agree), `pgstore/world.go effectiveWorld` (byte-identical collapse),
+`pgstore/search.go searchRankPrefix` (ranking on the identity/title prefix),
+migration `0014_read_indexes.sql` header (each index's reason, the tsv drop, the
+search_text rebuild and its lower() caveat), `pgstore.go` plimsoll note
+(optional capabilities must live on the store type to be type-assertable),
+`acl/declarative.go requestFor` (why reuse is safe only with both guards).
+
+## Project Documentation
+
+- [x] CLAUDE.md updated with new patterns — the "collection reads are
+content-free, batched per page, paged in the store" rule; the fourth raw-store
+exception (`rela dev seed`)
+- [x] docs/ updated for changed behaviour — `docs/postgres-backend.md`
+("Observing query cost", derived list indexes, corrected search paragraph,
+ordering semantics), `docs/data-entry.md` (sort semantics for absent values),
+`docs/data-entry/api-reference.md` ("Collection rows are content-free",
+`include_content`), `docs/acl-security.md` ("Query accounting is a Debug-only
+diagnostic")
+- [x] ~~Architecture docs updated~~ (N/A: no package boundary change beyond the
+new `perfseed` leaf, which is declared in `.go-arch-lint.yml` with its reason)
+
+## External Documentation
+
+- [x] ~~README updated~~ (N/A: no headline feature; the seeder is a developer tool)
+- [x] CLI reference updated — `docs/cli-reference.md` gains `rela dev seed`
+- [x] API docs updated — OpenAPI list parameters gain `include_content`; the
+API reference documents content-free rows

--- a/tickets/entities/features/FEAT-R012DX.md
+++ b/tickets/entities/features/FEAT-R012DX.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-R012DX
+type: feature
+title: Data-entry read paths are query-efficient on PostgreSQL
+summary: Every SPA-triggered request against the postgres backend issues a bounded, observable number of SQL statements, projects only the columns it renders, and hits an index for its predicates.
+description: 'The data-entry SPA drives the postgres backend through generic store methods that were designed for the filesystem store: full-row loads (markdown body included) for listings that render titles, per-row follow-up queries for relations and neighbours, and Go-side sorting/filtering after fetching everything. This feature covers (1) making the per-request query count observable so regressions are visible, (2) measuring the actual SQL against a realistic seeded project with ACL and worlds/faces, and (3) fixing the hot paths: header-only projections for listings, batched relation/neighbour loads, predicate pushdown and derived indexes where a query shape is static.'
+priority: high
+status: proposed
+---

--- a/tickets/entities/implementation-checklists/IMPL-BCZLPW.md
+++ b/tickets/entities/implementation-checklists/IMPL-BCZLPW.md
@@ -1,0 +1,74 @@
+---
+id: IMPL-BCZLPW
+type: implementation-checklist
+title: 'Implementation: PostgreSQL read-path performance audit: per-request query counting, seeded demo with ACL + worlds, slow-query driven optimisation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Tests added: `store/querystats_test.go`, `pgstore/tracer_test.go` +
+`tracer_pool_test.go` (DB-gated stats incl. Tx),
+`dataentry/requeststats_test.go` (header under Debug only, SSE excluded, router
+wiring), `perfseed_test.go` (determinism, stream independence, shape,
+referential integrity, load into memstore, cancel), storetest conformance for
+`RelationQuery.EntityIDs` (union-of-scalar-calls, nil vs empty, composition),
+`GraphQueryHeaders`, `OrderBy/Limit/Offset` (missing-largest ordering, window =
+slice, count ignores paging, headers page the same), `CountMatched`;
+`acl/requestreuse_test.go` (one walk per bound request, foreign request
+ignored); `dataentry/querybudget_test.go` (size independence + pinned
+constants), `rowcontent_test.go` (content omitted/opt-in on list and search,
+ordering + total intact), `listpushdown_test.go` (differential pushed-vs-Go for
+8 shapes × 2 page sizes × 3 pages, eligibility table, scoped total for a gated
+principal), `views_test` recursive traversal (set semantics), `queryplan`
+list-index specs, `pgstore` list index naming/DDL, EXPLAIN uses the list index
+with no Sort node, ranking prefers a title match, migration 0014 rebuild equals
+the store's composition, `userstatetest` batch lookups on mem/kv/pg.
+
+Edge cases from planning: dangling neighbour ids (absent from header batch →
+dropped, as before); duplicated ids per page; empty `EntityIDs` matches nothing
+with an explicit `::text[]` cast on pg and `(NULL)` on sqlite; page beyond the
+end (clamped window, correct total); sort key absent on some rows (largest-value
+semantics on both paths, pinned by the differential test); errored statements
+still counted; seeder at scale 0.01 and `--force`; foreign/mismatched
+`acl.Request` on ctx not reused.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+- AC1: `curl -D - .../api/v1/tasks` against `rela-server-postgres -verbose` shows `Server-Timing: db;dur=3.1;desc="8 queries"`; without `-verbose` the header is absent; the log carries one `msg=request` line per request.
+- AC2: `go test -run QueryBudget ./internal/dataentry/` — list 6, view section 11, search 3 store calls at both 10 and 50 rows.
+- AC3: `rela-postgres dev seed --project prototypes/perf/project --scale 1` → 19,117 rows + 47,549 relations in ~40 s; second run refuses ("store already holds 18,000 entities"); `.rela/audit.jsonl` carries a `perf-seed` record on the fs build; `rela analyze all` on a seeded fs copy reports no property/cardinality issues.
+- AC4: table in the ticket body (`.ignored/perf/baseline-before.tsv` vs `after-d4.tsv`, second pass): every listed endpoint's query count is now independent of rows; DB time drops 5–100× on lists, kanban, search, next actions; reader/editor rows match.
+- AC5: `TestGraphQueryExplainPagedListUsesDerivedListIndex` (index scan, no Sort); startup log on the perf DB shows two `rela_derived_list__` indexes created; `pg_indexes` confirms `entities_type_id_idx`, `entities_id_prefix_idx`, tsv index gone.
+- AC6: existing ACL list/view/search tests pass over batched paths; `TestListPushdown_ScopedTotalForGatedPrincipal` (total = visible count, denied type empty); world tests in `dataentry` and `storetest` pass with the faceless-type collapse (byte-identical results).
+- AC7: `TestListRows_OmitContentUnlessRequested`, `TestSearchRows_OmitContentUnlessRequested`; SPA components read no list-row content (grep); e2e run recorded below.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — `queryplan.StringShaped` is the one definition of "byte-comparable property" shared by prefilter pushdown, list pushdown and index derivation; `rowKey`/`loadRows` shared by content reload and hit loading; `edgesPerIndex`/`each` in perfseed
+- [x] No security issues introduced (Server-Timing gated on Debug; scoped counts only; batched reads go through the same gates; seeder is attributed and audited)
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-B7F1R4.md
+++ b/tickets/entities/planning-checklists/PLAN-B7F1R4.md
@@ -1,0 +1,472 @@
+---
+id: PLAN-B7F1R4
+type: planning-checklist
+title: 'Planning: PostgreSQL read-path performance audit: per-request query counting, seeded demo with ACL + worlds, slow-query driven optimisation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Problem.** The data-entry SPA drives `pgstore` through store calls shaped for
+the filesystem store. Three compounding defects, confirmed by code survey:
+
+1. *Full-row loads.* `entities.content` (the markdown body) sits in the same
+row as `properties`. `ListEntities`, `GraphQuery`, `GetEntity`, `ListRelations`,
+`SearchVisible` all select it. `ListEntityHeaders` (`pgstore/entity.go:93`,
+TKT-1ESTYJ) exists but only `_analyze` uses it, and the ACL pushdown
+(`visibility/pushdown.go`) has no header variant. List rows are serialized WITH
+`Content` (`entityserializer.go:54`) though no list/kanban/dashboard/search
+component reads it (verified by grep).
+2. *N+1 per row.* The list endpoint loads the entire type unpaginated
+(`api_v1.go:327` `scopedSortedEntities`), sorts and slices in Go (`:658-668`),
+then per page row does 2 relation queries (`worldneighbors.go:850`) and one
+`GetEntity` per neighbour (`relation_visibility.go:72`). Entity view table
+sections do one `ListRelations` + one `GetEntity` per row × per relation column
+(`sections.go:307` → `views_handler.go:801-829`). Search does `GetEntityState`
+per hit (`queryservice.go:201`). Affordances do `GetEntityState` per declared
+face (`affordances.go:1334`). Kanban fetches up to 50 pages sequentially, each
+paying the full pipeline (`KanbanView.vue:135`, `api/entities.ts:88`).
+`_position` reruns the whole list pipeline per detail page. `internal/tracer`
+BFS does `GetEntity` + `ListRelations` per visited node.
+3. *No observability.* The only query logging is `debugQueryTracer`
+(`pgstore/tracer.go`), Debug-level, all-or-nothing, no per-request aggregation.
+No request log middleware exists. No index/EXPLAIN coverage beyond
+`graphquery_explain_test.go`. Index gaps: no `(type, face)`, no JSONB index on
+`properties` (so `PropertyValues` and property predicates seq-scan), `HighestID`
+runs `LIKE 'PFX-%'` without `text_pattern_ops`, and `entities_search_tsv_idx` is
+maintained but never queried (verified: `search.go` uses LIKE + `similarity()`
+only; folds TKT-ZZL53L).
+
+**Scope:**
+
+IN:
+- A. Per-request query stats: count + total DB time on the request context,
+surfaced as a `Server-Timing` header and one slog `request` record **only when
+Debug logging is enabled** (`rela-server -verbose`, the condition that already
+gates the pgx tracer); nothing on the wire by default (RR-64OR7D). Plus a
+backend-agnostic store-call counting decorator for tests.
+- B. A seeded perf demo project (`prototypes/perf/project/`) with faces +
+worlds + `acl.yaml` (roles, membership edges, `visible:` redaction) and a full
+`data-entry.yaml` (lists with relation columns/filters, views with table
+sections, 2 kanbans, dashboard, gantt, next-actions), plus a deterministic `rela
+dev seed` command that fills any store (fs or pg build) at a chosen scale.
+- C. Baseline measurement: query count, DB ms, wall ms per SPA endpoint × 3
+principals × default/published world, plus the postgres slow-query log with
+`auto_explain`. Recorded in the ticket.
+- D. Optimisations, in impact order, each pinned by a query-budget test:
+  1. Batch loads: `RelationQuery.EntityIDs` (plural of `EntityID` under
+identical `Direction`/`FromFace` semantics; fs/mem/pg/sqlite + storetest),
+neighbour titles via `ListEntityHeaders{IDs}` filtered by the existing
+`visibility.HeaderFilterer`, section relation columns batched per section,
+search hits batched, faces batched, tracer BFS batched per frontier.
+  2. Content-free listings: a `store.GraphHeaderQueryer` optional capability
+(`GraphQueryHeaders`, pg-native projection + generic fallback) and
+`visibility.listPushdownHeaders`, so BOTH AllowAll and Query principals read
+headers (RR-O5W4A3); list/search/kanban/dashboard rows omit `content` unless
+`?include_content=true`.
+  3. Push pagination + count into the store for the common list shape (no
+relation filter, no free text, sort on id/updated_at or a declared scalar
+property): paging fields set only on the per-request copy in `listPushdown`; the
+handler receives only the scoped `matched` count (RR-J1VAW0). Go path stays as
+fallback for other shapes.
+  4. Indexes: migration `0014_read_indexes.sql` adding `entities (type,
+face)`, `entities (id text_pattern_ops) WHERE face=''`, GIN `jsonb_path_ops` on
+`properties`; `DROP INDEX entities_search_tsv_idx` with a comment naming the
+LIKE/trgm strategy; docs paragraph corrected. Extend the derived-index
+reconciler eligibility to static `lists.*.where`/`sort` and kanban `where`
+shapes.
+  5. Cheap fixes: `a.Services()` rebuilt per row, `_position` computed from
+`MatchingIDs` instead of a full re-run; reconcile the 87-vs-104 plimsoll
+comment.
+- E. Docs: `docs/postgres-backend.md` section "Observing query cost", CLI
+reference for the seeder, API note on `include_content`, openapi update,
+CLAUDE.md rule + raw-store exception list (3 → 4).
+
+OUT (stay as their own tickets):
+- Server-side aggregation for count/breakdown cards (TKT-AIEGHU) and
+table-card limit/sort pushdown (TKT-8AUD1U) — wire-shape changes to the
+dashboard; this ticket only makes their rows content-free.
+- Bounding structured search (TKT-T0DK37) — easier after D.3; not done here.
+- Pushing field-visibility provenance into SQL (TKT-L59KUM).
+- Locale-aware sort semantics for property sort pushdown: pushdown is only
+used where the Go comparator and `ORDER BY ... COLLATE "C"` agree (id,
+timestamps, enum/string equality); otherwise the Go path stays.
+- Any change to write paths, versioning, sweep, or the change feed.
+- Frontend redesign of kanban fetching beyond consuming the cheaper API.
+
+**Acceptance Criteria:**
+
+1. **Observability.** With Debug logging enabled, every `/api/v1/*` response
+on the postgres build carries `Server-Timing: db;dur=<ms>;desc="<n> queries"`
+and one slog record `request` with method, path, status, wall_ms, queries,
+db_ms. With Debug disabled neither is emitted. Tests: postgres-tagged handler
+test asserts the header and that `n` equals the count observed by a test tracer;
+unit test for the context stats type; test that the header is absent at Info
+level.
+2. **Budget pins (backend-agnostic).** Using the counting store decorator
+over memstore: for a list page with relation columns, an entity view with a
+table section having 2 relation columns, a search, and a kanban page, the
+store-call count at 10 rows equals the count at 50 rows (size independence), and
+the measured constant is pinned with a comment giving the pre-change count
+(RR-CH8CX9). Targets: list ≤ 6, view ≤ 8, search ≤ 4.
+3. **Seeder.** `rela dev seed --profile perf --scale 1` writes a
+deterministic project (≈20k entities, ≈60k relations, faces on two types,
+membership edges for ACL) into the current backend with
+`store.WithAttribution(system:perf-seed)` and an audit record, refuses a
+non-empty store without `--force`, validates every id, and completes into local
+postgres in under 3 minutes. Same seed → identical ids/properties on both
+backends (conformance test at scale 0.01).
+4. **Measured improvement.** For each endpoint in the baseline table the
+after-column shows: list page, detail view, search, kanban page, dashboard →
+query count no longer grows with N (row count) and DB ms drops ≥ 5× at scale 1,
+for reader/editor/manager alike (RR-O5W4A3). The table lives in the ticket body.
+5. **Indexes proven.** Each new index has an EXPLAIN test in the pattern of
+`graphquery_explain_test.go` showing the target query uses it; the derived
+reconciler creates an index for a list `where:` shape and drops it when the
+config is removed (unit + DB test).
+6. **ACL unchanged.** Every batched path yields identical visible sets and
+redacted values to the per-row path: (a) a hidden neighbour in a batch of 50
+stays hidden and its title never appears in list `included`/section values; (b)
+an AllowAll principal under the `published` world doing a 50-row list with
+relation columns and a section view sees no draft-face title through any batched
+path (RR-7JCLZP); (c) a scoped principal's list `total` equals the visible
+count, not the table count (RR-J1VAW0); (d) a `visible:`-redacted field is
+redacted in header rows.
+7. **Wire compatibility.** List/search rows omit `content` by default;
+`?include_content=true` restores it; the SPA passes all e2e tests unchanged
+except where it intentionally stops requesting content; verified that
+`relationsPatch.ts:107` is fed by the detail endpoint, not a list row.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: approach is dictated by measured defects and existing patterns; the survey above IS the research)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A
+
+**Existing Solutions:**
+
+- `pgx.QueryTracer` is the library-level hook; already used by
+`debugQueryTracer` (`pgstore/tracer.go:22`, attached at `open.go:32`). The
+tracer slot is singular, so the counting tracer absorbs the debug logging rather
+than composing two tracers. No `MultiTracer` in pgx v5.
+- `store.HeaderReader`/`ListEntityHeaders` (`pgstore/entity.go:93`) honours
+`World`/`FaceIn` via the shared `buildEntitySelectSQL` — verified.
+`visibility.RedactHeader` (`policyreader.go:267`) and
+`HeaderFilterer.FilterHeaders` (`visibility.go:179`) already exist; what is
+missing is `visibleReader.filterVisibleHeaders` in dataentry and a header
+variant of the pushdown.
+- `EntityQuery.IDs` already batches entity lookups (`store.go:279`);
+`RelationQuery` has no batch endpoint field — needs `EntityIDs`.
+- `ListEntitiesPage` keyset paging (`store.go:251`) exists, unused by the list
+handler. ACL compiles to a `GraphQuery` (`acl/readquery.go:18-37`) copied per
+request in `pushdown.go:117-124`; `GraphCount` returns `(matched, total)`.
+- Derived-index reconciler (`pgstore/derivedschema.go`, `internal/queryplan`,
+TKT-03HCWT) — the sanctioned "automated indexes" mechanism; extend eligibility
+rather than adding a second one. EXPLAIN test harness at
+`graphquery_explain_test.go:124`.
+- Seeding: `scripts/generate-test-data.sh` (bash, own 4-type schema, no
+ACL/faces), `graphquery_bench_test.go:63 benchSetup` (Go, 10k rows, test-only),
+`prototypes/worlds/project` (richest faces/worlds/ACL config, zero data).
+Nothing seeds thousands of rows into postgres.
+- Middleware chain `router.go:182-238`; `stampAuditPrincipal` (`:913`) is
+the outermost wrapper touching every request. No request-id or access-log
+middleware exists.
+- Local postgres: Postgres.app 15.17 on 127.0.0.1:5432 (superuser), with
+`auto_explain` available; `log_min_duration_statement` currently -1. Migrations:
+next free number is 0014 (two `0003_*` files exist, so the runner orders by full
+filename).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+*A. Query stats.*
+- `internal/store/querystats.go`: `type QueryStats struct{ queries, nanos atomic.Int64 }`
+with `WithQueryStats(ctx) (context.Context, *QueryStats)` and
+`QueryStatsFrom(ctx) *QueryStats` (nil when absent). Lives in `store` because
+both `pgstore` and `dataentry` may import it under arch-lint and it is part of
+the store contract ("a store reports its work").
+- `pgstore/tracer.go`: `queryTracer{debug bool}`, always attached in
+`Open`. `TraceQueryStart` returns ctx unchanged when neither stats nor debug
+apply (no alloc — preserves the documented production guarantee); otherwise
+stores start time. `TraceQueryEnd` increments stats and logs at Debug when
+enabled. `Tx` views share the pool so they are covered.
+- `dataentry/requeststats.go`: `requestStats(next, enabled func() bool)`
+wrapped outermost beside `stampAuditPrincipal`; when Debug is enabled it
+installs stats, wraps the ResponseWriter to add `Server-Timing` at first
+`WriteHeader`, and logs the `request` record after `next.ServeHTTP`. SSE paths
+excluded from the header (streams). When disabled it is a pass-through.
+- `internal/store/storetest/counting.go`: a `store.Store` decorator counting
+method calls by name, for budget tests on memstore. Counts store calls, not SQL
+— which is what dataentry's N+1s are made of; the pgstore test pins SQL for one
+representative endpoint so the two stay aligned.
+
+*B. Perf demo project + seeder.*
+- `prototypes/perf/project/{schema.yaml,acl.yaml,data-entry.yaml,templates/}`.
+Domain: `policy` (faces draft/published, `bare_face: draft`), `document` (faces
+en/nl), `control`, `risk`, `project`, `task` (status enum, start/due dates,
+`parent-of` for gantt), `person` (`visible:`-redacted salary), `team`.
+Relations: mitigates, implements, belongs-to, assigned-to, depends-on, member-of
+(membership relation), parent-of, references. Worlds: published (otherwise
+exclude), editorial (otherwise default), site-nl (select [nl,en]). Roles: reader
+(world:published + policy@published, no risk/person), editor, manager;
+assignments via `member-of` edges to teams. **No `unique:` properties**
+(store-level writes bypass entitymanager's unique scan, RR-7EJIWL). data-entry:
+lists with relation columns and a relation filter, views with table sections,
+kanbans (task by status, policy pipeline), dashboard (count/breakdown/table),
+gantt on project/task, next-actions.
+- `internal/perfseed`: pure generator `Generate(Profile, scale, seed)`
+emitting `entity.Entity`/`entity.Relation` from word banks with a seeded PRNG;
+ids are prefix+counter (unique by construction) and pass `storeutil.ValidateID`;
+bodies 0.5–8 KB markdown. `Load(ctx, store, gen)` writes through `store.Store`
+inside `Tx` batches under `store.WithAttribution(system:perf-seed)`, faces via
+faced ids, and writes one audit record `perf-seed`.
+- `internal/cli/dev_seed.go`: `rela dev seed --profile perf --scale N
+[--seed S] [--force]`; raw-store write at operator trust (fourth sanctioned
+exception after `db migrate`, `history-purge`, data-migration/GC; CLAUDE.md list
+updated), refuses when `CountEntities > 0` unless `--force`. On pg the version
+sweep captures one version per seeded row; accepted as realistic load and
+documented.
+
+*C. Baseline.* Script in `.ignored/perf/` (not committed): creates database
+`rela_perf`, `ALTER DATABASE rela_perf SET log_min_duration_statement = 20`,
+`SET session_preload_libraries = 'auto_explain'`, `auto_explain.log_min_duration
+= 20ms` (reload only, no restart, RR-BPGZ4C); starts `rela-server-postgres
+-verbose`; curls the SPA's endpoint set (`_schema`, `_config`, `_dashboard`,
+`_sidebar`, list pages 1/2 for each list, `_views` for 5 entities per type,
+`_position`, `_search` free text and `type:` queries, kanban pages, `_gantts`,
+`_commands`) as reader/editor/manager × default/published/site-nl worlds; parses
+`Server-Timing`; collects the postgres log. Results go into the ticket as a
+table.
+
+*D. Optimisations* (each its own commit with its budget test; all new dataentry
+helpers are free functions taking their read seams, in the `visibleRelationIDs`
+shape — never `App` methods, RR-CHIFV2):
+1. `store.RelationQuery.EntityIDs []string`: plural of `EntityID`, same
+`Direction`/`FromFace` composition; nil = unfiltered, empty = none;
+fs/mem/pg/sqlite; storetest asserts `{EntityIDs:[a,b], FromFace:&f}` == union of
+the two scalar calls (RR-E0PJ0B). One dataentry helper `pageQueries(req)` builds
+every batched `EntityQuery`/`RelationQuery`, stamping
+`World`/`FaceIn`/`FromFace` from the request so no call site hand-builds one
+(RR-7JCLZP). `servedFacePageEdges` → one `ListRelations{EntityIDs: pageIDs}`;
+`worldNeighborsForPage` same. `visibleRelationIDs` → `ListEntityHeaders{IDs}`
+then new `visibleReader.filterVisibleHeaders` delegating to the existing
+`HeaderFilterer`. `resolveRelationColumnValues` → per-section batch: one
+`ListRelations` for all row ids and types, one header batch for targets.
+`runVisibleFreeTextSearch` → `ListEntities{IDs}` (world-aware). `computeFaces` →
+one `ListEntities{IDs:[id], AllStates:true}`. `tracer` BFS → per-frontier
+`ListRelations{EntityIDs}`.
+2. `store.GraphHeaderQueryer` optional capability (`GraphQueryHeaders(ctx,
+GraphQuery) iter.Seq2[EntityHeader, error]`), pg-native, generic fallback
+dropping content; `visibility.listPushdownHeaders` mirrors `listPushdown` for
+all three branches; `visibleReader.listHeaders`. Serializer gets a header
+variant that omits `content`. `handleV1ListEntities`, `handleV1Search`, kanban
+and dashboard card queries use it; `?include_content=true` keeps the entity
+path.
+3. List pushdown: when there is no relation filter, no free text, and the
+sort key is id/updated_at or a declared scalar property (metamodel allowlist),
+call `GraphCount` through a helper returning only `matched`, and a paged
+`GraphQuery` with `OrderBy`/`Limit`/`Offset` set on the per-request copy inside
+`listPushdown` (test mirrors the world-bleed test). pg implements in SQL
+(`properties->>$n` parameterised, `NULLS LAST` matching the Go comparator),
+fs/mem via `graphquerynaive`.
+4. Migration `0014_read_indexes.sql` (above) + `queryplan` eligibility for
+list/kanban `where:` and list `sort:` (index `(type, (properties->>sortkey))`),
+same all-or-nothing reconcile rule.
+5. Hoist `a.Services()`; `_position` via `MatchingIDs` over the sorted id
+list; reconcile the plimsoll comment.
+
+**Alternatives considered:**
+- A `DBTX` counting decorator instead of the pgx tracer: misses the listener
+connection and needs `Begin`-returned `Tx` wrapping; tracer covers all.
+- A separate `internal/querystats` package: adds an arch-lint component for
+one 40-line type; `store` already is the shared contract.
+- Always-on `Server-Timing`: rejected — the query count is row-dependent on
+fallback paths and would be a machine-readable existence channel (RR-64OR7D); it
+is an operator diagnostic.
+- Seeding via `rela import`/`rela sync push` from generated markdown: import
+has no face support and sync's relation path cannot address a tail
+(BUG-FACEVER); direct store writes avoid both and are 10× faster.
+- Seeder as a shell script (extending `generate-test-data.sh`): heredoc per
+file is too slow at 20k and cannot write postgres.
+- `OmitContent bool` on `EntityQuery`: rejected for the same reason
+TKT-1ESTYJ rejected it — a content-less `entity.Entity` lies to the 337
+`.Content` readers; keep the typed header.
+- A second redaction implementation for headers: rejected; `RedactHeader`
+exists and `Redact` is documented non-composable — single point stays.
+- Fixing kanban by a dedicated endpoint: not needed once list pages are
+cheap and content-free; revisit if measurement says otherwise.
+
+**Files to modify:**
+- `internal/store/store.go` (RelationQuery.EntityIDs, GraphQuery paging,
+GraphHeaderQueryer), `internal/store/querystats.go` (new),
+`internal/store/storetest/*` (conformance for the new fields, counting
+decorator)
+- `internal/store/pgstore/{tracer.go,open.go,relation.go,entity.go,graphquery.go,derivedschema.go,migrations/0014_read_indexes.sql}`
+  + `graphquery_explain_test.go`, new `tracer_stats_test.go`
+- `internal/store/{fsstore,memstore,sqlitestore,graphquerynaive}` (EntityIDs, paging, header fallback)
+- `internal/queryplan` (list/kanban shapes)
+- `internal/visibility/pushdown.go` (header pushdown, paging on the copy)
+- `internal/dataentry/{router.go,requeststats.go(new),api_v1.go,worldneighbors.go,relation_visibility.go,views_handler.go,sections.go,queryservice.go,affordances.go,entityserializer.go,visiblereader.go,services.go,app.go}` + tests
+- `internal/tracer/tracer.go`
+- `internal/perfseed/*` (new), `internal/cli/dev_seed.go` (new), `.go-arch-lint.yml`
+- `prototypes/perf/project/*` (new)
+- `frontend/src/api/entities.ts` (no content on list fetches; kanban page size)
+- `internal/openapi`, `docs/postgres-backend.md`, `docs/cli-reference.md`, `docs/data-entry.md`, `docs/acl-security.md`, `CLAUDE.md`
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+- `?include_content=true|false`: boolean parse, anything else → false.
+- `?page`/`per_page` already validated; pushdown reuses the parsed values
+and caps `per_page` as today.
+- Sort key pushdown: allowlist = declared scalar properties of the type from
+the metamodel; anything else falls back to the Go comparator. Never interpolated
+— properties go through `properties->>$n` parameters.
+- Seeder flags: `--scale` float in (0, 10], `--seed` int, `--profile` from a
+fixed set; operator shell trust, same as `db migrate`.
+
+**Security-Sensitive Operations:**
+- *Read-side ACL.* Every batched read replaces a per-row gated read; the
+batch runs through the same `filterVisible`/`FilterHeaders` +
+`Redact`/`RedactHeader` on raw store rows exactly once. Row-gating stays a
+pushed `ReadQuery` allowlist — no runtime deny introduced. Batched queries are
+built by one helper that stamps `World`/`FaceIn`/`FromFace`, closing the
+AllowAll + FaceIn fail-open shape (AC6b).
+- *Count oracle.* Only the ACL-scoped `matched` count reaches the handler
+(AC6c), mirroring today's `len(entities)` (RR-SSPCCI).
+- *Server-Timing header / request log.* Emitted only under Debug logging;
+documented in `docs/acl-security.md` beside the timing-exposure note
+(TKT-VR5U3Q) as an operator diagnostic that must not be enabled on a
+multi-principal deployment without understanding it exposes per-response query
+counts.
+- *Seeder* writes raw store (no entitymanager): operator-only, audited,
+attributed, refuses non-empty store; never wired into the server.
+- *Indexes* change no semantics; the derived reconciler keeps its
+all-or-nothing rule (invalid `data-entry.yaml` → no reconcile).
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+- AC1: `store/querystats_test.go` (concurrent increments, nil when absent);
+`pgstore/tracer_stats_test.go` (DB-gated: N queries → stats N, Tx included, no
+ctx alloc when absent and debug off); `dataentry/requeststats_test.go` (header
+present on API under Debug, absent under Info, absent on SSE, record fields).
+- AC2: `dataentry/querybudget_test.go` over memstore + counting decorator:
+list page 10 vs 50 rows with 2 relation columns; view with table section; search
+100 hits; kanban page; equality across sizes plus pinned constant.
+- AC3: `perfseed` determinism test (same seed twice → identical ids and
+property hashes), fs vs mem parity at scale 0.01, refuse-non-empty test, id
+validation test, attribution/audit record test.
+- AC4: manual, recorded table (before/after), postgres slow log excerpt.
+- AC5: EXPLAIN tests per index; reconciler unit test for list `where:` shape
+→ spec; DB test create/drop.
+- AC6: visibility tests a–d for list, section and search, including the
+AllowAll-under-published-world case and the world-bleed mirror test for paging
+fields on the copy.
+- AC7: e2e suite green; openapi test updated for `include_content`;
+`relationsPatch.ts` data source verified.
+
+**Edge Cases:**
+- Page with zero relations; neighbour ids duplicated across rows; neighbour
+id that no longer exists (dangling relation) — batch returns fewer headers than
+ids, map lookup yields "unknown" exactly as today.
+- Entity with faces where only a non-default face exists in the world.
+- `EntityIDs` empty slice vs nil: nil = unfiltered, empty = matches nothing
+(pin in storetest; pg uses `= ANY($1::text[])` with an explicit cast).
+- `per_page` > cap, `page` beyond last page under pushdown → empty data,
+correct total.
+- Sort on a property absent on some rows: pushed `ORDER BY` NULLS LAST must
+match the Go comparator's placement; test both.
+- Stats when a query errors: still counted, duration recorded.
+- Seeder at scale 0.01 (≈200 entities) and `--force` on a non-empty store.
+
+**Negative Tests:**
+- `?include_content=maybe` → treated as false.
+- Sort key not a declared property → Go path, no SQL error.
+- Seeder on non-empty store without `--force` → exit 1, nothing written.
+- Invalid `data-entry.yaml` → reconciler leaves existing derived indexes.
+- Header path handed to a `.Content` consumer → does not compile (type).
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+- *Scope size.* Five optimisation slices plus seeder plus observability is
+`xl` territory. Mitigation: ship as sequential PRs on one ticket in the order A
+→ B → C → D.1 → D.2 → D.4 → D.3 → D.5, each independently mergeable; because A
+emits nothing by default, stop points after C and after D.2 are safe and would
+spin the rest into child tickets.
+- *Sort-pushdown semantic drift* (`localeCompare` vs `COLLATE "C"`).
+Mitigation: pushdown only for keys where the comparators provably agree;
+differential test comparing Go path and pushed path on the seeded set.
+- *Header pushdown duplicates GraphQuery SQL.* Mitigation: pg builds both
+from one `buildGraphQuerySQL` with a projection switch, as
+`buildEntityHeaderListSQL` already does for `ListEntities`.
+- *Wire change (content omitted).* Some external client may read `content`
+from list rows. Mitigation: opt-in `include_content`, documented, openapi
+updated; MCP and CLI do not use the v1 list endpoint.
+- *Migration on large tables.* GIN on `properties` and `text_pattern_ops`
+index builds lock briefly; migrations already run under an advisory lock at
+startup. Documented in the postgres guide.
+- *Local measurement not representative.* Localhost postgres hides network
+latency, which makes N+1 worse in production, not better; the query-count metric
+is latency-independent, which is why AC4 is stated in counts first.
+
+**Effort:** l for A–C + D.1–D.2; xl if all of D ships in this ticket.
+
+## Documentation Planning
+
+- [x] User-facing docs identified
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] docs/postgres-backend.md — "Observing query cost" (Server-Timing under
+`-verbose`, request log, slow-query log recipe), new indexes, extended derived
+index eligibility, corrected search paragraph (LIKE/trgm, no tsvector)
+- [x] docs/cli-reference.md — `rela dev seed`
+- [x] docs/data-entry.md — `include_content`, list rows are content-free
+- [x] docs/acl-security.md — Server-Timing note beside timing exposure
+- [x] CLAUDE.md — rule: "listings read headers, never full entities; batch
+neighbour loads by page, never per row"; raw-store exception list 3 → 4
+- [x] ~~docs/metamodel.md~~ (N/A: no schema syntax changes)
+- [x] ~~README.md~~ (N/A: operator docs live in docs/)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-64OR7D, RR-7EJIWL, RR-CH8CX9, RR-BPGZ4C
+(self-review); RR-O5W4A3, RR-J1VAW0, RR-7JCLZP, RR-E0PJ0B, RR-WQ3DQS, RR-CHIFV2
+(go-architect review). All addressed in the plan above; confirmed claims
+(ListEntityHeaders honours World/FaceIn; frontend reads no list-row content; tsv
+index unused; next migration 0014) folded into Research.

--- a/tickets/entities/review-checklists/REV-01BJAX.md
+++ b/tickets/entities/review-checklists/REV-01BJAX.md
@@ -1,0 +1,102 @@
+---
+id: REV-01BJAX
+type: review-checklist
+title: 'Review: PostgreSQL read-path performance audit: per-request query counting, seeded demo with ACL + worlds, slow-query driven optimisation'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+**Evidence (final run on e3c32de0, 2026-09-04):**
+- `just coverage-check`: package floor (50%) PASS, total floor (65%) PASS, total 79.2%. `internal/worldreader` was at 37.8% after the batching and is at 93.2% after `relations_page_test.go`.
+- `go test -race -tags postgres` over pgstore, appbuild, userstate, search, dataentry: ok (dataentry 458 s). `go test -race -tags sqlite ./internal/store/sqlitestore/`: ok.
+- `golangci-lint run ./...`: 0 issues. `just plimsoll`: OK. `just comment-lint`: no unresolvable doc links across 13,236 comments. `go-arch-lint check`: OK.
+- e2e (`just build-server-e2e && npm test`): 280 passed, 8 skipped, 1 failed (`create-redirect.spec.ts` "rapid create (stress)"), which passed 2/2 on an isolated rerun; it ran while the coverage and postgres suites were competing for CPU. The earlier git-crypt failure was real (lock indicator lost on header rows) and is fixed by `EntityHeader.Inaccessible`.
+- Pre-existing, out of scope: `go test -tags sqlite ./internal/appbuild/` fails `TestBuild_StateRows_WarnAtStartup` on `develop` too (the test's build constraint excludes postgres/memorybackend but not sqlite, and the sqlite build never reads entity files). CI does not run sqlite-tagged tests for that package.
+- Re-measured `.ignored/perf/baseline.sh` on the review-fixed build: status codes and query counts identical to the pre-review run on every endpoint (the review fixes are query-neutral); timings not comparable because the suites were running concurrently.
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** cranky-code-reviewer: RR-T3GR05 (critical, `ne` relation
+filter failed open), RR-LCS2Y3 (critical, JSON-null sort parity), RR-GQTAPX
+(critical, requestFor partial identity match; also raised by the security
+reviewer), RR-Q8488L (significant, BFS reorder unpinned), RR-9P8JYE
+(significant, per-row matcher allocation), RR-VNZV71 (significant, false
+redaction doc), RR-7LL8MB (significant, dead wrapper), RR-EQBQ7Q (significant,
+migration 0014 rewrite cost), RR-E8XF0Y, RR-K4DLZ8, RR-E2KNIT, RR-FV3O0H,
+RR-PN1STR (minor), RR-04KFJA (nit). rela-security-reviewer: RR-SR2NS0 (minor,
+header gate missing faceReadable) plus the requestFor finding folded into
+RR-GQTAPX. All 15 are `addressed` with resolutions; none deferred. Fixes are in
+commit e3c32de0.
+
+**Self-review:** the diff is confined to the read path, the seeder,
+observability and docs. No write-path, versioning, sweep or change-feed code
+changed. One deliberate cross-cutting change: `store.EntityHeader` gained
+`Inaccessible` so header rows keep the git-crypt lock marker.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+1. **Observability**: PASS. `requeststats_test.go` asserts the `Server-Timing` header and `request` record under Debug, absence at Info, absence on SSE; `pgstore/tracer_test.go` and `tracer_pool_test.go` assert the count matches the statements issued, including inside `Tx`; `store/querystats_test.go` covers the ctx type. Verified live on the perf server (`-verbose` prints `request ... queries=N db_ms=...`).
+2. **Budget pins**: PASS with one target missed. `querybudget_test.go` over `storetest.Counting` asserts 10-row and 50-row reads are equal and pins list page = 6 (target ≤ 6), search = 3 (target ≤ 4), view with a two-column table section = 11 (target ≤ 8). The view constant is above target because a view does entry load, two traverse passes, collection load, section columns plus target headers, entry edges and the membership walk, each one bounded query; it no longer grows with rows (was 1208 queries on the seeded project view, now 42).
+3. **Seeder**: PASS. `perfseed_test.go` covers determinism (same seed → identical ids and properties), id validation, entity and relation counts, refusal of a non-empty store, attribution and the audit record. Scale 1 into local postgres: 19,117 rows, 47,549 relations in about 40 s (target < 3 min).
+4. **Measured improvement**: PASS. Table in the ticket body: list page 207 → 8 queries, 180 → 3 ms; kanban 807 → 8, 215 → 10 ms; project view 1208 → 42; search `type:task` 66,004 → 4 queries, 3.2 s → 41 ms; free text 5.1 s → 1.2 s; next actions 7 queries, 12 ms. Query counts no longer depend on row count for reader, editor and manager alike.
+5. **Indexes proven**: PASS. `graphquery_explain_test.go` gains `TestGraphQueryExplainPagedListUsesDerivedListIndex`; migration 0014 indexes have EXPLAIN coverage for the `(type, id)` and id-prefix scans; `derivedschema_test.go` covers list-index create and drop on config removal; `queryplan` unit tests cover the `listIndexSpec` shapes.
+6. **ACL unchanged**: PASS. (a) `acl_list_test.go` hidden neighbour in a batch; (b) `acl_views_test.go` AllowAll under `published` sees no draft title through batched section and list paths; (c) `listpushdown_test.go` scoped total equals the visible count via `CountMatched`; (d) `rowcontent_test.go` redaction and `TestListRows_KeepInaccessibleMarker` on header rows. `visibleHeaderIDs` applies `faceReadable` exactly as `filterVisible` (RR-SR2NS0).
+7. **Wire compatibility**: PASS. List and search rows omit `content` by default; `include_content=true` restores it (`rowcontent_test.go`, openapi updated); e2e suite green; `relationsPatch.ts` reads the detail endpoint, not a list row.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-CF2ZL2
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+Follow-ups recorded in the ticket body rather than left as TODOs: `_position`
+and gantt still load whole-type headers; free-text search on very common terms;
+views with `display: content`; fs seeding is slow at scale 1.
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-04KFJA.md
+++ b/tickets/entities/review-responses/RR-04KFJA.md
@@ -1,0 +1,9 @@
+---
+id: RR-04KFJA
+type: review-response
+title: PrincipalStore claimed to be consumer-side while embedding a producer interface
+finding: The interface embeds store.GraphQueryer and its doc called that consumer-side on purpose.
+severity: nit
+resolution: 'Doc corrected: it names exactly the graph-query surface store.GraphQueryHeaders takes; the embed stays because that helper needs the full GraphQueryer.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-64OR7D.md
+++ b/tickets/entities/review-responses/RR-64OR7D.md
@@ -1,0 +1,9 @@
+---
+id: RR-64OR7D
+type: review-response
+title: Server-Timing query count is a hidden-row oracle until batching lands
+finding: Before D.1 replaces per-row neighbour loads, the number of SQL statements a list page issues is a function of how many neighbour rows exist, including rows the principal cannot read (the per-neighbour GetEntity runs before filterVisible). Exposing that count in a response header to every client turns the existing internal cost into a count oracle over hidden rows, contrary to the row-level rule in CLAUDE.md. Even after batching, exposing DB timings by default adds a channel that was previously only observable as coarse wall time.
+severity: significant
+resolution: 'Plan changed: the Server-Timing header and the per-request log record are emitted only when Debug logging is enabled (rela-server -verbose), the same condition that already gates the pgx tracer. Nothing reaches the wire by default, so the ordering of PRs no longer matters for this channel. Documented in docs/acl-security.md beside the timing-exposure note.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7EJIWL.md
+++ b/tickets/entities/review-responses/RR-7EJIWL.md
@@ -1,0 +1,9 @@
+---
+id: RR-7EJIWL
+type: review-response
+title: 'Seeder bypasses entitymanager: unique: and id validation are unenforced'
+finding: The seeder writes through store.Store directly. On fs/mem/sqlite the `unique:` rule is enforced only by entitymanager's untransacted scan, so a raw-store seeder can silently create duplicates; ids are validated by storeutil.ValidateID only on some paths. Automations and validations also do not run, so seeded data may be in a state the app never produces (e.g. no checklist entities for in-progress tasks).
+severity: significant
+resolution: 'Plan changed: the perf schema declares no unique: properties; the generator validates every id with storeutil.ValidateID and generates ids by construction (prefix + counter) so duplicates are impossible; the seeder refuses a non-empty store; automation-derived entities (checklists) are not part of the profile, and the profile is documented as data-only. Writes carry store.WithAttribution for a system:perf-seed principal and an audit record.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7JCLZP.md
+++ b/tickets/entities/review-responses/RR-7JCLZP.md
@@ -1,0 +1,9 @@
+---
+id: RR-7JCLZP
+type: review-response
+title: Batched reads are new construction sites for the AllowAll + FaceIn fail-open shape
+finding: 'pushdown.go:83-95 documents that the AllowAll branch never builds a GraphQuery, so FaceIn must be carried on the EntityQuery or the most privileged principals get no face narrowing. Every batched read in D.1 (ListRelations{EntityIDs}, ListEntityHeaders{IDs}, computeFaces, section columns) can forget it, and the failure is silent: a manager sees a draft title under the published world. AC6 covers hidden neighbours but not this shape.'
+severity: significant
+resolution: 'AC6 extended with an AllowAll-under-published-world test: 50-row list with relation columns and a section view, asserting no draft-face title appears through any batched path. Batched EntityQuery/RelationQuery values are built by one helper that stamps World/FaceIn/FromFace from the request, so no call site constructs them by hand.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7LL8MB.md
+++ b/tickets/entities/review-responses/RR-7LL8MB.md
@@ -1,0 +1,9 @@
+---
+id: RR-7LL8MB
+type: review-response
+title: Dead resolveRelationColumnValues left behind after section batching
+finding: No non-test callers remained, and the wrapper built a row entity with an empty Type that would mis-resolve direction if called.
+severity: significant
+resolution: Deleted. The tests that used it now go through a test-only helper over resolveRelationColumns with the row's type supplied.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-9P8JYE.md
+++ b/tickets/entities/review-responses/RR-9P8JYE.md
@@ -1,0 +1,9 @@
+---
+id: RR-9P8JYE
+type: review-response
+title: storeutil.MatchRelation allocated the EntityIDs set per relation row
+finding: The EntityIDs branch built a lookup map inside MatchRelation; fsstore and memstore call it once per relation, so an N-row scan with an M-element batch was N allocations of size M.
+severity: significant
+resolution: storeutil.NewRelationMatcher compiles the query (and its set) once into a predicate; MatchRelation delegates to it; every fsstore and memstore loop (ListRelations, ListRelationsPage, CountRelations) builds the matcher once per call.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BPGZ4C.md
+++ b/tickets/entities/review-responses/RR-BPGZ4C.md
@@ -1,0 +1,9 @@
+---
+id: RR-BPGZ4C
+type: review-response
+title: 'Slow-query tooling: pg_stat_statements needs a server restart; docs claim tsvector search'
+finding: The baseline plan names pg_stat_statements, which requires shared_preload_libraries and a restart of the local Postgres.app instance used by other projects. Separately, dropping entities_search_tsv_idx contradicts docs/postgres-backend.md:149 which says search uses a tsvector GIN index; the docs must be corrected in the same change or the drop is confusing.
+severity: minor
+resolution: Baseline uses ALTER DATABASE ... SET log_min_duration_statement and session_preload_libraries=auto_explain on a dedicated rela_perf database (reload only, no restart); pg_stat_statements is optional. docs/postgres-backend.md search paragraph is corrected to describe the trigram LIKE + similarity strategy in the same change as the index drop.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CH8CX9.md
+++ b/tickets/entities/review-responses/RR-CH8CX9.md
@@ -1,0 +1,9 @@
+---
+id: RR-CH8CX9
+type: review-response
+title: Budget tests should pin size-independence, not guessed constants
+finding: AC2 states numeric budgets (≤ 6, ≤ 8, ≤ 4) that are estimates. The ACL request resolution also issues store calls (member-of closure via the store-backed acl.Graph), so the constant is wiring-dependent. A fixed number will either be wrong on day one or be tuned to whatever the implementation happens to do.
+severity: minor
+resolution: 'AC2 rewritten: budget tests assert that the store-call count for a 10-row page equals the count for a 50-row page (size independence) and pin the measured constant afterwards with a comment recording the pre-change count; the numbers in the plan are targets, not assertions.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-CHIFV2.md
+++ b/tickets/entities/review-responses/RR-CHIFV2.md
@@ -1,0 +1,9 @@
+---
+id: RR-CHIFV2
+type: review-response
+title: New batching helpers must be free functions, not App methods (plimsoll cap)
+finding: app.go:172 pins //plimsoll:max-methods=87 while worldneighbors.go:85 cites 104; one is stale. The batching rewrites and the Services() hoist will want helpers; adding them to App breaks the cap.
+severity: minor
+resolution: Plan states all new batching helpers are free functions taking their read seams (the visibleRelationIDs shape); the 87-vs-104 discrepancy is reconciled in the first PR.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-E0PJ0B.md
+++ b/tickets/entities/review-responses/RR-E0PJ0B.md
@@ -1,0 +1,9 @@
+---
+id: RR-E0PJ0B
+type: review-response
+title: RelationQuery.EntityIDs must compose with Direction and FromFace exactly like EntityID
+finding: RelationQuery already carries FromFace (store.go:434) and Direction. A batch that ignores FromFace returns state-tailed edges a per-row call excluded. sqlitestore (relation.go:110-120) also implements EntityID and needs the plural.
+severity: minor
+resolution: Plan defines EntityIDs as the plural of EntityID under identical Direction and FromFace semantics, implemented in fs/mem/pg/sqlite, with a storetest case asserting {EntityIDs:[a,b], FromFace:&f} equals the union of the two scalar calls, and nil vs empty pinned.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-E2KNIT.md
+++ b/tickets/entities/review-responses/RR-E2KNIT.md
@@ -1,0 +1,9 @@
+---
+id: RR-E2KNIT
+type: review-response
+title: listpushdown differential test compared the naive comparator to itself
+finding: The test runs over memstore, so both the pushed and Go paths use graphquerynaive; the cross-backend guarantee lives in storetest, whose fixture lacked colliding/null cases.
+severity: minor
+resolution: The adversarial cases (colliding keys, absent keys, JSON null, asc/desc, windows, count under paging) live in RunGraphPagingTests, which every backend runs through RunAll; the dataentry test keeps its role of pinning the handler's eligibility and page arithmetic.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-E8XF0Y.md
+++ b/tickets/entities/review-responses/RR-E8XF0Y.md
@@ -1,0 +1,9 @@
+---
+id: RR-E8XF0Y
+type: review-response
+title: Four godoc comments displaced onto the wrong declaration
+finding: New functions were spliced between an existing doc comment and its declaration in pgstore/graphquery.go, pgstore/world.go, store/graphquery.go and storetest/graphquery.go, so godoc showed one function's doc on another.
+severity: minor
+resolution: Each displaced doc moved back onto its own declaration; verified with grep that GraphCount, worldSQL, GraphBranch and mustRel are immediately preceded by their comments.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-EQBQ7Q.md
+++ b/tickets/entities/review-responses/RR-EQBQ7Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-EQBQ7Q
+type: review-response
+title: Migration 0014 rewrites every entity row inside the migration transaction
+finding: 'An unqualified UPDATE of search_text under the migration advisory lock, auto-applied on first open: a full table rewrite plus trigram index rebuild that blocks startup with no progress signal.'
+severity: significant
+resolution: 'The UPDATE now touches only rows whose search_text IS DISTINCT FROM the new composition (a re-run is cheap), the migration header explains the one-time cost, and docs/postgres-backend.md tells operators to run `rela db migrate` as a deploy step if the pause must not land on the first request. Batching a first-time rewrite is not done: the migration runs in one transaction by design.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FV3O0H.md
+++ b/tickets/entities/review-responses/RR-FV3O0H.md
@@ -1,0 +1,9 @@
+---
+id: RR-FV3O0H
+type: review-response
+title: statsResponseWriter does not forward http.Hijacker
+finding: A direct w.(http.Hijacker) assertion would fail under Debug and succeed without it; no handler hijacks today.
+severity: minor
+resolution: 'Documented on the type: add a forwarder before any handler hijacks. Not forwarded speculatively — an unused interface method is the kind of API that rots.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-GQTAPX.md
+++ b/tickets/entities/review-responses/RR-GQTAPX.md
@@ -1,0 +1,9 @@
+---
+id: RR-GQTAPX
+type: review-response
+title: requestFor reused a ctx Request on an incomplete identity match
+finding: The reuse guard compared User and Tool only, while Request.ceiling is compiled from PrincipalType and Scopes and Globals from Roles. Two principals sharing User+Tool but differing in verified claims carry different ceilings; a stale wider one would be reused. Raised by both the code and the security review.
+severity: critical
+resolution: requestFor compares the whole principal with principal.Equal (identity plus every verified claim). requestreuse_test gains a same-user/different-claims subtest asserting a fresh scope is opened, and the different-principal subtest asserts the walk ran.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-J1VAW0.md
+++ b/tickets/entities/review-responses/RR-J1VAW0.md
@@ -1,0 +1,9 @@
+---
+id: RR-J1VAW0
+type: review-response
+title: Paging pushdown must ride the per-request GraphQuery copy and expose only the scoped count
+finding: pushdown.go:117-124 copies *rqr.Query because the ACL layer reuses the compiled result per principal. New OrderBy/Limit/Offset fields set on the shared value would bleed one request's page into another caller's. GraphCount returns (matched, total); the handler holding both can trivially return the unscoped total, which is the RR-SSPCCI count oracle.
+severity: significant
+resolution: Plan states that OrderBy/Limit/Offset are set only on the shallow copy made in listPushdown, with a test mirroring the existing world-bleed test; the list handler receives only the matched count from GraphCount via a helper that does not return total, and a test asserts a scoped principal's response total equals the visible count.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-K4DLZ8.md
+++ b/tickets/entities/review-responses/RR-K4DLZ8.md
@@ -1,0 +1,9 @@
+---
+id: RR-K4DLZ8
+type: review-response
+title: TrimSuffix of the id ORDER BY relied on an invariant enforced elsewhere
+finding: buildGraphQuerySQLSelect trims the plain ORDER BY only in the default-world arm; that is correct only because graphWorldScope returns distinctOn and rankOrder together, which nothing asserted.
+severity: minor
+resolution: The pairing is asserted at the call site (a one-sided return panics with a message naming the invariant) so a future change cannot corrupt the SQL silently.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LCS2Y3.md
+++ b/tickets/entities/review-responses/RR-LCS2Y3.md
@@ -1,0 +1,9 @@
+---
+id: RR-LCS2Y3
+type: review-response
+title: JSON-null sort keys ordered differently on the pushed path vs the Go path
+finding: 'Both Go comparators keyed on map-key presence; a property present with a nil value compared as the text "<nil>" and landed between dates and absent rows, while PostgreSQL''s ->> yields NULL and sorts it last. Reachable: pgstore.unmarshalProps preserves JSON null as a present key, and YAML `due:` produces it. Both fixtures seeded only absent keys.'
+severity: critical
+resolution: graphquerynaive.sortValue and applyV1Sorting treat a nil value as absent (largest), matching SQL; RunGraphPagingTests seeds a JSON-null row (T-6) with pinned asc/desc orders and count on all four backends; the listpushdown differential fixture seeds two null rows.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-O5W4A3.md
+++ b/tickets/entities/review-responses/RR-O5W4A3.md
@@ -1,0 +1,9 @@
+---
+id: RR-O5W4A3
+type: review-response
+title: ACL pushdown has no header variant, so content-free listings miss gated principals
+finding: visibility listPushdown (internal/visibility/pushdown.go:56-131) returns full entities on all three branches; GraphQueryer (internal/store/graphquery.go:177) has no header-projecting method, and gantt_handler.go:304-306 already documents falling back to full-entity loads for that reason. D.2 as written would serve headers only to AllowAll principals; every real ACL user keeps paying for the body.
+severity: significant
+resolution: 'D.2 gains an explicit sub-task: a store.GraphHeaderQueryer optional capability (GraphQueryHeaders, type-asserted like store.Formatter) with a pg-native projection and a generic fallback, plus visibility.listPushdownHeaders used by visibleReader for listings. The plan now states that both AllowAll and Query principals take the header path; the Go fallback (relation filters, free text) also reads headers.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PN1STR.md
+++ b/tickets/entities/review-responses/RR-PN1STR.md
@@ -1,0 +1,9 @@
+---
+id: RR-PN1STR
+type: review-response
+title: --force help text understated its reach
+finding: The flag disables the only content check, so a forced seed interleaves generated rows with real data; the attribution and audit record that make them removable were documented only on the type.
+severity: minor
+resolution: The flag help now says the rows sit beside real ones and names the perf-seed attribution and audit record as the way to find and remove them.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Q8488L.md
+++ b/tickets/entities/review-responses/RR-Q8488L.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q8488L
+type: review-response
+title: Recursive view traversal silently changed depth-first to breadth-first
+finding: Collections preserve first-seen order, so the batched per-level walk reorders rendered rows in every recursive view section; the recursive tests pinned only the id set.
+severity: significant
+resolution: The breadth-first order is deliberate (one relation query per level) and now pinned by TestViewTraversal_RecursiveIsBreadthFirst on a branching fixture where depth-first would differ; the godoc states the order.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SR2NS0.md
+++ b/tickets/entities/review-responses/RR-SR2NS0.md
@@ -1,0 +1,9 @@
+---
+id: RR-SR2NS0
+type: review-response
+title: visibleHeaderIDs dropped the face half of the gate filterVisible applied
+finding: 'Security review: the header-based neighbour gate applied PermitsReadMany only, not faceReadable. Not exploitable today because the query is default-face-only, but a latent under-check once a caller adds a World or AllStates.'
+severity: minor
+resolution: visibleHeaderIDs applies faceReadable per candidate exactly as filterVisible does; headers carry Face so it costs nothing.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-T3GR05.md
+++ b/tickets/entities/review-responses/RR-T3GR05.md
@@ -1,0 +1,9 @@
+---
+id: RR-T3GR05
+type: review-response
+title: matchRelationFilterMany failed open on ne when the store errored
+finding: Both error paths returned a partial or empty verdict map; the caller evaluates operator==ne && !matched[id], so an empty map made every row match the exclusion filter and the request still returned 200. A backend fault silently widened a narrowing filter (api_v1.go). Same swallow shape in the view section resolvers.
+severity: critical
+resolution: matchRelationFilterMany returns (map, error); applyRelationFilters wraps it in errListLoad so the request fails loud. The section resolvers (relationColumnTargets, visibleTitles) log a Warn naming the relation and count before truncating, since a view renders what it could load but never quietly.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VNZV71.md
+++ b/tickets/entities/review-responses/RR-VNZV71.md
@@ -1,0 +1,9 @@
+---
+id: RR-VNZV71
+type: review-response
+title: loadRowContent doc claimed a redaction re-projection it does not implement
+finding: The comment said the whole entity is re-projected onto the row's redacted property set; the code copies Content only. Behaviourally fine (Redact is property-only) but a false security claim.
+severity: significant
+resolution: 'Comment rewritten to state what is true: only the body is copied, redaction is property-only, the redacted property map is left exactly as gated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-WQ3DQS.md
+++ b/tickets/entities/review-responses/RR-WQ3DQS.md
@@ -1,0 +1,9 @@
+---
+id: RR-WQ3DQS
+type: review-response
+title: 'Seeder is a fourth raw-store exception: attribution, sweep interaction and CLAUDE.md list'
+finding: Root CLAUDE.md enumerates three raw-store exceptions, each with operator-shell trust, explicit audit and store.WithAttribution. The plan names audit but not attribution, and does not decide what the version sweep does with 20k bulk-inserted rows. kong supports hidden commands but there is no precedent; hidden is obscurity, not a boundary.
+severity: minor
+resolution: Seeder writes with store.WithAttribution(system:perf-seed) and an audit record; the sweep capturing one version per seeded row is accepted as realistic load and documented; CLAUDE.md's exception list becomes four entries. The command is not hidden; it lives under `rela dev seed` with help text stating it is a raw-store developer tool.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-1U8XYN.md
+++ b/tickets/entities/tickets/TKT-1U8XYN.md
@@ -1,0 +1,79 @@
+---
+id: TKT-1U8XYN
+type: ticket
+title: 'PostgreSQL read-path performance audit: per-request query counting, seeded demo with ACL + worlds, slow-query driven optimisation'
+kind: enhancement
+priority: high
+effort: l
+status: done
+---
+
+## Problem
+
+The data-entry SPA drives `pgstore` through store methods designed around the
+filesystem store. Nothing today tells us how many SQL statements a single page
+load issues, and the seeded projects used for testing are small enough that N+1
+patterns and full-body loads never show up as latency.
+
+## Requested (2026-09-04)
+
+1. Examine all code paths, especially those triggered by the data-entry SPA, for performance issues on PostgreSQL.
+2. Fill a demo app with realistic content and inspect the slow-query log.
+3. Add query-counting logic so each request reports how many queries it issued.
+4. Optimise each hot path: drop the markdown body from listings, add automated indexes, batch per-row loads.
+5. Set up a complex demo (or several) including ACL and worlds/faces.
+
+## Related backlog (overlapping, do not duplicate)
+
+- TKT-AIEGHU server-side aggregation for count/breakdown cards (still open; rows are now content-free, so a count card ships 3.5 MB instead of 53 MB at 11k tasks — the aggregate endpoint remains the real fix)
+- TKT-8AUD1U dashboard table cards: push limit and sort into the query (still open; `store.GraphQuery.OrderBy/Limit/Offset` now exist to build on)
+- TKT-T0DK37 bound the structured search path (still open)
+- TKT-ZZL53L drop or use `entities_search_tsv_idx` — **done here** (migration 0014 drops it)
+- TKT-L59KUM push field-visibility match provenance into SQL (still open)
+- TKT-1ESTYJ (done) introduced `ListEntityHeaders`; this ticket moved lists, search, kanban, scope navigation, neighbour gating and the principal lookup onto headers
+
+## What shipped
+
+1. **Per-request query accounting** — `store.QueryStats` on the request context, filled by the pgx tracer (always attached, no allocation when unused), reported as `Server-Timing: db;dur=<ms>;desc="<n> queries"` and one `request` slog record — only under `-verbose` (RR-64OR7D). `storetest.Counting` decorator + `querybudget_test.go` pin store-call counts at 10 vs 50 rows for list, view section and search.
+2. **Perf demo** — `prototypes/perf/project` (8 types, policy draft/published + document en/nl faces, three worlds, ACL with team membership and `visible:` redaction, lists with relation columns/filters, views with table sections, two kanbans, dashboard, gantt, next actions) and `rela dev seed --scale N` (`internal/perfseed`, deterministic, attributed, audited, refuses a non-empty store). Scale 1 into local postgres: 19,117 rows, 47,549 relations, ~40 s.
+3. **Batching** — `RelationQuery.EntityIDs` on all four backends; page edges in one query (world path: one per distinct face), neighbour gating over headers, section relation columns per section, view collection loads and traversal per frontier, search hits per face, relation filters per filter; `Declarative.AuthorizeWrite` reuses the request's `acl.Request` (was six membership walks per row); principal lookup pushed into a graph query.
+4. **Content-free rows** — lists, search, kanban, scope navigation and neighbour heads read `EntityHeader`s (`store.GraphHeaderQueryer` + generic fallback); `include_content=true` reloads the served page only. Documented in the API reference and OpenAPI.
+5. **Paging pushdown** — `GraphQuery.OrderBy/Limit/Offset` (naive + pg), `store.MatchedCounter`; `listpushdown.go` pushes simple list shapes (no free text, no relation filter, `=`/`!=` and sort on string-shaped properties); world resolution collapses to the default world for faceless types; ordering semantics unified (absent value = largest) across Go and SQL.
+6. **Indexes and search** — migration 0014: `(type, id)` and id-prefix partial indexes, `entities_search_tsv_idx` dropped, `search_text` rebuilt as id/properties/body; ranking by similarity over the first 1 KB; derived `rela_derived_list__` indexes from list `sort:`/static `=` filters (EXPLAIN-tested); prefilter pushdown widened to enum/date/custom types.
+7. **Next actions** — `SnoozedUntilMany`/`LastShownMany` on `userstate.Store` (mem/kv/pg + conformance); the engine judges all candidates in two statements.
+
+## Baseline vs after (alice/manager, warmed second pass, scale 1)
+
+| request | queries before → after | db ms before → after | bytes before → after |
+|---|---|---|---|
+| `_schema` / `_config` / `_dashboard` / `_sidebar` / `_commands` | 1–3 → 1–3 | 23–29 → 0.3–0.6 | – |
+| `_next_action` | 45 → 7 | 188 → 12 | 241 → 241 |
+| list tasks page (25 rows, sort due) | 207 → 8 | 180 → 3.1 | 110 KB → 12 KB |
+| list open_tasks (filter + sort) | 207 → 8 | 175 → 15 | 139 KB → 14 KB |
+| list projects / persons / policys / documents / risks / controls | 207 → 8 | 34–58 → 2–10 | 109–152 KB → 9–22 KB |
+| kanban tasks page (100 rows) | 807 → 8 | 215 → 9.8 | 508 KB → 58 KB |
+| kanban policys page (100 rows) | 807 → 8 | 61 → 13 | 531 KB → 44 KB |
+| `_views/project/PRJ-0001` | 1208 → 42 | 95 → 23 | 99 KB → 99 KB |
+| `_views/task` / `policy` / `person` | 33–61 → 23–29 | 13–17 → 3–8 | unchanged |
+| GET task / task relations | 15 / 36 → 9 / 22 | 25 / 27 → 1.7 / 1.9 | unchanged |
+| `_search q=type:task` (11k hits) | 66,004 → 4 | 3,219 → 41 | 53.5 MB → 3.5 MB |
+| `_search q=type:task prop:status!=done` | 49,426 → 4 | 2,420 → 37 | 40 MB → 2.6 MB |
+| `_search q=type:task prop:priority=critical prop:status!=done` | 12,346 → 4 | 712 → 10 | 10 MB → 0.65 MB |
+| `_search q=telemetry` (free text, matches 59% of rows) | 7,004 → 5 | 5,072 → 1,233 | 1.9 MB → 0.29 MB |
+| `_position` (task in list scope) | 4 → 4 | 158 → 40 | – |
+| `_gantts/delivery` | 6 → 6 | 87 → 74 | 376 KB |
+| list policys `?world=published` / `editorial` | 207 → 8 | 34–44 → 4–6 | 152 KB → 11 KB |
+| `_views/policy/POL-0001?world=published` | 59 → 28 | 16 → 4 | unchanged |
+
+Editor and reader principals track these numbers; a denied type is 5 queries and
+empty.
+
+## Left for follow-up tickets
+
+- `_position` and the gantt still load a whole type (headers): position could rank inside the store; the gantt could load the forest by frontier from visible roots.
+- Free-text search on a term present in most rows is bounded by the trigram similarity over the prefix (~1.2 s at 19k rows); a rarer term uses the trgm index.
+- Views with `display: content` sections still load collected entities whole (needed for the body).
+- The fs backend seeds slowly (one file + index write per row); the seeder documents using a small scale there.
+
+Reproduce: seed as above, `rela-server-postgres -verbose`, run
+`.ignored/perf/baseline.sh` twice and read the second pass.

--- a/tickets/relations/FEAT-R012DX--requires--data-entry-server.md
+++ b/tickets/relations/FEAT-R012DX--requires--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-R012DX
+relation: requires
+to: data-entry-server
+---

--- a/tickets/relations/FEAT-R012DX--requires--store-backends.md
+++ b/tickets/relations/FEAT-R012DX--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-R012DX
+relation: requires
+to: store-backends
+---

--- a/tickets/relations/TKT-1U8XYN--affects--data-entry-server.md
+++ b/tickets/relations/TKT-1U8XYN--affects--data-entry-server.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: affects
+to: data-entry-server
+---

--- a/tickets/relations/TKT-1U8XYN--affects--store-backends.md
+++ b/tickets/relations/TKT-1U8XYN--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-1U8XYN--has-docs--DOCS-CF2ZL2.md
+++ b/tickets/relations/TKT-1U8XYN--has-docs--DOCS-CF2ZL2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-docs
+to: DOCS-CF2ZL2
+---

--- a/tickets/relations/TKT-1U8XYN--has-implementation--IMPL-BCZLPW.md
+++ b/tickets/relations/TKT-1U8XYN--has-implementation--IMPL-BCZLPW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-implementation
+to: IMPL-BCZLPW
+---

--- a/tickets/relations/TKT-1U8XYN--has-planning--PLAN-B7F1R4.md
+++ b/tickets/relations/TKT-1U8XYN--has-planning--PLAN-B7F1R4.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-planning
+to: PLAN-B7F1R4
+---

--- a/tickets/relations/TKT-1U8XYN--has-review--REV-01BJAX.md
+++ b/tickets/relations/TKT-1U8XYN--has-review--REV-01BJAX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review
+to: REV-01BJAX
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-04KFJA.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-04KFJA.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-04KFJA
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-64OR7D.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-64OR7D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-64OR7D
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-7EJIWL.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-7EJIWL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-7EJIWL
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-7JCLZP.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-7JCLZP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-7JCLZP
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-7LL8MB.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-7LL8MB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-7LL8MB
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-9P8JYE.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-9P8JYE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-9P8JYE
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-BPGZ4C.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-BPGZ4C.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-BPGZ4C
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-CH8CX9.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-CH8CX9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-CH8CX9
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-CHIFV2.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-CHIFV2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-CHIFV2
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-E0PJ0B.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-E0PJ0B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-E0PJ0B
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-E2KNIT.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-E2KNIT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-E2KNIT
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-E8XF0Y.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-E8XF0Y.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-E8XF0Y
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-EQBQ7Q.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-EQBQ7Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-EQBQ7Q
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-FV3O0H.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-FV3O0H.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-FV3O0H
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-GQTAPX.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-GQTAPX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-GQTAPX
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-J1VAW0.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-J1VAW0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-J1VAW0
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-K4DLZ8.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-K4DLZ8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-K4DLZ8
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-LCS2Y3.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-LCS2Y3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-LCS2Y3
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-O5W4A3.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-O5W4A3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-O5W4A3
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-PN1STR.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-PN1STR.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-PN1STR
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-Q8488L.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-Q8488L.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-Q8488L
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-SR2NS0.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-SR2NS0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-SR2NS0
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-T3GR05.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-T3GR05.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-T3GR05
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-VNZV71.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-VNZV71.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-VNZV71
+---

--- a/tickets/relations/TKT-1U8XYN--has-review-response--RR-WQ3DQS.md
+++ b/tickets/relations/TKT-1U8XYN--has-review-response--RR-WQ3DQS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: has-review-response
+to: RR-WQ3DQS
+---

--- a/tickets/relations/TKT-1U8XYN--implements--FEAT-R012DX.md
+++ b/tickets/relations/TKT-1U8XYN--implements--FEAT-R012DX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-1U8XYN
+relation: implements
+to: FEAT-R012DX
+---


### PR DESCRIPTION
## Summary

TKT-1U8XYN. Makes the data-entry read path query-efficient on PostgreSQL, and adds the tooling to see that it is.

- **Per-request query accounting**: a pgx tracer fills `store.QueryStats` on the request context; under `-verbose` every API response carries `Server-Timing: db;dur=<ms>;desc="<n> queries"` and the log gets one `request` record. Nothing is emitted below Debug (the count is an existence channel on unbatched paths).
- **Perf demo + seeder**: `prototypes/perf/project` (8 types, faces on policy/document, three worlds, ACL with team membership and `visible:` redaction, lists/views/kanbans/dashboard/gantt/next-actions) and `rela dev seed --scale N` (deterministic, attributed, audited, refuses a non-empty store; fourth sanctioned raw-store exception).
- **Batching**: `RelationQuery.EntityIDs` on all four backends; page edges, neighbour gating, section relation columns, view traversal, search hits and relation filters load per page instead of per row; `AuthorizeWrite` reuses the request's ACL scope (was six membership walks per row); principal lookup is a graph query.
- **Content-free rows**: lists, search, kanban, scope navigation and neighbour heads read `EntityHeader`s (`store.GraphHeaderQueryer` + fallback); `include_content=true` reloads the served page only.
- **Paging pushdown**: `GraphQuery.OrderBy/Limit/Offset`, `store.MatchedCounter`; `listpushdown.go` pushes simple list shapes into SQL; world resolution collapses to the default world for faceless types; absent/JSON-null sorts as largest on both Go and SQL paths.
- **Indexes and search**: migration 0014 (`(type,id)` and id-prefix partial indexes, drops the unused tsvector index, rebuilds `search_text` as id/properties/body); similarity ranking over a 1 KB prefix; derived `rela_derived_list__` indexes from list `sort:`/static filters (EXPLAIN-tested).
- **Next actions**: batched `SnoozedUntilMany`/`LastShownMany`.

## Measured (seeded project, scale 1, manager principal, warmed)

| request | queries before → after | db ms before → after |
|---|---|---|
| list page (25 rows) | 207 → 8 | 180 → 3 |
| kanban page (100 rows) | 807 → 8 | 215 → 10 |
| project view | 1208 → 42 | 95 → 23 |
| `_search q=type:task` (11k hits) | 66,004 → 4 | 3,219 → 41 |
| free-text search | 7,004 → 5 | 5,072 → 1,233 |
| `_next_action` | 45 → 7 | 188 → 12 |

Full table and follow-ups in the ticket body.

## Review

Design review (10 findings) and code review + security review (15 findings, 3 critical) are recorded as review-responses on the ticket; all addressed in-branch. Budget tests (`querybudget_test.go`) pin store-call counts at 10 vs 50 rows so a regression names itself.

## Notes for the operator

Migration 0014 rewrites `search_text` once on first open (one-time cost proportional to table size); `docs/postgres-backend.md` explains running `rela db migrate` as a deploy step if that pause must not land on the first request.

https://claude.ai/code/session_0113QXFoZWnLZTALhrJKafFy
