### PR TITLE
feat(comments): annotate entities by property, section and text range (TKT-FIO205)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -174,6 +174,11 @@ vendors:
   # the grant this narrow is what stops a consumer importing neoq types
   # directly and re-coupling every producer to the queue implementation.
   neoq:        { in: [github.com/acaloiaro/neoq, github.com/acaloiaro/neoq/**] }
+  # Text-range anchoring for comments (TKT-FIO205 stage 2). Granted ONLY to
+  # internal/comments, which contains it in textresolve.go: the library's
+  # Anchor/ResolveResult types must not escape into handlers or the wire, so
+  # comments.TextAnchor mirrors its fields and converts at that one seam.
+  textanchor:  { in: github.com/vloothuis/textanchor }
   # uuid: the per-job fingerprint when a caller supplies no IdempotencyKey.
   # A random fingerprint is what DISABLES neoq's payload-equality dedup, so
   # two identical-payload jobs both run unless dedup was asked for by name.
@@ -1039,6 +1044,8 @@ deps:
     mayDependOn:
       - entity
       - principal
+    canUse:
+      - textanchor
   memcomments:
     mayDependOn:
       - comments

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -411,6 +411,11 @@ deps:
       - calfeed
       - caldavalias
       - canonical
+      # The commentary layer (TKT-FIO205). dataentry owns the HTTP surface and
+      # the ACL gating; it does NOT choose a comment backend — like userstate
+      # above, that is a wiring-site decision, so only the `comments` package
+      # is granted here, never filecomments/memcomments.
+      - comments
       - cmdexec
       - config
       - conflict

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -13,6 +13,7 @@ exclude:
   - internal/jobs/jobstest
   - internal/mail/mailtest
   - internal/userstate/userstatetest
+  - internal/comments/commentstest
   - internal/schedulerstate/schedulerstatetest
   - frontend
   - e2e
@@ -118,6 +119,9 @@ components:
   nextaction:       { in: internal/nextaction }
   memuserstate:     { in: internal/userstate/memuserstate }
   kvuserstate:      { in: internal/userstate/kvuserstate }
+  comments:         { in: internal/comments }
+  memcomments:      { in: internal/comments/memcomments }
+  filecomments:     { in: internal/comments/filecomments }
   schedulerstate:   { in: internal/schedulerstate }
   kvschedstate:     { in: internal/schedulerstate/kvstate }
   pattern:          { in: internal/pattern }
@@ -1014,6 +1018,28 @@ deps:
     mayDependOn:
       - state
       - userstate
+  # comments is user commentary ABOUT entities, not graph content — a remark on
+  # a property is not a fact the operator declared in schema.yaml. It therefore
+  # depends on entity (for the EntityObserver signature it implements) and
+  # principal (to stamp an unforgeable author), but deliberately NOT on store or
+  # entitymanager: routing commentary through the graph write path would drag it
+  # into the audit log, version capture, search and /_schema, none of which are
+  # wanted for a note someone left on a field.
+  comments:
+    mayDependOn:
+      - entity
+      - principal
+  memcomments:
+    mayDependOn:
+      - comments
+  # The default backend writes one YAML document per target through the shared
+  # storage seam, so a thread is diffable like the entities it annotates.
+  filecomments:
+    mayDependOn:
+      - comments
+      - storage
+    canUse:
+      - yaml
   # schedulerstate is the per-task scheduler bookkeeping seam (last successful
   # run, failure count, next retry). Deliberately NOT dependent on store: a
   # last-run stamp is a fact about a deployment's operation, not graph content,

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -558,6 +558,11 @@ deps:
       - userstate
       - memuserstate
       - kvuserstate
+      # Likewise the commentary layer: the root picks the backend and hands the
+      # service to the App, which nil-checks it to decide whether the feature
+      # exists at all.
+      - comments
+      - filecomments
       - datamigration
       # Bridges conditionlint's next-action condition compiler to the seam
       # dataentry declares, so the app never imports the predicate engine.

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -178,7 +178,7 @@ vendors:
   # internal/comments, which contains it in textresolve.go: the library's
   # Anchor/ResolveResult types must not escape into handlers or the wire, so
   # comments.TextAnchor mirrors its fields and converts at that one seam.
-  textanchor:  { in: github.com/vloothuis/textanchor }
+  textanchor:  { in: [github.com/vloothuis/textanchor, github.com/vloothuis/textanchor/**] }
   # uuid: the per-job fingerprint when a caller supplies no IdempotencyKey.
   # A random fingerprint is what DISABLES neoq's payload-equality dedup, so
   # two identical-payload jobs both run unless dedup was asked for by name.

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -98,6 +98,7 @@ exclude:
     - ^internal/mail/mailtest # shared conformance test kit (exercised via the smtp + memory transports)
     - ^internal/schedulerstate/schedulerstatetest # shared conformance test kit (exercised via scheduler-state backends)
     - ^internal/userstate/userstatetest # shared conformance test kit (exercised via mem/kv/pgstore backends)
+    - ^internal/comments/commentstest # shared conformance test kit (exercised via the file + memory backends)
     - ^internal/appbuild/backendtest # build-tagged test backend supplier; the postgres half only compiles under -tags postgres
     - ^internal/store/pgstore  # covered by the dedicated postgres CI job (needs a live DB; skipped without RELA_TEST_DATABASE_URL)
     - ^internal/entitymanager/entitymanagertest # shared test doubles (PanicOnUse etc.), exercised via consumers

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ go build -o rela ./cmd/rela
 | [CalDAV: syncing to-dos with Apple Reminders and other clients](docs/caldav.md) | Sync to-do collections two-way with Apple Reminders and other CalDAV clients |
 | [CalDAV to-do (VTODO) client compatibility](docs/caldav-clients.md) | Which task apps speak VTODO, and what each does with formatted descriptions |
 | [Data Migration](docs/data-migration.md) | Detect schema shape changes and migrate stored content with generated, reviewable migrations |
+| [Comments: Annotating Entities, Fields and Text](docs/comments.md) | Enable commenting, control who may comment, and understand how anchors survive edits |
 
 ### Tutorials
 

--- a/cmd/rela-server/main.go
+++ b/cmd/rela-server/main.go
@@ -475,6 +475,7 @@ func main() {
 	// CalDAV needs the alias service to remember client-created resources;
 	// without it the routes are not registered at all.
 	app.SetCalDAVAliases(svc.CalDAVAliases())
+	app.SetComments(svc.Comments())
 
 	wireWorlds(app, svc)
 

--- a/docs-project/entities/guides/GUIDE-comments.md
+++ b/docs-project/entities/guides/GUIDE-comments.md
@@ -1,0 +1,218 @@
+---
+id: GUIDE-comments
+type: guide
+title: "Comments: Annotating Entities, Fields and Text"
+status: published
+order: 26
+audience: intermediate
+summary: "Enable commenting, control who may comment, and understand how anchors survive edits"
+---
+
+Comments let people annotate an entity without changing it: a remark on a
+property, on a view section, or on a selected range of the markdown body.
+
+They are deliberately **not** part of your graph. A comment is a remark *about*
+an entity, not a fact *in* your domain model, so comments live in their own
+store with their own permissions — outside `store.Store`, outside the audit log,
+outside `/api/v1/_schema`. That separation is what makes the author
+**unforgeable**: rela owns the read and write path end to end, writes the author
+from the request principal, and never reads it from the request body.
+
+## Enabling comments
+
+Commenting is off until you ask for it. Add a top-level `comments:` block to
+`schema.yaml`:
+
+```yaml
+comments:
+  enabled: true
+  on: ["ticket", "feature"]
+```
+
+`on:` lists the entity types that accept comments. The wildcard `"*"` means
+every type your project declares:
+
+```yaml
+comments:
+  enabled: true
+  on: ["*"]
+```
+
+An empty `on:` with `enabled: true` is a **load error**, not a silent
+"everything" or a silent "nothing" — both readings are defensible, so rela
+refuses to guess.
+
+With no `comments:` block at all the feature does not exist: the routes answer
+404, no storage directory is created, and `/api/v1/_schema` is byte-identical to
+a rela built before commenting existed.
+
+### Where comments are stored
+
+On the default (filesystem) backend, one YAML file per target under
+`.rela/comments/`:
+
+```text
+.rela/comments/
+  TKT-001.yaml
+  TKT-001@draft.yaml
+  FEAT-002.yaml
+```
+
+They are diffable and hand-editable like the entities they annotate. A target's
+whole thread lives in one file, so writes are atomic (temp file, fsync, rename)
+— a torn write would otherwise lose a whole conversation rather than one remark.
+
+## Permissions
+
+Six permissions, granted through a role's `permissions:` list exactly like the
+`history:read` family:
+
+| Permission | Grants |
+|---|---|
+| `comment:read` | See a target's comments |
+| `comment:add` | Post a comment |
+| `comment:update-own` | Edit or resolve your own comments |
+| `comment:update-any` | Edit or resolve anyone's |
+| `comment:delete-own` | Delete your own |
+| `comment:delete-any` | Delete anyone's |
+
+```yaml
+roles:
+  reviewer:
+    read: ["ticket"]
+    permissions:
+      - comment:read
+      - comment:add
+      - comment:update-own
+      - comment:delete-own
+
+  editor:
+    read: ["ticket"]
+    permissions:
+      - comment:read
+      - comment:add
+      - comment:update-any
+      - comment:delete-any
+```
+
+`-any` implies `-own`. "Own" is a comparison of the stored author against the
+requesting principal — rela has no `own` primitive in the graph, and comments
+are not in the graph, so there is no edge to test.
+
+Two rules are enforced and worth knowing:
+
+- **`comment:read` is floored by the target's read verdict.** A principal who
+  cannot read an entity cannot read its comments however the comment grants
+  read, and cannot tell "no comments" from "not allowed" — the response is the
+  same 404 a missing entity produces. Whether an entity exists stays a secret.
+- **A mutating permission requires `comment:read`**, validated when `acl.yaml`
+  loads. A role granting only `comment:delete-any` would let its holder remove
+  comments it can never see. `comment:add` is exempt: write-only commenting is a
+  coherent posture, the same way `create` is exempt from the entity write⊆read
+  rule.
+
+A permission conferred by an **ownership relation to the target** is honoured,
+so "the assignee may comment on their own ticket" works without a special case.
+
+### Identity is required
+
+A comment is refused when the request has no resolvable identity, rather than
+being stored as `unknown`. A comment nobody is recorded as having written could
+never satisfy an `-own` check, so its author could neither edit nor delete it.
+
+If you run rela-server without authentication, set `RELA_DATAENTRY_USER` or
+point `-principal-header` at whatever your proxy injects.
+
+## The three anchor kinds
+
+### Property
+
+Attaches to a named property. Drift-free by construction: a property name is a
+*name*, not an offset, so it survives any edit to the entity.
+
+In the UI, a small indicator sits beside each property label — a count when the
+field has comments, a green check when they are all resolved, and a faint ⊕ on
+hover when it has none.
+
+### Section
+
+Attaches to a view section by its operator-authored `sectionId` from
+`data-entry.yaml`. Also a name, so also drift-free.
+
+### Text range
+
+Attaches to selected text in the markdown body. Select text, click **Comment**,
+and the range renders highlighted.
+
+This one anchors to content people can edit, so it works differently: rela
+stores the quote plus its surrounding context (prefix, suffix, containing
+sentence, nearest heading, paragraph index) and **re-locates it on every read**.
+Byte offsets are never stored — an offset is invalidated by any edit earlier in
+the body, and on the filesystem backend by a plain re-save, since rela reflows
+markdown to 80 columns on write.
+
+Consequences worth understanding:
+
+- **A comment survives edits around it.** Insert a paragraph above the quoted
+  text and the highlight still lands on the right words.
+- **A comment on text that was edited away is reported detached**, never
+  silently re-attached to something else. It still appears in the comments
+  panel, flagged, showing what it was written about.
+- **A match below the confidence threshold is flagged "may have moved"** rather
+  than being presented as an exact location.
+
+### Images and diagrams
+
+An image or a mermaid/PlantUML diagram cannot be text-selected, so it gets its
+own affordance: hover it and a comment button appears. Behind the scenes these
+anchor to the block's markdown source, so they behave exactly like a text
+anchor.
+
+## Comments are per content state
+
+If your project uses [content states](content-states.md), comments belong to
+**one face**. A remark on the draft ("this paragraph needs a source") is not a
+remark on the published version, and would be misleading if shown there — the
+published text may not even contain the quoted words.
+
+The default face keeps the bare id, so a project that never uses faces sees
+exactly the storage layout above, and comments written before you adopted faces
+keep working unchanged.
+
+## The HTTP surface
+
+```text
+GET    /api/v1/_comments/{type}/{id}              list a target's comments
+POST   /api/v1/_comments/{type}/{id}              add one
+PATCH  /api/v1/_comments/{type}/{id}/{commentID}  edit the body / resolve
+DELETE /api/v1/_comments/{type}/{id}/{commentID}  remove one
+POST   /api/v1/_comments/{type}/{id}/resolve      check whether a selection can be anchored
+```
+
+Add a `@face` suffix to the id to address one content state:
+`/api/v1/_comments/ticket/TKT-001@draft`.
+
+`id` and `author` in a create body are **ignored** — the server mints the ID and
+writes the author from the request principal. That is not a validation nicety:
+accepting a client-supplied ID would let a caller overwrite someone else's
+comment by reusing it.
+
+## What comments deliberately do not do
+
+- **No entity type.** Comments never enter `store.Store`, `entitymanager`, the
+  audit log or `/_schema`.
+- **No versioning.** A comment's edit history is not kept.
+- **No search indexing.** Comments are not returned by `/_search`.
+- **No threading.** A reply is a separate comment sharing an anchor; they render
+  together because they resolve to the same place.
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| Comment body | 16 KB, no control characters except tab and newline |
+| Comments per target | 500 |
+| Anchored quote | 5 characters minimum, 2 KB maximum |
+
+The quote minimum exists because a shorter selection cannot be re-located
+reliably — accepting one would mint a comment that detaches on the next edit.

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,0 +1,212 @@
+<!-- This file is auto-generated from docs-project/entities/. Do not edit directly. -->
+
+# Comments: Annotating Entities, Fields and Text
+
+Comments let people annotate an entity without changing it: a remark on a
+property, on a view section, or on a selected range of the markdown body.
+
+They are deliberately **not** part of your graph. A comment is a remark *about*
+an entity, not a fact *in* your domain model, so comments live in their own
+store with their own permissions — outside `store.Store`, outside the audit log,
+outside `/api/v1/_schema`. That separation is what makes the author
+**unforgeable**: rela owns the read and write path end to end, writes the author
+from the request principal, and never reads it from the request body.
+
+## Enabling comments
+
+Commenting is off until you ask for it. Add a top-level `comments:` block to
+`schema.yaml`:
+
+```yaml
+comments:
+  enabled: true
+  on: ["ticket", "feature"]
+```
+
+`on:` lists the entity types that accept comments. The wildcard `"*"` means
+every type your project declares:
+
+```yaml
+comments:
+  enabled: true
+  on: ["*"]
+```
+
+An empty `on:` with `enabled: true` is a **load error**, not a silent
+"everything" or a silent "nothing" — both readings are defensible, so rela
+refuses to guess.
+
+With no `comments:` block at all the feature does not exist: the routes answer
+404, no storage directory is created, and `/api/v1/_schema` is byte-identical to
+a rela built before commenting existed.
+
+### Where comments are stored
+
+On the default (filesystem) backend, one YAML file per target under
+`.rela/comments/`:
+
+```text
+.rela/comments/
+  TKT-001.yaml
+  TKT-001@draft.yaml
+  FEAT-002.yaml
+```
+
+They are diffable and hand-editable like the entities they annotate. A target's
+whole thread lives in one file, so writes are atomic (temp file, fsync, rename)
+— a torn write would otherwise lose a whole conversation rather than one remark.
+
+## Permissions
+
+Six permissions, granted through a role's `permissions:` list exactly like the
+`history:read` family:
+
+| Permission | Grants |
+|---|---|
+| `comment:read` | See a target's comments |
+| `comment:add` | Post a comment |
+| `comment:update-own` | Edit or resolve your own comments |
+| `comment:update-any` | Edit or resolve anyone's |
+| `comment:delete-own` | Delete your own |
+| `comment:delete-any` | Delete anyone's |
+
+```yaml
+roles:
+  reviewer:
+    read: ["ticket"]
+    permissions:
+      - comment:read
+      - comment:add
+      - comment:update-own
+      - comment:delete-own
+
+  editor:
+    read: ["ticket"]
+    permissions:
+      - comment:read
+      - comment:add
+      - comment:update-any
+      - comment:delete-any
+```
+
+`-any` implies `-own`. "Own" is a comparison of the stored author against the
+requesting principal — rela has no `own` primitive in the graph, and comments
+are not in the graph, so there is no edge to test.
+
+Two rules are enforced and worth knowing:
+
+- **`comment:read` is floored by the target's read verdict.** A principal who
+  cannot read an entity cannot read its comments however the comment grants
+  read, and cannot tell "no comments" from "not allowed" — the response is the
+  same 404 a missing entity produces. Whether an entity exists stays a secret.
+- **A mutating permission requires `comment:read`**, validated when `acl.yaml`
+  loads. A role granting only `comment:delete-any` would let its holder remove
+  comments it can never see. `comment:add` is exempt: write-only commenting is a
+  coherent posture, the same way `create` is exempt from the entity write⊆read
+  rule.
+
+A permission conferred by an **ownership relation to the target** is honoured,
+so "the assignee may comment on their own ticket" works without a special case.
+
+### Identity is required
+
+A comment is refused when the request has no resolvable identity, rather than
+being stored as `unknown`. A comment nobody is recorded as having written could
+never satisfy an `-own` check, so its author could neither edit nor delete it.
+
+If you run rela-server without authentication, set `RELA_DATAENTRY_USER` or
+point `-principal-header` at whatever your proxy injects.
+
+## The three anchor kinds
+
+### Property
+
+Attaches to a named property. Drift-free by construction: a property name is a
+*name*, not an offset, so it survives any edit to the entity.
+
+In the UI, a small indicator sits beside each property label — a count when the
+field has comments, a green check when they are all resolved, and a faint ⊕ on
+hover when it has none.
+
+### Section
+
+Attaches to a view section by its operator-authored `sectionId` from
+`data-entry.yaml`. Also a name, so also drift-free.
+
+### Text range
+
+Attaches to selected text in the markdown body. Select text, click **Comment**,
+and the range renders highlighted.
+
+This one anchors to content people can edit, so it works differently: rela
+stores the quote plus its surrounding context (prefix, suffix, containing
+sentence, nearest heading, paragraph index) and **re-locates it on every read**.
+Byte offsets are never stored — an offset is invalidated by any edit earlier in
+the body, and on the filesystem backend by a plain re-save, since rela reflows
+markdown to 80 columns on write.
+
+Consequences worth understanding:
+
+- **A comment survives edits around it.** Insert a paragraph above the quoted
+  text and the highlight still lands on the right words.
+- **A comment on text that was edited away is reported detached**, never
+  silently re-attached to something else. It still appears in the comments
+  panel, flagged, showing what it was written about.
+- **A match below the confidence threshold is flagged "may have moved"** rather
+  than being presented as an exact location.
+
+### Images and diagrams
+
+An image or a mermaid/PlantUML diagram cannot be text-selected, so it gets its
+own affordance: hover it and a comment button appears. Behind the scenes these
+anchor to the block's markdown source, so they behave exactly like a text
+anchor.
+
+## Comments are per content state
+
+If your project uses [content states](content-states.md), comments belong to
+**one face**. A remark on the draft ("this paragraph needs a source") is not a
+remark on the published version, and would be misleading if shown there — the
+published text may not even contain the quoted words.
+
+The default face keeps the bare id, so a project that never uses faces sees
+exactly the storage layout above, and comments written before you adopted faces
+keep working unchanged.
+
+## The HTTP surface
+
+```text
+GET    /api/v1/_comments/{type}/{id}              list a target's comments
+POST   /api/v1/_comments/{type}/{id}              add one
+PATCH  /api/v1/_comments/{type}/{id}/{commentID}  edit the body / resolve
+DELETE /api/v1/_comments/{type}/{id}/{commentID}  remove one
+POST   /api/v1/_comments/{type}/{id}/resolve      check whether a selection can be anchored
+```
+
+Add a `@face` suffix to the id to address one content state:
+`/api/v1/_comments/ticket/TKT-001@draft`.
+
+`id` and `author` in a create body are **ignored** — the server mints the ID and
+writes the author from the request principal. That is not a validation nicety:
+accepting a client-supplied ID would let a caller overwrite someone else's
+comment by reusing it.
+
+## What comments deliberately do not do
+
+- **No entity type.** Comments never enter `store.Store`, `entitymanager`, the
+  audit log or `/_schema`.
+- **No versioning.** A comment's edit history is not kept.
+- **No search indexing.** Comments are not returned by `/_search`.
+- **No threading.** A reply is a separate comment sharing an anchor; they render
+  together because they resolve to the same place.
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| Comment body | 16 KB, no control characters except tab and newline |
+| Comments per target | 500 |
+| Anchored quote | 5 characters minimum, 2 KB maximum |
+
+The quote minimum exists because a shorter selection cannot be re-located
+reliably — accepting one would mint a comment that detaches on the next edit.

--- a/e2e/pages/comments.page.ts
+++ b/e2e/pages/comments.page.ts
@@ -1,0 +1,169 @@
+import { type Locator, expect } from "@playwright/test";
+import { BasePage } from "./base.page";
+
+/** Page object for the commentary layer on an entity detail view
+ *  (TKT-FIO205). Selectors mirror the components' stable class prefixes:
+ *  `.ci-` for the per-field indicator and its popover, `.tsc-` for
+ *  select-to-comment, `.tcp-` for a clicked highlight's thread, `.bco-` for the
+ *  image/diagram overlay, and `.comments-panel` for the collapsed catch-all. */
+export class CommentsPage extends BasePage {
+  /** Open an entity's detail view and wait for its heading. */
+  async openEntity(type: string, id: string) {
+    await this.navigateTo(`/entity/${type}/${id}`);
+    await expect(this.page.locator("h1").first()).toBeVisible();
+  }
+
+  // ── Per-field indicators ───────────────────────────────────────────
+
+  /** The comment indicator beside a property label. */
+  fieldIndicator(property: string): Locator {
+    return this.page
+      .locator(".property-item")
+      .filter({ hasText: property })
+      .locator(".ci-btn")
+      .first();
+  }
+
+  /** Open a field's comment popover. */
+  async openField(property: string) {
+    await this.fieldIndicator(property).click();
+    await expect(this.page.locator(".ci-pop")).toBeVisible();
+  }
+
+  /** Post a comment from the currently-open field popover. */
+  async postFieldComment(body: string) {
+    await this.page.locator(".ci-composer .ci-input").fill(body);
+    await this.page.locator(".ci-composer button[type=submit]").click();
+    // The composer clears on success, which is the settle signal.
+    await expect(this.page.locator(".ci-composer .ci-input")).toHaveValue("");
+  }
+
+  /** Delete the first comment in the open field popover, confirming the modal. */
+  async deleteFirstFieldComment() {
+    await this.page.locator(".ci-pop .ci-mini--danger").first().click();
+    await this.page
+      .locator(".modal button, [role=dialog] button")
+      .filter({ hasText: /^Delete$/ })
+      .last()
+      .click();
+  }
+
+  /** Close whatever popover is open. */
+  async dismissPopover() {
+    await this.page.keyboard.press("Escape");
+  }
+
+  /** Comment bodies visible in the open field popover. */
+  fieldCommentBodies(): Locator {
+    return this.page.locator(".ci-pop .ci-body");
+  }
+
+  /** The count shown on a field's indicator, or null when it has none. */
+  async fieldCommentCount(property: string): Promise<string | null> {
+    const badge = this.fieldIndicator(property).locator(".ci-count");
+    return (await badge.count()) === 0 ? null : badge.innerText();
+  }
+
+  // ── Select-to-comment on the body ──────────────────────────────────
+
+  /** Select a phrase in the rendered body, so the comment affordance appears.
+   *
+   *  Uses a DOM Range rather than a drag: a drag over rendered markdown is
+   *  pixel-dependent and flakes, while the anchor under test is the SELECTED
+   *  TEXT, which a Range specifies exactly. */
+  async selectBodyText(phrase: string) {
+    await this.page.evaluate((needle) => {
+      const host = document.querySelector(".content-body");
+      if (!host) throw new Error("no rendered body on this page");
+      const walker = document.createTreeWalker(host, NodeFilter.SHOW_TEXT);
+      let node: Node | null;
+      while ((node = walker.nextNode())) {
+        const i = (node.textContent ?? "").indexOf(needle);
+        if (i === -1) continue;
+        const range = document.createRange();
+        range.setStart(node, i);
+        range.setEnd(node, i + needle.length);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        document.dispatchEvent(new Event("selectionchange"));
+        return;
+      }
+      throw new Error(`phrase not found in body: ${needle}`);
+    }, phrase);
+  }
+
+  /** The "Comment" button offered for a valid selection. */
+  selectionButton(): Locator {
+    return this.page.locator(".tsc-btn");
+  }
+
+  /** The notice shown when a selection cannot be anchored. */
+  blockedNotice(): Locator {
+    return this.page.locator(".tsc-blocked");
+  }
+
+  /** Comment on the current selection. */
+  async commentOnSelection(body: string) {
+    await this.selectionButton().click();
+    await this.page.locator(".tsc-input").fill(body);
+    await this.page.locator(".tsc-submit").click();
+    // The composer unmounts on success.
+    await expect(this.page.locator(".tsc-form")).toHaveCount(0);
+  }
+
+  // ── Highlights ─────────────────────────────────────────────────────
+
+  /** Highlights rendered over commented body text. */
+  highlights(): Locator {
+    return this.page.locator(".content-body mark[data-comment-id]");
+  }
+
+  /** Open the thread for a highlight by its text. */
+  async openHighlight(text: string) {
+    await this.highlights().filter({ hasText: text }).first().click();
+    await expect(this.page.locator(".tcp")).toBeVisible();
+  }
+
+  /** Comment bodies in the open highlight thread. */
+  highlightCommentBodies(): Locator {
+    return this.page.locator(".tcp .tcp-body");
+  }
+
+  /** Reply within the open highlight thread. */
+  async replyInThread(body: string) {
+    await this.page.locator(".tcp-reply textarea").fill(body);
+    await this.page.locator(".tcp-reply button[type=submit]").click();
+    await expect(this.page.locator(".tcp-reply textarea")).toHaveValue("");
+  }
+
+  // ── Image / diagram blocks ─────────────────────────────────────────
+
+  /** Comment affordances over images and diagrams. */
+  blockButtons(): Locator {
+    return this.page.locator(".bco-btn");
+  }
+
+  // ── The catch-all panel ────────────────────────────────────────────
+
+  /** The collapsed "All comments" header. */
+  panelHeader(): Locator {
+    return this.page.locator(".comments-panel .panel-header");
+  }
+
+  /** Expand the catch-all panel. */
+  async expandPanel() {
+    await this.panelHeader().click();
+    await expect(this.page.locator(".comments-panel .comment-list")).toBeVisible();
+  }
+
+  /** Comment rows inside the expanded panel. */
+  panelComments(): Locator {
+    return this.page.locator(".comments-panel .comment");
+  }
+
+  /** The panel's summary text ("4 total · 2 not on a field"). */
+  panelSummary(): Locator {
+    return this.page.locator(".comments-panel .panel-summary");
+  }
+}

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -17,3 +17,4 @@ export { HistoryPage } from './history.page';
 export { RelationHistoryPage } from './relation-history.page';
 export { CustomisationPage } from './customisation.page';
 export { PendingPage } from './pending.page';
+export { CommentsPage } from './comments.page';

--- a/e2e/tests/comments.spec.ts
+++ b/e2e/tests/comments.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from './fixtures';
+import { CommentsPage } from '../pages';
+
+/**
+ * Entity commenting (TKT-FIO205).
+ *
+ * The unit and Go tests cover the anchor algebra and the ACL; these cover what
+ * only a real browser can: that a selection in RENDERED markdown resolves to
+ * the right span of SOURCE markdown, that a highlight survives the round-trip
+ * through the renderer and DOMPurify, and that the surfaces stay in agreement.
+ */
+test.describe('Comments', () => {
+  // TASK-001 is seeded with a markdown body ("Write unit tests for auth
+  // module."), and the task view renders it — a text anchor needs both.
+  const TYPE = 'task';
+  const ID = 'TASK-001';
+
+  test.afterEach(async ({ api }) => {
+    // Comments live outside the entity store, so removing them means deleting
+    // each one; the entity itself is seed data other specs rely on.
+    const res = await api.listComments(TYPE, ID).catch(() => null);
+    for (const c of res?.comments ?? []) {
+      await api.deleteComment(TYPE, ID, c.id).catch(() => {});
+    }
+  });
+
+  test('comments on a property, and the indicator counts it', async ({ appPage }) => {
+    const comments = new CommentsPage(appPage);
+    await comments.openEntity(TYPE, ID);
+
+    expect(await comments.fieldCommentCount('status')).toBeNull();
+
+    await comments.openField('status');
+    await comments.postFieldComment('Should this still be draft?');
+
+    await expect(comments.fieldCommentBodies()).toHaveText([
+      'Should this still be draft?',
+    ]);
+    expect(await comments.fieldCommentCount('status')).toBe('1');
+  });
+
+  test('comments on selected body text and highlights it', async ({ appPage }) => {
+    const comments = new CommentsPage(appPage);
+    await comments.openEntity(TYPE, ID);
+
+    await comments.selectBodyText('unit tests for auth');
+    await expect(comments.selectionButton()).toBeVisible();
+    await comments.commentOnSelection('Which auth module?');
+
+    // The highlight proves the whole round-trip: the rendered selection
+    // resolved to a source range, and the mark survived the re-render and
+    // DOMPurify's attribute allowlist.
+    await expect(comments.highlights()).toHaveCount(1);
+    await expect(comments.highlights().first()).toHaveText('unit tests for auth');
+  });
+
+  test('opens a highlight thread and accepts a reply', async ({ appPage }) => {
+    const comments = new CommentsPage(appPage);
+    await comments.openEntity(TYPE, ID);
+
+    await comments.selectBodyText('unit tests for auth');
+    await comments.commentOnSelection('First remark');
+
+    await comments.openHighlight('unit tests for auth');
+    await expect(comments.highlightCommentBodies()).toHaveText(['First remark']);
+
+    // A reply shares the anchor, so the thread must show BOTH — the bug that
+    // made a saved reply look lost was the popover showing only one.
+    await comments.replyInThread('A reply on the same text');
+    await expect(comments.highlightCommentBodies()).toHaveText([
+      'First remark',
+      'A reply on the same text',
+    ]);
+  });
+
+  test('the catch-all panel counts comments with no field row', async ({ appPage }) => {
+    const comments = new CommentsPage(appPage);
+    await comments.openEntity(TYPE, ID);
+
+    await comments.openField('status');
+    await comments.postFieldComment('On a field');
+    await comments.dismissPopover();
+
+    await comments.selectBodyText('unit tests for auth');
+    await comments.commentOnSelection('On the body');
+
+    // A text anchor has no field row, so it is what the summary counts.
+    await expect(comments.panelSummary()).toContainText('2 total');
+    await expect(comments.panelSummary()).toContainText('1 not on a field');
+
+    await comments.expandPanel();
+    await expect(comments.panelComments()).toHaveCount(2);
+  });
+
+  test('deleting from a field popover updates the panel without a reload', async ({
+    appPage,
+  }) => {
+    const comments = new CommentsPage(appPage);
+    await comments.openEntity(TYPE, ID);
+
+    await comments.openField('status');
+    await comments.postFieldComment('Doomed comment');
+    await comments.dismissPopover();
+
+    await comments.expandPanel();
+    await expect(comments.panelComments()).toHaveCount(1);
+
+    // Regression: the panel used to fetch its own copy of the thread, so a
+    // delete elsewhere left a stale row until the page was reloaded.
+    await comments.openField('status');
+    await comments.deleteFirstFieldComment();
+
+    await expect(comments.panelComments()).toHaveCount(0);
+  });
+
+  test('survives an edit that moves the anchored text', async ({ appPage, api }) => {
+    const comments = new CommentsPage(appPage);
+    await comments.openEntity(TYPE, ID);
+
+    await comments.selectBodyText('unit tests for auth');
+    await comments.commentOnSelection('Still about the same words');
+
+    // Insert a paragraph ABOVE the quote: every byte offset after it shifts,
+    // which is precisely what a stored offset could not survive.
+    await api.setEntityContent(
+      'tasks',
+      ID,
+      'A paragraph added later, which shifts every offset below it.\n\n' +
+        'Write unit tests for auth module.\n',
+    );
+    await comments.openEntity(TYPE, ID);
+
+    await expect(comments.highlights()).toHaveCount(1);
+    await expect(comments.highlights().first()).toHaveText('unit tests for auth');
+  });
+});

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -190,6 +190,13 @@ export interface ApiHelpers {
   ): Promise<EntityResponse>;
   deleteEntity(plural: string, id: string): Promise<void>;
   listEntities(plural: string, query?: string): Promise<PaginatedResponse>;
+  /** Replace an entity's markdown BODY. Separate from updateEntity, which
+   *  carries only properties. */
+  setEntityContent(plural: string, id: string, content: string): Promise<EntityResponse>;
+  /** A target's comment thread (TKT-FIO205). Comments live outside the entity
+   *  store, so seeding and cleanup do not ride entity CRUD. */
+  listComments(type: string, id: string): Promise<{ comments: { id: string }[] }>;
+  deleteComment(type: string, id: string, commentId: string): Promise<void>;
   createRelation(
     fromPlural: string,
     fromId: string,
@@ -514,7 +521,13 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   },
 
   serverUrl: async ({ testProject, serverBinary }, use, testInfo) => {
-    const { proc, url, logs } = await spawnServer(serverBinary, testProject);
+    // A resolvable identity. Most specs do not care, but comments REFUSE an
+    // unstamped principal rather than recording "unknown" (TKT-FIO205): a
+    // comment nobody is recorded as writing can never satisfy an *-own
+    // permission check, so it could be neither edited nor deleted.
+    const { proc, url, logs } = await spawnServer(serverBinary, testProject, {
+      RELA_DATAENTRY_USER: "e2e@example.com",
+    });
     try {
       await use(url);
     } finally {
@@ -676,6 +689,19 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       async listEntities(plural, query) {
         const p = query ? `${plural}?${query}` : plural;
         return (await call("GET", p)).json();
+      },
+      async setEntityContent(plural, id, content) {
+        // Separate from updateEntity, which sends only `properties`: a comment
+        // spec needs to rewrite the BODY to exercise anchor drift.
+        return (await call("PATCH", `${plural}/${id}`, { content })).json();
+      },
+      // Comments (TKT-FIO205) live outside the entity store, so seeding and
+      // cleanup need their own helpers rather than riding entity CRUD.
+      async listComments(type, id) {
+        return (await call("GET", `_comments/${type}/${id}`)).json();
+      },
+      async deleteComment(type, id, commentId) {
+        await call("DELETE", `_comments/${type}/${id}/${commentId}`);
       },
       async setRelationMeta(fromPlural, fromId, relation, toType, toId, meta) {
         // Modern JSON:API relations body: upsert the edge with its meta. A PATCH
@@ -993,6 +1019,13 @@ relations:
     from: [task]
     to: [bug]
     inverse: fixedBy
+
+# Commenting (TKT-FIO205). Enabled for every type so the comment specs can use
+# whichever seed entity is convenient; the ACL is untouched, so the default
+# no-policy deployment applies and every principal may comment.
+comments:
+  enabled: true
+  on: ["*"]
 `;
 
 const DATA_ENTRY_YAML = `
@@ -1331,6 +1364,10 @@ views:
             widget: checkbox
           - property: title
             widget: textarea
+      # The entry's markdown body. Needed by the comment specs: a text-range
+      # anchor has nothing to attach to unless the body actually renders.
+      - source: entry
+        display: content
       - heading: "Implements"
         source: implemented
         display: list

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -133,3 +133,32 @@ export async function deleteComment(
 ): Promise<void> {
   await api.delete(`${targetPath(entityType, entityId)}/${encodeURIComponent(commentId)}`)
 }
+
+export interface ResolveCheck {
+  anchorable: boolean
+  reason?: string
+}
+
+/**
+ * Asks whether a selection could be anchored, without creating anything.
+ *
+ * Used to decide whether to OFFER commenting: some selections have no
+ * contiguous source range (one spanning table cells, for instance), and letting
+ * a user write a comment that then fails on save is the worse outcome.
+ *
+ * A non-anchorable selection is a successful response with `anchorable: false`,
+ * not an error — so a genuine network failure stays distinguishable.
+ */
+export async function checkAnchorable(
+  entityType: string,
+  entityId: string,
+  quote: string,
+  prefix: string,
+  suffix: string
+): Promise<ResolveCheck> {
+  return api.post<ResolveCheck>(`${targetPath(entityType, entityId)}/resolve`, {
+    quote,
+    quote_prefix: prefix,
+    quote_suffix: suffix,
+  })
+}

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -67,11 +67,19 @@ export interface AddCommentRequest {
   anchor: {
     kind: CommentAnchorKind
     ref: string
-    /** For a `text` anchor: the selected body text. The server derives the
-     *  surrounding context from its own copy of the body, so only the quote
-     *  and which occurrence it was cross the wire. */
+    /** For a `text` anchor: the selected body text, as RENDERED. */
     quote?: string
-    quote_index?: number
+    /**
+     * Rendered text immediately before/after the selection.
+     *
+     * These pick WHICH occurrence of a repeated quote was meant. They can only
+     * select among real occurrences — the quote must still be found in the body
+     * — so they narrow, never introduce, a location. Omitting them makes a
+     * repeated quote resolve to the first match, which once put a comment on
+     * "Geordend" onto "Ongeordend".
+     */
+    quote_prefix?: string
+    quote_suffix?: string
   }
   body: string
 }

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -1,0 +1,99 @@
+import { api } from './client'
+
+/**
+ * How a comment is pinned to part of an entity.
+ *
+ * Both kinds are drift-free by construction: a property name and an
+ * operator-authored section id are NAMES, not offsets, so they survive any
+ * edit to the entity body. Text-range anchoring (stage 2) will add a kind
+ * here; nothing in this shape forecloses it.
+ */
+export type CommentAnchorKind = 'property' | 'section'
+
+export interface CommentAnchor {
+  kind: CommentAnchorKind
+  ref: string
+}
+
+/** One comment as served by `/api/v1/_comments/...`. */
+export interface Comment {
+  id: string
+  /** Server-stamped from the request principal; never client-supplied. */
+  author: string
+  created_at: string
+  anchor: CommentAnchor
+  body: string
+  resolved: boolean
+  /**
+   * The anchor no longer names anything on the entity. Soft by design
+   * (DEC-HWZHA): the comment still renders, flagged as orphaned, rather than
+   * being hidden or rejected.
+   */
+  detached?: boolean
+  /**
+   * Server-computed permission hints, mirroring `_actions`. They drive which
+   * controls are shown; they are not the gate. The server re-authorizes every
+   * mutation, so a client that ignores them gains nothing.
+   */
+  editable: boolean
+  deletable: boolean
+}
+
+interface CommentListResponse {
+  comments: Comment[]
+}
+
+export interface AddCommentRequest {
+  anchor: CommentAnchor
+  body: string
+}
+
+/** Mutable fields. Omitting one leaves it unchanged — resolving does not require echoing the body. */
+export interface UpdateCommentRequest {
+  body?: string
+  resolved?: boolean
+}
+
+function targetPath(entityType: string, entityId: string): string {
+  return `/_comments/${encodeURIComponent(entityType)}/${encodeURIComponent(entityId)}`
+}
+
+/**
+ * listComments returns a target's comments, oldest first.
+ *
+ * Rejects with a 404 both when the entity cannot be read and when commenting
+ * is disabled — the two are deliberately indistinguishable, so callers must
+ * treat a failure as "no comment thread here", never as proof of absence.
+ */
+export async function listComments(entityType: string, entityId: string): Promise<Comment[]> {
+  const resp = await api.get<CommentListResponse>(targetPath(entityType, entityId))
+  return resp.comments
+}
+
+/** addComment creates a comment. Author, id and timestamp are server-written. */
+export async function addComment(
+  entityType: string,
+  entityId: string,
+  req: AddCommentRequest
+): Promise<Comment> {
+  return api.post<Comment>(targetPath(entityType, entityId), req)
+}
+
+/** updateComment edits a comment's body and/or resolved flag. */
+export async function updateComment(
+  entityType: string,
+  entityId: string,
+  commentId: string,
+  req: UpdateCommentRequest
+): Promise<void> {
+  await api.patch<void>(`${targetPath(entityType, entityId)}/${encodeURIComponent(commentId)}`, req)
+}
+
+/** deleteComment removes a comment. */
+export async function deleteComment(
+  entityType: string,
+  entityId: string,
+  commentId: string
+): Promise<void> {
+  await api.delete(`${targetPath(entityType, entityId)}/${encodeURIComponent(commentId)}`)
+}

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -3,16 +3,36 @@ import { api } from './client'
 /**
  * How a comment is pinned to part of an entity.
  *
- * Both kinds are drift-free by construction: a property name and an
- * operator-authored section id are NAMES, not offsets, so they survive any
- * edit to the entity body. Text-range anchoring (stage 2) will add a kind
- * here; nothing in this shape forecloses it.
+ * `property` and `section` are drift-free by construction — a property name and
+ * an operator-authored section id are NAMES, not offsets, so they survive any
+ * edit to the body. `text` (stage 2) anchors to body content the user CAN edit
+ * away, so it stores a quote plus surrounding context and is re-located
+ * server-side on every read; when that fails it reports as detached rather than
+ * silently pointing somewhere wrong.
  */
-export type CommentAnchorKind = 'property' | 'section'
+export type CommentAnchorKind = 'property' | 'section' | 'text'
 
 export interface CommentAnchor {
   kind: CommentAnchorKind
   ref: string
+  /** The anchored body text, for a `text` anchor. Echoed so the UI can show
+   *  WHAT was commented on even when the range no longer resolves. */
+  quote?: string
+  /**
+   * Byte offsets into the entity body, resolved server-side on every read.
+   * Present only for a text anchor that located successfully.
+   *
+   * Never stored — an offset is invalidated by any edit earlier in the body.
+   * Slice with these, never with `quote.length`: the located range can differ
+   * from the quote (it absorbs whitespace the formatter moved).
+   */
+  start?: number
+  end?: number
+  /** Resolver score, 0-1. */
+  confidence?: number
+  /** Located, but far enough from an exact match that the UI should say the
+   *  text may have moved. */
+  uncertain?: boolean
 }
 
 /** One comment as served by `/api/v1/_comments/...`. */
@@ -44,7 +64,15 @@ interface CommentListResponse {
 }
 
 export interface AddCommentRequest {
-  anchor: CommentAnchor
+  anchor: {
+    kind: CommentAnchorKind
+    ref: string
+    /** For a `text` anchor: the selected body text. The server derives the
+     *  surrounding context from its own copy of the body, so only the quote
+     *  and which occurrence it was cross the wire. */
+    quote?: string
+    quote_index?: number
+  }
   body: string
 }
 

--- a/frontend/src/components/common/PropertyDisplay.vue
+++ b/frontend/src/components/common/PropertyDisplay.vue
@@ -43,6 +43,10 @@ interface PropertyRow {
   widget: Component
   propertyName: string
   propertyDef?: PropertyDef
+  // Position in the rendered list, exposed via the label-affordance slot so a
+  // consumer can reason about a field's place in the grid row (the comment
+  // popover flips its alignment near the right edge).
+  index: number
 }
 
 // Precompute rows once per properties array change instead of recomputing
@@ -50,7 +54,7 @@ interface PropertyRow {
 // present, use the form-side resolve(); otherwise fall back to a
 // WidgetRoutingHint derived from the wire-level shape (RR-UD2B).
 const rows = computed<PropertyRow[]>(() =>
-  props.properties.map((prop) => {
+  props.properties.map((prop, index) => {
     const propertyName = prop.propType ?? prop.name
     if (prop.propertyDef) {
       return {
@@ -58,6 +62,7 @@ const rows = computed<PropertyRow[]>(() =>
         widget: defaultRegistry.resolve(undefined, prop.propertyDef),
         propertyName,
         propertyDef: prop.propertyDef,
+        index,
       }
     }
     // No schema def -- use a routing hint. Mirrors EntityDetail's
@@ -69,6 +74,7 @@ const rows = computed<PropertyRow[]>(() =>
       prop,
       widget: defaultRegistry.resolveFromHint({ kind, propertyName }),
       propertyName,
+      index,
     }
   })
 )
@@ -89,7 +95,14 @@ function isLong(prop: PropertyItem): boolean {
       :class="{ 'property-long': isLong(row.prop) }"
       :style="isLong(row.prop) ? undefined : fieldSpanStyle(row.prop.span)"
     >
-      <dt>{{ row.prop.label }}</dt>
+      <dt>
+        {{ row.prop.label }}
+        <!-- Per-field affordances (the comment indicator, TKT-FIO205). A slot
+             rather than a prop because PropertyDisplay is shared with dense
+             surfaces — list cells, kanban cards — where a comment control
+             would be noise. Only the detail view fills it. -->
+        <slot name="label-affordance" :property="row.prop" :index="row.index" />
+      </dt>
       <dd>
         <InaccessibleField
           v-if="row.prop.inaccessible"

--- a/frontend/src/components/entity/BlockCommentOverlay.vue
+++ b/frontend/src/components/entity/BlockCommentOverlay.vue
@@ -1,0 +1,339 @@
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount, nextTick } from 'vue'
+import { useUIStore } from '@/stores'
+import { addComment, type Comment } from '@/api/comments'
+import { getErrorMessage } from '@/api/errors'
+import { findCommentableBlocks, type CommentableBlock } from '@/utils/blockAnchor'
+
+/**
+ * Comment affordances for body blocks that cannot be text-selected
+ * (TKT-FIO205): images, mermaid and PlantUML diagrams.
+ *
+ * Select-to-comment cannot reach them — there is no text to select — so this
+ * places a button over each block. The anchor is the block's SOURCE markdown
+ * (`![alt](url)`, a fence body), which means it rides the existing `text`
+ * anchor kind rather than needing a new one: re-resolution and the detached
+ * flag come for free.
+ */
+const props = defineProps<{
+  entityType: string
+  entityId: string
+  /** The rendered body element to scan. */
+  container: HTMLElement | null
+  /** Re-scan whenever this changes — the body was re-rendered. */
+  renderKey: unknown
+  /** All comments on this entity, to show which blocks already have one. */
+  comments: Comment[]
+}>()
+
+const emit = defineEmits<{ added: [] }>()
+
+const uiStore = useUIStore()
+
+interface Placed extends CommentableBlock {
+  top: number
+  left: number
+  /** Comments already anchored to this block's source. */
+  existing: Comment[]
+}
+
+const blocks = ref<Placed[]>([])
+const composingFor = ref<string | null>(null)
+const body = ref('')
+const submitting = ref(false)
+
+/**
+ * Re-measures every commentable block.
+ *
+ * Positions are absolute within the body's own positioning context, so they
+ * survive page scroll — but not a re-render or a resize, which is why this
+ * re-runs on renderKey and on the observers below.
+ */
+function scan() {
+  const host = props.container
+  if (!host) {
+    blocks.value = []
+    return
+  }
+  const source = host.dataset.commentSource || ''
+  const hostRect = host.getBoundingClientRect()
+
+  blocks.value = findCommentableBlocks(host, source).map((b) => {
+    const r = b.el.getBoundingClientRect()
+    return {
+      ...b,
+      top: r.top - hostRect.top + 6,
+      left: r.left - hostRect.left + 6,
+      existing: props.comments.filter(
+        (c) => c.anchor.kind === 'text' && c.anchor.quote === b.quote
+      ),
+    }
+  })
+}
+
+/**
+ * Images load asynchronously and diagrams are replaced after render, so a
+ * single scan measures the wrong geometry. Re-measure as the body settles.
+ */
+let observer: ResizeObserver | null = null
+
+function observe() {
+  observer?.disconnect()
+  const host = props.container
+  if (!host || typeof ResizeObserver === 'undefined') return
+  observer = new ResizeObserver(() => scan())
+  observer.observe(host)
+  for (const img of host.querySelectorAll('img')) {
+    if (!img.complete) img.addEventListener('load', scan, { once: true })
+  }
+}
+
+watch(
+  () => [props.container, props.renderKey, props.comments] as const,
+  async () => {
+    await nextTick()
+    scan()
+    observe()
+  },
+  { immediate: true, deep: false }
+)
+
+onBeforeUnmount(() => observer?.disconnect())
+
+function startComposing(b: Placed) {
+  composingFor.value = b.quote
+  body.value = ''
+}
+
+function cancel() {
+  composingFor.value = null
+  body.value = ''
+}
+
+async function submit(b: Placed) {
+  const text = body.value.trim()
+  if (!text || submitting.value) return
+  submitting.value = true
+  try {
+    await addComment(props.entityType, props.entityId, {
+      // The block's source markdown IS the quote — the ordinary text path from
+      // here, so drift handling needs no special case.
+      anchor: { kind: 'text', ref: '', quote: b.quote },
+      body: text,
+    })
+    cancel()
+    emit('added')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="bco">
+    <div
+      v-for="b in blocks"
+      :key="b.quote"
+      class="bco-anchor"
+      :style="{ top: `${b.top}px`, left: `${b.left}px` }"
+    >
+      <button
+        type="button"
+        class="bco-btn"
+        :class="{ 'bco-btn--has': b.existing.length > 0 }"
+        :title="
+          b.existing.length > 0
+            ? `${b.existing.length} comment(s) on this ${b.kind}`
+            : `Comment on this ${b.kind}`
+        "
+        @click.stop="startComposing(b)"
+      >
+        <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 1a7 7 0 0 0-6.1 10.4L1 15l3.8-.9A7 7 0 1 0 8 1Z" />
+        </svg>
+        <span v-if="b.existing.length > 0">{{ b.existing.length }}</span>
+      </button>
+
+      <form
+        v-if="composingFor === b.quote"
+        class="bco-form"
+        @submit.prevent="submit(b)"
+        @click.stop
+      >
+        <p class="bco-target">On this {{ b.kind }}</p>
+
+        <!-- Existing remarks, so the composer is a thread rather than a
+             write-only box — the block has no highlight to click. -->
+        <ul v-if="b.existing.length > 0" class="bco-list">
+          <li v-for="c in b.existing" :key="c.id" class="bco-cmt">
+            <b>{{ c.author }}</b>
+            <p>{{ c.body }}</p>
+          </li>
+        </ul>
+
+        <textarea
+          v-model="body"
+          class="bco-input"
+          rows="3"
+          placeholder="Add a comment…"
+          aria-label="Comment body"
+          @keydown.meta.enter="submit(b)"
+          @keydown.ctrl.enter="submit(b)"
+        />
+        <div class="bco-actions">
+          <span class="bco-hint">⌘↵ to post</span>
+          <button type="button" class="bco-cancel" @click="cancel">Cancel</button>
+          <button type="submit" class="bco-submit" :disabled="submitting || !body.trim()">
+            {{ submitting ? 'Adding…' : 'Comment' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* The overlay itself never intercepts pointer events — only its buttons do —
+ * so an image stays clickable and text under it stays selectable. */
+.bco {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.bco-anchor {
+  position: absolute;
+  pointer-events: auto;
+}
+
+.bco-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 7px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--card-bg);
+  color: var(--muted-text);
+  box-shadow: var(--shadow-sm, 0 1px 3px rgb(0 0 0 / 12%));
+  cursor: pointer;
+  font: 600 var(--font-size-sm) / 1 inherit;
+  opacity: 0.75;
+  transition: opacity 0.12s;
+}
+.bco-btn:hover,
+.bco-btn:focus-visible {
+  opacity: 1;
+  border-color: var(--accent-color);
+}
+.bco-btn svg {
+  width: 12px;
+  height: 12px;
+}
+.bco-btn--has {
+  opacity: 1;
+  background: var(--comment-highlight);
+  border-color: var(--comment-highlight);
+  color: var(--text-color);
+}
+.bco-btn:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+.bco-form {
+  position: absolute;
+  top: 28px;
+  left: 0;
+  z-index: 27;
+  width: 320px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg, 8px);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-lg, 0 10px 30px rgb(0 0 0 / 16%));
+}
+
+.bco-target {
+  margin: 0 0 8px;
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+
+.bco-list {
+  list-style: none;
+  margin: 0 0 8px;
+  padding: 0;
+  max-height: 160px;
+  overflow-y: auto;
+}
+.bco-cmt {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-color);
+  font-size: var(--font-size-sm);
+}
+.bco-cmt:last-child {
+  border-bottom: 0;
+}
+.bco-cmt p {
+  margin: 2px 0 0;
+  color: var(--text-color);
+  white-space: pre-wrap;
+}
+
+.bco-input {
+  width: 100%;
+  padding: 6px 8px;
+  resize: vertical;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 5px);
+  background: var(--input-bg);
+  color: var(--text-color);
+  font: inherit;
+  font-size: var(--font-size-base);
+}
+.bco-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+.bco-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 7px;
+}
+.bco-hint {
+  margin-right: auto;
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+.bco-cancel,
+.bco-submit {
+  padding: 4px 11px;
+  border-radius: var(--radius-sm, 5px);
+  font: 600 var(--font-size-sm) / 1.4 inherit;
+  cursor: pointer;
+}
+.bco-cancel {
+  border: 1px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+.bco-submit {
+  border: 1px solid var(--accent-color);
+  background: var(--accent-color);
+  color: #fff;
+}
+.bco-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/components/entity/CommentIndicator.test.ts
+++ b/frontend/src/components/entity/CommentIndicator.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CommentIndicator from './CommentIndicator.vue'
+import { addComment, updateComment, deleteComment, type Comment } from '@/api/comments'
+
+const mockConfirm = vi.fn<() => Promise<boolean>>()
+vi.mock('@/composables/useConfirm', () => ({
+  useConfirm: () => ({ confirm: mockConfirm }),
+}))
+
+vi.mock('@/api/comments', () => ({
+  addComment: vi.fn(),
+  updateComment: vi.fn(),
+  deleteComment: vi.fn(),
+}))
+
+const mockAdd = vi.mocked(addComment)
+const mockUpdate = vi.mocked(updateComment)
+const mockDelete = vi.mocked(deleteComment)
+
+const ENTITY_TYPE = 'ticket'
+const ENTITY_ID = 'TKT-001'
+const ANCHOR = { kind: 'property', ref: 'priority' } as const
+
+function comment(over: Partial<Comment> = {}): Comment {
+  return {
+    id: 'c1',
+    author: 'alice@example.com',
+    created_at: '2026-09-01T10:00:00Z',
+    anchor: { ...ANCHOR },
+    body: 'looks wrong',
+    resolved: false,
+    editable: true,
+    deletable: true,
+    ...over,
+  }
+}
+
+function mountIndicator(comments: Comment[] = [], flip = false) {
+  return mount(CommentIndicator, {
+    props: { entityType: ENTITY_TYPE, entityId: ENTITY_ID, anchor: { ...ANCHOR }, comments, flip },
+    attachTo: document.body,
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  mockConfirm.mockResolvedValue(true)
+})
+
+describe('CommentIndicator', () => {
+  it('shows a count for a commented field', () => {
+    const w = mountIndicator([comment(), comment({ id: 'c2' })])
+
+    expect(w.find('.ci-count').text()).toBe('2')
+    expect(w.find('.ci-btn').classes()).toContain('ci-btn--has')
+  })
+
+  it('marks a field whose comments are all resolved as done, not open', () => {
+    const w = mountIndicator([comment({ resolved: true })])
+
+    expect(w.find('.ci-btn').classes()).toContain('ci-btn--done')
+    expect(w.find('.ci-btn').classes()).not.toContain('ci-btn--has')
+  })
+
+  it('stays present but empty-styled when the field has no comments', () => {
+    const w = mountIndicator([])
+
+    expect(w.find('.ci-btn').exists()).toBe(true)
+    expect(w.find('.ci-btn').classes()).toContain('ci-btn--empty')
+    expect(w.find('.ci-count').exists()).toBe(false)
+  })
+
+  it('flags a detached anchor on the indicator itself', () => {
+    const w = mountIndicator([comment({ detached: true })])
+
+    expect(w.find('.ci-btn').classes()).toContain('ci-btn--detached')
+  })
+
+  it('opens and closes the popover', async () => {
+    const w = mountIndicator([comment()])
+    expect(w.find('.ci-pop').exists()).toBe(false)
+
+    await w.find('.ci-btn').trigger('click')
+    expect(w.find('.ci-pop').exists()).toBe(true)
+    expect(w.find('.ci-body').text()).toBe('looks wrong')
+
+    await w.find('.ci-x').trigger('click')
+    expect(w.find('.ci-pop').exists()).toBe(false)
+  })
+
+  it('closes on Escape', async () => {
+    const w = mountIndicator([comment()])
+    await w.find('.ci-btn').trigger('click')
+    expect(w.find('.ci-pop').exists()).toBe(true)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await w.vm.$nextTick()
+
+    expect(w.find('.ci-pop').exists()).toBe(false)
+  })
+
+  it('posts against its own anchor and emits changed', async () => {
+    const w = mountIndicator([])
+    mockAdd.mockResolvedValue(comment({ id: 'new' }))
+
+    await w.find('.ci-btn').trigger('click')
+    await w.find('.ci-composer .ci-input').setValue('a new remark')
+    await w.find('.ci-composer').trigger('submit')
+    await vi.waitFor(() => expect(mockAdd).toHaveBeenCalled())
+
+    expect(mockAdd).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID, {
+      anchor: { ...ANCHOR },
+      body: 'a new remark',
+    })
+    expect(w.emitted('changed')).toHaveLength(1)
+  })
+
+  it('resolves without echoing the body back', async () => {
+    const existing = comment()
+    const w = mountIndicator([existing])
+    mockUpdate.mockResolvedValue()
+
+    await w.find('.ci-btn').trigger('click')
+    await w
+      .findAll('.ci-mini')
+      .find((b) => b.text() === 'Resolve')
+      ?.trigger('click')
+    await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+
+    expect(mockUpdate).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID, existing.id, { resolved: true })
+    expect(w.emitted('changed')).toHaveLength(1)
+  })
+
+  it('deletes only after the confirmation is accepted', async () => {
+    const existing = comment()
+    const w = mountIndicator([existing])
+    mockDelete.mockResolvedValue()
+    mockConfirm.mockResolvedValue(false)
+
+    await w.find('.ci-btn').trigger('click')
+    await w
+      .findAll('.ci-mini')
+      .find((b) => b.text() === 'Delete')
+      ?.trigger('click')
+    await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalled())
+
+    expect(mockDelete).not.toHaveBeenCalled()
+    expect(w.emitted('changed')).toBeUndefined()
+  })
+
+  it('hides controls the server did not grant', async () => {
+    const w = mountIndicator([comment({ editable: false, deletable: false })])
+
+    await w.find('.ci-btn').trigger('click')
+
+    expect(w.findAll('.ci-cmt .ci-mini')).toHaveLength(0)
+  })
+
+  it('opens right-aligned when told to flip', async () => {
+    const w = mountIndicator([comment()], true)
+    await w.find('.ci-btn').trigger('click')
+
+    expect(w.find('.ci-pop').classes()).toContain('ci-pop--flip')
+  })
+})

--- a/frontend/src/components/entity/CommentIndicator.vue
+++ b/frontend/src/components/entity/CommentIndicator.vue
@@ -1,0 +1,528 @@
+<script setup lang="ts">
+import { ref, computed, watch, onBeforeUnmount, nextTick, useTemplateRef } from 'vue'
+import { useUIStore } from '@/stores'
+import { useConfirm } from '@/composables/useConfirm'
+import {
+  addComment,
+  updateComment,
+  deleteComment,
+  type Comment,
+  type CommentAnchor,
+} from '@/api/comments'
+import { getErrorMessage } from '@/api/errors'
+
+/**
+ * A comment affordance anchored to one field (TKT-FIO205).
+ *
+ * Renders a small indicator beside the property label and, on click, a popover
+ * holding that anchor's thread plus a composer.
+ *
+ * # Why the indicator sits by the LABEL, not the value
+ *
+ * A field is a column (label above value) on a 12-column grid, so a field may
+ * be a third of the row wide. Trailing the value puts the badge at a position
+ * that moves with the value's length, which on a shared row reads as belonging
+ * to the neighbouring field. The label is a fixed anchor point at any span.
+ *
+ * # Data flows in, mutations flow out
+ *
+ * The parent owns the comment list (one fetch per entity, not one per field).
+ * This component receives its slice and emits `changed` so the parent refetches
+ * — a per-field fetch would be N requests for N fields.
+ */
+const props = defineProps<{
+  entityType: string
+  entityId: string
+  anchor: CommentAnchor
+  /** This anchor's comments, already filtered by the parent. */
+  comments: Comment[]
+  /**
+   * Open the popover to the right instead of the left. The parent decides,
+   * because only it knows the field's position in the row: a popover is wider
+   * than a 4-column field, so on the last column a left-aligned one would
+   * overflow the card.
+   */
+  flip?: boolean
+}>()
+
+const emit = defineEmits<{ changed: [] }>()
+
+const uiStore = useUIStore()
+const { confirm } = useConfirm()
+
+const open = ref(false)
+const body = ref('')
+const submitting = ref(false)
+const editingId = ref<string | null>(null)
+const editBody = ref('')
+const rootRef = useTemplateRef<HTMLElement>('root')
+const composerRef = useTemplateRef<HTMLTextAreaElement>('composer')
+
+const total = computed(() => props.comments.length)
+const openCount = computed(() => props.comments.filter((c) => !c.resolved).length)
+const allResolved = computed(() => total.value > 0 && openCount.value === 0)
+const detached = computed(() => props.comments.some((c) => c.detached))
+
+/** Unresolved first: a settled remark should not bury an active one. */
+const ordered = computed(() =>
+  [...props.comments].sort((a, b) => Number(a.resolved) - Number(b.resolved))
+)
+
+const title = computed(() => {
+  if (total.value === 0) return `Comment on ${props.anchor.ref}`
+  const noun = total.value === 1 ? 'comment' : 'comments'
+  return `${total.value} ${noun} on ${props.anchor.ref}`
+})
+
+async function toggle() {
+  open.value = !open.value
+  if (open.value) {
+    await nextTick()
+    composerRef.value?.focus()
+  }
+}
+
+function close() {
+  open.value = false
+  editingId.value = null
+  editBody.value = ''
+}
+
+async function submit() {
+  const text = body.value.trim()
+  if (!text || submitting.value) return
+  submitting.value = true
+  try {
+    await addComment(props.entityType, props.entityId, { anchor: props.anchor, body: text })
+    body.value = ''
+    emit('changed')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  } finally {
+    submitting.value = false
+  }
+}
+
+function startEdit(c: Comment) {
+  editingId.value = c.id
+  editBody.value = c.body
+}
+
+async function saveEdit(c: Comment) {
+  const text = editBody.value.trim()
+  if (!text) return
+  try {
+    await updateComment(props.entityType, props.entityId, c.id, { body: text })
+    editingId.value = null
+    emit('changed')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+async function toggleResolved(c: Comment) {
+  try {
+    await updateComment(props.entityType, props.entityId, c.id, { resolved: !c.resolved })
+    emit('changed')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+async function remove(c: Comment) {
+  // Branch on the boolean: useConfirm resolves false if the shell unmounts
+  // while the dialog is open, and a DELETE must not fire on that path.
+  const ok = await confirm({
+    title: 'Delete comment',
+    message: 'Delete this comment? This cannot be undone.',
+    confirmLabel: 'Delete',
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    await deleteComment(props.entityType, props.entityId, c.id)
+    emit('changed')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+function onDocClick(e: MouseEvent) {
+  if (!rootRef.value?.contains(e.target as Node)) close()
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') close()
+}
+
+// Listeners only exist while the popover is open — a document-level handler per
+// field would otherwise be one listener per property on every entity page.
+watch(open, (isOpen) => {
+  if (isOpen) {
+    document.addEventListener('click', onDocClick)
+    document.addEventListener('keydown', onKeydown)
+  } else {
+    document.removeEventListener('click', onDocClick)
+    document.removeEventListener('keydown', onKeydown)
+  }
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocClick)
+  document.removeEventListener('keydown', onKeydown)
+})
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+</script>
+
+<template>
+  <span ref="root" class="comment-indicator">
+    <button
+      type="button"
+      class="ci-btn"
+      :class="{
+        'ci-btn--has': total > 0 && !allResolved,
+        'ci-btn--done': allResolved,
+        'ci-btn--empty': total === 0,
+        'ci-btn--detached': detached,
+      }"
+      :title="title"
+      :aria-label="title"
+      :aria-expanded="open"
+      @click.stop="toggle"
+    >
+      <svg
+        v-if="allResolved"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path d="M3 8.5 6.5 12 13 4.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+      <svg v-else-if="total > 0" viewBox="0 0 16 16" fill="currentColor">
+        <path d="M8 1a7 7 0 0 0-6.1 10.4L1 15l3.8-.9A7 7 0 1 0 8 1Z" />
+      </svg>
+      <svg v-else viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6">
+        <path d="M8 4.5v7M4.5 8h7" stroke-linecap="round" />
+      </svg>
+      <span v-if="total > 0" class="ci-count">{{ total }}</span>
+    </button>
+
+    <div v-if="open" class="ci-pop" :class="{ 'ci-pop--flip': flip }" @click.stop>
+      <header class="ci-pop-head">
+        <span
+          >Comments on <code>{{ anchor.ref }}</code></span
+        >
+        <button type="button" class="ci-x" aria-label="Close" @click="close">✕</button>
+      </header>
+
+      <ul v-if="ordered.length > 0" class="ci-list">
+        <li
+          v-for="c in ordered"
+          :key="c.id"
+          class="ci-cmt"
+          :class="{ 'ci-cmt--resolved': c.resolved }"
+        >
+          <div class="ci-meta">
+            <b>{{ c.author }}</b>
+            <span>{{ formatDate(c.created_at) }}</span>
+            <span
+              v-if="c.detached"
+              class="ci-detached"
+              title="The property this comment points at no longer exists"
+              >detached</span
+            >
+          </div>
+
+          <template v-if="editingId === c.id">
+            <textarea v-model="editBody" class="ci-input" rows="3" />
+            <div class="ci-acts">
+              <button class="ci-mini ci-mini--primary" @click="saveEdit(c)">Save</button>
+              <button class="ci-mini" @click="editingId = null">Cancel</button>
+            </div>
+          </template>
+
+          <template v-else>
+            <p class="ci-body">{{ c.body }}</p>
+            <div class="ci-acts">
+              <button v-if="c.editable" class="ci-mini" @click="toggleResolved(c)">
+                {{ c.resolved ? 'Reopen' : 'Resolve' }}
+              </button>
+              <button v-if="c.editable" class="ci-mini" @click="startEdit(c)">Edit</button>
+              <button v-if="c.deletable" class="ci-mini ci-mini--danger" @click="remove(c)">
+                Delete
+              </button>
+            </div>
+          </template>
+        </li>
+      </ul>
+
+      <!-- Always offered: whether this user may post is the server's call, and
+           a hidden box would misreport a permission we were never told. -->
+      <form class="ci-composer" @submit.prevent="submit">
+        <textarea
+          ref="composer"
+          v-model="body"
+          class="ci-input"
+          rows="3"
+          :placeholder="total > 0 ? 'Reply…' : 'Add a comment…'"
+          aria-label="Comment body"
+          @keydown.meta.enter="submit"
+          @keydown.ctrl.enter="submit"
+        />
+        <div class="ci-composer-row">
+          <span class="ci-hint">⌘↵ to post</span>
+          <button
+            type="submit"
+            class="ci-mini ci-mini--primary"
+            :disabled="submitting || !body.trim()"
+          >
+            {{ submitting ? 'Adding…' : 'Comment' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </span>
+</template>
+
+<style scoped>
+.comment-indicator {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.ci-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 19px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: none;
+  cursor: pointer;
+  font: 600 var(--font-size-sm) / 1 inherit;
+  color: var(--muted-text);
+}
+.ci-btn svg {
+  width: 11px;
+  height: 11px;
+}
+
+.ci-btn--has {
+  background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 30%, transparent);
+  color: var(--accent-color);
+}
+.ci-btn--done {
+  background: color-mix(in srgb, var(--success-color) 14%, transparent);
+  border-color: color-mix(in srgb, var(--success-color) 32%, transparent);
+  color: var(--success-color);
+}
+.ci-btn--detached {
+  background: color-mix(in srgb, var(--warning-color) 22%, transparent);
+  border-color: color-mix(in srgb, var(--warning-color) 45%, transparent);
+  color: var(--text-color);
+}
+
+/* Empty fields stay quiet until the row is hovered or the control is focused.
+ * Focus-visible is not optional here: an opacity-0 control that never reveals
+ * on keyboard focus is unreachable without a mouse. */
+.ci-btn--empty {
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.property-item:hover .ci-btn--empty,
+.ci-btn--empty:hover,
+.ci-btn--empty:focus-visible,
+.ci-btn--empty[aria-expanded='true'] {
+  opacity: 0.55;
+}
+.ci-btn--empty:hover,
+.ci-btn--empty:focus-visible {
+  opacity: 1;
+}
+
+.ci-btn:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+/* ── Popover ─────────────────────────────────────────────────── */
+.ci-pop {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 6px);
+  left: 0;
+  width: 340px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg, 8px);
+  box-shadow: var(--shadow-lg, 0 10px 30px rgba(0, 0, 0, 0.16));
+  text-align: left;
+  cursor: default;
+}
+/* Flipped, the popover extends LEFTWARD from the indicator.
+ *
+ * `right: 0` here aligns to the indicator's right edge, not the field's — the
+ * indicator is the positioning parent and is only ~30px wide. That is what we
+ * want: the popover hangs left from the badge the user clicked, which keeps it
+ * inside the content area near the right edge of the grid.
+ *
+ * It is NOT a substitute for the field-position check the parent does: on a
+ * full-width field the badge sits near the LEFT of the page, so flipping there
+ * would push the popover under the sidebar. Hence `flip` is only ever set for a
+ * field that is genuinely rightmost on a SHARED row. */
+.ci-pop--flip {
+  left: auto;
+  right: 0;
+}
+
+.ci-pop-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+.ci-pop-head code {
+  color: var(--text-color);
+}
+.ci-x {
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--muted-text);
+  font-size: var(--font-size-sm);
+}
+
+.ci-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.ci-cmt {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+.ci-cmt:last-child {
+  border-bottom: 0;
+}
+.ci-cmt--resolved {
+  opacity: 0.6;
+}
+
+.ci-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+  margin-bottom: 3px;
+}
+.ci-meta b {
+  color: var(--text-color);
+}
+.ci-detached {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--warning-color);
+  color: var(--text-color);
+}
+
+.ci-body {
+  margin: 0 0 6px;
+  font-size: var(--font-size-base);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.ci-acts {
+  display: flex;
+  gap: 5px;
+}
+.ci-mini {
+  font: var(--font-size-sm) / 1.4 inherit;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+  cursor: pointer;
+}
+.ci-mini--primary {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+  color: #fff;
+}
+.ci-mini--danger {
+  color: var(--error-color);
+}
+.ci-mini:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.ci-mini:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+.ci-composer {
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-color);
+}
+.ci-input {
+  width: 100%;
+  padding: 6px 8px;
+  resize: vertical;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 5px);
+  background: var(--input-bg);
+  color: var(--text-color);
+  font: inherit;
+  font-size: var(--font-size-base);
+}
+.ci-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+.ci-composer-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 6px;
+}
+.ci-hint {
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+
+/* On a narrow viewport the popover cannot sit beside a field at all — the
+ * grid has already collapsed to one column, so it spans the row instead. */
+@media (max-width: 640px) {
+  .ci-pop,
+  .ci-pop--flip {
+    left: 0;
+    right: 0;
+    width: auto;
+  }
+}
+</style>

--- a/frontend/src/components/entity/CommentsPanel.test.ts
+++ b/frontend/src/components/entity/CommentsPanel.test.ts
@@ -65,11 +65,22 @@ function seedType(over: Partial<EntityType> = {}) {
   ]) as never
 }
 
-async function mountPanel(sectionIds: string[] = []) {
+/**
+ * Mounts the panel and expands it.
+ *
+ * The panel is collapsed by default — property comments now render at their own
+ * field, so this surface exists for the ones with no field row. `expand: false`
+ * is for the tests that assert the collapsed header itself.
+ */
+async function mountPanel(sectionIds: string[] = [], expand = true) {
   const w = mount(CommentsPanel, {
     props: { entityType: ENTITY_TYPE, entityId: ENTITY_ID, sectionIds },
   })
   await vi.waitFor(() => expect(w.vm).toBeTruthy())
+  await w.vm.$nextTick()
+  if (expand && w.find('.panel-header').exists()) {
+    await w.find('.panel-header').trigger('click')
+  }
   await w.vm.$nextTick()
   await w.vm.$nextTick()
   return w
@@ -212,5 +223,40 @@ describe('CommentsPanel', () => {
 
     expect(w.find('.comments-error').exists()).toBe(true)
     expect(w.text()).not.toContain('No comments yet')
+  })
+})
+
+describe('CommentsPanel collapsing', () => {
+  it('is collapsed by default and summarises what is folded away', async () => {
+    seedType()
+    mockList.mockResolvedValue([
+      comment({ id: 'p1', anchor: { kind: 'property', ref: 'status' } }),
+      comment({ id: 's1', anchor: { kind: 'section', ref: 'details' } }),
+      comment({ id: 'd1', anchor: { kind: 'property', ref: 'gone' }, detached: true }),
+    ])
+
+    const w = await mountPanel([], false)
+
+    // Collapsed: the header is there, the thread is not.
+    expect(w.find('.panel-header').exists()).toBe(true)
+    expect(w.find('.comment').exists()).toBe(false)
+
+    // The summary counts comments with no field row of their own — the
+    // section-anchored one and the detached one, not the plain property one.
+    expect(w.find('.panel-summary').text()).toContain('3 total')
+    expect(w.find('.panel-summary').text()).toContain('2 not on a field')
+  })
+
+  it('expands on click', async () => {
+    seedType()
+    mockList.mockResolvedValue([comment()])
+
+    const w = await mountPanel([], false)
+    expect(w.find('.comment').exists()).toBe(false)
+
+    await w.find('.panel-header').trigger('click')
+    await w.vm.$nextTick()
+
+    expect(w.find('.comment').exists()).toBe(true)
   })
 })

--- a/frontend/src/components/entity/CommentsPanel.test.ts
+++ b/frontend/src/components/entity/CommentsPanel.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import CommentsPanel from './CommentsPanel.vue'
+import { useSchemaStore } from '@/stores/schema'
+import {
+  listComments,
+  addComment,
+  updateComment,
+  deleteComment,
+  type Comment,
+} from '@/api/comments'
+import type { EntityType } from '@/types'
+
+// The confirm dialog is a singleton composable backed by a modal mounted in
+// App.vue; mocking it keeps the delete tests about the delete path rather than
+// about dialog plumbing.
+const mockConfirm = vi.fn<() => Promise<boolean>>()
+vi.mock('@/composables/useConfirm', () => ({
+  useConfirm: () => ({ confirm: mockConfirm }),
+}))
+
+vi.mock('@/api/comments', () => ({
+  listComments: vi.fn(),
+  addComment: vi.fn(),
+  updateComment: vi.fn(),
+  deleteComment: vi.fn(),
+}))
+
+const mockList = vi.mocked(listComments)
+const mockAdd = vi.mocked(addComment)
+const mockUpdate = vi.mocked(updateComment)
+const mockDelete = vi.mocked(deleteComment)
+
+const ENTITY_TYPE = 'ticket'
+const ENTITY_ID = 'TKT-001'
+
+function comment(over: Partial<Comment> = {}): Comment {
+  return {
+    id: 'c1',
+    author: 'alice@example.com',
+    created_at: '2026-09-01T10:00:00Z',
+    anchor: { kind: 'property', ref: 'status' },
+    body: 'looks wrong',
+    resolved: false,
+    editable: true,
+    deletable: true,
+    ...over,
+  }
+}
+
+/** Registers the entity type, defaulting to commentable. */
+function seedType(over: Partial<EntityType> = {}) {
+  const schemaStore = useSchemaStore()
+  schemaStore.entityTypes = new Map([
+    [
+      ENTITY_TYPE,
+      {
+        label: 'Ticket',
+        properties: { title: { type: 'string' }, status: { type: 'string' } },
+        commentable: true,
+        ...over,
+      },
+    ],
+  ]) as never
+}
+
+async function mountPanel(sectionIds: string[] = []) {
+  const w = mount(CommentsPanel, {
+    props: { entityType: ENTITY_TYPE, entityId: ENTITY_ID, sectionIds },
+  })
+  await vi.waitFor(() => expect(w.vm).toBeTruthy())
+  await w.vm.$nextTick()
+  await w.vm.$nextTick()
+  return w
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  mockList.mockResolvedValue([])
+  mockConfirm.mockResolvedValue(true)
+})
+
+describe('CommentsPanel', () => {
+  it('renders nothing for a type the schema does not mark commentable', async () => {
+    seedType({ commentable: false })
+    const w = await mountPanel()
+
+    expect(w.find('.comments-panel').exists()).toBe(false)
+    // The panel must not probe the API for a type it will not render for.
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it("lists a commentable type's thread", async () => {
+    seedType()
+    const existing = comment({ body: 'the status is stale' })
+    mockList.mockResolvedValue([existing])
+
+    const w = await mountPanel()
+
+    expect(mockList).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID)
+    expect(w.find('.comment-body').text()).toBe(existing.body)
+    expect(w.find('.comment-author').text()).toBe(existing.author)
+    expect(w.find('.comment-anchor').text()).toBe(existing.anchor.ref)
+  })
+
+  it('offers both property and section anchors', async () => {
+    seedType()
+    const w = await mountPanel(['history'])
+
+    const values = w.findAll('.anchor-select option').map((o) => o.attributes('value'))
+    expect(values).toContain('property:status')
+    expect(values).toContain('section:history')
+  })
+
+  it('posts a comment with the selected anchor and clears the box', async () => {
+    seedType()
+    const created = comment({ id: 'c2', body: 'needs a second look' })
+    mockAdd.mockResolvedValue(created)
+
+    const w = await mountPanel()
+    await w.find('.anchor-select').setValue('property:title')
+    await w.find('.comment-input').setValue(created.body)
+    await w.find('.comment-form').trigger('submit')
+    await vi.waitFor(() => expect(mockAdd).toHaveBeenCalled())
+    await w.vm.$nextTick()
+
+    expect(mockAdd).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID, {
+      anchor: { kind: 'property', ref: 'title' },
+      body: created.body,
+    })
+    expect(w.find('.comment-body').text()).toBe(created.body)
+    expect((w.find('.comment-input').element as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('resolves a comment without echoing its body back', async () => {
+    seedType()
+    const existing = comment()
+    mockList.mockResolvedValue([existing])
+    mockUpdate.mockResolvedValue()
+
+    const w = await mountPanel()
+    const resolveBtn = w.findAll('button').find((b) => b.text() === 'Resolve')
+    await resolveBtn?.trigger('click')
+    await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled())
+    await w.vm.$nextTick()
+
+    expect(mockUpdate).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID, existing.id, { resolved: true })
+    expect(w.find('.comment').classes()).toContain('comment-resolved')
+  })
+
+  it('deletes a comment once confirmed', async () => {
+    seedType()
+    const existing = comment()
+    mockList.mockResolvedValue([existing])
+    mockDelete.mockResolvedValue()
+
+    const w = await mountPanel()
+    const deleteBtn = w.findAll('button').find((b) => b.text() === 'Delete')
+    await deleteBtn?.trigger('click')
+    await vi.waitFor(() => expect(mockDelete).toHaveBeenCalled())
+    await w.vm.$nextTick()
+
+    expect(mockDelete).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID, existing.id)
+    expect(w.find('.comment').exists()).toBe(false)
+  })
+
+  it('keeps a comment when the delete confirmation is declined', async () => {
+    seedType()
+    mockList.mockResolvedValue([comment()])
+    mockConfirm.mockResolvedValue(false)
+
+    const w = await mountPanel()
+    await w
+      .findAll('button')
+      .find((b) => b.text() === 'Delete')
+      ?.trigger('click')
+    await vi.waitFor(() => expect(mockConfirm).toHaveBeenCalled())
+    await w.vm.$nextTick()
+
+    expect(mockDelete).not.toHaveBeenCalled()
+    expect(w.find('.comment').exists()).toBe(true)
+  })
+
+  it('flags a detached anchor without hiding the comment', async () => {
+    seedType()
+    const orphan = comment({ detached: true, anchor: { kind: 'property', ref: 'removed_field' } })
+    mockList.mockResolvedValue([orphan])
+
+    const w = await mountPanel()
+
+    expect(w.find('.comment-detached').exists()).toBe(true)
+    expect(w.find('.comment-body').text()).toBe(orphan.body)
+  })
+
+  it('hides controls the server did not grant', async () => {
+    seedType()
+    mockList.mockResolvedValue([comment({ editable: false, deletable: false })])
+
+    const w = await mountPanel()
+
+    const labels = w.findAll('.comment-actions button').map((b) => b.text())
+    expect(labels).toEqual([])
+  })
+
+  it('reports a failed load rather than rendering an empty thread', async () => {
+    seedType()
+    mockList.mockRejectedValue(new Error('nope'))
+
+    const w = await mountPanel()
+
+    expect(w.find('.comments-error').exists()).toBe(true)
+    expect(w.text()).not.toContain('No comments yet')
+  })
+})

--- a/frontend/src/components/entity/CommentsPanel.test.ts
+++ b/frontend/src/components/entity/CommentsPanel.test.ts
@@ -3,13 +3,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import CommentsPanel from './CommentsPanel.vue'
 import { useSchemaStore } from '@/stores/schema'
-import {
-  listComments,
-  addComment,
-  updateComment,
-  deleteComment,
-  type Comment,
-} from '@/api/comments'
+import { addComment, updateComment, deleteComment, type Comment } from '@/api/comments'
 import type { EntityType } from '@/types'
 
 // The confirm dialog is a singleton composable backed by a modal mounted in
@@ -21,13 +15,11 @@ vi.mock('@/composables/useConfirm', () => ({
 }))
 
 vi.mock('@/api/comments', () => ({
-  listComments: vi.fn(),
   addComment: vi.fn(),
   updateComment: vi.fn(),
   deleteComment: vi.fn(),
 }))
 
-const mockList = vi.mocked(listComments)
 const mockAdd = vi.mocked(addComment)
 const mockUpdate = vi.mocked(updateComment)
 const mockDelete = vi.mocked(deleteComment)
@@ -72,9 +64,9 @@ function seedType(over: Partial<EntityType> = {}) {
  * field, so this surface exists for the ones with no field row. `expand: false`
  * is for the tests that assert the collapsed header itself.
  */
-async function mountPanel(sectionIds: string[] = [], expand = true) {
+async function mountPanel(sectionIds: string[] = [], expand = true, comments: Comment[] = []) {
   const w = mount(CommentsPanel, {
-    props: { entityType: ENTITY_TYPE, entityId: ENTITY_ID, sectionIds },
+    props: { entityType: ENTITY_TYPE, entityId: ENTITY_ID, comments, sectionIds },
   })
   await vi.waitFor(() => expect(w.vm).toBeTruthy())
   await w.vm.$nextTick()
@@ -89,7 +81,6 @@ async function mountPanel(sectionIds: string[] = [], expand = true) {
 beforeEach(() => {
   setActivePinia(createPinia())
   vi.clearAllMocks()
-  mockList.mockResolvedValue([])
   mockConfirm.mockResolvedValue(true)
 })
 
@@ -99,18 +90,14 @@ describe('CommentsPanel', () => {
     const w = await mountPanel()
 
     expect(w.find('.comments-panel').exists()).toBe(false)
-    // The panel must not probe the API for a type it will not render for.
-    expect(mockList).not.toHaveBeenCalled()
   })
 
   it("lists a commentable type's thread", async () => {
     seedType()
     const existing = comment({ body: 'the status is stale' })
-    mockList.mockResolvedValue([existing])
 
-    const w = await mountPanel()
+    const w = await mountPanel([], true, [existing])
 
-    expect(mockList).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID)
     expect(w.find('.comment-body').text()).toBe(existing.body)
     expect(w.find('.comment-author').text()).toBe(existing.author)
     expect(w.find('.comment-anchor').text()).toBe(existing.anchor.ref)
@@ -141,48 +128,48 @@ describe('CommentsPanel', () => {
       anchor: { kind: 'property', ref: 'title' },
       body: created.body,
     })
-    expect(w.find('.comment-body').text()).toBe(created.body)
+    // The parent owns the list, so the panel reports the change rather than
+    // splicing its own copy — which is what kept it in sync with the
+    // per-field indicators.
+    expect(w.emitted('changed')).toHaveLength(1)
     expect((w.find('.comment-input').element as HTMLTextAreaElement).value).toBe('')
   })
 
   it('resolves a comment without echoing its body back', async () => {
     seedType()
     const existing = comment()
-    mockList.mockResolvedValue([existing])
     mockUpdate.mockResolvedValue()
 
-    const w = await mountPanel()
+    const w = await mountPanel([], true, [existing])
     const resolveBtn = w.findAll('button').find((b) => b.text() === 'Resolve')
     await resolveBtn?.trigger('click')
     await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled())
     await w.vm.$nextTick()
 
     expect(mockUpdate).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID, existing.id, { resolved: true })
-    expect(w.find('.comment').classes()).toContain('comment-resolved')
+    expect(w.emitted('changed')).toHaveLength(1)
   })
 
   it('deletes a comment once confirmed', async () => {
     seedType()
     const existing = comment()
-    mockList.mockResolvedValue([existing])
     mockDelete.mockResolvedValue()
 
-    const w = await mountPanel()
+    const w = await mountPanel([], true, [existing])
     const deleteBtn = w.findAll('button').find((b) => b.text() === 'Delete')
     await deleteBtn?.trigger('click')
     await vi.waitFor(() => expect(mockDelete).toHaveBeenCalled())
     await w.vm.$nextTick()
 
     expect(mockDelete).toHaveBeenCalledWith(ENTITY_TYPE, ENTITY_ID, existing.id)
-    expect(w.find('.comment').exists()).toBe(false)
+    expect(w.emitted('changed')).toHaveLength(1)
   })
 
   it('keeps a comment when the delete confirmation is declined', async () => {
     seedType()
-    mockList.mockResolvedValue([comment()])
     mockConfirm.mockResolvedValue(false)
 
-    const w = await mountPanel()
+    const w = await mountPanel([], true, [comment()])
     await w
       .findAll('button')
       .find((b) => b.text() === 'Delete')
@@ -197,9 +184,8 @@ describe('CommentsPanel', () => {
   it('flags a detached anchor without hiding the comment', async () => {
     seedType()
     const orphan = comment({ detached: true, anchor: { kind: 'property', ref: 'removed_field' } })
-    mockList.mockResolvedValue([orphan])
 
-    const w = await mountPanel()
+    const w = await mountPanel([], true, [orphan])
 
     expect(w.find('.comment-detached').exists()).toBe(true)
     expect(w.find('.comment-body').text()).toBe(orphan.body)
@@ -207,35 +193,30 @@ describe('CommentsPanel', () => {
 
   it('hides controls the server did not grant', async () => {
     seedType()
-    mockList.mockResolvedValue([comment({ editable: false, deletable: false })])
-
-    const w = await mountPanel()
+    const w = await mountPanel([], true, [comment({ editable: false, deletable: false })])
 
     const labels = w.findAll('.comment-actions button').map((b) => b.text())
     expect(labels).toEqual([])
   })
 
-  it('reports a failed load rather than rendering an empty thread', async () => {
+  it('renders the empty state when there is nothing to show', async () => {
     seedType()
-    mockList.mockRejectedValue(new Error('nope'))
 
     const w = await mountPanel()
 
-    expect(w.find('.comments-error').exists()).toBe(true)
-    expect(w.text()).not.toContain('No comments yet')
+    expect(w.find('.comment').exists()).toBe(false)
+    expect(w.text()).toContain('No comments yet')
   })
 })
 
 describe('CommentsPanel collapsing', () => {
   it('is collapsed by default and summarises what is folded away', async () => {
     seedType()
-    mockList.mockResolvedValue([
+    const w = await mountPanel([], false, [
       comment({ id: 'p1', anchor: { kind: 'property', ref: 'status' } }),
       comment({ id: 's1', anchor: { kind: 'section', ref: 'details' } }),
       comment({ id: 'd1', anchor: { kind: 'property', ref: 'gone' }, detached: true }),
     ])
-
-    const w = await mountPanel([], false)
 
     // Collapsed: the header is there, the thread is not.
     expect(w.find('.panel-header').exists()).toBe(true)
@@ -249,14 +230,39 @@ describe('CommentsPanel collapsing', () => {
 
   it('expands on click', async () => {
     seedType()
-    mockList.mockResolvedValue([comment()])
-
-    const w = await mountPanel([], false)
+    const w = await mountPanel([], false, [comment()])
     expect(w.find('.comment').exists()).toBe(false)
 
     await w.find('.panel-header').trigger('click')
     await w.vm.$nextTick()
 
     expect(w.find('.comment').exists()).toBe(true)
+  })
+})
+
+describe('CommentsPanel is not a second source of truth', () => {
+  // Regression: the panel used to fetch its own copy of the thread. Deleting a
+  // comment from a field popover refreshed the indicators but left the panel
+  // rendering the deleted row until a page reload — two lists, one of them
+  // stale. Comments now arrive as a prop, so there is nothing to diverge.
+  it('never fetches; it renders exactly the comments it is given', async () => {
+    seedType()
+    const given = [comment({ id: 'only-one', body: 'from the parent' })]
+
+    const w = await mountPanel([], true, given)
+
+    expect(w.findAll('.comment')).toHaveLength(1)
+    expect(w.find('.comment-body').text()).toBe(given[0].body)
+  })
+
+  it('re-renders when the parent replaces the list', async () => {
+    seedType()
+    const w = await mountPanel([], true, [comment({ id: 'a' }), comment({ id: 'b' })])
+    expect(w.findAll('.comment')).toHaveLength(2)
+
+    // What a parent reload after a delete looks like.
+    await w.setProps({ comments: [comment({ id: 'a' })] })
+
+    expect(w.findAll('.comment')).toHaveLength(1)
   })
 })

--- a/frontend/src/components/entity/CommentsPanel.vue
+++ b/frontend/src/components/entity/CommentsPanel.vue
@@ -44,6 +44,11 @@ const loading = ref(false)
  */
 const loadError = ref<string | null>(null)
 
+// Collapsed by default (TKT-FIO205). Since property comments now render at
+// their own field, this panel is the CATCH-ALL: it is where section-anchored
+// and detached comments live, because neither has a field row to sit on.
+const expanded = ref(false)
+
 const newBody = ref('')
 const newAnchorKey = ref('')
 const submitting = ref(false)
@@ -91,6 +96,13 @@ const sortedComments = computed(() =>
 )
 
 const unresolvedCount = computed(() => comments.value.filter((c) => !c.resolved).length)
+
+// Comments with no field row of their own. These are the reason the panel
+// still exists: a section anchor names a view heading, and a detached one
+// points at a property that is gone — neither can render beside a field.
+const homelessCount = computed(
+  () => comments.value.filter((c) => c.anchor.kind !== 'property' || c.detached).length
+)
 
 function anchorLabel(anchor: CommentAnchor): string {
   return anchor.kind === 'section' ? `Section: ${anchor.ref}` : anchor.ref
@@ -222,18 +234,34 @@ defineExpose({ load })
 
 <template>
   <section v-if="commentable" class="comments-panel">
-    <header class="panel-header">
+    <header
+      class="panel-header"
+      role="button"
+      tabindex="0"
+      :aria-expanded="expanded"
+      @click="expanded = !expanded"
+      @keydown.enter.prevent="expanded = !expanded"
+      @keydown.space.prevent="expanded = !expanded"
+    >
+      <span class="chev" aria-hidden="true">{{ expanded ? '▾' : '▸' }}</span>
       <h2>
-        Comments
+        All comments
         <span v-if="unresolvedCount > 0" class="unresolved-count">{{ unresolvedCount }} open</span>
       </h2>
+      <span class="panel-summary">
+        {{ comments.length }} total<template v-if="homelessCount > 0">
+          · {{ homelessCount }} not on a field</template
+        >
+      </span>
     </header>
 
-    <div v-if="loading" class="comments-state">Loading comments…</div>
+    <div v-if="loading && expanded" class="comments-state">Loading comments…</div>
 
-    <div v-else-if="loadError" class="comments-state comments-error">{{ loadError }}</div>
+    <div v-else-if="loadError && expanded" class="comments-state comments-error">
+      {{ loadError }}
+    </div>
 
-    <template v-else>
+    <template v-else-if="expanded">
       <ul v-if="sortedComments.length > 0" class="comment-list">
         <li
           v-for="comment in sortedComments"
@@ -332,9 +360,31 @@ defineExpose({ load })
 .panel-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 10px;
   padding: 16px 24px;
   border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  user-select: none;
+}
+
+.panel-header:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+.chev {
+  color: var(--muted-text);
+  font-size: var(--font-size-sm);
+}
+
+/* Pushed to the right edge so the counts read as a summary of what is folded
+ * away, rather than as part of the title. */
+.panel-summary {
+  margin-left: auto;
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
 }
 
 .panel-header h2 {

--- a/frontend/src/components/entity/CommentsPanel.vue
+++ b/frontend/src/components/entity/CommentsPanel.vue
@@ -1,0 +1,461 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useSchemaStore, useUIStore } from '@/stores'
+import {
+  listComments,
+  addComment,
+  updateComment,
+  deleteComment,
+  type Comment,
+  type CommentAnchor,
+} from '@/api/comments'
+import { getErrorMessage } from '@/api/errors'
+import { useConfirm } from '@/composables/useConfirm'
+
+/**
+ * The entity's comment thread (TKT-FIO205, stage 1).
+ *
+ * Renders only when the type is `commentable` in the schema. That flag is
+ * policy — "commenting is possible here" — never permission: the server
+ * re-authorizes every call, so the panel may still be present for a user who
+ * cannot post, and a 403 is the honest answer rather than something the UI
+ * pretends to prevent.
+ */
+const props = defineProps<{
+  entityType: string
+  entityId: string
+  /**
+   * Section ids from the entity's configured view, offered as anchor targets
+   * alongside the type's properties.
+   */
+  sectionIds?: string[]
+}>()
+
+const schemaStore = useSchemaStore()
+const uiStore = useUIStore()
+const { confirm } = useConfirm()
+
+const comments = ref<Comment[]>([])
+const loading = ref(false)
+/**
+ * Set when the thread could not be loaded. Distinct from "no comments": a
+ * failed load must not render as an empty thread, or a permissions problem
+ * looks like a clean slate.
+ */
+const loadError = ref<string | null>(null)
+
+const newBody = ref('')
+const newAnchorKey = ref('')
+const submitting = ref(false)
+
+const editingId = ref<string | null>(null)
+const editBody = ref('')
+
+const typeDef = computed(() => schemaStore.getEntityType(props.entityType))
+
+/** Commenting is possible for this type. The server decides who may act. */
+const commentable = computed(() => typeDef.value?.commentable === true)
+
+/**
+ * The anchor targets a user can attach a comment to: every declared property,
+ * then any section the view configures.
+ *
+ * Keyed as `kind:ref` so the two namespaces cannot collide — a property and a
+ * section may legitimately share a name.
+ */
+interface AnchorOption {
+  key: string
+  label: string
+  anchor: CommentAnchor
+}
+
+const anchorOptions = computed<AnchorOption[]>(() => {
+  const options: AnchorOption[] = []
+  const properties = typeDef.value?.properties ?? {}
+  for (const name of Object.keys(properties)) {
+    options.push({ key: `property:${name}`, label: name, anchor: { kind: 'property', ref: name } })
+  }
+  for (const id of props.sectionIds ?? []) {
+    options.push({
+      key: `section:${id}`,
+      label: `Section: ${id}`,
+      anchor: { kind: 'section', ref: id },
+    })
+  }
+  return options
+})
+
+/** Unresolved first, so an active thread is not buried under settled remarks. */
+const sortedComments = computed(() =>
+  [...comments.value].sort((a, b) => Number(a.resolved) - Number(b.resolved))
+)
+
+const unresolvedCount = computed(() => comments.value.filter((c) => !c.resolved).length)
+
+function anchorLabel(anchor: CommentAnchor): string {
+  return anchor.kind === 'section' ? `Section: ${anchor.ref}` : anchor.ref
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+async function load() {
+  if (!commentable.value) return
+  loading.value = true
+  loadError.value = null
+  try {
+    comments.value = await listComments(props.entityType, props.entityId)
+  } catch (err) {
+    // A 404 here means "cannot read the target, or commenting is off" — the
+    // server makes those indistinguishable on purpose. Either way there is no
+    // thread to show, so report it rather than rendering an empty one.
+    comments.value = []
+    loadError.value = getErrorMessage(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submit() {
+  const option = anchorOptions.value.find((o) => o.key === newAnchorKey.value)
+  if (!option || !newBody.value.trim() || submitting.value) return
+
+  submitting.value = true
+  try {
+    const created = await addComment(props.entityType, props.entityId, {
+      anchor: option.anchor,
+      body: newBody.value.trim(),
+    })
+    comments.value = [...comments.value, created]
+    newBody.value = ''
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  } finally {
+    submitting.value = false
+  }
+}
+
+function startEdit(comment: Comment) {
+  editingId.value = comment.id
+  editBody.value = comment.body
+}
+
+function cancelEdit() {
+  editingId.value = null
+  editBody.value = ''
+}
+
+/**
+ * Applies a change and reflects it locally.
+ *
+ * PATCH returns 204, so there is no server copy to swap in; the local record
+ * is patched from what we sent. Any field the server would have changed
+ * independently is picked up by the next load.
+ */
+async function applyUpdate(comment: Comment, patch: { body?: string; resolved?: boolean }) {
+  try {
+    await updateComment(props.entityType, props.entityId, comment.id, patch)
+    comments.value = comments.value.map((c) => (c.id === comment.id ? { ...c, ...patch } : c))
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+async function saveEdit(comment: Comment) {
+  const body = editBody.value.trim()
+  if (!body) return
+  await applyUpdate(comment, { body })
+  cancelEdit()
+}
+
+async function toggleResolved(comment: Comment) {
+  await applyUpdate(comment, { resolved: !comment.resolved })
+}
+
+async function remove(comment: Comment) {
+  // Branch on the boolean: useConfirm resolves false if the shell unmounts
+  // while the dialog is open, and a DELETE must not fire on that path.
+  const ok = await confirm({
+    title: 'Delete comment',
+    message: 'Delete this comment? This cannot be undone.',
+    confirmLabel: 'Delete',
+    danger: true,
+  })
+  if (!ok) return
+
+  try {
+    await deleteComment(props.entityType, props.entityId, comment.id)
+    comments.value = comments.value.filter((c) => c.id !== comment.id)
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+// Reload when the panel points at a different entity. `immediate` covers the
+// initial mount, so there is no separate onMounted doing the same call.
+watch(
+  () => [props.entityType, props.entityId, commentable.value] as const,
+  () => {
+    comments.value = []
+    cancelEdit()
+    void load()
+  },
+  { immediate: true }
+)
+
+// Default the anchor picker to the first available target once the schema has
+// loaded, so posting a comment never requires touching the select first.
+watch(
+  anchorOptions,
+  (options) => {
+    if (!options.some((o) => o.key === newAnchorKey.value)) {
+      newAnchorKey.value = options[0]?.key ?? ''
+    }
+  },
+  { immediate: true }
+)
+
+defineExpose({ load })
+</script>
+
+<template>
+  <section v-if="commentable" class="comments-panel">
+    <header class="panel-header">
+      <h2>
+        Comments
+        <span v-if="unresolvedCount > 0" class="unresolved-count">{{ unresolvedCount }} open</span>
+      </h2>
+    </header>
+
+    <div v-if="loading" class="comments-state">Loading comments…</div>
+
+    <div v-else-if="loadError" class="comments-state comments-error">{{ loadError }}</div>
+
+    <template v-else>
+      <ul v-if="sortedComments.length > 0" class="comment-list">
+        <li
+          v-for="comment in sortedComments"
+          :key="comment.id"
+          class="comment"
+          :class="{ 'comment-resolved': comment.resolved }"
+        >
+          <div class="comment-meta">
+            <span class="comment-anchor">{{ anchorLabel(comment.anchor) }}</span>
+            <span
+              v-if="comment.detached"
+              class="comment-detached"
+              title="The property this comment points at no longer exists on this entity"
+            >
+              detached
+            </span>
+            <span class="comment-author">{{ comment.author }}</span>
+            <span class="comment-date">{{ formatDate(comment.created_at) }}</span>
+          </div>
+
+          <div v-if="editingId === comment.id" class="comment-edit">
+            <textarea v-model="editBody" class="comment-input" rows="3" />
+            <div class="comment-actions">
+              <button class="btn btn-sm btn-primary" @click="saveEdit(comment)">Save</button>
+              <button class="btn btn-sm btn-secondary" @click="cancelEdit">Cancel</button>
+            </div>
+          </div>
+
+          <template v-else>
+            <p class="comment-body">{{ comment.body }}</p>
+            <div class="comment-actions">
+              <button
+                v-if="comment.editable"
+                class="btn btn-sm btn-secondary"
+                @click="toggleResolved(comment)"
+              >
+                {{ comment.resolved ? 'Reopen' : 'Resolve' }}
+              </button>
+              <button
+                v-if="comment.editable"
+                class="btn btn-sm btn-secondary"
+                @click="startEdit(comment)"
+              >
+                Edit
+              </button>
+              <button
+                v-if="comment.deletable"
+                class="btn btn-sm btn-danger"
+                @click="remove(comment)"
+              >
+                Delete
+              </button>
+            </div>
+          </template>
+        </li>
+      </ul>
+
+      <div v-else class="comments-state">No comments yet.</div>
+
+      <!-- Always offered: whether this user may post is the server's call, and
+           a hidden box would misreport a permission we have not been told. -->
+      <form class="comment-form" @submit.prevent="submit">
+        <select v-model="newAnchorKey" class="anchor-select" aria-label="Comment anchor">
+          <option v-for="option in anchorOptions" :key="option.key" :value="option.key">
+            {{ option.label }}
+          </option>
+        </select>
+        <textarea
+          v-model="newBody"
+          class="comment-input"
+          rows="3"
+          placeholder="Add a comment…"
+          aria-label="Comment body"
+        />
+        <button
+          type="submit"
+          class="btn btn-sm btn-primary"
+          :disabled="submitting || !newBody.trim() || !newAnchorKey"
+        >
+          {{ submitting ? 'Adding…' : 'Add comment' }}
+        </button>
+      </form>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.comments-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  margin-bottom: 24px;
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--text-color);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.unresolved-count {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--accent-color);
+  color: var(--accent-contrast-text, #fff);
+}
+
+.comments-state {
+  padding: 16px 24px;
+  color: var(--muted-text);
+  font-size: 14px;
+}
+
+.comments-error {
+  color: var(--error-color, #c00);
+}
+
+.comment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.comment {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.comment-resolved {
+  opacity: 0.6;
+}
+
+.comment-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted-text);
+  margin-bottom: 8px;
+}
+
+.comment-anchor {
+  font-family: var(--mono-font, monospace);
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--input-bg);
+  color: var(--text-color);
+}
+
+.comment-detached {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--warning-color, #b58900);
+  color: #fff;
+}
+
+.comment-author {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.comment-body {
+  margin: 0 0 8px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--text-color);
+}
+
+.comment-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-color);
+}
+
+.comment-input,
+.anchor-select {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-color);
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.comment-input:focus,
+.anchor-select:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+/* `.btn`, `.btn-sm` and the variants are global (unscoped, App.vue) — only the
+ * panel-specific placement is declared here. Redeclaring them scoped would
+ * compile to a [data-v-*] selector that outranks and silently forks the themed
+ * originals. */
+.comment-form .btn {
+  align-self: flex-start;
+}
+</style>

--- a/frontend/src/components/entity/CommentsPanel.vue
+++ b/frontend/src/components/entity/CommentsPanel.vue
@@ -2,7 +2,6 @@
 import { ref, computed, watch } from 'vue'
 import { useSchemaStore, useUIStore } from '@/stores'
 import {
-  listComments,
   addComment,
   updateComment,
   deleteComment,
@@ -25,24 +24,28 @@ const props = defineProps<{
   entityType: string
   entityId: string
   /**
+   * The target's comments. Owned by the parent, which fetches ONCE per entity
+   * and shares the same array with the per-field indicators.
+   *
+   * This used to be fetched here independently, which meant two copies of the
+   * same thread: deleting a comment from a field popover refreshed the
+   * indicators but left this panel showing the deleted row until a reload.
+   */
+  comments: Comment[]
+  /**
    * Section ids from the entity's configured view, offered as anchor targets
    * alongside the type's properties.
    */
   sectionIds?: string[]
 }>()
 
+// Every mutation reports up rather than editing a local copy — one source of
+// truth is what keeps this panel and the field indicators in agreement.
+const emit = defineEmits<{ changed: [] }>()
+
 const schemaStore = useSchemaStore()
 const uiStore = useUIStore()
 const { confirm } = useConfirm()
-
-const comments = ref<Comment[]>([])
-const loading = ref(false)
-/**
- * Set when the thread could not be loaded. Distinct from "no comments": a
- * failed load must not render as an empty thread, or a permissions problem
- * looks like a clean slate.
- */
-const loadError = ref<string | null>(null)
 
 // Collapsed by default (TKT-FIO205). Since property comments now render at
 // their own field, this panel is the CATCH-ALL: it is where section-anchored
@@ -92,16 +95,16 @@ const anchorOptions = computed<AnchorOption[]>(() => {
 
 /** Unresolved first, so an active thread is not buried under settled remarks. */
 const sortedComments = computed(() =>
-  [...comments.value].sort((a, b) => Number(a.resolved) - Number(b.resolved))
+  [...props.comments].sort((a, b) => Number(a.resolved) - Number(b.resolved))
 )
 
-const unresolvedCount = computed(() => comments.value.filter((c) => !c.resolved).length)
+const unresolvedCount = computed(() => props.comments.filter((c) => !c.resolved).length)
 
 // Comments with no field row of their own. These are the reason the panel
 // still exists: a section anchor names a view heading, and a detached one
 // points at a property that is gone — neither can render beside a field.
 const homelessCount = computed(
-  () => comments.value.filter((c) => c.anchor.kind !== 'property' || c.detached).length
+  () => props.comments.filter((c) => c.anchor.kind !== 'property' || c.detached).length
 )
 
 function anchorLabel(anchor: CommentAnchor): string {
@@ -113,35 +116,18 @@ function formatDate(iso: string): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
 }
 
-async function load() {
-  if (!commentable.value) return
-  loading.value = true
-  loadError.value = null
-  try {
-    comments.value = await listComments(props.entityType, props.entityId)
-  } catch (err) {
-    // A 404 here means "cannot read the target, or commenting is off" — the
-    // server makes those indistinguishable on purpose. Either way there is no
-    // thread to show, so report it rather than rendering an empty one.
-    comments.value = []
-    loadError.value = getErrorMessage(err)
-  } finally {
-    loading.value = false
-  }
-}
-
 async function submit() {
   const option = anchorOptions.value.find((o) => o.key === newAnchorKey.value)
   if (!option || !newBody.value.trim() || submitting.value) return
 
   submitting.value = true
   try {
-    const created = await addComment(props.entityType, props.entityId, {
+    await addComment(props.entityType, props.entityId, {
       anchor: option.anchor,
       body: newBody.value.trim(),
     })
-    comments.value = [...comments.value, created]
     newBody.value = ''
+    emit('changed')
   } catch (err) {
     uiStore.error(getErrorMessage(err))
   } finally {
@@ -169,7 +155,7 @@ function cancelEdit() {
 async function applyUpdate(comment: Comment, patch: { body?: string; resolved?: boolean }) {
   try {
     await updateComment(props.entityType, props.entityId, comment.id, patch)
-    comments.value = comments.value.map((c) => (c.id === comment.id ? { ...c, ...patch } : c))
+    emit('changed')
   } catch (err) {
     uiStore.error(getErrorMessage(err))
   }
@@ -199,22 +185,21 @@ async function remove(comment: Comment) {
 
   try {
     await deleteComment(props.entityType, props.entityId, comment.id)
-    comments.value = comments.value.filter((c) => c.id !== comment.id)
+    emit('changed')
   } catch (err) {
     uiStore.error(getErrorMessage(err))
   }
 }
 
-// Reload when the panel points at a different entity. `immediate` covers the
-// initial mount, so there is no separate onMounted doing the same call.
+// Drop half-finished local edits when the panel points at a different entity.
+// The comment list itself is the parent's to reload — this only clears state
+// that would otherwise leak from one entity's thread into another's.
 watch(
-  () => [props.entityType, props.entityId, commentable.value] as const,
+  () => [props.entityType, props.entityId] as const,
   () => {
-    comments.value = []
     cancelEdit()
-    void load()
-  },
-  { immediate: true }
+    newBody.value = ''
+  }
 )
 
 // Default the anchor picker to the first available target once the schema has
@@ -228,8 +213,6 @@ watch(
   },
   { immediate: true }
 )
-
-defineExpose({ load })
 </script>
 
 <template>
@@ -255,13 +238,7 @@ defineExpose({ load })
       </span>
     </header>
 
-    <div v-if="loading && expanded" class="comments-state">Loading comments…</div>
-
-    <div v-else-if="loadError && expanded" class="comments-state comments-error">
-      {{ loadError }}
-    </div>
-
-    <template v-else-if="expanded">
+    <template v-if="expanded">
       <ul v-if="sortedComments.length > 0" class="comment-list">
         <li
           v-for="comment in sortedComments"

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -116,9 +116,7 @@ const worldAbsent = computed(() => viewData.value?._world_absent === true)
 
 // The world that has no face here. Falls back to the requested world name, so
 // the banner still reads correctly against a server that omits the field.
-const worldAbsentName = computed(
-  () => viewData.value?._world_absent_name || world.value || '',
-)
+const worldAbsentName = computed(() => viewData.value?._world_absent_name || world.value || '')
 
 // --- The ONE read-only seam ----------------------------------------------
 //
@@ -141,7 +139,9 @@ const readOnly = computed(() => isWorldBound.value && !worldAbsent.value)
 // (return_to / from precedence). Two parallel concerns: scope-nav walks
 // a list; backTarget answers "where do I go back to". Both can be active
 // at once.
-const { scopeNav, loadScopeNav, scopeTarget, navigateScope } = useScopeNavigation(() => props.entityId)
+const { scopeNav, loadScopeNav, scopeTarget, navigateScope } = useScopeNavigation(
+  () => props.entityId
+)
 const backTarget = useBackTarget()
 
 // State
@@ -175,9 +175,7 @@ const loadedCommands = ref<Command[]>([])
 //
 // Gated HERE rather than on the two button sites (desktop header + mobile
 // overflow) so a third render site cannot be added without inheriting it.
-const commands = computed<Command[]>(() =>
-  readOnly.value ? [] : loadedCommands.value,
-)
+const commands = computed<Command[]>(() => (readOnly.value ? [] : loadedCommands.value))
 
 // Prev/next within a list re-fetches this component in place. Blanking the
 // page to a centred spinner on every step was the worst layout shift in
@@ -188,13 +186,10 @@ const commands = computed<Command[]>(() =>
 // already on screen, stepping to a neighbour holds it until the next
 // resolves, so nothing is shown at all. (2) On a genuine cold load, the
 // gate still suppresses anything quicker than the navigation delay.
-const showBlockLoader = useDelayedPending(
-  () => loading.value && !viewData.value,
-  {
-    delay: PENDING_TIMINGS.navDelayMs,
-    minDuration: PENDING_TIMINGS.navMinDurationMs,
-  }
-)
+const showBlockLoader = useDelayedPending(() => loading.value && !viewData.value, {
+  delay: PENDING_TIMINGS.navDelayMs,
+  minDuration: PENDING_TIMINGS.navMinDurationMs,
+})
 const showOverflowMenu = ref(false)
 
 const commandModalRef = ref<InstanceType<typeof CommandModal> | null>(null)
@@ -284,7 +279,6 @@ const editTarget = computed<RouteLocationRaw | undefined>(() => {
   return { name: 'form-edit', params: { id: editFormId.value, entityId: props.entityId } }
 })
 
-
 // The entry's content section gets a custom renderer (mermaid + interactive
 // checkboxes) instead of the generic section render-path. Other content
 // sections — content cards from configured views — use the generic path.
@@ -334,10 +328,23 @@ function commentsForProperty(name: string): Comment[] {
   return commentsByProperty.value.get(name) ?? []
 }
 
+/**
+ * The entity id addressed for comments, carrying the resolved face.
+ *
+ * Comments are per content state (FEAT-9CD2MX): a remark on the draft is not a
+ * remark on the published version. The view response reports which face the
+ * world actually served, so the thread follows the content on screen rather
+ * than always addressing the default face.
+ */
+const commentEntityId = computed(() => {
+  const face = viewData.value?.entry?._world?.face
+  return face ? `${props.entityId}@${face}` : props.entityId
+})
+
 async function loadComments() {
   if (!commentsEnabled.value) return
   try {
-    comments.value = await listComments(props.entityType, props.entityId)
+    comments.value = await listComments(props.entityType, commentEntityId.value)
   } catch {
     // A failure here means "cannot read the target, or commenting is off" —
     // the server makes those indistinguishable on purpose. Either way there is
@@ -692,11 +699,7 @@ async function loadView() {
     // neighbour (TKT-WRLDAPI item 4b). Without it this page rendered draft
     // content while the selector said "published" — the API was correct and
     // the page simply never asked.
-    viewData.value = await fetchView(
-      props.entityType,
-      props.entityId,
-      worldParam.value,
-    )
+    viewData.value = await fetchView(props.entityType, props.entityId, worldParam.value)
     if (viewData.value?.entry) {
       // Seed the autosave baseline so the first toggle's no-op
       // suppression can compare against server state without waiting
@@ -772,9 +775,7 @@ async function requestDelete() {
 // Always an array. The wire keeps `_copies` absent (no capability) distinct
 // from `[]` (none declared), but this page renders nothing for both, so the
 // distinction is collapsed HERE, once, rather than carried into every reader.
-const copyOffers = computed<CopyOffer[]>(() =>
-  readOnly.value ? [] : (entry.value?._copies ?? []),
-)
+const copyOffers = computed<CopyOffer[]>(() => (readOnly.value ? [] : (entry.value?._copies ?? [])))
 
 // Faces render on EVERY screen, world-bound or not — a reader wants the way
 // back to the draft, an author wants to see what readers see, and the
@@ -786,10 +787,9 @@ const copyOffers = computed<CopyOffer[]>(() =>
 // produce a dead control — the affordance-that-lies shape.
 const faceOptions = computed<Face[] | undefined>(() =>
   entry.value?._faces?.filter(
-    (f) => schemaStore.worldForFace(props.entityType, f.face) !== undefined,
-  ),
+    (f) => schemaStore.worldForFace(props.entityType, f.face) !== undefined
+  )
 )
-
 
 function goToFace(f: Face) {
   // Addressed by WORLD, not by face: `?world=` is the read-selection
@@ -836,13 +836,13 @@ async function runCopy(offer: CopyOffer) {
       // Still worth telling them it succeeded — they asked for it — but name
       // the entity, since the page in front of them is no longer the subject.
       uiStore.success(
-        res.created ? `Created the ${face} face of ${subject}` : `Updated the ${face} face of ${subject}`,
+        res.created
+          ? `Created the ${face} face of ${subject}`
+          : `Updated the ${face} face of ${subject}`
       )
       return
     }
-    uiStore.success(
-      res.created ? `Created the ${face} face` : `Updated the ${face} face`,
-    )
+    uiStore.success(res.created ? `Created the ${face} face` : `Updated the ${face} face`)
     // Reload so the offers recompute: a face that now exists may no longer be
     // offered, and the entry's own content may have moved.
     await loadView()
@@ -889,9 +889,8 @@ const canReachDefaultWorld = computed(() => schemaStore.worldReadable(''))
 // The operator's announcement for the world on screen, or '' to announce
 // nothing. Config, not data — served identically to every principal.
 const worldBanner = computed<string>(
-  () => (world.value ? schemaStore.worlds.get(world.value)?.banner : '') || '',
+  () => (world.value ? schemaStore.worlds.get(world.value)?.banner : '') || ''
 )
-
 
 // The button NAMES A DESTINATION, so it is labelled from the destination
 // rather than from a guess about the project's vocabulary.
@@ -911,7 +910,7 @@ const worldBanner = computed<string>(
 // type-neutral and never wrong, which is the right thing to say when the type
 // declares no name for its default face at all.
 const defaultFaceLabel = computed<string>(
-  () => schemaStore.faceLabel(props.entityType, '') || 'default',
+  () => schemaStore.faceLabel(props.entityType, '') || 'default'
 )
 
 // --- The header's mobile home ------------------------------------------
@@ -932,12 +931,8 @@ const showHistory = computed(() => schemaStore.historyEnabled)
 // The same filters the menu components apply to their own props, so the
 // mobile rows and the desktop menus offer an identical set. Duplicating the
 // PREDICATE would let the two drift; duplicating the call does not.
-const overflowFaces = computed<Face[]>(() =>
-  faceOptions.value ?? [],
-)
-const overflowCopies = computed<CopyOffer[]>(() =>
-  copyOffers.value.filter((o) => o.allowed),
-)
+const overflowFaces = computed<Face[]>(() => faceOptions.value ?? [])
+const overflowCopies = computed<CopyOffer[]>(() => copyOffers.value.filter((o) => o.allowed))
 
 // Whether the overflow button renders at all. One expression, read by both
 // the button and its contents: a fourth affordance is added here and cannot
@@ -947,7 +942,7 @@ const hasOverflow = computed(
     commands.value.length > 0 ||
     overflowFaces.value.length > 0 ||
     overflowCopies.value.length > 0 ||
-    showHistory.value,
+    showHistory.value
 )
 
 function goToDefaultWorld() {
@@ -980,7 +975,7 @@ function backTargetAfterDelete(): string {
 // and the template renders plain text instead of an anchor.
 function entityTarget(
   entity: { id: string; type: string },
-  cellLink?: string,
+  cellLink?: string
 ): RouteLocationRaw | undefined {
   const path = entityDetailHref(entity, { cellLink })
   if (!path) return undefined
@@ -1002,7 +997,7 @@ function navigateToEntity(entity: { id: string; type: string }, cellLink?: strin
 function onCellLinkClick(
   event: MouseEvent,
   entity: { id: string; type: string },
-  cellLink?: string,
+  cellLink?: string
 ) {
   if (shouldDeferToBrowser(event)) return
   event.preventDefault()
@@ -1314,7 +1309,7 @@ watch(
   () => worldParam.value,
   () => {
     loadView()
-  },
+  }
 )
 
 // Watch for route changes
@@ -1363,21 +1358,13 @@ watch(
       <div v-if="backTarget || scopeNav" class="scope-nav mobile-topbar">
         <BackButton v-if="backTarget" :target="backTarget" />
         <template v-if="scopeNav">
-          <RouterLink
-            v-if="scopeTarget('prev')"
-            class="scope-nav-btn"
-            :to="scopeTarget('prev')!"
-          >
+          <RouterLink v-if="scopeTarget('prev')" class="scope-nav-btn" :to="scopeTarget('prev')!">
             ← Prev <kbd>P</kbd>
           </RouterLink>
           <span v-else class="scope-nav-btn disabled">← Prev</span>
           <span class="scope-nav-progress">[{{ scopeNav.current }}/{{ scopeNav.total }}]</span>
           <span class="scope-nav-label">{{ scopeNav.label }}</span>
-          <RouterLink
-            v-if="scopeTarget('next')"
-            class="scope-nav-btn"
-            :to="scopeTarget('next')!"
-          >
+          <RouterLink v-if="scopeTarget('next')" class="scope-nav-btn" :to="scopeTarget('next')!">
             Next → <kbd>N</kbd>
           </RouterLink>
           <span v-else class="scope-nav-btn disabled">Next →</span>
@@ -1418,14 +1405,10 @@ watch(
         variant="absent"
         :label="`Not in the ${worldAbsentName} world`"
       >
-        This entity has no {{ worldAbsentName }} face yet. You are looking at
-        the {{ defaultFaceLabel }} face, which is where edits are saved.
+        This entity has no {{ worldAbsentName }} face yet. You are looking at the
+        {{ defaultFaceLabel }} face, which is where edits are saved.
         <template #actions>
-          <button
-            v-if="canReachDefaultWorld"
-            class="btn btn-secondary"
-            @click="goToDefaultWorld"
-          >
+          <button v-if="canReachDefaultWorld" class="btn btn-secondary" @click="goToDefaultWorld">
             Go to {{ defaultFaceLabel }}
           </button>
         </template>
@@ -1450,11 +1433,7 @@ watch(
             : 'Read-only in this world.'
         }}
         <template #actions>
-          <button
-            v-if="canReachDefaultWorld"
-            class="btn btn-secondary"
-            @click="goToDefaultWorld"
-          >
+          <button v-if="canReachDefaultWorld" class="btn btn-secondary" @click="goToDefaultWorld">
             Go to {{ defaultFaceLabel }}
           </button>
         </template>
@@ -1482,11 +1461,7 @@ watch(
             a world, where copyOffers is empty; see its comment for why.
           -->
           <CopyMenu :offers="copyOffers" :busy="copyBusy" @invoke="runCopy" />
-          <RouterLink
-            v-if="editTarget"
-            class="btn btn-secondary"
-            :to="editTarget"
-          >
+          <RouterLink v-if="editTarget" class="btn btn-secondary" :to="editTarget">
             Edit <kbd>E</kbd>
           </RouterLink>
           <!--
@@ -1497,7 +1472,9 @@ watch(
             not have. The mobile block below gates on the SAME flag; both sites
             must, which is the trap this header just walked into three times.
           -->
-          <RouterLink v-if="showHistory" class="btn btn-secondary" :to="historyTarget">History</RouterLink>
+          <RouterLink v-if="showHistory" class="btn btn-secondary" :to="historyTarget"
+            >History</RouterLink
+          >
           <ExportMenu :url-for="(t: string) => entityExportUrl(entityType, entityId, t)" />
           <button v-if="canDelete" class="btn btn-danger" @click="requestDelete">
             Delete <kbd>Del</kbd>
@@ -1585,11 +1562,7 @@ watch(
               >
                 {{ o.label || o.name }}
               </button>
-              <RouterLink
-                v-if="showHistory"
-                class="overflow-menu-item"
-                :to="historyTarget"
-              >
+              <RouterLink v-if="showHistory" class="overflow-menu-item" :to="historyTarget">
                 History
               </RouterLink>
             </div>
@@ -1695,7 +1668,7 @@ watch(
             <template v-if="commentsEnabled" #label-affordance="{ property, index }">
               <CommentIndicator
                 :entity-type="entityType"
-                :entity-id="entityId"
+                :entity-id="commentEntityId"
                 :anchor="{ kind: 'property', ref: property.name }"
                 :comments="commentsForProperty(property.name)"
                 :flip="shouldFlipPopover(section.fields, index)"
@@ -1726,7 +1699,7 @@ watch(
             <TextSelectionComment
               v-if="commentsEnabled"
               :entity-type="entityType"
-              :entity-id="entityId"
+              :entity-id="commentEntityId"
               :container="contentRef"
               @added="loadComments"
             />
@@ -1737,7 +1710,7 @@ watch(
             <BlockCommentOverlay
               v-if="commentsEnabled"
               :entity-type="entityType"
-              :entity-id="entityId"
+              :entity-id="commentEntityId"
               :container="contentRef"
               :render-key="renderedEntryContent"
               :comments="comments"
@@ -1749,7 +1722,7 @@ watch(
             <TextCommentPopover
               v-if="commentsEnabled && textCommentPos && openTextComments.length > 0"
               :entity-type="entityType"
-              :entity-id="entityId"
+              :entity-id="commentEntityId"
               :comments="openTextComments"
               :position="textCommentPos"
               @changed="loadComments"
@@ -2089,7 +2062,7 @@ watch(
              block sees the page it always saw. -->
         <CommentsPanel
           :entity-type="entityType"
-          :entity-id="entityId"
+          :entity-id="commentEntityId"
           :comments="comments"
           :section-ids="commentSectionIds"
           @changed="loadComments"
@@ -2725,5 +2698,4 @@ watch(
     padding-bottom: 16px;
   }
 }
-
 </style>

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -1980,7 +1980,9 @@ watch(
         <CommentsPanel
           :entity-type="entityType"
           :entity-id="entityId"
+          :comments="comments"
           :section-ids="commentSectionIds"
+          @changed="loadComments"
         />
       </div>
 

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -39,8 +39,10 @@ import type { Component } from 'vue'
 import DocumentsPanel from '@/components/entity/DocumentsPanel.vue'
 import CommentsPanel from '@/components/entity/CommentsPanel.vue'
 import CommentIndicator from '@/components/entity/CommentIndicator.vue'
+import TextSelectionComment from '@/components/entity/TextSelectionComment.vue'
 import { listComments, type Comment } from '@/api/comments'
 import { shouldFlipPopover } from '@/utils/popoverFlip'
+import { applyHighlights, type HighlightRange } from '@/utils/commentHighlight'
 import CommandModal from '@/components/entity/CommandModal.vue'
 import ExportMenu from '@/components/entity/ExportMenu.vue'
 import { entityExportUrl } from '@/api/transforms'
@@ -367,14 +369,32 @@ const refResolver = computed<EntityRefResolver | undefined>(() => {
   }
 })
 
-const renderedEntryContent = computed(() =>
-  entryContentSection.value
-    ? renderMarkdown(entryContentSection.value.content || '', {
-        refResolver: refResolver.value,
-        interactive: true,
-      })
-    : ''
+// Text-anchored comments as source ranges (TKT-FIO205 stage 2). Offsets are
+// resolved server-side per read; a detached anchor has none and is simply not
+// highlighted (it still shows in the panel).
+const textHighlights = computed<HighlightRange[]>(() =>
+  comments.value
+    .filter((c) => c.anchor.kind === 'text' && c.anchor.start != null && c.anchor.end != null)
+    .map((c) => ({
+      id: c.id,
+      start: c.anchor.start as number,
+      end: c.anchor.end as number,
+      uncertain: c.anchor.uncertain,
+    }))
 )
+
+const renderedEntryContent = computed(() => {
+  if (!entryContentSection.value) return ''
+  // Marks are inserted into the SOURCE before rendering: the server's offsets
+  // are source coordinates, and re-finding the text in the rendered DOM would
+  // mean re-implementing the matcher against a document the renderer (and then
+  // mermaid) has already transformed.
+  const source = applyHighlights(entryContentSection.value.content || '', textHighlights.value)
+  return renderMarkdown(source, {
+    refResolver: refResolver.value,
+    interactive: true,
+  })
+})
 
 // Re-renders re-process mermaid diagrams inside the content body. Checkbox
 // clicks are handled via delegation on contentRef (see contentClick), which
@@ -1604,17 +1624,28 @@ watch(
                Function ref instead of string ref because this template lives
                inside a v-for: Vue would otherwise collect template-refs of
                the same name into an array per iteration. -->
-          <div
-            v-else-if="section === entryContentSection"
-            :ref="
-              (el) => {
-                contentRef = el as HTMLElement | null
-              }
-            "
-            class="content-body md-body"
-            @click="contentClick"
-            v-html="renderedEntryContent"
-          />
+          <div v-else-if="section === entryContentSection" class="entry-content-host">
+            <div
+              :ref="
+                (el) => {
+                  contentRef = el as HTMLElement | null
+                }
+              "
+              class="content-body md-body"
+              @click="contentClick"
+              v-html="renderedEntryContent"
+            />
+            <!-- Select-to-comment over the body (TKT-FIO205 stage 2). Absolute
+                 within .entry-content-host, so its offsets are relative to the
+                 body rather than the viewport. -->
+            <TextSelectionComment
+              v-if="commentsEnabled"
+              :entity-type="entityType"
+              :entity-id="entityId"
+              :container="contentRef"
+              @added="loadComments"
+            />
+          </div>
 
           <!-- Other content sections (e.g. content cards from a configured view). -->
           <div
@@ -1967,6 +1998,33 @@ watch(
 </template>
 
 <style scoped>
+/* Positioning context for the select-to-comment popup, so its coordinates are
+ * relative to the body rather than the viewport (which would drift on scroll). */
+.entry-content-host {
+  position: relative;
+}
+
+/* Text-anchored comment highlights (TKT-FIO205 stage 2).
+ *
+ * :deep() because the marks are inserted into v-html output, which scoped-style
+ * hashing does not reach. */
+.content-body :deep(mark[data-comment-id]) {
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border-bottom: 2px solid var(--accent-color);
+  border-radius: 2px;
+  padding: 0 1px;
+  color: inherit;
+  cursor: pointer;
+}
+
+/* An uncertain anchor resolved below the exact band: the text may have moved,
+ * so it reads as provisional rather than as a confirmed location. */
+.content-body :deep(mark[data-comment-uncertain]) {
+  background: color-mix(in srgb, var(--warning-color) 30%, transparent);
+  border-bottom-style: dashed;
+  border-bottom-color: var(--warning-color);
+}
+
 .entity-detail {
   max-width: 1200px;
   padding: 0 0 24px;

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -41,6 +41,7 @@ import CommentsPanel from '@/components/entity/CommentsPanel.vue'
 import CommentIndicator from '@/components/entity/CommentIndicator.vue'
 import TextSelectionComment from '@/components/entity/TextSelectionComment.vue'
 import TextCommentPopover from '@/components/entity/TextCommentPopover.vue'
+import BlockCommentOverlay from '@/components/entity/BlockCommentOverlay.vue'
 import { listComments, type Comment } from '@/api/comments'
 import { shouldFlipPopover } from '@/utils/popoverFlip'
 import { applyHighlights, type HighlightRange } from '@/utils/commentHighlight'
@@ -1715,6 +1716,7 @@ watch(
                 }
               "
               class="content-body md-body"
+              :data-comment-source="entryContentSection.content || ''"
               @click="contentClick"
               v-html="renderedEntryContent"
             />
@@ -1726,6 +1728,19 @@ watch(
               :entity-type="entityType"
               :entity-id="entityId"
               :container="contentRef"
+              @added="loadComments"
+            />
+
+            <!-- Comment affordances for blocks that cannot be text-selected:
+                 images and mermaid/PlantUML diagrams. They anchor to the
+                 block's SOURCE markdown, so they ride the same `text` kind. -->
+            <BlockCommentOverlay
+              v-if="commentsEnabled"
+              :entity-type="entityType"
+              :entity-id="entityId"
+              :container="contentRef"
+              :render-key="renderedEntryContent"
+              :comments="comments"
               @added="loadComments"
             />
 

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -37,6 +37,7 @@ import type { WidgetRoutingHint } from '@/widgets/types'
 import type { PropertyDef } from '@/types'
 import type { Component } from 'vue'
 import DocumentsPanel from '@/components/entity/DocumentsPanel.vue'
+import CommentsPanel from '@/components/entity/CommentsPanel.vue'
 import CommandModal from '@/components/entity/CommandModal.vue'
 import ExportMenu from '@/components/entity/ExportMenu.vue'
 import { entityExportUrl } from '@/api/transforms'
@@ -292,6 +293,13 @@ const entryContentSection = computed(() => {
   if (!sections) return null
   return sections.find(isEntryContentSection) || null
 })
+
+// Section ids offered as comment anchor targets (TKT-FIO205). `sectionId` is
+// the operator-authored name from data-entry.yaml, which is why it is anchorable
+// at all: it is a NAME, not an offset, so it survives edits to the entity body.
+const commentSectionIds = computed(
+  () => viewData.value?.sections?.map((s) => s.sectionId).filter(Boolean) ?? []
+)
 
 const checkboxStats = computed(() => {
   const c = entryContentSection.value?.content
@@ -1876,6 +1884,15 @@ watch(
              container's flex `gap` for free instead of duplicating that
              spacing via its own margin. -->
         <DocumentsPanel :entity-type="entityType" :entity-id="entityId" />
+
+        <!-- Comment thread. Self-gating: renders nothing unless the schema
+             marks this type commentable, so a project with no `comments:`
+             block sees the page it always saw. -->
+        <CommentsPanel
+          :entity-type="entityType"
+          :entity-id="entityId"
+          :section-ids="commentSectionIds"
+        />
       </div>
 
       <CommandModal ref="commandModalRef" :entity-id="entityId" />

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -38,6 +38,9 @@ import type { PropertyDef } from '@/types'
 import type { Component } from 'vue'
 import DocumentsPanel from '@/components/entity/DocumentsPanel.vue'
 import CommentsPanel from '@/components/entity/CommentsPanel.vue'
+import CommentIndicator from '@/components/entity/CommentIndicator.vue'
+import { listComments, type Comment } from '@/api/comments'
+import { shouldFlipPopover } from '@/utils/popoverFlip'
 import CommandModal from '@/components/entity/CommandModal.vue'
 import ExportMenu from '@/components/entity/ExportMenu.vue'
 import { entityExportUrl } from '@/api/transforms'
@@ -301,6 +304,45 @@ const commentSectionIds = computed(
   () => viewData.value?.sections?.map((s) => s.sectionId).filter(Boolean) ?? []
 )
 
+// ─── Per-field comments (TKT-FIO205) ─────────────────────────────────────
+//
+// Fetched ONCE per entity and grouped by anchor ref, not once per field: a
+// per-field request would be N round-trips for N properties, and the server
+// already returns the whole thread in one call.
+const comments = ref<Comment[]>([])
+
+const commentsEnabled = computed(
+  () => schemaStore.getEntityType(props.entityType)?.commentable === true
+)
+
+const commentsByProperty = computed(() => {
+  const byRef = new Map<string, Comment[]>()
+  for (const c of comments.value) {
+    if (c.anchor.kind !== 'property') continue
+    const bucket = byRef.get(c.anchor.ref)
+    if (bucket) bucket.push(c)
+    else byRef.set(c.anchor.ref, [c])
+  }
+  return byRef
+})
+
+function commentsForProperty(name: string): Comment[] {
+  return commentsByProperty.value.get(name) ?? []
+}
+
+async function loadComments() {
+  if (!commentsEnabled.value) return
+  try {
+    comments.value = await listComments(props.entityType, props.entityId)
+  } catch {
+    // A failure here means "cannot read the target, or commenting is off" —
+    // the server makes those indistinguishable on purpose. Either way there is
+    // no thread to show, and the page's primary content must still render, so
+    // this degrades to "no comments" rather than surfacing an error.
+    comments.value = []
+  }
+}
+
 const checkboxStats = computed(() => {
   const c = entryContentSection.value?.content
   return c ? getCheckboxStats(c) : null
@@ -557,7 +599,9 @@ async function loadView() {
       // for the response of a sentinel PATCH.
       contentAutoSave.recordServerSnapshot(viewData.value.entry)
     }
-    await Promise.all([loadCommands(), loadScopeNav()])
+    // loadComments swallows its own failures (see its doc): a comment-service
+    // problem must not fail the entity view it decorates.
+    await Promise.all([loadCommands(), loadScopeNav(), loadComments()])
   } catch (err) {
     if (isCancelledFetch(err)) return
     error.value = getErrorMessage(err, 'Failed to load entity')
@@ -1540,7 +1584,21 @@ watch(
           <PropertyDisplay
             v-else-if="section.display === 'properties'"
             :properties="mapFieldsToProperties(section.fields)"
-          />
+          >
+            <!-- Comment affordance per field (TKT-FIO205). Filled only here:
+                 the same component renders list cells and kanban cards, where
+                 a comment control would be noise. -->
+            <template v-if="commentsEnabled" #label-affordance="{ property, index }">
+              <CommentIndicator
+                :entity-type="entityType"
+                :entity-id="entityId"
+                :anchor="{ kind: 'property', ref: property.name }"
+                :comments="commentsForProperty(property.name)"
+                :flip="shouldFlipPopover(section.fields, index)"
+                @changed="loadComments"
+              />
+            </template>
+          </PropertyDisplay>
 
           <!-- Entry content with mermaid + interactive checkboxes.
                Function ref instead of string ref because this template lives

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -466,8 +466,21 @@ const contentAutoSave = useAutoSave({
 function contentClick(event: MouseEvent) {
   const target = event.target as HTMLElement | null
 
-  // A comment highlight opens its thread. Checked before the checkbox branch
-  // because both are delegated from the same handler and a mark can wrap one.
+  // The chip beside a highlighted link opens that link's thread. Checked first
+  // because it sits inside the mark it belongs to.
+  const chip = target?.closest<HTMLElement>('[data-comment-chip]')
+  if (chip) {
+    event.preventDefault()
+    openTextComment(chip.dataset.commentId, chip)
+    return
+  }
+
+  // A LINK inside a highlight keeps its own click: navigation is the primary
+  // action, and the chip above is how that thread is reached instead.
+  if (target?.closest('a[href]')) return
+
+  // Any other comment highlight opens its thread. Checked before the checkbox
+  // branch because both are delegated from the same handler.
   const mark = target?.closest<HTMLElement>('mark[data-comment-id]')
   if (mark) {
     event.preventDefault()
@@ -510,10 +523,24 @@ function closeTextComment() {
   textCommentAnchorEl.value = null
 }
 
-/** The comments sharing the clicked highlight's anchor. */
-const openTextComments = computed(() =>
-  comments.value.filter((c) => c.id === openTextCommentId.value)
-)
+/**
+ * The whole thread at the clicked highlight — every comment resolving to the
+ * same range, not just the one whose id is on the mark.
+ *
+ * Replies are separate comments sharing an anchor (stage 1 has no threading),
+ * so they resolve to the SAME range and only the first one gets a mark. Keying
+ * the popover on the mark's id alone showed a single comment and made a saved
+ * reply look lost.
+ */
+const openTextComments = computed(() => {
+  const clicked = comments.value.find((c) => c.id === openTextCommentId.value)
+  if (!clicked) return []
+  const { start, end } = clicked.anchor
+  if (start == null || end == null) return [clicked]
+  return comments.value.filter(
+    (c) => c.anchor.kind === 'text' && c.anchor.start === start && c.anchor.end === end
+  )
+})
 
 /**
  * Where to place the thread popover, in coordinates relative to the body.
@@ -2079,18 +2106,41 @@ watch(
  * :deep() because the marks are inserted into v-html output, which scoped-style
  * hashing does not reach. */
 .content-body :deep(mark[data-comment-id]) {
-  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
-  border-bottom: 2px solid var(--accent-color);
+  /* Yellow, the annotation convention — and distinct from the accent blue that
+   * already marks links and interactive chrome in the body. */
+  background: color-mix(in srgb, var(--comment-highlight) 32%, transparent);
+  border-bottom: 2px solid var(--comment-highlight);
   border-radius: 2px;
   padding: 0 1px;
   color: inherit;
   cursor: pointer;
 }
 
+/* A highlighted LINK keeps its own click: navigation is the primary action and
+ * a mark must not swallow it. The chip beside it opens the thread instead. */
+.content-body :deep(mark[data-comment-id] a) {
+  cursor: pointer;
+}
+
+.content-body :deep(.comment-chip) {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: super;
+  margin-left: 2px;
+  padding: 0 4px;
+  border: 0;
+  border-radius: 8px;
+  background: var(--comment-highlight);
+  color: var(--text-color);
+  font-size: 10px;
+  line-height: 1.5;
+  cursor: pointer;
+}
+
 /* An uncertain anchor resolved below the exact band: the text may have moved,
  * so it reads as provisional rather than as a confirmed location. */
 .content-body :deep(mark[data-comment-uncertain]) {
-  background: color-mix(in srgb, var(--warning-color) 30%, transparent);
+  background: color-mix(in srgb, var(--warning-color) 34%, transparent);
   border-bottom-style: dashed;
   border-bottom-color: var(--warning-color);
 }

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -40,6 +40,7 @@ import DocumentsPanel from '@/components/entity/DocumentsPanel.vue'
 import CommentsPanel from '@/components/entity/CommentsPanel.vue'
 import CommentIndicator from '@/components/entity/CommentIndicator.vue'
 import TextSelectionComment from '@/components/entity/TextSelectionComment.vue'
+import TextCommentPopover from '@/components/entity/TextCommentPopover.vue'
 import { listComments, type Comment } from '@/api/comments'
 import { shouldFlipPopover } from '@/utils/popoverFlip'
 import { applyHighlights, type HighlightRange } from '@/utils/commentHighlight'
@@ -464,6 +465,16 @@ const contentAutoSave = useAutoSave({
 
 function contentClick(event: MouseEvent) {
   const target = event.target as HTMLElement | null
+
+  // A comment highlight opens its thread. Checked before the checkbox branch
+  // because both are delegated from the same handler and a mark can wrap one.
+  const mark = target?.closest<HTMLElement>('mark[data-comment-id]')
+  if (mark) {
+    event.preventDefault()
+    openTextComment(mark.dataset.commentId, mark)
+    return
+  }
+
   const checkbox = target?.closest<HTMLInputElement>('input[type="checkbox"][data-cb-idx]')
   if (!checkbox) return
   event.preventDefault()
@@ -473,6 +484,51 @@ function contentClick(event: MouseEvent) {
   if (Number.isNaN(idx)) return
   handleCheckboxToggle(idx)
 }
+
+/**
+ * The text comment whose thread is open, plus where to anchor its popover.
+ *
+ * Held here rather than in the highlight itself: the marks live inside v-html
+ * output, so there is no component per highlight to own the state.
+ */
+const openTextCommentId = ref<string | null>(null)
+const textCommentAnchorEl = ref<HTMLElement | null>(null)
+
+function openTextComment(id: string | undefined, el: HTMLElement) {
+  if (!id) return
+  // Clicking the open highlight again closes it, matching the field indicators.
+  if (openTextCommentId.value === id) {
+    closeTextComment()
+    return
+  }
+  openTextCommentId.value = id
+  textCommentAnchorEl.value = el
+}
+
+function closeTextComment() {
+  openTextCommentId.value = null
+  textCommentAnchorEl.value = null
+}
+
+/** The comments sharing the clicked highlight's anchor. */
+const openTextComments = computed(() =>
+  comments.value.filter((c) => c.id === openTextCommentId.value)
+)
+
+/**
+ * Where to place the thread popover, in coordinates relative to the body.
+ *
+ * Read from the clicked element rather than tracked reactively: the mark is
+ * re-created on every render of the body, so a stored reference would go stale.
+ */
+const textCommentPos = computed(() => {
+  const el = textCommentAnchorEl.value
+  const host = contentRef.value
+  if (!el || !host) return null
+  const r = el.getBoundingClientRect()
+  const h = host.getBoundingClientRect()
+  return { top: r.bottom - h.top + 6, left: Math.max(0, r.left - h.left) }
+})
 
 function handleCheckboxToggle(index: number) {
   const current = entry.value
@@ -1644,6 +1700,18 @@ watch(
               :entity-id="entityId"
               :container="contentRef"
               @added="loadComments"
+            />
+
+            <!-- The thread for a clicked highlight. Anchored to the mark, which
+                 lives in v-html output and so has no component of its own. -->
+            <TextCommentPopover
+              v-if="commentsEnabled && textCommentPos && openTextComments.length > 0"
+              :entity-type="entityType"
+              :entity-id="entityId"
+              :comments="openTextComments"
+              :position="textCommentPos"
+              @changed="loadComments"
+              @close="closeTextComment"
             />
           </div>
 

--- a/frontend/src/components/entity/TextCommentPopover.vue
+++ b/frontend/src/components/entity/TextCommentPopover.vue
@@ -1,0 +1,395 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
+import { useUIStore } from '@/stores'
+import { useConfirm } from '@/composables/useConfirm'
+import { addComment, updateComment, deleteComment, type Comment } from '@/api/comments'
+import { getErrorMessage } from '@/api/errors'
+
+/**
+ * The thread for a text-anchored comment, opened by clicking its highlight
+ * (TKT-FIO205 stage 2).
+ *
+ * Separate from CommentIndicator because a highlight has no component of its
+ * own: the marks are inserted into the body's `v-html` output, so the parent
+ * owns both the click state and the placement, and passes them here.
+ */
+const props = defineProps<{
+  entityType: string
+  entityId: string
+  /** The clicked highlight's comments. */
+  comments: Comment[]
+  /** Placement in coordinates relative to the body element. */
+  position: { top: number; left: number }
+}>()
+
+const emit = defineEmits<{ changed: []; close: [] }>()
+
+const uiStore = useUIStore()
+const { confirm } = useConfirm()
+
+const editingId = ref<string | null>(null)
+const editBody = ref('')
+const rootRef = useTemplateRef<HTMLElement>('root')
+
+const replyBody = ref('')
+const replying = ref(false)
+
+/**
+ * Posts a reply against the SAME anchor as the comment being replied to.
+ *
+ * Stage 1 has no threading — replies are separate comments that happen to share
+ * an anchor, which is why this re-sends the original's quote and context rather
+ * than a parent id. That keeps the reply pinned to the same text even after the
+ * body is edited, since it re-resolves independently.
+ */
+async function submitReply() {
+  const text = replyBody.value.trim()
+  const first = props.comments[0]
+  if (!text || !first || replying.value) return
+
+  replying.value = true
+  try {
+    await addComment(props.entityType, props.entityId, {
+      anchor: {
+        kind: 'text',
+        ref: '',
+        quote: first.anchor.quote,
+        // The stored quote is SOURCE text, so no rendered-text context applies;
+        // it is already unique enough to have resolved once.
+      },
+      body: text,
+    })
+    replyBody.value = ''
+    emit('changed')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  } finally {
+    replying.value = false
+  }
+}
+
+function startEdit(c: Comment) {
+  editingId.value = c.id
+  editBody.value = c.body
+}
+
+async function saveEdit(c: Comment) {
+  const text = editBody.value.trim()
+  if (!text) return
+  try {
+    await updateComment(props.entityType, props.entityId, c.id, { body: text })
+    editingId.value = null
+    emit('changed')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+async function toggleResolved(c: Comment) {
+  try {
+    await updateComment(props.entityType, props.entityId, c.id, { resolved: !c.resolved })
+    emit('changed')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+async function remove(c: Comment) {
+  // Branch on the boolean: useConfirm resolves false if the shell unmounts
+  // while the dialog is open, and a DELETE must not fire on that path.
+  const ok = await confirm({
+    title: 'Delete comment',
+    message: 'Delete this comment? This cannot be undone.',
+    confirmLabel: 'Delete',
+    danger: true,
+  })
+  if (!ok) return
+  try {
+    await deleteComment(props.entityType, props.entityId, c.id)
+    emit('changed')
+    emit('close')
+  } catch (err) {
+    uiStore.error(getErrorMessage(err))
+  }
+}
+
+function onDocClick(e: MouseEvent) {
+  const target = e.target as HTMLElement | null
+  // A click on a highlight is the parent's to interpret — it may be opening a
+  // different thread, and closing here first would fight that.
+  if (target?.closest('mark[data-comment-id]')) return
+  if (!rootRef.value?.contains(target)) emit('close')
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+
+onMounted(() => {
+  document.addEventListener('click', onDocClick)
+  document.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocClick)
+  document.removeEventListener('keydown', onKeydown)
+})
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+</script>
+
+<template>
+  <div
+    ref="root"
+    class="tcp"
+    :style="{ top: `${position.top}px`, left: `${position.left}px` }"
+    @click.stop
+  >
+    <header class="tcp-head">
+      <span class="tcp-title">Comment on selection</span>
+      <button type="button" class="tcp-x" aria-label="Close" @click="emit('close')">✕</button>
+    </header>
+
+    <ul class="tcp-list">
+      <li
+        v-for="c in comments"
+        :key="c.id"
+        class="tcp-cmt"
+        :class="{ 'tcp-cmt--resolved': c.resolved }"
+      >
+        <blockquote v-if="c.anchor.quote" class="tcp-quote">{{ c.anchor.quote }}</blockquote>
+        <div class="tcp-meta">
+          <b>{{ c.author }}</b>
+          <span>{{ formatDate(c.created_at) }}</span>
+          <span v-if="c.anchor.uncertain" class="tcp-flag" title="The text may have moved">
+            may have moved
+          </span>
+          <span
+            v-if="c.detached"
+            class="tcp-flag tcp-flag--detached"
+            title="The quoted text is gone"
+          >
+            detached
+          </span>
+        </div>
+
+        <template v-if="editingId === c.id">
+          <textarea v-model="editBody" class="tcp-input" rows="3" />
+          <div class="tcp-acts">
+            <button class="tcp-mini tcp-mini--primary" @click="saveEdit(c)">Save</button>
+            <button class="tcp-mini" @click="editingId = null">Cancel</button>
+          </div>
+        </template>
+
+        <template v-else>
+          <p class="tcp-body">{{ c.body }}</p>
+          <div class="tcp-acts">
+            <button v-if="c.editable" class="tcp-mini" @click="toggleResolved(c)">
+              {{ c.resolved ? 'Reopen' : 'Resolve' }}
+            </button>
+            <button v-if="c.editable" class="tcp-mini" @click="startEdit(c)">Edit</button>
+            <button v-if="c.deletable" class="tcp-mini tcp-mini--danger" @click="remove(c)">
+              Delete
+            </button>
+          </div>
+        </template>
+      </li>
+    </ul>
+
+    <!-- Replies are separate comments sharing this anchor: stage 1 has no
+         threading, so they re-resolve independently against the same text. -->
+    <form class="tcp-reply" @submit.prevent="submitReply">
+      <textarea
+        v-model="replyBody"
+        class="tcp-input"
+        rows="2"
+        placeholder="Reply…"
+        aria-label="Reply"
+        @keydown.meta.enter="submitReply"
+        @keydown.ctrl.enter="submitReply"
+      />
+      <div class="tcp-reply-row">
+        <span class="tcp-hint">⌘↵ to post</span>
+        <button
+          type="submit"
+          class="tcp-mini tcp-mini--primary"
+          :disabled="replying || !replyBody.trim()"
+        >
+          {{ replying ? 'Posting…' : 'Reply' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.tcp {
+  position: absolute;
+  z-index: 26;
+  width: 340px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg, 8px);
+  box-shadow: var(--shadow-lg, 0 10px 30px rgb(0 0 0 / 16%));
+  text-align: left;
+}
+
+.tcp-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+.tcp-title {
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+.tcp-x {
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--muted-text);
+  font-size: var(--font-size-sm);
+}
+
+.tcp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 340px;
+  overflow-y: auto;
+}
+.tcp-cmt {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+.tcp-cmt:last-child {
+  border-bottom: 0;
+}
+.tcp-cmt--resolved {
+  opacity: 0.6;
+}
+
+/* The anchored text, so the thread states what it is about even when the
+ * highlight is scrolled out of view or has detached. */
+.tcp-quote {
+  margin: 0 0 6px;
+  padding: 3px 8px;
+  border-left: 3px solid var(--accent-color);
+  background: var(--bg-color);
+  color: var(--muted-text);
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  max-height: 3.4em;
+  overflow: hidden;
+}
+
+.tcp-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+  margin-bottom: 3px;
+}
+.tcp-meta b {
+  color: var(--text-color);
+}
+.tcp-flag {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--warning-color);
+  color: var(--text-color);
+}
+.tcp-flag--detached {
+  background: var(--error-color);
+  color: #fff;
+}
+
+.tcp-body {
+  margin: 0 0 6px;
+  font-size: var(--font-size-base);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.tcp-acts {
+  display: flex;
+  gap: 5px;
+}
+.tcp-mini {
+  font: var(--font-size-sm) / 1.4 inherit;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+  cursor: pointer;
+}
+.tcp-mini--primary {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+  color: #fff;
+}
+.tcp-mini--danger {
+  color: var(--error-color);
+}
+.tcp-mini:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+.tcp-reply {
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-color);
+}
+.tcp-reply-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 6px;
+}
+.tcp-hint {
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+.tcp-mini:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.tcp-input {
+  width: 100%;
+  padding: 6px 8px;
+  resize: vertical;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 5px);
+  background: var(--input-bg);
+  color: var(--text-color);
+  font: inherit;
+  font-size: var(--font-size-base);
+}
+.tcp-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+@media (max-width: 640px) {
+  .tcp {
+    left: 0;
+    right: 0;
+    width: auto;
+  }
+}
+</style>

--- a/frontend/src/components/entity/TextSelectionComment.vue
+++ b/frontend/src/components/entity/TextSelectionComment.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, nextTick, useTemplateRef } from 'vue'
 import { useUIStore } from '@/stores'
-import { addComment } from '@/api/comments'
+import { addComment, checkAnchorable } from '@/api/comments'
 import { getErrorMessage } from '@/api/errors'
 
 /**
@@ -41,6 +41,17 @@ const quote = ref('')
 const quotePrefix = ref('')
 const quoteSuffix = ref('')
 const anchorPos = ref<{ top: number; left: number } | null>(null)
+/**
+ * Why the current selection cannot be commented on, or null when it can.
+ *
+ * Some selections have no contiguous source range — one spanning table cells is
+ * the common case — so the server is asked BEFORE the affordance is offered.
+ * Letting someone write a comment that then fails to save is the worse outcome.
+ */
+const blockedReason = ref<string | null>(null)
+const checking = ref(false)
+/** Guards against an older check resolving after a newer selection. */
+let checkToken = 0
 const composing = ref(false)
 const body = ref('')
 const submitting = ref(false)
@@ -52,6 +63,8 @@ function reset() {
   quote.value = ''
   quotePrefix.value = ''
   quoteSuffix.value = ''
+  blockedReason.value = null
+  checkToken++
   body.value = ''
 }
 
@@ -114,6 +127,35 @@ function onSelectionChange() {
     top: rect.bottom - host.top + 6,
     left: Math.max(0, rect.left - host.left),
   }
+  void verifySelection()
+}
+
+/** Asks the server whether this selection can anchor, before offering to comment. */
+async function verifySelection() {
+  const token = ++checkToken
+  blockedReason.value = null
+  checking.value = true
+  try {
+    const res = await checkAnchorable(
+      props.entityType,
+      props.entityId,
+      quote.value,
+      quotePrefix.value,
+      quoteSuffix.value
+    )
+    // Discard a stale answer: the user may have re-selected while this was in
+    // flight, and applying it would describe the wrong selection.
+    if (token !== checkToken) return
+    blockedReason.value = res.anchorable
+      ? null
+      : res.reason || 'This selection cannot be commented on'
+  } catch {
+    // A failed CHECK must not block commenting: the create path validates
+    // again, so the worst case is the old behaviour (an error on save).
+    if (token === checkToken) blockedReason.value = null
+  } finally {
+    if (token === checkToken) checking.value = false
+  }
 }
 
 async function startComposing() {
@@ -173,11 +215,25 @@ onBeforeUnmount(() => {
     :style="{ top: `${anchorPos.top}px`, left: `${anchorPos.left}px` }"
     @mousedown.prevent
   >
-    <button v-if="!composing" type="button" class="tsc-btn" @click="startComposing">
+    <!-- Blocked: say why, and do not offer a composer that cannot succeed. -->
+    <span v-if="!composing && blockedReason" class="tsc-blocked" :title="blockedReason">
+      <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M8 1.5 15 14H1L8 1.5Zm0 4.5v4m0 2v.5" stroke="currentColor" fill="none" />
+      </svg>
+      Can't comment here
+    </span>
+
+    <button
+      v-else-if="!composing"
+      type="button"
+      class="tsc-btn"
+      :disabled="checking"
+      @click="startComposing"
+    >
       <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
         <path d="M8 1a7 7 0 0 0-6.1 10.4L1 15l3.8-.9A7 7 0 1 0 8 1Z" />
       </svg>
-      Comment
+      {{ checking ? 'Checking…' : 'Comment' }}
     </button>
 
     <form v-else class="tsc-form" @submit.prevent="submit">
@@ -227,8 +283,33 @@ onBeforeUnmount(() => {
   height: 12px;
   color: var(--accent-color);
 }
-.tsc-btn:hover {
+.tsc-btn:hover:not(:disabled) {
   border-color: var(--accent-color);
+}
+.tsc-btn:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+/* Shown in place of the Comment button when the selection cannot be anchored,
+ * so the reason is visible BEFORE anything is typed. */
+.tsc-blocked {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 6px);
+  background: var(--card-bg);
+  color: var(--muted-text);
+  box-shadow: var(--shadow-lg, 0 4px 12px rgb(0 0 0 / 12%));
+  font: 600 var(--font-size-sm) / 1 inherit;
+  cursor: help;
+}
+.tsc-blocked svg {
+  width: 12px;
+  height: 12px;
+  color: var(--warning-color);
 }
 
 .tsc-form {

--- a/frontend/src/components/entity/TextSelectionComment.vue
+++ b/frontend/src/components/entity/TextSelectionComment.vue
@@ -1,0 +1,291 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, nextTick, useTemplateRef } from 'vue'
+import { useUIStore } from '@/stores'
+import { addComment } from '@/api/comments'
+import { getErrorMessage } from '@/api/errors'
+
+/**
+ * Select-to-comment for an entity's markdown body (TKT-FIO205 stage 2).
+ *
+ * Watches for a text selection inside the body element and offers a floating
+ * "Comment" button; accepting opens a small composer anchored to the selection.
+ *
+ * # Only the quote crosses the wire
+ *
+ * The browser has RENDERED text; the anchor lives in SOURCE coordinates. Rather
+ * than map between them here — which would mean re-implementing the server's
+ * render↔source mapping in TypeScript — the client sends the selected string
+ * and the server locates it in its own copy of the body. That also means a
+ * client cannot describe context the entity does not contain.
+ *
+ * `quote_index` disambiguates a selection whose text occurs more than once: we
+ * count occurrences of the quote in the rendered body up to the selection, which
+ * matches source order because the renderer preserves it.
+ */
+const props = defineProps<{
+  entityType: string
+  entityId: string
+  /** The rendered body element to watch for selections. */
+  container: HTMLElement | null
+}>()
+
+const emit = defineEmits<{ added: [] }>()
+
+const uiStore = useUIStore()
+
+/** Minimum selection length, mirroring the server's MinQuoteRunes. */
+const MIN_QUOTE_RUNES = 5
+
+const quote = ref('')
+const quoteIndex = ref(0)
+const anchorPos = ref<{ top: number; left: number } | null>(null)
+const composing = ref(false)
+const body = ref('')
+const submitting = ref(false)
+const composerRef = useTemplateRef<HTMLTextAreaElement>('composer')
+
+function reset() {
+  anchorPos.value = null
+  composing.value = false
+  quote.value = ''
+  quoteIndex.value = 0
+  body.value = ''
+}
+
+/**
+ * Counts how many times `text` appears in the container before `range`, so the
+ * server can anchor to the occurrence the user actually selected.
+ */
+function occurrenceOf(container: HTMLElement, range: Range, text: string): number {
+  const before = range.cloneRange()
+  before.selectNodeContents(container)
+  before.setEnd(range.startContainer, range.startOffset)
+  const prefix = before.toString()
+
+  let count = 0
+  let idx = prefix.indexOf(text)
+  while (idx !== -1) {
+    count++
+    idx = prefix.indexOf(text, idx + text.length)
+  }
+  return count
+}
+
+function onSelectionChange() {
+  // A selection made while the composer is open must not move the anchor from
+  // under it — the user is typing about the text they already picked.
+  if (composing.value) return
+
+  const container = props.container
+  const sel = window.getSelection()
+  if (!container || !sel || sel.isCollapsed || sel.rangeCount === 0) {
+    anchorPos.value = null
+    return
+  }
+
+  const range = sel.getRangeAt(0)
+  if (!container.contains(range.commonAncestorContainer)) {
+    anchorPos.value = null
+    return
+  }
+
+  const text = sel.toString().trim()
+  if ([...text].length < MIN_QUOTE_RUNES) {
+    anchorPos.value = null
+    return
+  }
+
+  const rect = range.getBoundingClientRect()
+  const host = container.getBoundingClientRect()
+  quote.value = text
+  quoteIndex.value = occurrenceOf(container, range, text)
+  anchorPos.value = {
+    top: rect.bottom - host.top + 6,
+    left: Math.max(0, rect.left - host.left),
+  }
+}
+
+async function startComposing() {
+  composing.value = true
+  await nextTick()
+  composerRef.value?.focus()
+}
+
+async function submit() {
+  const text = body.value.trim()
+  if (!text || submitting.value) return
+  submitting.value = true
+  try {
+    await addComment(props.entityType, props.entityId, {
+      anchor: { kind: 'text', ref: '', quote: quote.value, quote_index: quoteIndex.value },
+      body: text,
+    })
+    reset()
+    window.getSelection()?.removeAllRanges()
+    emit('added')
+  } catch (err) {
+    // The most likely failure is a stale tab: the body changed since it was
+    // rendered, so the quote no longer exists server-side. The message says so.
+    uiStore.error(getErrorMessage(err))
+  } finally {
+    submitting.value = false
+  }
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    reset()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('selectionchange', onSelectionChange)
+  document.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('selectionchange', onSelectionChange)
+  document.removeEventListener('keydown', onKeydown)
+})
+</script>
+
+<template>
+  <div
+    v-if="anchorPos"
+    class="tsc"
+    :style="{ top: `${anchorPos.top}px`, left: `${anchorPos.left}px` }"
+    @mousedown.prevent
+  >
+    <button v-if="!composing" type="button" class="tsc-btn" @click="startComposing">
+      <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M8 1a7 7 0 0 0-6.1 10.4L1 15l3.8-.9A7 7 0 1 0 8 1Z" />
+      </svg>
+      Comment
+    </button>
+
+    <form v-else class="tsc-form" @submit.prevent="submit">
+      <blockquote class="tsc-quote">{{ quote }}</blockquote>
+      <textarea
+        ref="composer"
+        v-model="body"
+        class="tsc-input"
+        rows="3"
+        placeholder="Add a comment…"
+        aria-label="Comment body"
+        @keydown.meta.enter="submit"
+        @keydown.ctrl.enter="submit"
+      />
+      <div class="tsc-actions">
+        <span class="tsc-hint">⌘↵ to post</span>
+        <button type="button" class="tsc-cancel" @click="reset">Cancel</button>
+        <button type="submit" class="tsc-submit" :disabled="submitting || !body.trim()">
+          {{ submitting ? 'Adding…' : 'Comment' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<style scoped>
+.tsc {
+  position: absolute;
+  z-index: 25;
+}
+
+.tsc-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 6px);
+  background: var(--card-bg);
+  color: var(--text-color);
+  box-shadow: var(--shadow-lg, 0 4px 12px rgb(0 0 0 / 12%));
+  cursor: pointer;
+  font: 600 var(--font-size-sm) / 1 inherit;
+}
+.tsc-btn svg {
+  width: 12px;
+  height: 12px;
+  color: var(--accent-color);
+}
+.tsc-btn:hover {
+  border-color: var(--accent-color);
+}
+
+.tsc-form {
+  width: 320px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg, 8px);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-lg, 0 10px 30px rgb(0 0 0 / 16%));
+}
+
+/* The quoted text, so the composer states what is being commented on — the
+ * selection highlight is lost the moment focus moves to the textarea. */
+.tsc-quote {
+  margin: 0 0 8px;
+  padding: 4px 8px;
+  border-left: 3px solid var(--accent-color);
+  background: var(--bg-color);
+  color: var(--muted-text);
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  max-height: 3.6em;
+  overflow: hidden;
+}
+
+.tsc-input {
+  width: 100%;
+  padding: 6px 8px;
+  resize: vertical;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 5px);
+  background: var(--input-bg);
+  color: var(--text-color);
+  font: inherit;
+  font-size: var(--font-size-base);
+}
+.tsc-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow:
+    0 0 0 2px var(--focus-ring-gap),
+    0 0 0 4px var(--focus-ring);
+}
+
+.tsc-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 7px;
+}
+.tsc-hint {
+  margin-right: auto;
+  font-size: var(--font-size-sm);
+  color: var(--muted-text);
+}
+.tsc-cancel,
+.tsc-submit {
+  padding: 4px 11px;
+  border-radius: var(--radius-sm, 5px);
+  font: 600 var(--font-size-sm) / 1.4 inherit;
+  cursor: pointer;
+}
+.tsc-cancel {
+  border: 1px solid var(--border-color);
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+.tsc-submit {
+  border: 1px solid var(--accent-color);
+  background: var(--accent-color);
+  color: #fff;
+}
+.tsc-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/components/entity/TextSelectionComment.vue
+++ b/frontend/src/components/entity/TextSelectionComment.vue
@@ -18,9 +18,9 @@ import { getErrorMessage } from '@/api/errors'
  * and the server locates it in its own copy of the body. That also means a
  * client cannot describe context the entity does not contain.
  *
- * `quote_index` disambiguates a selection whose text occurs more than once: we
- * count occurrences of the quote in the rendered body up to the selection, which
- * matches source order because the renderer preserves it.
+ * The rendered text either side of the selection goes with it, so the server can
+ * tell WHICH occurrence of a repeated quote was meant — without it, "eordend"
+ * selected inside "Geordend" resolves to the earlier "Ongeordend".
  */
 const props = defineProps<{
   entityType: string
@@ -37,7 +37,9 @@ const uiStore = useUIStore()
 const MIN_QUOTE_RUNES = 5
 
 const quote = ref('')
-const quoteIndex = ref(0)
+/** Rendered text either side of the selection, for occurrence disambiguation. */
+const quotePrefix = ref('')
+const quoteSuffix = ref('')
 const anchorPos = ref<{ top: number; left: number } | null>(null)
 const composing = ref(false)
 const body = ref('')
@@ -48,27 +50,34 @@ function reset() {
   anchorPos.value = null
   composing.value = false
   quote.value = ''
-  quoteIndex.value = 0
+  quotePrefix.value = ''
+  quoteSuffix.value = ''
   body.value = ''
 }
 
+/** How much rendered text to send either side of the selection. */
+const CONTEXT_CHARS = 60
+
 /**
- * Counts how many times `text` appears in the container before `range`, so the
- * server can anchor to the occurrence the user actually selected.
+ * Rendered text immediately before and after the selection.
+ *
+ * This is what lets the server pick the right occurrence of a repeated quote.
+ * Taken from the container's rendered text — the same coordinate space as the
+ * quote itself — so the two agree.
  */
-function occurrenceOf(container: HTMLElement, range: Range, text: string): number {
+function contextAround(container: HTMLElement, range: Range): { prefix: string; suffix: string } {
   const before = range.cloneRange()
   before.selectNodeContents(container)
   before.setEnd(range.startContainer, range.startOffset)
-  const prefix = before.toString()
 
-  let count = 0
-  let idx = prefix.indexOf(text)
-  while (idx !== -1) {
-    count++
-    idx = prefix.indexOf(text, idx + text.length)
+  const after = range.cloneRange()
+  after.selectNodeContents(container)
+  after.setStart(range.endContainer, range.endOffset)
+
+  return {
+    prefix: before.toString().slice(-CONTEXT_CHARS),
+    suffix: after.toString().slice(0, CONTEXT_CHARS),
   }
-  return count
 }
 
 function onSelectionChange() {
@@ -98,7 +107,9 @@ function onSelectionChange() {
   const rect = range.getBoundingClientRect()
   const host = container.getBoundingClientRect()
   quote.value = text
-  quoteIndex.value = occurrenceOf(container, range, text)
+  const ctx = contextAround(container, range)
+  quotePrefix.value = ctx.prefix
+  quoteSuffix.value = ctx.suffix
   anchorPos.value = {
     top: rect.bottom - host.top + 6,
     left: Math.max(0, rect.left - host.left),
@@ -117,7 +128,13 @@ async function submit() {
   submitting.value = true
   try {
     await addComment(props.entityType, props.entityId, {
-      anchor: { kind: 'text', ref: '', quote: quote.value, quote_index: quoteIndex.value },
+      anchor: {
+        kind: 'text',
+        ref: '',
+        quote: quote.value,
+        quote_prefix: quotePrefix.value,
+        quote_suffix: quoteSuffix.value,
+      },
       body: text,
     })
     reset()

--- a/frontend/src/styles/scales.css
+++ b/frontend/src/styles/scales.css
@@ -25,6 +25,17 @@
  * renaming or revaluing the four contract steps is not.
  */
 :root {
+  /* Comment-highlight yellow (TKT-FIO205).
+   *
+   * SPA-only, so it lives here rather than in tokens.css: that file is copied
+   * byte-identically into the Go binary and served to custom apps, and a
+   * commenting colour is not part of that frozen contract.
+   *
+   * Yellow because it is the annotation convention, and because the accent
+   * blue already marks links and interactive chrome inside a rendered body —
+   * a blue highlight over a blue link read as one thing. */
+  --comment-highlight: #f5c518;
+
   /* Spacing — 4px base. Covers the observed 4/6/8/12/16/24/32/48 cluster
    * without the rem/px mixing. Use these for padding, margin, and gap. */
   --space-3xs: 2px;
@@ -105,6 +116,10 @@
  * as tokens.css (App.vue toggles the class on <html>). Exercised by the two
  * migrated call sites below, so this branch is not dead code. */
 :root.dark {
+  /* Lifted and slightly desaturated: the light yellow over a dark surface is
+   * harsh, and the highlight sits behind body text that must stay readable. */
+  --comment-highlight: #d4a72c;
+
   --shadow-sm: 0 1px 3px rgb(0 0 0 / 30%);
   --shadow-md: 0 2px 8px rgb(0 0 0 / 40%);
   --shadow-lg: 0 4px 12px rgb(0 0 0 / 45%);

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -68,6 +68,12 @@ export interface EntityType {
   // Which declared face the bare id addresses, mirroring `bare_face:` in
   // the schema. Empty when the type declares no faces, or names none.
   bare_face?: string
+  // Whether this type accepts comments (TKT-FIO205). Policy, not permission:
+  // it decides whether to render a comment affordance at all, never whether
+  // the current user may use it — the server re-authorizes every call, so a
+  // UI that shows the box to someone without `comment:add` gets a 403, not a
+  // write.
+  commentable?: boolean
 }
 
 // FaceInfo mirrors v1.FaceDef — one declared content state of a type.

--- a/frontend/src/utils/blockAnchor.test.ts
+++ b/frontend/src/utils/blockAnchor.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { blockQuote, findCommentableBlocks } from './blockAnchor'
+
+/** Builds a detached container from HTML, as the rendered body would look. */
+function render(html: string): HTMLElement {
+  const el = document.createElement('div')
+  el.innerHTML = html
+  document.body.appendChild(el)
+  return el
+}
+
+/**
+ * Builds a <pre> whose text is set safely.
+ *
+ * Mermaid sources contain `-->`, which inside an innerHTML string terminates an
+ * HTML comment and silently mangles the parse — the fixture, not the code under
+ * test, was what first failed here.
+ */
+function renderPre(text: string, cls = 'mermaid'): HTMLElement {
+  const host = document.createElement('div')
+  const pre = document.createElement('pre')
+  pre.className = cls
+  pre.textContent = text
+  host.appendChild(pre)
+  document.body.appendChild(host)
+  return pre
+}
+
+describe('blockQuote', () => {
+  it('finds the markdown for an image by its URL', () => {
+    const source = 'Intro.\n\n![Placeholder](https://example.com/pic.png "A title")\n\nAfter.'
+    const img = render('<img src="https://example.com/pic.png" alt="Placeholder">')
+      .firstElementChild as HTMLElement
+
+    expect(blockQuote(img, source)).toBe('![Placeholder](https://example.com/pic.png "A title")')
+  })
+
+  it('finds an image with empty alt text', () => {
+    // Alt is often empty, which is why the URL is what the lookup keys on.
+    const source = 'Text.\n\n![](https://example.com/x.png)\n'
+    const img = render('<img src="https://example.com/x.png" alt="">')
+      .firstElementChild as HTMLElement
+
+    expect(blockQuote(img, source)).toBe('![](https://example.com/x.png)')
+  })
+
+  it('prefers a stashed diagram source when the renderer kept one', () => {
+    const diagramSource = 'graph TD\n  A --> B'
+    const source = `Before.\n\n\`\`\`mermaid\n${diagramSource}\n\`\`\`\n`
+    const el = render('<div class="mermaid"></div>').firstElementChild as HTMLElement
+    el.dataset.diagramSource = diagramSource
+
+    expect(blockQuote(el, source)).toBe(diagramSource)
+  })
+
+  it('falls back to a pre ancestor for an unrendered diagram fence', () => {
+    const body = 'graph TD\n  A --> B'
+    const source = `Before.\n\n\`\`\`mermaid\n${body}\n\`\`\`\n`
+    const pre = renderPre(body)
+
+    expect(blockQuote(pre, source)).toBe(body)
+  })
+
+  it('returns null when the source cannot be located', () => {
+    // Better no affordance than one anchored on a guess.
+    const img = render('<img src="https://elsewhere.example/none.png">')
+      .firstElementChild as HTMLElement
+
+    expect(blockQuote(img, 'A body mentioning no such image.')).toBeNull()
+  })
+})
+
+describe('findCommentableBlocks', () => {
+  it('finds images and diagrams, labelling each', () => {
+    const diagramSource = 'graph TD\n  A --> B'
+    const source = `![Pic](https://example.com/p.png)\n\n\`\`\`mermaid\n${diagramSource}\n\`\`\`\n`
+    const container = render('<p><img src="https://example.com/p.png"></p>')
+    const pre = document.createElement('pre')
+    pre.className = 'mermaid'
+    pre.textContent = diagramSource
+    container.appendChild(pre)
+
+    const found = findCommentableBlocks(container, source)
+
+    expect(found).toHaveLength(2)
+    expect(found.map((b) => b.kind).sort()).toEqual(['diagram', 'image'])
+    expect(found.find((b) => b.kind === 'image')?.quote).toBe('![Pic](https://example.com/p.png)')
+  })
+
+  it('omits a block whose source cannot be traced', () => {
+    const container = render('<img src="https://elsewhere.example/x.png">')
+
+    expect(findCommentableBlocks(container, 'Unrelated body text.')).toEqual([])
+  })
+
+  it('counts a mermaid svg inside a wrapper once', () => {
+    // The <svg> and its wrapper both match the selector; offering two
+    // affordances on one diagram would be a duplicate control.
+    const diagramSource = 'graph TD\n  A --> B'
+    const source = `\`\`\`mermaid\n${diagramSource}\n\`\`\`\n`
+    const container = render('<div></div>')
+    const pre = document.createElement('pre')
+    pre.className = 'mermaid'
+    pre.setAttribute('data-source', diagramSource)
+    pre.appendChild(document.createElement('svg'))
+    container.appendChild(pre)
+
+    expect(findCommentableBlocks(container, source)).toHaveLength(1)
+  })
+})

--- a/frontend/src/utils/blockAnchor.ts
+++ b/frontend/src/utils/blockAnchor.ts
@@ -1,0 +1,126 @@
+/**
+ * Comment anchors for body blocks that cannot be text-selected (TKT-FIO205).
+ *
+ * An image, a mermaid diagram or a PlantUML diagram renders as an `<img>` or an
+ * `<svg>`: there is no text to select, so select-to-comment cannot reach them.
+ *
+ * # Why this needs no new anchor kind
+ *
+ * The rendered output has no text, but the SOURCE always does — an image is
+ * `![alt](url)` and a diagram is a fenced block with a body. Anchoring to that
+ * source text reuses the existing `text` kind exactly as prose does, which
+ * means no new server-side kind, no storage migration, and drift handling
+ * (re-resolution, the detached flag) comes for free.
+ *
+ * What the block affordance supplies is a QUOTE the user could not select
+ * themselves. Everything downstream is the ordinary text path.
+ */
+
+/** Blocks that get a comment affordance, in DOM-query form. */
+const COMMENTABLE_BLOCKS = [
+  'img',
+  // The rendered-mermaid wrapper carries `data-source`; the bare <svg> inside
+  // it does not, so match the wrapper (see renderMermaidDiagrams).
+  '.mermaid-diagram',
+  'svg[id^="mermaid"]',
+  '.mermaid',
+  'pre.mermaid',
+  '.plantuml-diagram-wrapper',
+].join(',')
+
+/** A commentable block found in the rendered body. */
+export interface CommentableBlock {
+  el: HTMLElement
+  /** Source text to anchor on — the quote sent to the server. */
+  quote: string
+  /** Human label for the affordance, e.g. "image" or "diagram". */
+  kind: 'image' | 'diagram'
+}
+
+/**
+ * Finds the source text for a rendered block.
+ *
+ * Returns null when the block cannot be traced back to source — a diagram
+ * whose fence was consumed by the renderer with nothing recoverable, say. A
+ * null means "offer no affordance", which is the safe direction: an anchor
+ * built on a guess would attach a comment to the wrong place.
+ */
+export function blockQuote(el: HTMLElement, source: string): string | null {
+  // A diagram keeps its source on the element when the renderer stashes it,
+  // which is the most reliable handle we have — and for a rendered mermaid SVG
+  // it is the ONLY one, since the <pre> it replaced is gone.
+  const stashed = el.dataset.diagramSource || el.getAttribute('data-source')
+  if (stashed && source.includes(stashed.trim())) return stashed.trim()
+
+  // A mermaid SVG replaced a <pre> whose text was the fence body. The wrapper
+  // keeps that text on the container in rela's renderer.
+  const pre = el.closest('pre')
+  if (pre?.textContent && source.includes(pre.textContent.trim())) {
+    return pre.textContent.trim()
+  }
+
+  // An image: find its markdown by URL, which is unique enough in practice and
+  // present verbatim in the source.
+  const src = el.getAttribute('src')
+  if (src) {
+    const found = findImageMarkdown(source, src)
+    if (found) return found
+  }
+
+  return null
+}
+
+/**
+ * Locates the markdown for an image with the given src.
+ *
+ * Matches `![alt](url …)` on the URL rather than the alt text: alt is often
+ * empty, and the URL is what makes the reference unique. The optional title
+ * after the URL is included so the quote covers the whole image expression.
+ */
+function findImageMarkdown(source: string, src: string): string | null {
+  const idx = source.indexOf(src)
+  if (idx === -1) return null
+
+  // Walk back to the opening `![` and forward to the closing `)`.
+  const open = source.lastIndexOf('![', idx)
+  if (open === -1) return null
+  const close = source.indexOf(')', idx)
+  if (close === -1) return null
+
+  const candidate = source.slice(open, close + 1)
+  // Guard against spanning unrelated content when the URL appears twice.
+  return candidate.includes(src) ? candidate : null
+}
+
+/**
+ * Finds every commentable block in a rendered body, paired with its source.
+ *
+ * Blocks whose source cannot be located are omitted rather than offered with a
+ * guessed anchor.
+ */
+export function findCommentableBlocks(container: HTMLElement, source: string): CommentableBlock[] {
+  const out: CommentableBlock[] = []
+  const seen = new Set<Element>()
+
+  for (const el of container.querySelectorAll<HTMLElement>(COMMENTABLE_BLOCKS)) {
+    // An <svg> and its wrapper both match; keep the outermost so a diagram
+    // gets one affordance rather than two stacked on the same pixels.
+    const wrapper =
+      el.closest<HTMLElement>('.mermaid-diagram, .plantuml-diagram-wrapper, .mermaid, pre') ?? el
+    if (seen.has(wrapper)) continue
+    seen.add(wrapper)
+
+    const quote = blockQuote(el, source)
+    if (!quote) continue
+
+    out.push({
+      el: wrapper,
+      quote,
+      kind:
+        wrapper.tagName.toLowerCase() === 'img' && !wrapper.closest('.plantuml-diagram-wrapper')
+          ? 'image'
+          : 'diagram',
+    })
+  }
+  return out
+}

--- a/frontend/src/utils/commentHighlight.test.ts
+++ b/frontend/src/utils/commentHighlight.test.ts
@@ -164,3 +164,32 @@ describe('applyHighlights and indented code blocks', () => {
     expect(out).toContain('<mark data-comment-id="c1">Prose worth marking</mark>')
   })
 })
+
+describe('applyHighlights and links', () => {
+  // A mark wrapping a link used to swallow the click, leaving the link dead.
+  // The chip carries the thread so the link keeps navigating.
+  it('appends a chip when the marked text contains a markdown link', () => {
+    const body = 'See the [rela docs](https://example.com/docs) for details.'
+    const out = applyHighlights(body, [byteRange(body, '[rela docs](https://example.com/docs)')])
+
+    expect(out).toContain('data-comment-chip="true"')
+    expect(out).toContain('data-comment-id="c1"')
+    // The link markup itself is untouched inside the mark.
+    expect(out).toContain('[rela docs](https://example.com/docs)')
+  })
+
+  it('appends a chip for a bare autolink', () => {
+    const body = 'Reference: https://example.com/page here.'
+    const out = applyHighlights(body, [byteRange(body, 'https://example.com/page')])
+
+    expect(out).toContain('data-comment-chip="true"')
+  })
+
+  it('adds no chip for ordinary prose', () => {
+    const body = 'Just some ordinary prose to mark up.'
+    const out = applyHighlights(body, [byteRange(body, 'ordinary prose')])
+
+    expect(out).not.toContain('data-comment-chip')
+    expect(out).toContain('<mark data-comment-id="c1">ordinary prose</mark>')
+  })
+})

--- a/frontend/src/utils/commentHighlight.test.ts
+++ b/frontend/src/utils/commentHighlight.test.ts
@@ -92,3 +92,47 @@ describe('applyHighlights', () => {
     expect(applyHighlights('', [{ id: 'x', start: 0, end: 1 }])).toBe('')
   })
 })
+
+describe('applyHighlights leaves code untouched', () => {
+  // Regression: a mark inserted into a code span rendered as literal
+  // `<mark data-comment-id="…">` text, because markdown does not parse HTML
+  // inside code. Skipping the highlight is strictly better than showing markup.
+  it('skips a range inside an inline code span', () => {
+    const body = 'Rename it with `rela rename id` today.'
+    const out = applyHighlights(body, [byteRange(body, 'rela rename id')])
+
+    expect(out).toBe(body)
+    expect(out).not.toContain('<mark')
+  })
+
+  it('skips a range that only partially overlaps code', () => {
+    const body = 'Rename it with `rela rename id` today.'
+    // Starts in plain text, ends inside the code span.
+    const out = applyHighlights(body, [byteRange(body, 'with `rela rename')])
+
+    expect(out).toBe(body)
+  })
+
+  it('skips a range inside a fenced block', () => {
+    const body = 'Before.\n\n```sh\nrela rename id TKT-1 TKT-2\n```\n\nAfter.'
+    const out = applyHighlights(body, [byteRange(body, 'rela rename id TKT-1')])
+
+    expect(out).toBe(body)
+  })
+
+  it('still marks prose alongside code in the same document', () => {
+    const body = 'Rename it with `rela rename id` today, then verify the result.'
+    const out = applyHighlights(body, [byteRange(body, 'verify the result')])
+
+    expect(out).toContain('<mark data-comment-id="c1">verify the result</mark>')
+    // The code span is untouched.
+    expect(out).toContain('`rela rename id`')
+  })
+
+  it('does not treat backticks inside a fence as inline spans', () => {
+    const body = 'Text.\n\n```\na ` stray backtick\n```\n\nMore prose here to mark.'
+    const out = applyHighlights(body, [byteRange(body, 'More prose here')])
+
+    expect(out).toContain('<mark data-comment-id="c1">More prose here</mark>')
+  })
+})

--- a/frontend/src/utils/commentHighlight.test.ts
+++ b/frontend/src/utils/commentHighlight.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { applyHighlights, type HighlightRange } from './commentHighlight'
+
+/** Byte offsets of `needle` within `body`, as the Go server would report them. */
+function byteRange(body: string, needle: string, id = 'c1'): HighlightRange {
+  const bytes = new TextEncoder().encode(body)
+  const target = new TextEncoder().encode(needle)
+  outer: for (let i = 0; i + target.length <= bytes.length; i++) {
+    for (let j = 0; j < target.length; j++) {
+      if (bytes[i + j] !== target[j]) continue outer
+    }
+    return { id, start: i, end: i + target.length }
+  }
+  throw new Error(`needle not found: ${needle}`)
+}
+
+describe('applyHighlights', () => {
+  const body = 'The quick brown fox jumps over the lazy dog.'
+
+  it('wraps a single range', () => {
+    const out = applyHighlights(body, [byteRange(body, 'brown fox')])
+
+    expect(out).toBe(
+      'The quick <mark data-comment-id="c1">brown fox</mark> jumps over the lazy dog.'
+    )
+  })
+
+  it('wraps several ranges without shifting each other', () => {
+    // The bug this guards: applying front-to-back makes every insertion shift
+    // the offsets of the ranges after it, so the second mark lands mid-word.
+    const out = applyHighlights(body, [
+      byteRange(body, 'The quick', 'a'),
+      byteRange(body, 'lazy dog', 'b'),
+    ])
+
+    expect(out).toContain('<mark data-comment-id="a">The quick</mark>')
+    expect(out).toContain('<mark data-comment-id="b">lazy dog</mark>')
+  })
+
+  it('marks uncertain ranges distinctly', () => {
+    const r = { ...byteRange(body, 'brown fox'), uncertain: true }
+    const out = applyHighlights(body, [r])
+
+    expect(out).toContain('data-comment-uncertain="true"')
+  })
+
+  it('slices correctly across multi-byte characters', () => {
+    // JS strings are UTF-16 and the server sends BYTE offsets, so slicing the
+    // string directly would cut in the wrong place after any non-ASCII text.
+    const utf = 'Le café serveert góéde köffie vandaag.'
+    const out = applyHighlights(utf, [byteRange(utf, 'góéde köffie')])
+
+    expect(out).toContain('<mark data-comment-id="c1">góéde köffie</mark>')
+    // The text either side must be preserved intact.
+    expect(out).toContain('Le café serveert ')
+    expect(out).toContain(' vandaag.')
+  })
+
+  it('drops overlapping ranges rather than nesting them', () => {
+    const a = byteRange(body, 'quick brown', 'a')
+    const b = byteRange(body, 'brown fox', 'b') // overlaps a
+
+    const out = applyHighlights(body, [a, b])
+
+    expect(out).toContain('<mark data-comment-id="a">quick brown</mark>')
+    expect(out).not.toContain('data-comment-id="b"')
+    // Exactly one opening and one closing tag — no interleaving.
+    expect(out.match(/<mark /g)).toHaveLength(1)
+    expect(out.match(/<\/mark>/g)).toHaveLength(1)
+  })
+
+  it('drops ranges outside the body', () => {
+    // Offsets resolved against a body that has since changed.
+    const out = applyHighlights(body, [
+      { id: 'past-end', start: 10, end: 9999 },
+      { id: 'negative', start: -5, end: 4 },
+      { id: 'empty', start: 4, end: 4 },
+    ])
+
+    expect(out).toBe(body)
+  })
+
+  it('escapes a quote in the id rather than breaking out of the attribute', () => {
+    const out = applyHighlights(body, [{ ...byteRange(body, 'fox'), id: 'a"><script>x' }])
+
+    expect(out).not.toContain('"><script>')
+    expect(out).toContain('&quot;')
+  })
+
+  it('returns the body unchanged when there is nothing to mark', () => {
+    expect(applyHighlights(body, [])).toBe(body)
+    expect(applyHighlights('', [{ id: 'x', start: 0, end: 1 }])).toBe('')
+  })
+})

--- a/frontend/src/utils/commentHighlight.test.ts
+++ b/frontend/src/utils/commentHighlight.test.ts
@@ -136,3 +136,31 @@ describe('applyHighlights leaves code untouched', () => {
     expect(out).toContain('<mark data-comment-id="c1">More prose here</mark>')
   })
 })
+
+describe('applyHighlights and indented code blocks', () => {
+  // Regression: only fenced and inline code were skipped, so a 4-space
+  // indented block still received a mark and rendered
+  // `<mark data-comment-id="…">` as literal text inside <pre><code>.
+  it('skips a range inside a 4-space indented block', () => {
+    const body =
+      'Intro.\n\n    Ingesprongen codeblok (vier spaties).\n    Praesent commodo.\n\nAfter.'
+    const out = applyHighlights(body, [byteRange(body, 'Ingesprongen codeblok')])
+
+    expect(out).toBe(body)
+    expect(out).not.toContain('<mark')
+  })
+
+  it('skips a tab-indented block', () => {
+    const body = 'Intro.\n\n\tcode line here\n\nAfter.'
+    const out = applyHighlights(body, [byteRange(body, 'code line here')])
+
+    expect(out).toBe(body)
+  })
+
+  it('still marks prose that merely follows an indented block', () => {
+    const body = 'Intro.\n\n    indented code here\n\nProse worth marking follows.'
+    const out = applyHighlights(body, [byteRange(body, 'Prose worth marking')])
+
+    expect(out).toContain('<mark data-comment-id="c1">Prose worth marking</mark>')
+  })
+})

--- a/frontend/src/utils/commentHighlight.ts
+++ b/frontend/src/utils/commentHighlight.ts
@@ -1,0 +1,109 @@
+/**
+ * Marking commented text ranges in an entity body (TKT-FIO205 stage 2).
+ *
+ * # Why the marking happens in SOURCE, before rendering
+ *
+ * The server resolves each text anchor against the stored markdown and returns
+ * byte offsets into it. Those coordinates are only meaningful in the source, so
+ * the marks have to be inserted there and carried THROUGH the markdown render —
+ * trying to re-find the text in the rendered DOM would mean re-implementing the
+ * matcher in the browser, against a document the renderer has already
+ * transformed (and that mermaid/PlantUML mutate again afterwards).
+ *
+ * Marks are emitted as inline HTML because markdown renderers pass raw HTML
+ * through. They are stripped by DOMPurify unless the tag and its attributes are
+ * allowlisted — see `markdown.ts`.
+ */
+
+/** The tag used for a highlight. Must be allowlisted in the sanitiser config. */
+export const HIGHLIGHT_TAG = 'mark'
+
+/** Attribute carrying the comment id, so a click can open the right thread. */
+export const HIGHLIGHT_ID_ATTR = 'data-comment-id'
+
+/** Attribute set when the anchor resolved below the exact-match band. */
+export const HIGHLIGHT_UNCERTAIN_ATTR = 'data-comment-uncertain'
+
+/** A resolved range to mark. Offsets are BYTES into the source body. */
+export interface HighlightRange {
+  id: string
+  start: number
+  end: number
+  uncertain?: boolean
+}
+
+/**
+ * Wraps each range in the source with a highlight tag.
+ *
+ * Ranges are applied back-to-front so each insertion cannot shift the offsets
+ * of the ones not yet applied — the standard reason to iterate in reverse here,
+ * and the bug that appears immediately if you don't.
+ *
+ * Overlapping ranges are dropped rather than nested: markdown renderers do not
+ * reliably handle interleaved inline HTML, and a half-open tag would corrupt
+ * the rest of the document. The dropped comment still appears in the panel, so
+ * nothing is lost — it just isn't highlighted.
+ *
+ * Offsets are byte-based (Go's coordinates); JavaScript strings are UTF-16, so
+ * the body is converted to bytes and back rather than sliced directly. Slicing
+ * a JS string with a Go byte offset silently mis-cuts any body containing a
+ * multi-byte character.
+ */
+export function applyHighlights(body: string, ranges: HighlightRange[]): string {
+  if (!body || ranges.length === 0) return body
+
+  const bytes = new TextEncoder().encode(body)
+  const usable = selectNonOverlapping(ranges, bytes.length)
+  if (usable.length === 0) return body
+
+  const decoder = new TextDecoder()
+  let out = ''
+  let cursor = bytes.length
+
+  // Back-to-front: later insertions never disturb earlier offsets.
+  for (let i = usable.length - 1; i >= 0; i--) {
+    const r = usable[i]
+    out =
+      openTag(r) +
+      decoder.decode(bytes.slice(r.start, r.end)) +
+      `</${HIGHLIGHT_TAG}>` +
+      decoder.decode(bytes.slice(r.end, cursor)) +
+      out
+    cursor = r.start
+  }
+  return decoder.decode(bytes.slice(0, cursor)) + out
+}
+
+function openTag(r: HighlightRange): string {
+  const uncertain = r.uncertain ? ` ${HIGHLIGHT_UNCERTAIN_ATTR}="true"` : ''
+  // The id is server-minted (an opaque token), but it still lands in an HTML
+  // attribute, so quote-escape it rather than trusting the generator's alphabet.
+  return `<${HIGHLIGHT_TAG} ${HIGHLIGHT_ID_ATTR}="${escapeAttr(r.id)}"${uncertain}>`
+}
+
+function escapeAttr(v: string): string {
+  return v.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+}
+
+/**
+ * Sorts ranges and drops any that overlap one already kept, or that fall
+ * outside the body.
+ *
+ * An out-of-range offset means the body changed between the read that resolved
+ * it and this render — dropping it is right, since marking an arbitrary span
+ * would attach a remark to text nobody selected.
+ */
+function selectNonOverlapping(ranges: HighlightRange[], size: number): HighlightRange[] {
+  const sorted = [...ranges]
+    .filter((r) => r.start >= 0 && r.end <= size && r.start < r.end)
+    .sort((a, b) => a.start - b.start || a.end - b.end)
+
+  const kept: HighlightRange[] = []
+  let lastEnd = -1
+  for (const r of sorted) {
+    if (r.start < lastEnd) continue // overlaps the previous keeper
+    kept.push(r)
+    lastEnd = r.end
+  }
+  return kept
+}

--- a/frontend/src/utils/commentHighlight.ts
+++ b/frontend/src/utils/commentHighlight.ts
@@ -126,30 +126,48 @@ interface ByteSpan {
 }
 
 /**
- * Finds the byte ranges of fenced blocks and inline code spans.
+ * Finds the byte ranges of every construct markdown renders verbatim: fenced
+ * blocks, INDENTED (4-space) blocks, and inline code spans.
  *
- * Deliberately conservative: a run of backticks opens a span that closes at the
- * next run of the same length, and ``` opens a fence to the next ```. Anything
- * it over-claims merely loses a highlight, which is the safe direction — while
- * anything it MISSES renders raw `<mark…>` markup at the user.
+ * Deliberately conservative — anything it over-claims merely loses a highlight,
+ * which is the safe direction, while anything it MISSES renders raw `<mark…>`
+ * markup at the user. Indented blocks were missed at first and did exactly
+ * that.
  */
 function findCodeSpans(body: string): ByteSpan[] {
   const enc = new TextEncoder()
   const spans: ByteSpan[] = []
+  const covered = (from: number, to: number) =>
+    spans.some((f) => {
+      const s = byteSpanOf(enc, body, from, to)
+      return s.start >= f.start && s.end <= f.end
+    })
 
-  // Fenced blocks first, so their inner backticks are not read as inline code.
+  // Fenced blocks first, so their contents are not re-read as anything else.
   const fence = /^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?(?:^[ \t]*\1[ \t]*$|$)/gm
   let m: RegExpExecArray | null
   while ((m = fence.exec(body)) !== null) {
     spans.push(byteSpanOf(enc, body, m.index, m.index + m[0].length))
   }
 
-  // Inline spans, skipping anything already inside a fence.
+  // Indented code blocks: runs of lines starting with 4 spaces or a tab.
+  //
+  // This over-claims a deeply nested list item, which markdown may render as a
+  // list rather than code. That costs a highlight on a nested bullet and is the
+  // trade this function is explicitly biased toward — the alternative is
+  // guessing list context here, and guessing WRONG shows raw markup.
+  const indented = /^(?:(?: {4}|\t)[^\n]*\n?)+/gm
+  while ((m = indented.exec(body)) !== null) {
+    if (!covered(m.index, m.index + m[0].length)) {
+      spans.push(byteSpanOf(enc, body, m.index, m.index + m[0].length))
+    }
+  }
+
+  // Inline spans, skipping anything already inside a block.
   const inline = /(`+)(?:[\s\S]*?)\1/g
   while ((m = inline.exec(body)) !== null) {
-    const span = byteSpanOf(enc, body, m.index, m.index + m[0].length)
-    if (!spans.some((f) => span.start >= f.start && span.end <= f.end)) {
-      spans.push(span)
+    if (!covered(m.index, m.index + m[0].length)) {
+      spans.push(byteSpanOf(enc, body, m.index, m.index + m[0].length))
     }
   }
   return spans

--- a/frontend/src/utils/commentHighlight.ts
+++ b/frontend/src/utils/commentHighlight.ts
@@ -13,6 +13,14 @@
  * Marks are emitted as inline HTML because markdown renderers pass raw HTML
  * through. They are stripped by DOMPurify unless the tag and its attributes are
  * allowlisted — see `markdown.ts`.
+ *
+ * # Code is skipped, not marked
+ *
+ * Inside a code span or fence, markdown renders HTML LITERALLY — so a mark
+ * inserted there shows the user `<mark data-comment-id="...">` as text instead
+ * of a highlight. Any range touching code is therefore left unmarked; the
+ * comment still lists in the panel, it just gets no highlight. Rendering the
+ * markup raw would be strictly worse than rendering nothing.
  */
 
 /** The tag used for a highlight. Must be allowlisted in the sanitiser config. */
@@ -53,7 +61,10 @@ export function applyHighlights(body: string, ranges: HighlightRange[]): string 
   if (!body || ranges.length === 0) return body
 
   const bytes = new TextEncoder().encode(body)
-  const usable = selectNonOverlapping(ranges, bytes.length)
+  const codeSpans = findCodeSpans(body)
+  const usable = selectNonOverlapping(ranges, bytes.length).filter(
+    (r) => !overlapsCode(r, codeSpans)
+  )
   if (usable.length === 0) return body
 
   const decoder = new TextDecoder()
@@ -106,4 +117,53 @@ function selectNonOverlapping(ranges: HighlightRange[], size: number): Highlight
     lastEnd = r.end
   }
   return kept
+}
+
+/** A byte range of the source that markdown renders verbatim. */
+interface ByteSpan {
+  start: number
+  end: number
+}
+
+/**
+ * Finds the byte ranges of fenced blocks and inline code spans.
+ *
+ * Deliberately conservative: a run of backticks opens a span that closes at the
+ * next run of the same length, and ``` opens a fence to the next ```. Anything
+ * it over-claims merely loses a highlight, which is the safe direction — while
+ * anything it MISSES renders raw `<mark…>` markup at the user.
+ */
+function findCodeSpans(body: string): ByteSpan[] {
+  const enc = new TextEncoder()
+  const spans: ByteSpan[] = []
+
+  // Fenced blocks first, so their inner backticks are not read as inline code.
+  const fence = /^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?(?:^[ \t]*\1[ \t]*$|$)/gm
+  let m: RegExpExecArray | null
+  while ((m = fence.exec(body)) !== null) {
+    spans.push(byteSpanOf(enc, body, m.index, m.index + m[0].length))
+  }
+
+  // Inline spans, skipping anything already inside a fence.
+  const inline = /(`+)(?:[\s\S]*?)\1/g
+  while ((m = inline.exec(body)) !== null) {
+    const span = byteSpanOf(enc, body, m.index, m.index + m[0].length)
+    if (!spans.some((f) => span.start >= f.start && span.end <= f.end)) {
+      spans.push(span)
+    }
+  }
+  return spans
+}
+
+/** Converts UTF-16 string indexes to the byte offsets the server speaks. */
+function byteSpanOf(enc: TextEncoder, body: string, from: number, to: number): ByteSpan {
+  return {
+    start: enc.encode(body.slice(0, from)).length,
+    end: enc.encode(body.slice(0, to)).length,
+  }
+}
+
+/** True when the range touches any code span at all — even partially. */
+function overlapsCode(r: HighlightRange, spans: ByteSpan[]): boolean {
+  return spans.some((s) => r.start < s.end && s.start < r.end)
 }

--- a/frontend/src/utils/commentHighlight.ts
+++ b/frontend/src/utils/commentHighlight.ts
@@ -32,12 +32,26 @@ export const HIGHLIGHT_ID_ATTR = 'data-comment-id'
 /** Attribute set when the anchor resolved below the exact-match band. */
 export const HIGHLIGHT_UNCERTAIN_ATTR = 'data-comment-uncertain'
 
+/** Attribute marking the chip that opens a thread for a link highlight. */
+export const HIGHLIGHT_CHIP_ATTR = 'data-comment-chip'
+
 /** A resolved range to mark. Offsets are BYTES into the source body. */
 export interface HighlightRange {
   id: string
   start: number
   end: number
   uncertain?: boolean
+}
+
+/**
+ * True when the marked source contains a markdown link.
+ *
+ * A highlighted link must keep its own click — navigation is the primary
+ * action, and a mark that swallows it makes the link dead. Such a range gets a
+ * chip appended instead, which is what opens the thread.
+ */
+function containsLink(marked: string): boolean {
+  return /\[[^\]]*\]\([^)]*\)|<https?:\/\/|https?:\/\/\S/.test(marked)
 }
 
 /**
@@ -74,10 +88,12 @@ export function applyHighlights(body: string, ranges: HighlightRange[]): string 
   // Back-to-front: later insertions never disturb earlier offsets.
   for (let i = usable.length - 1; i >= 0; i--) {
     const r = usable[i]
+    const marked = decoder.decode(bytes.slice(r.start, r.end))
     out =
       openTag(r) +
-      decoder.decode(bytes.slice(r.start, r.end)) +
+      marked +
       `</${HIGHLIGHT_TAG}>` +
+      (containsLink(marked) ? chipFor(r) : '') +
       decoder.decode(bytes.slice(r.end, cursor)) +
       out
     cursor = r.start
@@ -90,6 +106,19 @@ function openTag(r: HighlightRange): string {
   // The id is server-minted (an opaque token), but it still lands in an HTML
   // attribute, so quote-escape it rather than trusting the generator's alphabet.
   return `<${HIGHLIGHT_TAG} ${HIGHLIGHT_ID_ATTR}="${escapeAttr(r.id)}"${uncertain}>`
+}
+
+/**
+ * The chip that opens a thread for a highlight wrapping a link.
+ *
+ * Rendered as a button so it is keyboard-reachable; the click handler keys on
+ * the same comment id the mark carries.
+ */
+function chipFor(r: HighlightRange): string {
+  return (
+    `<button type="button" class="comment-chip" ${HIGHLIGHT_CHIP_ATTR}="true" ` +
+    `${HIGHLIGHT_ID_ATTR}="${escapeAttr(r.id)}" title="Show comment">💬</button>`
+  )
 }
 
 function escapeAttr(v: string): string {
@@ -112,6 +141,11 @@ function selectNonOverlapping(ranges: HighlightRange[], size: number): Highlight
   const kept: HighlightRange[] = []
   let lastEnd = -1
   for (const r of sorted) {
+    // An IDENTICAL range is a reply sharing the anchor, not a competing
+    // highlight: one mark represents the whole thread, and clicking it opens
+    // every comment at that range.
+    const prev = kept[kept.length - 1]
+    if (prev && prev.start === r.start && prev.end === r.end) continue
     if (r.start < lastEnd) continue // overlaps the previous keeper
     kept.push(r)
     lastEnd = r.end

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -107,9 +107,15 @@ export function renderMarkdown(
 
   const rawHtml = instance.parse(content) as string
 
-  // Allow data-cb-idx attribute through DOMPurify
+  // Allowlist the attributes rela adds to rendered markdown. DOMPurify strips
+  // anything not listed, silently — so a new marker attribute that is not added
+  // here simply vanishes, with no error to debug.
+  //
+  // `mark` itself needs no ADD_TAGS: it is in DOMPurify's default allowlist.
+  // The comment attributes carry a server-minted id and a boolean; neither is
+  // a URL or a script sink.
   return DOMPurify.sanitize(rawHtml, {
-    ADD_ATTR: ['data-cb-idx'],
+    ADD_ATTR: ['data-cb-idx', 'data-comment-id', 'data-comment-uncertain'],
   })
 }
 

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -115,7 +115,7 @@ export function renderMarkdown(
   // The comment attributes carry a server-minted id and a boolean; neither is
   // a URL or a script sink.
   return DOMPurify.sanitize(rawHtml, {
-    ADD_ATTR: ['data-cb-idx', 'data-comment-id', 'data-comment-uncertain'],
+    ADD_ATTR: ['data-cb-idx', 'data-comment-id', 'data-comment-uncertain', 'data-comment-chip'],
   })
 }
 

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -57,14 +57,14 @@ export interface RenderMarkdownOptions {
 
 export function renderMarkdown(
   content: string,
-  refResolverOrOptions?: EntityRefResolver | RenderMarkdownOptions,
+  refResolverOrOptions?: EntityRefResolver | RenderMarkdownOptions
 ): string {
   if (!content) return ''
 
   const options: RenderMarkdownOptions =
     typeof refResolverOrOptions === 'function'
       ? { refResolver: refResolverOrOptions }
-      : refResolverOrOptions ?? {}
+      : (refResolverOrOptions ?? {})
 
   // Per-render Marked instance + counter so each call numbers its own
   // checkboxes from 0. EntityDetail.vue maps data-cb-idx back to the
@@ -100,9 +100,7 @@ export function renderMarkdown(
         return `<input data-cb-idx="${idx}" type="checkbox"${checkedAttr}> `
       },
     },
-    walkTokens: refResolver
-      ? (token) => rewriteEntityRefToken(token, refResolver)
-      : undefined,
+    walkTokens: refResolver ? (token) => rewriteEntityRefToken(token, refResolver) : undefined,
   })
 
   const rawHtml = instance.parse(content) as string
@@ -222,7 +220,16 @@ mermaidPurifier.addHook('uponSanitizeElement', (node, data) => {
 // thing strict mermaid still lets through from a hostile label: the event
 // handler is stripped but the element survives, which is enough for a request
 // to an attacker-chosen URL when the diagram is viewed.
-const LABEL_FORBID_TAGS = ['img', 'picture', 'source', 'video', 'audio', 'iframe', 'object', 'embed']
+const LABEL_FORBID_TAGS = [
+  'img',
+  'picture',
+  'source',
+  'video',
+  'audio',
+  'iframe',
+  'object',
+  'embed',
+]
 
 /**
  * Sanitize a mermaid-produced SVG and return it as a detached element.
@@ -335,7 +342,13 @@ export async function renderMermaidDiagrams(container: HTMLElement): Promise<voi
     const id = `mermaid-${++mermaidCounter}`
     try {
       const { svg } = await mermaid.render(id, source)
-      pre.replaceWith(sanitizeMermaidSVG(svg))
+      const rendered = sanitizeMermaidSVG(svg)
+      // Carry the fence body onto the SVG. Replacing the <pre> otherwise
+      // discards the only trace of the source, and the comment layer needs it
+      // to anchor a remark to the diagram (TKT-FIO205) — there is no text to
+      // select in an SVG.
+      if (rendered instanceof Element) rendered.setAttribute('data-source', source)
+      pre.replaceWith(rendered)
     } catch (err) {
       console.error('Mermaid render error:', err)
       // Leave the block as-is on error.
@@ -347,9 +360,7 @@ export async function renderMermaidDiagrams(container: HTMLElement): Promise<voi
   // router's scroll-to-anchor) re-check their targets on this event rather
   // than polling on an arbitrary interval.
   if (targets.length > 0) {
-    container.dispatchEvent(
-      new CustomEvent('rela:mermaid-rendered', { bubbles: true }),
-    )
+    container.dispatchEvent(new CustomEvent('rela:mermaid-rendered', { bubbles: true }))
   }
 }
 
@@ -413,7 +424,7 @@ function plantUMLImageURL(serverURL: string, source: string): string | null {
  */
 export function renderPlantUMLDiagrams(
   container: HTMLElement,
-  serverURL: string | undefined | null,
+  serverURL: string | undefined | null
 ): number {
   if (!serverURL) return 0
 

--- a/frontend/src/utils/popoverFlip.test.ts
+++ b/frontend/src/utils/popoverFlip.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { shouldFlipPopover, GRID_COLUMNS } from './popoverFlip'
+
+/** Builds a field list from authored spans; `undefined` means "no span". */
+function fields(...spans: (number | undefined)[]) {
+  return spans.map((span) => ({ span }))
+}
+
+describe('shouldFlipPopover', () => {
+  // Regression: flipping aligns the popover to the INDICATOR's right edge, and
+  // a full-width field's indicator sits beside its label near the left of the
+  // page — so flipping threw the popover off-screen under the sidebar (seen at
+  // x=5px against a content area starting at x=264).
+  it('does NOT flip a full-width field, whose indicator is at the far left', () => {
+    expect(shouldFlipPopover(fields(undefined, undefined), 0)).toBe(false)
+    expect(shouldFlipPopover(fields(undefined, undefined), 1)).toBe(false)
+    expect(shouldFlipPopover(fields(12), 0)).toBe(false)
+  })
+
+  it('flips only the last field of a three-across row', () => {
+    const row = fields(4, 4, 4) // exactly fills 12
+
+    expect(shouldFlipPopover(row, 0)).toBe(false)
+    expect(shouldFlipPopover(row, 1)).toBe(false)
+    expect(shouldFlipPopover(row, 2)).toBe(true)
+  })
+
+  it('flips the last field of each row across a wrap', () => {
+    // 4+4+4 fills row one; the next 4+4 start row two.
+    const twoRows = fields(4, 4, 4, 4, 4)
+
+    expect(shouldFlipPopover(twoRows, 2)).toBe(true) // ends row one
+    expect(shouldFlipPopover(twoRows, 3)).toBe(false) // starts row two
+    expect(shouldFlipPopover(twoRows, 4)).toBe(true) // last field overall
+  })
+
+  it('flips a field whose neighbour cannot fit beside it', () => {
+    // 8 + 6 = 14 > 12, so the 6 wraps. Both end up alone on their row, but
+    // both are narrower than full width, so their indicators sit far enough
+    // right for a leftward popover to stay on screen.
+    const row = fields(8, 6)
+
+    expect(shouldFlipPopover(row, 0)).toBe(true)
+    expect(shouldFlipPopover(row, 1)).toBe(true)
+  })
+
+  it('does not flip a field with room left beside it', () => {
+    // 6 + 6 shares a row; the first has a neighbour to its right.
+    expect(shouldFlipPopover(fields(6, 6), 0)).toBe(false)
+    expect(shouldFlipPopover(fields(6, 6), 1)).toBe(true)
+  })
+
+  it('flips the trailing field of a partially-filled row', () => {
+    // 4 + 4 leaves 4 columns empty, but nothing follows — grid does not
+    // stretch items, so this field is still the rightmost rendered one.
+    expect(shouldFlipPopover(fields(4, 4), 1)).toBe(true)
+  })
+
+  it('treats an out-of-range or zero span as full width, and so does not flip', () => {
+    for (const bad of [0, -3, GRID_COLUMNS + 1, 99]) {
+      expect(shouldFlipPopover(fields(bad, 4), 0)).toBe(false)
+    }
+  })
+
+  it('is safe on missing input and out-of-range indexes', () => {
+    expect(shouldFlipPopover(undefined, 0)).toBe(false)
+    expect(shouldFlipPopover([], 0)).toBe(false)
+    expect(shouldFlipPopover(fields(4, 4), -1)).toBe(false)
+    expect(shouldFlipPopover(fields(4, 4), 9)).toBe(false)
+  })
+})

--- a/frontend/src/utils/popoverFlip.ts
+++ b/frontend/src/utils/popoverFlip.ts
@@ -1,0 +1,73 @@
+/**
+ * Grid-row arithmetic for anchored popovers (TKT-FIO205).
+ *
+ * A field's comment popover is wider than a narrow field, so a left-aligned one
+ * on the rightmost field of a row overflows its container. Flipping it to
+ * right-aligned is a correctness fix, not a polish item — otherwise the popover
+ * is clipped off-screen and its composer is unreachable.
+ *
+ * Lives here rather than in EntityDetail so it is testable on its own: it is
+ * pure arithmetic over authored spans, and the off-by-one cases (a row that
+ * exactly fills 12, a field that wraps) are exactly what a unit test should pin.
+ */
+
+/** The property grid's track count. Mirrors styles/properties-list.css. */
+export const GRID_COLUMNS = 12
+
+/** The subset of a view field this needs: its authored width, if any. */
+export interface SpannedField {
+  span?: number
+}
+
+/**
+ * Reports whether the field at `index` should open its popover right-aligned.
+ *
+ * True when the field is the rightmost on a SHARED grid row. Spans are walked
+ * in order to find where rows break, mirroring CSS Grid: an item that does not
+ * fit the columns remaining wraps to the next row, leaving the remainder empty
+ * (it does NOT stretch to fill).
+ *
+ * A FULL-WIDTH field is deliberately excluded even though it is trivially
+ * "rightmost". Flipping aligns the popover to the INDICATOR's right edge, and a
+ * full-width field's indicator sits beside its label near the left of the page
+ * — so flipping there throws the popover off the left edge, under the sidebar.
+ * Only a field that shares its row with others has its indicator far enough
+ * right for a leftward popover to stay on screen.
+ */
+export function shouldFlipPopover(fields: SpannedField[] | undefined, index: number): boolean {
+  if (!fields || index < 0 || index >= fields.length) return false
+
+  let used = 0
+  for (let i = 0; i < fields.length; i++) {
+    const span = clampSpan(fields[i]?.span)
+    // Wrapped onto a new row: this item did not fit in what was left.
+    if (used + span > GRID_COLUMNS) used = 0
+    used += span
+
+    if (i === index) {
+      // Alone on its row: the indicator is at the far left, so a leftward
+      // popover would leave the content area. Keep it opening rightward.
+      if (span >= GRID_COLUMNS) return false
+
+      // Rightmost when the row is full, or when the NEXT field could not fit
+      // beside it — in both cases nothing follows on this row.
+      if (used >= GRID_COLUMNS) return true
+      const next = clampSpan(fields[i + 1]?.span)
+      return i + 1 >= fields.length || used + next > GRID_COLUMNS
+    }
+  }
+  return false
+}
+
+/**
+ * Normalises an authored span onto the track count.
+ *
+ * Absent, zero and out-of-range all mean "full width", matching the
+ * `var(--field-span, 12)` fallback and utils/fieldSpan.ts's clamp — the server
+ * already rejects bad spans at load, so this is defence in depth against a
+ * hand-crafted response rather than a routine path.
+ */
+function clampSpan(span: number | undefined): number {
+  if (!span || span < 1 || span > GRID_COLUMNS) return GRID_COLUMNS
+  return span
+}

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/PuerkitoBio/goquery v1.12.0 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.14.5 // indirect
+	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
@@ -159,6 +160,7 @@ require (
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/vloothuis/textanchor v0.2.0 // indirect
 	github.com/wailsapp/go-webview2 v1.0.22 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWfYgjE5VnyWw=
 github.com/RoaringBitmap/roaring/v2 v2.14.5/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
+github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NTz+9sGw=
@@ -32,6 +34,7 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
@@ -145,6 +148,7 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dhui/dktest v0.4.6 h1:+DPKyScKSEp3VLtbMDHcUq6V5Lm5zfZZVb0Sk7Ahom4=
 github.com/dhui/dktest v0.4.6/go.mod h1:JHTSYDtKkvFNFHJKqCzVzqXecyv+tKt8EzceOmQOgbU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -400,6 +404,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vloothuis/textanchor v0.2.0 h1:K2w7j/HwdIYV0ovTmZuJ2vV+ED+jKily2i8hVm/9n38=
+github.com/vloothuis/textanchor v0.2.0/go.mod h1:UU2SGgqVOUYV4H8V8ctFfooeyA96Fln4gf5dVe4/sqU=
 github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6NZijQ58=
 github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=

--- a/internal/acl/commentperms_test.go
+++ b/internal/acl/commentperms_test.go
@@ -1,0 +1,134 @@
+package acl_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+)
+
+// TestCommentPermissions_AreBuiltin pins that every comment permission is
+// registered. An unregistered constant is reported as dead config by
+// `rela acl audit` while it is in fact live — the exact failure that let
+// history:read be flagged as a typo.
+func TestCommentPermissions_AreBuiltin(t *testing.T) {
+	t.Parallel()
+	builtin := acl.BuiltinPermissions()
+	for _, perm := range []string{
+		acl.PermCommentRead,
+		acl.PermCommentAdd,
+		acl.PermCommentUpdateOwn,
+		acl.PermCommentUpdateAny,
+		acl.PermCommentDeleteOwn,
+		acl.PermCommentDeleteAny,
+	} {
+		if !slices.Contains(builtin, perm) {
+			t.Errorf("BuiltinPermissions() is missing %q", perm)
+		}
+	}
+}
+
+// TestCommentPermissions_MutatingRequiresRead pins the coherence rule
+// (RR-60067I): a role that may change comments must be able to read them.
+// Without it a policy granting only comment:delete-any loads cleanly and lets
+// its holder remove comments it can never see.
+func TestCommentPermissions_MutatingRequiresRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		permissions []string
+		wantErr     bool
+	}{
+		{
+			name:        "update-own without read is refused",
+			permissions: []string{acl.PermCommentUpdateOwn},
+			wantErr:     true,
+		},
+		{
+			name:        "update-any without read is refused",
+			permissions: []string{acl.PermCommentUpdateAny},
+			wantErr:     true,
+		},
+		{
+			name:        "delete-own without read is refused",
+			permissions: []string{acl.PermCommentDeleteOwn},
+			wantErr:     true,
+		},
+		{
+			name:        "delete-any without read is refused",
+			permissions: []string{acl.PermCommentDeleteAny},
+			wantErr:     true,
+		},
+		{
+			name:        "add without read is allowed (write-only commenting)",
+			permissions: []string{acl.PermCommentAdd},
+			wantErr:     false,
+		},
+		{
+			name:        "read alone is allowed",
+			permissions: []string{acl.PermCommentRead},
+			wantErr:     false,
+		},
+		{
+			name:        "mutating with read is allowed",
+			permissions: []string{acl.PermCommentRead, acl.PermCommentDeleteAny},
+			wantErr:     false,
+		},
+		{
+			name:        "no comment permissions at all",
+			permissions: nil,
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var b strings.Builder
+			b.WriteString("roles:\n  reviewer:\n    read: [\"*\"]\n")
+			if len(tc.permissions) > 0 {
+				b.WriteString("    permissions: [" + strings.Join(tc.permissions, ", ") + "]\n")
+			}
+
+			_, err := acl.LoadPolicyBytes([]byte(b.String()))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected a load error for %v, got none", tc.permissions)
+				}
+				// The message must name both the offending permission and the
+				// fix, since an operator reading it has only the text to go on.
+				if !strings.Contains(err.Error(), acl.PermCommentRead) {
+					t.Errorf("error should name %q, got: %v", acl.PermCommentRead, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected load error: %v", err)
+			}
+		})
+	}
+}
+
+// TestCommentPermissions_ReadOnAnotherRoleDoesNotCount pins that the coherence
+// rule is evaluated PER ROLE. Roles are unioned at request time, but a policy
+// is validated role by role: a reviewer role holding delete-any is misconfigured
+// even if some other role in the file happens to grant read, because nothing
+// guarantees the same principal holds both.
+func TestCommentPermissions_ReadOnAnotherRoleDoesNotCount(t *testing.T) {
+	t.Parallel()
+
+	policy := `
+roles:
+  reader:
+    read: ["*"]
+    permissions: [comment:read]
+  moderator:
+    read: ["*"]
+    permissions: [comment:delete-any]
+`
+	if _, err := acl.LoadPolicyBytes([]byte(policy)); err == nil {
+		t.Fatal("expected a load error: moderator lacks comment:read of its own")
+	}
+}

--- a/internal/acl/policy.go
+++ b/internal/acl/policy.go
@@ -58,6 +58,49 @@ const PermHistoryRead = "history:read"
 // documented in docs/acl-security.md alongside it.
 const PermHistoryReadRedacted = "history:read-redacted"
 
+// Comment permissions gate the commentary layer (internal/comments), which
+// lives alongside the graph rather than in it. They are resolved PER TARGET
+// ENTITY via [Request.HoldsPermissionForEntity], so a role conferred by an
+// ownership relation to the commented-on entity grants them — "the assignee
+// may comment on their own ticket" needs no special case.
+//
+// Read is floored by the target's own read verdict: a principal who cannot
+// read an entity cannot read its comments however these grants read, because
+// otherwise a comment thread becomes an existence oracle for entities the
+// principal is denied.
+const (
+	// PermCommentRead permits listing an entity's comments.
+	PermCommentRead = "comment:read"
+
+	// PermCommentAdd permits adding a comment.
+	PermCommentAdd = "comment:add"
+
+	// PermCommentUpdateOwn permits editing or resolving a comment the
+	// principal authored.
+	PermCommentUpdateOwn = "comment:update-own"
+
+	// PermCommentUpdateAny permits editing or resolving anyone's comment — a
+	// moderator capability. Implies [PermCommentUpdateOwn].
+	PermCommentUpdateAny = "comment:update-any"
+
+	// PermCommentDeleteOwn permits deleting a comment the principal authored.
+	PermCommentDeleteOwn = "comment:delete-own"
+
+	// PermCommentDeleteAny permits deleting anyone's comment — a moderator
+	// capability. Implies [PermCommentDeleteOwn].
+	PermCommentDeleteAny = "comment:delete-any"
+)
+
+// mutatingCommentPerms are the comment permissions that require a covering
+// [PermCommentRead], mirroring the entity-verb rule that update/delete imply
+// read. [PermCommentAdd] is deliberately absent: write-only commenting (leave
+// a remark, cannot read the thread) is a coherent posture, exactly as
+// create-without-read is for entities.
+var mutatingCommentPerms = []string{
+	PermCommentUpdateOwn, PermCommentUpdateAny,
+	PermCommentDeleteOwn, PermCommentDeleteAny,
+}
+
 // BuiltinPermissions returns every global named permission rela itself ships
 // and consumes. These are granted through a role's `permissions:` list exactly
 // like the operator-defined delegate-X permissions, but — unlike those — they
@@ -70,7 +113,12 @@ const PermHistoryReadRedacted = "history:read-redacted"
 // added here; the alternative — each consumer hardcoding its own list — is
 // what let history:read be reported as dead config while it was in use.
 func BuiltinPermissions() []string {
-	return []string{PermHistoryRead, PermHistoryReadRedacted}
+	return []string{
+		PermHistoryRead, PermHistoryReadRedacted,
+		PermCommentRead, PermCommentAdd,
+		PermCommentUpdateOwn, PermCommentUpdateAny,
+		PermCommentDeleteOwn, PermCommentDeleteAny,
+	}
 }
 
 // Policy is the declarative ACL configuration parsed from `acl.yaml`
@@ -1259,35 +1307,74 @@ func (p *Policy) Validate() error {
 // complexity in bounds, the same way validateUnmatchedPrincipal was.
 func (p *Policy) validateWriteReadCoverage() error {
 	for name, role := range p.Roles {
-		// Update and Delete require read coverage: you must be able to read a
-		// type to modify or remove it (TKT-4LQMWP, was the write⊆read invariant
-		// RR-W2J6). Create is EXEMPT — a role may create a type it cannot read,
-		// reading back only what it authored via a role-conferring relation.
-		for _, verb := range []struct {
-			name  string
-			types []string
-		}{{"update", role.Update}, {"delete", role.Delete}} {
-			for _, t := range verb.types {
-				// Compare on the TYPE half. A state-shaped grant
-				// (`update: ["policy@draft"]`) still requires read coverage
-				// of `policy` — the face narrows WHICH FACE is writable,
-				// not which type — so checking the joined string would
-				// reject every state grant with a hint telling the operator
-				// to add "policy@draft" to their read list, which is not a
-				// thing a read list can hold.
-				target := grantTypeOf(t)
-				if !roleGrantsRead(role, target) {
-					hint := fmt.Sprintf("add %q (or \"*\")", target)
-					if target == "*" {
-						hint = `add "*"`
-					}
-					return fmt.Errorf(
-						"roles.%s: grants %s on %q without a covering read grant; "+
-							"%s to the role's read list — a principal must be able to "+
-							"read every type it can %s (create is exempt)",
-						name, verb.name, t, hint, verb.name)
-				}
+		if err := validateVerbReadCoverage(name, role); err != nil {
+			return err
+		}
+		if err := validateCommentPerms(name, role); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateVerbReadCoverage enforces that Update and Delete imply read: you must
+// be able to read a type to modify or remove it (TKT-4LQMWP, was the
+// write⊆read invariant RR-W2J6).
+//
+// Create is EXEMPT — a role may create a type it cannot read, reading back only
+// what it authored via a role-conferring relation.
+func validateVerbReadCoverage(name string, role RoleDef) error {
+	for _, verb := range []struct {
+		name  string
+		types []string
+	}{{"update", role.Update}, {"delete", role.Delete}} {
+		for _, t := range verb.types {
+			// Compare on the TYPE half. A state-shaped grant
+			// (`update: ["policy@draft"]`) still requires read coverage of
+			// `policy` — the face narrows WHICH FACE is writable, not which
+			// type — so checking the joined string would reject every state
+			// grant with a hint telling the operator to add "policy@draft" to
+			// their read list, which is not a thing a read list can hold.
+			target := grantTypeOf(t)
+			if roleGrantsRead(role, target) {
+				continue
 			}
+			hint := fmt.Sprintf("add %q (or \"*\")", target)
+			if target == "*" {
+				hint = `add "*"`
+			}
+			return fmt.Errorf(
+				"roles.%s: grants %s on %q without a covering read grant; "+
+					"%s to the role's read list — a principal must be able to "+
+					"read every type it can %s (create is exempt)",
+				name, verb.name, t, hint, verb.name)
+		}
+	}
+	return nil
+}
+
+// validateCommentPerms applies the covering-read rule to the commentary layer:
+// a role that may edit or delete comments must be able to read them.
+//
+// Without it a policy granting only comment:delete-any loads cleanly and lets
+// its holder remove comments it can never see — an unauditable capability and a
+// usability trap. [PermCommentAdd] is exempt for the same reason `create` is
+// exempt from the entity-verb rule: write-only commenting is a coherent posture.
+//
+// Evaluated PER ROLE. Roles union at request time, but nothing guarantees a
+// principal holding this role also holds one that grants the read, so a role
+// carrying a mutating permission alone is misconfigured on its own terms.
+func validateCommentPerms(name string, role RoleDef) error {
+	if slices.Contains(role.Permissions, PermCommentRead) {
+		return nil
+	}
+	for _, perm := range mutatingCommentPerms {
+		if slices.Contains(role.Permissions, perm) {
+			return fmt.Errorf(
+				"roles.%s: grants %q without %q; add %q to the role's "+
+					"permissions list — a principal must be able to read "+
+					"the comments it can change (%q is exempt)",
+				name, perm, PermCommentRead, PermCommentRead, PermCommentAdd)
 		}
 	}
 

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -443,6 +443,15 @@ type EntityType struct {
 	// `bare_face:` in the schema. Empty when the type declares no faces, or
 	// when it declares faces but names none of them as the bare one.
 	BareFace string `json:"bare_face,omitempty"`
+	// Commentable reports that this type accepts comments (TKT-FIO205), so the
+	// SPA knows whether to offer a comment affordance at all. Policy, not
+	// permission: it says commenting is POSSIBLE here, never that the current
+	// principal may do it — the `comment:*` grants answer that, and the server
+	// re-authorizes every call regardless of what this flag says.
+	//
+	// Omitted when false, so a project with no `comments:` block serves a
+	// schema byte-identical to one built before the feature existed.
+	Commentable bool `json:"commentable,omitempty"`
 }
 
 // Face is the JSON representation of one declared content state,

--- a/internal/appbuild/aliasfanout.go
+++ b/internal/appbuild/aliasfanout.go
@@ -1,0 +1,73 @@
+package appbuild
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+)
+
+// aliasFanout dispatches one identity-change notification to several
+// subscribers.
+//
+// [entitymanager.Deps.AliasRewriter] is a single field because it was
+// introduced for a single consumer (the CalDAV alias service). More than one
+// subsystem now holds references BY ENTITY ID — comments are keyed on the
+// target's id too — and both must learn about a rename. Fanning out here keeps
+// that a wiring concern: entitymanager still depends on the two methods it
+// calls, and does not grow a registry.
+//
+// Errors from every subscriber are joined rather than short-circuited, so one
+// failing subscriber cannot mask another's failure or stop it being notified.
+// The Manager logs what it gets back; see the AliasRewriter doc for why a
+// post-write hook cannot fail the write that already happened.
+type aliasFanout struct {
+	subscribers []entitymanager.AliasRewriter
+}
+
+var _ entitymanager.AliasRewriter = (*aliasFanout)(nil)
+
+// newAliasFanout returns a rewriter over the non-nil subscribers.
+//
+// Nil: returns nil when nothing subscribes, so the Manager's `if
+// AliasRewriter == nil` fast path still applies and an unused hook costs
+// nothing. Returns the single subscriber unwrapped when there is exactly one,
+// keeping the common case free of an indirection.
+func newAliasFanout(subs ...entitymanager.AliasRewriter) entitymanager.AliasRewriter {
+	live := make([]entitymanager.AliasRewriter, 0, len(subs))
+	for _, s := range subs {
+		if s != nil {
+			live = append(live, s)
+		}
+	}
+	switch len(live) {
+	case 0:
+		return nil
+	case 1:
+		return live[0]
+	default:
+		return &aliasFanout{subscribers: live}
+	}
+}
+
+// EntityRenamed notifies every subscriber that an entity's id changed.
+func (f *aliasFanout) EntityRenamed(ctx context.Context, oldID, newID string) error {
+	var errs []error
+	for _, s := range f.subscribers {
+		if err := s.EntityRenamed(ctx, oldID, newID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// EntityDeleted notifies every subscriber that an entity left the graph.
+func (f *aliasFanout) EntityDeleted(ctx context.Context, entityID string) error {
+	var errs []error
+	for _, s := range f.subscribers {
+		if err := s.EntityDeleted(ctx, entityID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/autocascade"
 	"github.com/Sourcehaven-BV/rela/internal/automation"
 	"github.com/Sourcehaven-BV/rela/internal/caldavalias"
+	"github.com/Sourcehaven-BV/rela/internal/comments"
 	"github.com/Sourcehaven-BV/rela/internal/computed"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -96,8 +97,14 @@ import (
 // Develop raised this to 26; the three recipient-scoped scheduler methods
 // take it to 29. They are exported because scheduler consumes them through
 // narrow capability interfaces; they do not add general Services getters.
+// Comments() (TKT-FIO205) takes it to 31: the commentary service is chosen and
+// constructed here and handed to the App at the wiring site, exactly like
+// CalDAVAliases() and UserState(). It is one more instance of the pattern this
+// comment already describes — a new subsystem composed by the facade — not a
+// new kind of growth, and the fix remains splitting the bundle (TKT-N0IKN9)
+// rather than hiding the getter.
 //
-//plimsoll:max-exported-methods=30
+//plimsoll:max-exported-methods=31
 type Services struct {
 	fs    storage.FS
 	paths *project.Context
@@ -130,9 +137,13 @@ type Services struct {
 	// durable PostgreSQL on the postgres build. Torn down in Close.
 	jobQueue      jobs.Queue
 	caldavAliases *caldavalias.Service
-	scriptEngine  *script.Engine
-	searchCloser  io.Closer
-	acl           acl.ACL
+	// comments is the commentary layer (internal/comments). Nil when the
+	// metamodel declares no `comments:` block — the feature then does not
+	// exist, and the data-entry app serves no comment routes.
+	comments     *comments.Service
+	scriptEngine *script.Engine
+	searchCloser io.Closer
+	acl          acl.ACL
 	// aclDeclarative is set when buildACL constructs a Declarative; nil
 	// for NopACL, ReadOnlyACL, or when Declarative construction fails.
 	aclDeclarative *acl.Declarative
@@ -318,6 +329,14 @@ func (s *Services) Jobs() jobs.Client { return s.jobQueue }
 // service is always constructed (an empty table is the normal first-run state),
 // so consumers need no nil check.
 func (s *Services) CalDAVAliases() *caldavalias.Service { return s.caldavAliases }
+
+// Comments returns the commentary service, or nil when the metamodel declares
+// no enabled `comments:` block.
+//
+// Nil means the feature does not exist for this project: the data-entry app
+// serves no comment routes and no storage is created. Callers must nil-check
+// rather than assume a usable service.
+func (s *Services) Comments() *comments.Service { return s.comments }
 
 // LuaReadDeps materializes the read-only Lua capability bundle with
 // UNRESTRICTED reads — the operator-trust-boundary wiring used by the CLI
@@ -1612,7 +1631,19 @@ func assemble(
 		return nil, err
 	}
 
-	mgr, err := buildEntityManager(base, st, aliases, templater, resolvedACL,
+	// Comments are keyed by target entity id, so the service must learn about
+	// renames and deletes. It rides the AliasRewriter hook rather than
+	// store.EntityObserver for the reason that hook documents: stores fire the
+	// observer with the error discarded, which is fine for a rebuildable search
+	// index but not for records that exist ONLY in the comment store.
+	commentSvc, err := buildComments(cfg.FS, cfg.Paths, base.meta)
+	if err != nil {
+		return nil, err
+	}
+
+	// Upstream's parameter order (readDeps after cascadeRunner) with the
+	// comment fanout wrapping the alias rewriter.
+	mgr, err := buildEntityManager(base, st, newAliasFanout(aliases, commentSvc), templater, resolvedACL,
 		autoEngine, cascadeRunner, readDeps, versions, tw, computedSet)
 	if err != nil {
 		return nil, err
@@ -1659,6 +1690,7 @@ func assemble(
 		stateKV:         stateKV,
 		jobQueue:        jobQueue,
 		caldavAliases:   aliases,
+		comments:        commentSvc,
 		scriptEngine:    cfg.ScriptEngine,
 		searchCloser:    searchCloser,
 		acl:             resolvedACL,

--- a/internal/appbuild/comments.go
+++ b/internal/appbuild/comments.go
@@ -1,0 +1,57 @@
+package appbuild
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/comments/filecomments"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// commentsDirName is the comment store's home inside the project's `.rela/`
+// directory.
+//
+// Under `.rela/` rather than beside `entities/` because comments are not graph
+// content: they should not appear as a sibling of the operator's data, and a
+// project that never enables commenting should see nothing at all.
+const commentsDirName = "comments"
+
+// buildComments constructs the commentary service, or nil when the metamodel
+// declares no enabled `comments:` block.
+//
+// Returning a genuinely nil *comments.Service (not a service over a no-op
+// store) is load-bearing in the same way versionServiceFor's nil is: the
+// data-entry app nil-checks it to decide whether to serve the comment routes
+// at all, so a disabled feature costs an operator no routes, no directory and
+// no storage — which is what AC1 asks for.
+//
+// Backend choice is deliberately NOT build-tagged today: the file backend is
+// correct for every current build (fs, memory, sqlite are all single-process,
+// and the postgres build's multi-process concern arrives with pgcomments in the
+// follow-up ticket). Making it a per-recipe choice before there is a second
+// backend would add four call sites that all pass the same thing.
+func buildComments(fs storage.FS, paths *project.Context, meta *metamodel.Metamodel) (*comments.Service, error) {
+	if !metamodel.NewCommentPolicy(meta).Enabled() {
+		return nil, nil //nolint:nilnil // a nil service IS the "feature disabled" signal; see the doc above.
+	}
+	if fs == nil || paths == nil || paths.CacheDir == "" {
+		// Commenting is configured but there is nowhere to put the data. This
+		// is a wiring failure, not a degradation: silently disabling a feature
+		// the operator switched on would surface later as comments vanishing.
+		return nil, errors.New("comments: enabled in the metamodel but no project cache directory is available")
+	}
+
+	store, err := filecomments.New(fs, filepath.Join(paths.CacheDir, commentsDirName))
+	if err != nil {
+		return nil, fmt.Errorf("comments: %w", err)
+	}
+	svc, err := comments.NewService(store, nil)
+	if err != nil {
+		return nil, fmt.Errorf("comments: %w", err)
+	}
+	return svc, nil
+}

--- a/internal/appbuild/comments_test.go
+++ b/internal/appbuild/comments_test.go
@@ -1,0 +1,143 @@
+package appbuild
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func commentsMeta(t *testing.T, enabled bool) *metamodel.Metamodel {
+	t.Helper()
+	src := `
+version: "1"
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    properties:
+      title:
+        type: string
+`
+	if enabled {
+		src += "comments:\n  enabled: true\n  on: [ticket]\n"
+	}
+	m, err := metamodel.Parse([]byte(src))
+	require.NoError(t, err)
+	return m
+}
+
+func paths(t *testing.T) *project.Context {
+	t.Helper()
+	root := t.TempDir()
+	return &project.Context{Root: root, CacheDir: filepath.Join(root, project.CacheDir)}
+}
+
+// TestBuildComments_DisabledYieldsNilService pins AC1's wiring half: with no
+// `comments:` block the service is genuinely nil, which is what lets the
+// data-entry app decide not to serve the routes at all.
+func TestBuildComments_DisabledYieldsNilService(t *testing.T) {
+	p := paths(t)
+	svc, err := buildComments(storage.NewOsFS(), p, commentsMeta(t, false))
+	require.NoError(t, err)
+	require.Nil(t, svc, "a nil service IS the disabled signal")
+
+	_, statErr := os.Stat(filepath.Join(p.CacheDir, commentsDirName))
+	require.ErrorIs(t, statErr, os.ErrNotExist, "a disabled feature creates no storage")
+}
+
+func TestBuildComments_EnabledYieldsService(t *testing.T) {
+	svc, err := buildComments(storage.NewOsFS(), paths(t), commentsMeta(t, true))
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+}
+
+// TestBuildComments_EnabledWithoutPathsFails pins that a configured feature
+// with nowhere to store data is a wiring error, not a silent downgrade —
+// otherwise an operator who switched commenting on would find it quietly
+// missing.
+func TestBuildComments_EnabledWithoutPathsFails(t *testing.T) {
+	t.Run("nil paths", func(t *testing.T) {
+		_, err := buildComments(storage.NewOsFS(), nil, commentsMeta(t, true))
+		require.Error(t, err)
+	})
+
+	t.Run("nil filesystem", func(t *testing.T) {
+		_, err := buildComments(nil, paths(t), commentsMeta(t, true))
+		require.Error(t, err)
+	})
+}
+
+// recordingRewriter captures the notifications it receives.
+//
+// The interface assertion is the compile-time guard that a fan-out subscriber
+// is substitutable for the entitymanager's single-rewriter field.
+var _ entitymanager.AliasRewriter = (*recordingRewriter)(nil)
+
+type recordingRewriter struct {
+	renamed []string
+	deleted []string
+	err     error
+}
+
+func (r *recordingRewriter) EntityRenamed(_ context.Context, oldID, newID string) error {
+	r.renamed = append(r.renamed, oldID+"->"+newID)
+	return r.err
+}
+
+func (r *recordingRewriter) EntityDeleted(_ context.Context, id string) error {
+	r.deleted = append(r.deleted, id)
+	return r.err
+}
+
+// TestAliasFanout_NilWhenNothingSubscribes pins that an unused hook stays nil,
+// so the Manager's nil fast path still applies.
+func TestAliasFanout_NilWhenNothingSubscribes(t *testing.T) {
+	require.Nil(t, newAliasFanout())
+	require.Nil(t, newAliasFanout(nil, nil))
+}
+
+// TestAliasFanout_UnwrapsSingleSubscriber keeps the common case free of an
+// indirection: with one subscriber there is nothing to fan out to.
+func TestAliasFanout_UnwrapsSingleSubscriber(t *testing.T) {
+	only := &recordingRewriter{}
+	got := newAliasFanout(nil, only)
+	require.Same(t, only, got)
+}
+
+func TestAliasFanout_NotifiesEverySubscriber(t *testing.T) {
+	a, b := &recordingRewriter{}, &recordingRewriter{}
+	fanout := newAliasFanout(a, b)
+	ctx := context.Background()
+
+	require.NoError(t, fanout.EntityRenamed(ctx, "TKT-old", "TKT-new"))
+	require.NoError(t, fanout.EntityDeleted(ctx, "TKT-1"))
+
+	require.Equal(t, []string{"TKT-old->TKT-new"}, a.renamed)
+	require.Equal(t, []string{"TKT-old->TKT-new"}, b.renamed)
+	require.Equal(t, []string{"TKT-1"}, a.deleted)
+	require.Equal(t, []string{"TKT-1"}, b.deleted)
+}
+
+// TestAliasFanout_OneFailureDoesNotSkipOthers pins the join-don't-short-circuit
+// rule. A failing CalDAV rewrite must not stop the comment store learning about
+// a rename — that would strand a thread for an unrelated reason.
+func TestAliasFanout_OneFailureDoesNotSkipOthers(t *testing.T) {
+	boom := errors.New("boom")
+	failing := &recordingRewriter{err: boom}
+	healthy := &recordingRewriter{}
+	fanout := newAliasFanout(failing, healthy)
+
+	err := fanout.EntityRenamed(context.Background(), "TKT-old", "TKT-new")
+	require.ErrorIs(t, err, boom)
+	require.Equal(t, []string{"TKT-old->TKT-new"}, healthy.renamed,
+		"a failing subscriber must not prevent the next one being notified")
+}

--- a/internal/comments/authz.go
+++ b/internal/comments/authz.go
@@ -1,0 +1,174 @@
+package comments
+
+import "context"
+
+// PermissionGate answers whether the ctx principal holds a named permission for
+// one entity.
+//
+// Declared here, at the consumer, rather than beside the ACL: this package
+// needs exactly one question answered and has no business seeing the rest of
+// the resolver. The wiring site supplies an adapter over
+// acl.Request.HoldsPermissionForEntity, which resolves permissions conferred by
+// an ownership relation to the subject as well as global grants.
+//
+// Nil: a nil PermissionGate means "no policy configured"; [Authorizer] treats
+// that as permitting everything, matching the CLI/desktop tier where there is
+// no principal to authorize.
+type PermissionGate interface {
+	HoldsPermission(ctx context.Context, subjectID, permission string) bool
+}
+
+// TargetReadGate answers whether the ctx principal may read the target entity
+// at all.
+//
+// Separate from [PermissionGate] because it answers a different question and
+// has a different failure mode: a denied read must be indistinguishable from a
+// missing entity, whereas a denied permission may say which permission was
+// missing (a permission name is config, and config is not secret).
+//
+// Nil: a nil TargetReadGate means "no policy configured" and permits.
+type TargetReadGate interface {
+	CanRead(ctx context.Context, entityType, entityID string) bool
+}
+
+// Action is a thing a principal may want to do to a comment.
+type Action int
+
+const (
+	// ActionRead lists an entity's comments.
+	ActionRead Action = iota
+	// ActionAdd adds a comment.
+	ActionAdd
+	// ActionUpdate edits or resolves an existing comment.
+	ActionUpdate
+	// ActionDelete removes an existing comment.
+	ActionDelete
+)
+
+// Authorizer decides whether a principal may act on a target's comments.
+//
+// It exists so the permission vocabulary is interpreted in ONE place: the
+// own/any split, the read floor and the inert/fail-closed rule are decided
+// here rather than at each HTTP handler, where a missed check is invisible.
+type Authorizer struct {
+	perms  PermissionGate
+	reads  TargetReadGate
+	active bool
+}
+
+// NewAuthorizer returns an Authorizer over the supplied gates.
+//
+// policyActive distinguishes the two ways a gate can be absent, and the
+// distinction is load-bearing (the same rule the statemachine transition guard
+// documents):
+//
+//   - No policy configured at all: the Authorizer is INERT and permits. This is
+//     the CLI/desktop tier, where there is no principal to authorize.
+//   - A policy IS configured but a gate is missing: that is a wiring failure on
+//     a served path, and the Authorizer FAILS CLOSED. A policy-backed
+//     deployment must not silently open commenting because plumbing broke.
+func NewAuthorizer(perms PermissionGate, reads TargetReadGate, policyActive bool) *Authorizer {
+	return &Authorizer{perms: perms, reads: reads, active: policyActive}
+}
+
+// CanRead reports whether the principal may list target's comments.
+//
+// Two conditions, both required: the target must be readable, and the principal
+// must hold [PermCommentRead] for it. The read floor is what stops a comment
+// thread becoming an existence oracle — without it, a principal granted
+// comment:read globally could probe which entities exist by asking for their
+// comments.
+func (a *Authorizer) CanRead(ctx context.Context, target Target) bool {
+	if !a.active {
+		return true
+	}
+	return a.canReadTarget(ctx, target) && a.holds(ctx, target.ID, permRead)
+}
+
+// CanAdd reports whether the principal may add a comment to target.
+//
+// Note this does NOT require [PermCommentRead]: write-only commenting is a
+// deliberate posture (leave a remark on something you cannot otherwise
+// discuss), mirroring the entity-verb rule where create is exempt from the
+// covering-read requirement. The target must still be readable — you cannot
+// comment on an entity you cannot see.
+func (a *Authorizer) CanAdd(ctx context.Context, target Target) bool {
+	if !a.active {
+		return true
+	}
+	return a.canReadTarget(ctx, target) && a.holds(ctx, target.ID, permAdd)
+}
+
+// CanUpdate reports whether the principal may edit or resolve c.
+//
+// The -any permission implies the -own one, so a moderator needs only
+// comment:update-any rather than both.
+func (a *Authorizer) CanUpdate(ctx context.Context, target Target, c Comment, principalUser string) bool {
+	return a.canMutate(ctx, target, c, principalUser, permUpdateOwn, permUpdateAny)
+}
+
+// CanDelete reports whether the principal may remove c.
+func (a *Authorizer) CanDelete(ctx context.Context, target Target, c Comment, principalUser string) bool {
+	return a.canMutate(ctx, target, c, principalUser, permDeleteOwn, permDeleteAny)
+}
+
+// canMutate is the shared own/any decision.
+//
+// Ownership is a string comparison of the stored author against the request
+// principal — NOT the graph's ownership mechanism, which tests for a conferring
+// EDGE and therefore cannot see a comment at all. Keeping the comparison here
+// means the ACL never has to learn about non-graph records.
+func (a *Authorizer) canMutate(
+	ctx context.Context, target Target, c Comment, principalUser, ownPerm, anyPerm string,
+) bool {
+	if !a.active {
+		return true
+	}
+	if !a.canReadTarget(ctx, target) {
+		return false
+	}
+	if a.holds(ctx, target.ID, anyPerm) {
+		return true
+	}
+	// An empty author or principal can never establish ownership. Comments are
+	// refused at write time when the author cannot be resolved, so this is
+	// belt-and-braces against a hand-edited file.
+	if principalUser == "" || c.Author == "" || c.Author != principalUser {
+		return false
+	}
+	return a.holds(ctx, target.ID, ownPerm)
+}
+
+// canReadTarget applies the read floor.
+func (a *Authorizer) canReadTarget(ctx context.Context, target Target) bool {
+	if a.reads == nil {
+		// Policy is active but the read gate is missing: fail closed.
+		return false
+	}
+	return a.reads.CanRead(ctx, target.Type, target.ID)
+}
+
+// holds resolves one named permission for the target entity.
+func (a *Authorizer) holds(ctx context.Context, subjectID, perm string) bool {
+	if a.perms == nil {
+		// Policy is active but the permission gate is missing: fail closed.
+		return false
+	}
+	return a.perms.HoldsPermission(ctx, subjectID, perm)
+}
+
+// Permission names, duplicated from internal/acl as plain strings.
+//
+// This package must not import internal/acl: comments sit below the
+// authorization layer and take a narrow gate interface instead, so importing
+// the resolver would invert that. The strings are part of the operator-facing
+// config vocabulary and so are stable by contract; acl's constants remain the
+// single source consumers reference.
+const (
+	permRead      = "comment:read"
+	permAdd       = "comment:add"
+	permUpdateOwn = "comment:update-own"
+	permUpdateAny = "comment:update-any"
+	permDeleteOwn = "comment:delete-own"
+	permDeleteAny = "comment:delete-any"
+)

--- a/internal/comments/authz.go
+++ b/internal/comments/authz.go
@@ -74,7 +74,7 @@ func NewAuthorizer(perms PermissionGate, reads TargetReadGate, policyActive bool
 // CanRead reports whether the principal may list target's comments.
 //
 // Two conditions, both required: the target must be readable, and the principal
-// must hold [PermCommentRead] for it. The read floor is what stops a comment
+// must hold `comment:read` for it. The read floor is what stops a comment
 // thread becoming an existence oracle — without it, a principal granted
 // comment:read globally could probe which entities exist by asking for their
 // comments.
@@ -87,7 +87,7 @@ func (a *Authorizer) CanRead(ctx context.Context, target Target) bool {
 
 // CanAdd reports whether the principal may add a comment to target.
 //
-// Note this does NOT require [PermCommentRead]: write-only commenting is a
+// Note this does NOT require `comment:read`: write-only commenting is a
 // deliberate posture (leave a remark on something you cannot otherwise
 // discuss), mirroring the entity-verb rule where create is exempt from the
 // covering-read requirement. The target must still be readable — you cannot

--- a/internal/comments/authz_test.go
+++ b/internal/comments/authz_test.go
@@ -1,0 +1,222 @@
+package comments_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+)
+
+// fakeGate grants exactly the permissions it is given, for every subject.
+type fakeGate struct {
+	granted map[string]bool
+	// subjectScoped, when set, grants only for this subject id — used to prove
+	// the gate is asked about the TARGET entity, not some ambient subject.
+	subjectScoped string
+	asked         []string
+}
+
+func (g *fakeGate) HoldsPermission(_ context.Context, subjectID, permission string) bool {
+	g.asked = append(g.asked, subjectID+"/"+permission)
+	if g.subjectScoped != "" && subjectID != g.subjectScoped {
+		return false
+	}
+	return g.granted[permission]
+}
+
+type fakeReads struct {
+	allow bool
+	asked []string
+}
+
+func (r *fakeReads) CanRead(_ context.Context, entityType, entityID string) bool {
+	r.asked = append(r.asked, entityType+"/"+entityID)
+	return r.allow
+}
+
+func grants(perms ...string) *fakeGate {
+	m := map[string]bool{}
+	for _, p := range perms {
+		m[p] = true
+	}
+	return &fakeGate{granted: m}
+}
+
+var tgt = comments.Target{Type: "ticket", ID: "TKT-1"}
+
+func aliceComment() comments.Comment {
+	return comments.Comment{ID: "c1", Author: "alice@example.com", Body: "x"}
+}
+
+// TestAuthorizer_PermissionStringsMatchACL pins the duplicated permission
+// names against the ACL's constants. This package cannot import internal/acl
+// (it sits below the authorization layer), so the strings are copied — and a
+// silent divergence would mean a permission an operator grants is never the one
+// checked, which no other test would catch.
+func TestAuthorizer_PermissionStringsMatchACL(t *testing.T) {
+	perms := grants(acl.PermCommentRead)
+	reads := &fakeReads{allow: true}
+	a := comments.NewAuthorizer(perms, reads, true)
+
+	require.True(t, a.CanRead(context.Background(), tgt),
+		"acl.PermCommentRead must be the string the authorizer asks for")
+
+	for _, tc := range []struct {
+		name string
+		perm string
+		call func(*comments.Authorizer) bool
+	}{
+		{"add", acl.PermCommentAdd, func(a *comments.Authorizer) bool {
+			return a.CanAdd(context.Background(), tgt)
+		}},
+		{"update-any", acl.PermCommentUpdateAny, func(a *comments.Authorizer) bool {
+			return a.CanUpdate(context.Background(), tgt, aliceComment(), "bob@example.com")
+		}},
+		{"delete-any", acl.PermCommentDeleteAny, func(a *comments.Authorizer) bool {
+			return a.CanDelete(context.Background(), tgt, aliceComment(), "bob@example.com")
+		}},
+		{"update-own", acl.PermCommentUpdateOwn, func(a *comments.Authorizer) bool {
+			return a.CanUpdate(context.Background(), tgt, aliceComment(), "alice@example.com")
+		}},
+		{"delete-own", acl.PermCommentDeleteOwn, func(a *comments.Authorizer) bool {
+			return a.CanDelete(context.Background(), tgt, aliceComment(), "alice@example.com")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := comments.NewAuthorizer(grants(tc.perm), &fakeReads{allow: true}, true)
+			require.True(t, tc.call(auth), "%s must be checked as %q", tc.name, tc.perm)
+		})
+	}
+}
+
+// TestAuthorizer_InertWithoutPolicy pins the CLI/desktop tier: with no policy
+// there is no principal to authorize, so everything is permitted.
+func TestAuthorizer_InertWithoutPolicy(t *testing.T) {
+	a := comments.NewAuthorizer(nil, nil, false)
+	ctx := context.Background()
+
+	require.True(t, a.CanRead(ctx, tgt))
+	require.True(t, a.CanAdd(ctx, tgt))
+	require.True(t, a.CanUpdate(ctx, tgt, aliceComment(), ""))
+	require.True(t, a.CanDelete(ctx, tgt, aliceComment(), ""))
+}
+
+// TestAuthorizer_FailsClosedWhenGatesMissing pins the other half of that rule:
+// a policy IS configured but the gate is absent, which is a wiring failure on a
+// served path. Opening commenting because plumbing broke would be the wrong
+// direction to fail.
+func TestAuthorizer_FailsClosedWhenGatesMissing(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no permission gate", func(t *testing.T) {
+		a := comments.NewAuthorizer(nil, &fakeReads{allow: true}, true)
+		require.False(t, a.CanRead(ctx, tgt))
+		require.False(t, a.CanAdd(ctx, tgt))
+	})
+
+	t.Run("no read gate", func(t *testing.T) {
+		a := comments.NewAuthorizer(grants(acl.PermCommentRead), nil, true)
+		require.False(t, a.CanRead(ctx, tgt))
+	})
+}
+
+// TestAuthorizer_ReadFloor pins that comment grants cannot override the
+// target's read verdict (AC7). Otherwise a principal granted comment:read
+// globally could probe which entities exist by asking for their comments.
+func TestAuthorizer_ReadFloor(t *testing.T) {
+	ctx := context.Background()
+	denied := &fakeReads{allow: false}
+	a := comments.NewAuthorizer(
+		grants(acl.PermCommentRead, acl.PermCommentAdd,
+			acl.PermCommentUpdateAny, acl.PermCommentDeleteAny),
+		denied, true)
+
+	require.False(t, a.CanRead(ctx, tgt), "unreadable target: no comment read")
+	require.False(t, a.CanAdd(ctx, tgt), "unreadable target: no comment add")
+	require.False(t, a.CanUpdate(ctx, tgt, aliceComment(), "alice@example.com"))
+	require.False(t, a.CanDelete(ctx, tgt, aliceComment(), "alice@example.com"))
+}
+
+// TestAuthorizer_VerbsAreIndependent pins AC5: holding one comment permission
+// does not confer another.
+func TestAuthorizer_VerbsAreIndependent(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("read does not confer add", func(t *testing.T) {
+		a := comments.NewAuthorizer(grants(acl.PermCommentRead), &fakeReads{allow: true}, true)
+		require.True(t, a.CanRead(ctx, tgt))
+		require.False(t, a.CanAdd(ctx, tgt))
+	})
+
+	t.Run("add does not confer read", func(t *testing.T) {
+		// Write-only commenting is a deliberate posture, so this direction
+		// must work too.
+		a := comments.NewAuthorizer(grants(acl.PermCommentAdd), &fakeReads{allow: true}, true)
+		require.True(t, a.CanAdd(ctx, tgt))
+		require.False(t, a.CanRead(ctx, tgt))
+	})
+
+	t.Run("update does not confer delete", func(t *testing.T) {
+		a := comments.NewAuthorizer(grants(acl.PermCommentUpdateAny), &fakeReads{allow: true}, true)
+		c := aliceComment()
+		require.True(t, a.CanUpdate(ctx, tgt, c, "bob@example.com"))
+		require.False(t, a.CanDelete(ctx, tgt, c, "bob@example.com"))
+	})
+}
+
+// TestAuthorizer_OwnVersusAny pins the ownership split.
+func TestAuthorizer_OwnVersusAny(t *testing.T) {
+	ctx := context.Background()
+	reads := func() *fakeReads { return &fakeReads{allow: true} }
+	alice := aliceComment()
+
+	t.Run("own permits editing your own comment", func(t *testing.T) {
+		a := comments.NewAuthorizer(grants(acl.PermCommentUpdateOwn), reads(), true)
+		require.True(t, a.CanUpdate(ctx, tgt, alice, "alice@example.com"))
+	})
+
+	t.Run("own refuses someone else's comment", func(t *testing.T) {
+		a := comments.NewAuthorizer(grants(acl.PermCommentUpdateOwn), reads(), true)
+		require.False(t, a.CanUpdate(ctx, tgt, alice, "bob@example.com"))
+	})
+
+	t.Run("any permits someone else's comment", func(t *testing.T) {
+		a := comments.NewAuthorizer(grants(acl.PermCommentUpdateAny), reads(), true)
+		require.True(t, a.CanUpdate(ctx, tgt, alice, "bob@example.com"))
+	})
+
+	t.Run("any implies own", func(t *testing.T) {
+		// A moderator holding only -any must not need -own as well to edit
+		// their own comment.
+		a := comments.NewAuthorizer(grants(acl.PermCommentDeleteAny), reads(), true)
+		require.True(t, a.CanDelete(ctx, tgt, alice, "alice@example.com"))
+	})
+
+	t.Run("empty author never establishes ownership", func(t *testing.T) {
+		// Defense against a hand-edited file: an author-less comment must not
+		// become editable by an author-less principal.
+		a := comments.NewAuthorizer(grants(acl.PermCommentUpdateOwn), reads(), true)
+		require.False(t, a.CanUpdate(ctx, tgt, comments.Comment{ID: "c1"}, ""))
+	})
+}
+
+// TestAuthorizer_AsksAboutTheTargetEntity pins that permissions are resolved
+// per target, which is what lets a role conferred by an ownership relation to
+// that entity grant them (AC6).
+func TestAuthorizer_AsksAboutTheTargetEntity(t *testing.T) {
+	ctx := context.Background()
+	perms := grants(acl.PermCommentRead)
+	perms.subjectScoped = "TKT-1"
+	reads := &fakeReads{allow: true}
+	a := comments.NewAuthorizer(perms, reads, true)
+
+	require.True(t, a.CanRead(ctx, comments.Target{Type: "ticket", ID: "TKT-1"}))
+	require.False(t, a.CanRead(ctx, comments.Target{Type: "ticket", ID: "TKT-2"}),
+		"a grant scoped to one entity must not leak to another")
+
+	require.Contains(t, reads.asked, "ticket/TKT-1")
+	require.Contains(t, perms.asked, "TKT-1/comment:read")
+}

--- a/internal/comments/comments.go
+++ b/internal/comments/comments.go
@@ -49,6 +49,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
 // Sentinel errors. Callers map these to transport-level responses; the HTTP
@@ -235,6 +237,26 @@ type Comment struct {
 type Target struct {
 	Type string
 	ID   string
+	// Face scopes the thread to one content state of the entity (FEAT-9CD2MX).
+	// The zero value addresses the default face, which is also what a faceless
+	// project always uses.
+	//
+	// Comments are PER FACE because a face is a distinct piece of content: a
+	// remark on the draft ("this paragraph needs a source") is not a remark on
+	// the published version, and surfacing it there would attach feedback to
+	// text that may not even contain the quote. The read gate is per face too,
+	// so a shared thread would also leak across a boundary the entity itself
+	// maintains.
+	Face entity.Face
+}
+
+// Key is the storage key for a target's thread.
+//
+// It is [entity.FormatStateRef], so the DEFAULT face serializes to the bare id
+// — which is what lets faces arrive without migrating a single stored comment:
+// every thread written before faces existed is already at its correct key.
+func (t Target) Key() string {
+	return entity.FormatStateRef(t.ID, t.Face)
 }
 
 // Store persists comments per target entity.
@@ -265,9 +287,17 @@ type Store interface {
 	// Delete removes one comment. Returns [ErrNotFound] if absent.
 	Delete(ctx context.Context, target Target, id string) error
 
-	// DeleteTarget removes every comment on a target. Deleting a target with
-	// no comments is not an error.
+	// DeleteTarget removes every comment on ONE target (one face). Deleting a
+	// target with no comments is not an error.
 	DeleteTarget(ctx context.Context, target Target) error
+
+	// DeleteAllFaces removes every thread belonging to an entity id, across
+	// all of its faces.
+	//
+	// Distinct from DeleteTarget: an entity delete takes the whole entity with
+	// it, so leaving a faced thread behind would strand comments at an id
+	// nothing can reach.
+	DeleteAllFaces(ctx context.Context, entityID string) error
 
 	// Rename re-keys a target's comments from oldID to newID, preserving
 	// order. Renaming a target with no comments is not an error.

--- a/internal/comments/comments.go
+++ b/internal/comments/comments.go
@@ -94,6 +94,18 @@ const (
 
 	// MaxPerTarget caps how many comments one entity may carry.
 	MaxPerTarget = 500
+
+	// MinQuoteRunes is the shortest text selection that may be anchored.
+	//
+	// Matched to the matcher's own floor (it refuses queries under 5 bytes):
+	// below this a quote is too generic to re-locate, so accepting one would
+	// mint a comment that detaches on the next edit.
+	MinQuoteRunes = 5
+
+	// MaxQuoteBytes caps a stored quote. Generous for a sentence or two, and
+	// bounded so a caller cannot store an entire body as an "anchor" — the
+	// resolver's cost scales with quote length.
+	MaxQuoteBytes = 2000
 )
 
 // AnchorKind identifies what part of an entity a comment is attached to.
@@ -114,7 +126,41 @@ const (
 	// heading rather than from user content — so it survives edits to the
 	// entity body.
 	AnchorSection AnchorKind = "section"
+
+	// AnchorText attaches a comment to a RANGE of the entity body (stage 2).
+	//
+	// Unlike the two name-based kinds, this one anchors to content that the
+	// user can edit out from under it. Ref is unused; [Anchor.Text] carries
+	// the quote plus the surrounding context that lets it be re-located after
+	// an edit, and a resolution that fails is reported as detached rather than
+	// dropped (DEC-HWZHA).
+	AnchorText AnchorKind = "text"
 )
+
+// TextAnchor is the stage-2 descriptor set for a body text range.
+//
+// The fields mirror github.com/vloothuis/textanchor's Anchor exactly, because
+// they are handed to it verbatim on resolve. They are stored rather than a byte
+// offset for the reason the whole feature exists: an offset is invalidated by
+// any edit earlier in the body, and on the fs backend by a plain re-save, since
+// fsstore reflows every body to 80 columns on write.
+//
+// Quote alone is not enough — the same words can occur twice — so Prefix and
+// Suffix disambiguate, ContainingSentence rescues short generic quotes, and the
+// structural pair (HeadingContext, ParagraphIndex) survives a rewrite of the
+// quoted sentence itself.
+type TextAnchor struct {
+	Quote              string `json:"quote"                          yaml:"quote"`
+	Prefix             string `json:"prefix,omitempty"               yaml:"prefix,omitempty"`
+	Suffix             string `json:"suffix,omitempty"               yaml:"suffix,omitempty"`
+	ContainingSentence string `json:"containing_sentence,omitempty"  yaml:"containing_sentence,omitempty"`
+	HeadingContext     string `json:"heading_context,omitempty"      yaml:"heading_context,omitempty"`
+	// ParagraphIndex is 0-based within the section named by HeadingContext,
+	// or -1 when not applicable. Zero is a MEANINGFUL value (the first
+	// paragraph), so this is never omitempty — dropping it would silently
+	// retarget a comment to whatever paragraph the zero value implies.
+	ParagraphIndex int `json:"paragraph_index" yaml:"paragraph_index"`
+}
 
 // Anchor locates a comment within its target entity.
 //
@@ -124,6 +170,12 @@ const (
 type Anchor struct {
 	Kind AnchorKind `json:"kind" yaml:"kind"`
 	Ref  string     `json:"ref"  yaml:"ref"`
+
+	// Text carries the descriptors for an [AnchorText] anchor, and is nil for
+	// every other kind. A pointer so a property or section comment serializes
+	// exactly as it did before this field existed — which is what lets stage 2
+	// ship without migrating a single stored comment.
+	Text *TextAnchor `json:"text,omitempty" yaml:"text,omitempty"`
 }
 
 // Validate reports whether the anchor is structurally usable.
@@ -135,11 +187,27 @@ type Anchor struct {
 func (a Anchor) Validate() error {
 	switch a.Kind {
 	case AnchorProperty, AnchorSection:
+		if strings.TrimSpace(a.Ref) == "" {
+			return fmt.Errorf("%w: ref must not be empty", ErrInvalidAnchor)
+		}
+	case AnchorText:
+		// Ref is unused for a text anchor; the descriptors carry the location.
+		if a.Text == nil {
+			return fmt.Errorf("%w: text anchor requires a text descriptor", ErrInvalidAnchor)
+		}
+		// A quote shorter than this cannot be located reliably — the matcher
+		// itself refuses queries under 5 bytes, and a 2-character quote would
+		// match almost anywhere. Refusing at the boundary gives the caller a
+		// 400 instead of a comment that is born detached.
+		if len([]rune(strings.TrimSpace(a.Text.Quote))) < MinQuoteRunes {
+			return fmt.Errorf("%w: quote must be at least %d characters",
+				ErrInvalidAnchor, MinQuoteRunes)
+		}
+		if len(a.Text.Quote) > MaxQuoteBytes {
+			return fmt.Errorf("%w: quote exceeds %d bytes", ErrInvalidAnchor, MaxQuoteBytes)
+		}
 	default:
 		return fmt.Errorf("%w: unknown kind %q", ErrInvalidAnchor, a.Kind)
-	}
-	if strings.TrimSpace(a.Ref) == "" {
-		return fmt.Errorf("%w: ref must not be empty", ErrInvalidAnchor)
 	}
 	return nil
 }

--- a/internal/comments/comments.go
+++ b/internal/comments/comments.go
@@ -1,0 +1,234 @@
+// Package comments holds user commentary attached to entities: a remark about
+// a property or a view section, stored alongside the graph rather than in it.
+//
+// # Why this is not in the graph
+//
+// A comment is a remark *about* an entity, not a fact *in* the domain model the
+// operator declared in schema.yaml. Modeling one as an entity would mean
+// fabricating a type the operator never wrote, and would drag commentary
+// through every mechanism the graph owns: the audit log, version capture, the
+// search index, `analyze_*`, and `/_schema`. None of those are wanted for a
+// note someone left on a field.
+//
+// So this is a separate service with its own backends, deliberately outside
+// store.Store and entitymanager — the same call [internal/userstate] makes for
+// snoozes, and for the same reason.
+//
+// # Authorship is stamped, never supplied
+//
+// [Comment.Author] and [Comment.ID] are written by the server from the request
+// principal; a client-supplied value for either is ignored. This is the reason
+// the service owns its own write path rather than routing through the graph:
+// none of the in-graph seams can stamp a trustworthy identity (automation
+// template vars resolve to the *git config* user, computed properties cannot
+// see the principal, and the elevated Lua write handle deliberately exposes no
+// entity write). A forgeable author on a comment is a forgeable attribution of
+// what someone said.
+//
+// # Ordering and identity are part of the contract
+//
+// [Store.List] returns comments oldest-first, ties broken by ID, so a thread
+// renders identically on every backend. Implementations must not return
+// storage order. [commentstest.RunAll] pins this, along with the concurrency
+// and re-key behavior below — a contract asserted in one place beats three
+// backends that each behave slightly differently.
+//
+// # Lifecycle
+//
+// Comments are keyed by target entity ID, so the service tracks the graph:
+// [Service.EntityRenamed] re-keys a target's comments and
+// [Service.EntityDelete] removes them. Rename emits exactly one store callback
+// (never delete+put), so a service that ignored it would silently strand every
+// comment on a renamed entity.
+package comments
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// Sentinel errors. Callers map these to transport-level responses; the HTTP
+// layer turns [ErrNotFound] into a 404 and the validation errors into 400s.
+var (
+	// ErrNotFound reports that no comment with the given ID exists on the
+	// target. Returned by Update and Delete.
+	ErrNotFound = errors.New("comments: not found")
+
+	// ErrEmptyBody reports a comment whose body is empty or whitespace-only.
+	ErrEmptyBody = errors.New("comments: body must not be empty")
+
+	// ErrBodyTooLong reports a body over [MaxBodyBytes].
+	ErrBodyTooLong = errors.New("comments: body too long")
+
+	// ErrBodyControlChars reports a body containing control characters other
+	// than newline and tab. The file backend serializes to YAML, where a NUL
+	// is at best lossy and at worst breaks the document.
+	ErrBodyControlChars = errors.New("comments: body contains control characters")
+
+	// ErrTooManyComments reports that the target is at [MaxPerTarget].
+	ErrTooManyComments = errors.New("comments: target has too many comments")
+
+	// ErrUnknownAuthor reports an attempt to write with no resolved principal.
+	// Refused rather than stored as a placeholder: an "unknown" author makes
+	// every *-own permission check meaningless, since no one can prove
+	// ownership of a comment nobody is recorded as having written.
+	ErrUnknownAuthor = errors.New("comments: cannot attribute comment to an unknown principal")
+
+	// ErrInvalidAnchor reports a structurally invalid anchor (unknown kind, or
+	// an empty ref). Note this is NOT the "ref names nothing" case: an anchor
+	// pointing at a property that has since been removed is a soft condition
+	// per DEC-HWZHA and surfaces as a warning on read, never an error.
+	ErrInvalidAnchor = errors.New("comments: invalid anchor")
+)
+
+// Limits on a single comment and on one target's thread. Both exist to bound
+// the file backend, which holds a target's whole thread in one document that is
+// read in full on every List.
+const (
+	// MaxBodyBytes caps a single comment body.
+	MaxBodyBytes = 16 * 1024
+
+	// MaxPerTarget caps how many comments one entity may carry.
+	MaxPerTarget = 500
+)
+
+// AnchorKind identifies what part of an entity a comment is attached to.
+//
+// The set is deliberately open to extension: stage 2 adds a text-range kind
+// carrying a quote and surrounding context, which is why [Anchor] is a struct
+// with a kind discriminator rather than a bare property name. Adding a kind
+// must not require migrating stored comments.
+type AnchorKind string
+
+const (
+	// AnchorProperty attaches a comment to a named property. Ref is the
+	// property name.
+	AnchorProperty AnchorKind = "property"
+
+	// AnchorSection attaches a comment to a view section. Ref is the
+	// section's slug id, which is derived from the operator-authored view
+	// heading rather than from user content — so it survives edits to the
+	// entity body.
+	AnchorSection AnchorKind = "section"
+)
+
+// Anchor locates a comment within its target entity.
+//
+// Both current kinds anchor by NAME (a property name, a section slug), never by
+// offset, which is what makes them immune to edits of the entity body. That is
+// the whole reason stage 1 ships these two kinds and defers text ranges.
+type Anchor struct {
+	Kind AnchorKind `json:"kind" yaml:"kind"`
+	Ref  string     `json:"ref"  yaml:"ref"`
+}
+
+// Validate reports whether the anchor is structurally usable.
+//
+// It checks shape only. Whether Ref names a property or section that currently
+// exists is deliberately NOT checked: an entity may be edited, or hand-edited
+// outside rela, so a ref that resolves to nothing is an expected state that
+// surfaces as a warning on read (DEC-HWZHA).
+func (a Anchor) Validate() error {
+	switch a.Kind {
+	case AnchorProperty, AnchorSection:
+	default:
+		return fmt.Errorf("%w: unknown kind %q", ErrInvalidAnchor, a.Kind)
+	}
+	if strings.TrimSpace(a.Ref) == "" {
+		return fmt.Errorf("%w: ref must not be empty", ErrInvalidAnchor)
+	}
+	return nil
+}
+
+// Comment is one remark attached to one entity.
+//
+// ID, Author and CreatedAt are server-written on Add; a value supplied by a
+// client for any of them is discarded (see the package doc). Body is markdown,
+// stored verbatim and rendered — sanitized — by the caller.
+type Comment struct {
+	ID        string    `json:"id"         yaml:"id"`
+	Author    string    `json:"author"     yaml:"author"`
+	CreatedAt time.Time `json:"created_at" yaml:"created_at"`
+	UpdatedAt time.Time `json:"updated_at,omitzero" yaml:"updated_at,omitempty"`
+	Anchor    Anchor    `json:"anchor"     yaml:"anchor"`
+	Body      string    `json:"body"       yaml:"body"`
+	Resolved  bool      `json:"resolved"   yaml:"resolved"`
+}
+
+// Target identifies the entity a thread of comments belongs to.
+//
+// Type is carried alongside ID because the HTTP surface is addressed by
+// (type, id) and the read gate needs both; it is not part of the storage key,
+// since entity IDs are unique across types.
+type Target struct {
+	Type string
+	ID   string
+}
+
+// Store persists comments per target entity.
+//
+// Every implementation must pass [commentstest.RunAll], which pins the parts of
+// this contract that are easy to get subtly different: List's ordering, the
+// server-minted ID, and that concurrent Adds to one target both survive.
+//
+// Nil: no method returns a nil error with a nil result; List returns an empty
+// slice rather than nil when a target has no comments.
+type Store interface {
+	// List returns the target's comments, oldest first, ties broken by ID.
+	// A target with no comments yields an empty slice, not an error.
+	List(ctx context.Context, target Target) ([]Comment, error)
+
+	// Add appends c to the target's thread. The caller has already set ID,
+	// Author and CreatedAt; implementations persist them as given rather
+	// than minting their own, so the values in an audit trail and the values
+	// stored agree.
+	Add(ctx context.Context, target Target, c Comment) error
+
+	// Update replaces the body and resolved flag of the comment with the
+	// given ID. Returns [ErrNotFound] if it does not exist. Author,
+	// CreatedAt and Anchor are immutable — editing a comment must not let it
+	// change who said it or what it was about.
+	Update(ctx context.Context, target Target, id string, body string, resolved bool) error
+
+	// Delete removes one comment. Returns [ErrNotFound] if absent.
+	Delete(ctx context.Context, target Target, id string) error
+
+	// DeleteTarget removes every comment on a target. Deleting a target with
+	// no comments is not an error.
+	DeleteTarget(ctx context.Context, target Target) error
+
+	// Rename re-keys a target's comments from oldID to newID, preserving
+	// order. Renaming a target with no comments is not an error.
+	Rename(ctx context.Context, oldID, newID string) error
+}
+
+// ValidateBody applies the size and character rules to a comment body.
+//
+// Allowlist-shaped: newline and tab are the only control characters permitted,
+// because a body is prose. Everything else in the C0 range (and DEL) is
+// refused rather than escaped, since the file backend round-trips through YAML
+// where those bytes are lossy.
+func ValidateBody(body string) error {
+	if strings.TrimSpace(body) == "" {
+		return ErrEmptyBody
+	}
+	if len(body) > MaxBodyBytes {
+		return fmt.Errorf("%w: %d bytes exceeds the %d-byte limit", ErrBodyTooLong, len(body), MaxBodyBytes)
+	}
+	if !utf8.ValidString(body) {
+		return fmt.Errorf("%w: body is not valid UTF-8", ErrBodyControlChars)
+	}
+	for _, r := range body {
+		if r == '\n' || r == '\t' {
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("%w: U+%04X", ErrBodyControlChars, r)
+		}
+	}
+	return nil
+}

--- a/internal/comments/comments.go
+++ b/internal/comments/comments.go
@@ -37,7 +37,7 @@
 //
 // Comments are keyed by target entity ID, so the service tracks the graph:
 // [Service.EntityRenamed] re-keys a target's comments and
-// [Service.EntityDelete] removes them. Rename emits exactly one store callback
+// [Service.EntityDeleted] removes them. Rename emits exactly one store callback
 // (never delete+put), so a service that ignored it would silently strand every
 // comment on a renamed entity.
 package comments

--- a/internal/comments/commentstest/commentstest.go
+++ b/internal/comments/commentstest/commentstest.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
 // Factory builds a fresh, empty store for one subtest.
@@ -53,6 +54,104 @@ func RunAll(t *testing.T, f Factory) {
 	t.Run("Rename", func(t *testing.T) { RunRenameTests(t, f) })
 	t.Run("Concurrency", func(t *testing.T) { RunConcurrencyTests(t, f) })
 	t.Run("RoundTrip", func(t *testing.T) { RunRoundTripTests(t, f) })
+	t.Run("Faces", func(t *testing.T) { RunFaceTests(t, f) })
+}
+
+// RunFaceTests pins the per-face contract (FEAT-9CD2MX).
+//
+// Comments are scoped to a content state: a remark on the draft is not a remark
+// on the published version, and the read gate is per face too. The key is
+// entity.FormatStateRef, so the DEFAULT face keeps the bare id — which is what
+// lets faces arrive without migrating a single stored comment.
+func RunFaceTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	faced := func(id string, face entity.Face) comments.Target {
+		return comments.Target{Type: "ticket", ID: id, Face: face}
+	}
+
+	t.Run("faces of one entity are independent threads", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Add(ctx, faced("TKT-1", ""), comment("def", 0, "alice", "on default")))
+		require.NoError(t, s.Add(ctx, faced("TKT-1", "draft"), comment("dft", 0, "bob", "on draft")))
+
+		got, err := s.List(ctx, faced("TKT-1", ""))
+		require.NoError(t, err)
+		require.Equal(t, []string{"def"}, ids(got), "the default face must not see the draft's thread")
+
+		got, err = s.List(ctx, faced("TKT-1", "draft"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"dft"}, ids(got))
+	})
+
+	t.Run("the default face keeps the bare id, so stored threads need no migration", func(t *testing.T) {
+		s := f(t)
+		// Written WITHOUT a face, as every pre-faces comment was.
+		require.NoError(t, s.Add(ctx, target("TKT-1"), comment("old", 0, "alice", "before faces")))
+
+		// Read back through an explicit default face: same thread.
+		got, err := s.List(ctx, faced("TKT-1", ""))
+		require.NoError(t, err)
+		require.Equal(t, []string{"old"}, ids(got))
+	})
+
+	t.Run("DeleteTarget removes one face, not the others", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Add(ctx, faced("TKT-1", ""), comment("def", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, faced("TKT-1", "draft"), comment("dft", 0, "bob", "two")))
+
+		require.NoError(t, s.DeleteTarget(ctx, faced("TKT-1", "draft")))
+
+		got, err := s.List(ctx, faced("TKT-1", ""))
+		require.NoError(t, err)
+		require.Equal(t, []string{"def"}, ids(got), "deleting one face must leave the others")
+
+		got, err = s.List(ctx, faced("TKT-1", "draft"))
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("DeleteAllFaces removes every face's thread", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Add(ctx, faced("TKT-1", ""), comment("def", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, faced("TKT-1", "draft"), comment("dft", 0, "bob", "two")))
+		require.NoError(t, s.Add(ctx, faced("TKT-2", "draft"), comment("other", 0, "eve", "other")))
+
+		require.NoError(t, s.DeleteAllFaces(ctx, "TKT-1"))
+
+		for _, face := range []entity.Face{"", "draft"} {
+			got, err := s.List(ctx, faced("TKT-1", face))
+			require.NoError(t, err)
+			require.Empty(t, got, "face %q should be gone", face)
+		}
+		// A different entity is untouched, including one sharing a face name.
+		got, err := s.List(ctx, faced("TKT-2", "draft"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"other"}, ids(got))
+	})
+
+	t.Run("Rename moves every face", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Add(ctx, faced("TKT-1", ""), comment("def", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, faced("TKT-1", "draft"), comment("dft", 0, "bob", "two")))
+
+		require.NoError(t, s.Rename(ctx, "TKT-1", "TKT-9"))
+
+		// Renaming only the bare id would strand the draft thread at an id
+		// that no longer resolves.
+		got, err := s.List(ctx, faced("TKT-9", ""))
+		require.NoError(t, err)
+		require.Equal(t, []string{"def"}, ids(got))
+
+		got, err = s.List(ctx, faced("TKT-9", "draft"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"dft"}, ids(got), "the draft face must move with the rename")
+
+		got, err = s.List(ctx, faced("TKT-1", "draft"))
+		require.NoError(t, err)
+		require.Empty(t, got, "nothing may remain at the old id")
+	})
 }
 
 // RunEmptyTests pins the empty-target contract.

--- a/internal/comments/commentstest/commentstest.go
+++ b/internal/comments/commentstest/commentstest.go
@@ -1,0 +1,410 @@
+// Package commentstest is the conformance suite every [comments.Store]
+// implementation must pass.
+//
+// It exists because the parts of the contract most likely to diverge between
+// backends are the ones nobody notices: List's ordering, whether a returned
+// slice aliases stored state, and whether two concurrent Adds both survive. A
+// backend that gets those subtly wrong still passes a hand-written smoke test
+// and then behaves differently in production from the one the tests ran
+// against.
+package commentstest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+)
+
+// Factory builds a fresh, empty store for one subtest.
+type Factory func(t *testing.T) comments.Store
+
+var base = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+func target(id string) comments.Target {
+	return comments.Target{Type: "ticket", ID: id}
+}
+
+// comment builds a comment with a fixed anchor, offsetting CreatedAt so
+// ordering assertions are unambiguous.
+func comment(id string, offset time.Duration, author, body string) comments.Comment {
+	return comments.Comment{
+		ID:        id,
+		Author:    author,
+		CreatedAt: base.Add(offset),
+		Anchor:    comments.Anchor{Kind: comments.AnchorProperty, Ref: "status"},
+		Body:      body,
+	}
+}
+
+// RunAll runs every conformance suite against f.
+func RunAll(t *testing.T, f Factory) {
+	t.Helper()
+	t.Run("Empty", func(t *testing.T) { RunEmptyTests(t, f) })
+	t.Run("Ordering", func(t *testing.T) { RunOrderingTests(t, f) })
+	t.Run("Update", func(t *testing.T) { RunUpdateTests(t, f) })
+	t.Run("Delete", func(t *testing.T) { RunDeleteTests(t, f) })
+	t.Run("Isolation", func(t *testing.T) { RunIsolationTests(t, f) })
+	t.Run("Rename", func(t *testing.T) { RunRenameTests(t, f) })
+	t.Run("Concurrency", func(t *testing.T) { RunConcurrencyTests(t, f) })
+	t.Run("RoundTrip", func(t *testing.T) { RunRoundTripTests(t, f) })
+}
+
+// RunEmptyTests pins the empty-target contract.
+func RunEmptyTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("unknown target lists empty, not error", func(t *testing.T) {
+		s := f(t)
+		got, err := s.List(ctx, target("TKT-none"))
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("empty slice not nil", func(t *testing.T) {
+		// Callers marshal this straight to JSON, where nil becomes `null` and
+		// an empty slice becomes `[]`. A client distinguishing the two would
+		// see different shapes from different backends.
+		s := f(t)
+		got, err := s.List(ctx, target("TKT-none"))
+		require.NoError(t, err)
+		require.NotNil(t, got)
+	})
+
+	t.Run("DeleteTarget on empty target is not an error", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.DeleteTarget(ctx, target("TKT-none")))
+	})
+}
+
+// RunOrderingTests pins the ordering contract: oldest first, ID breaking ties.
+func RunOrderingTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("oldest first regardless of insertion order", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-1")
+		// Inserted newest-first so storage order and contract order differ; a
+		// backend returning insertion order fails here.
+		require.NoError(t, s.Add(ctx, tgt, comment("c3", 2*time.Hour, "alice", "third")))
+		require.NoError(t, s.Add(ctx, tgt, comment("c1", 0, "alice", "first")))
+		require.NoError(t, s.Add(ctx, tgt, comment("c2", time.Hour, "bob", "second")))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		require.Equal(t, []string{"c1", "c2", "c3"}, ids(got))
+	})
+
+	t.Run("identical timestamps break ties by ID", func(t *testing.T) {
+		// A coarse clock can stamp two comments in one tick; without the
+		// tie-break the thread would reorder between reads.
+		s := f(t)
+		tgt := target("TKT-1")
+		require.NoError(t, s.Add(ctx, tgt, comment("zzz", 0, "alice", "z")))
+		require.NoError(t, s.Add(ctx, tgt, comment("aaa", 0, "alice", "a")))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Equal(t, []string{"aaa", "zzz"}, ids(got))
+	})
+}
+
+// RunUpdateTests pins which fields an update may change.
+func RunUpdateTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("updates body and resolved", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-1")
+		require.NoError(t, s.Add(ctx, tgt, comment("c1", 0, "alice", "before")))
+
+		require.NoError(t, s.Update(ctx, tgt, "c1", "after", true))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "after", got[0].Body)
+		require.True(t, got[0].Resolved)
+	})
+
+	t.Run("does not change author, created_at or anchor", func(t *testing.T) {
+		// An edit must not be able to rewrite who said something or what it
+		// was about — otherwise "edit your own comment" becomes a way to
+		// reattribute someone else's.
+		s := f(t)
+		tgt := target("TKT-1")
+		orig := comment("c1", 0, "alice", "before")
+		require.NoError(t, s.Add(ctx, tgt, orig))
+
+		require.NoError(t, s.Update(ctx, tgt, "c1", "after", false))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Equal(t, orig.Author, got[0].Author)
+		require.True(t, orig.CreatedAt.Equal(got[0].CreatedAt))
+		require.Equal(t, orig.Anchor, got[0].Anchor)
+	})
+
+	t.Run("missing comment reports ErrNotFound", func(t *testing.T) {
+		s := f(t)
+		err := s.Update(ctx, target("TKT-1"), "nope", "x", false)
+		require.ErrorIs(t, err, comments.ErrNotFound)
+	})
+}
+
+// RunDeleteTests pins deletion.
+func RunDeleteTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("removes only the named comment", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-1")
+		require.NoError(t, s.Add(ctx, tgt, comment("c1", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, tgt, comment("c2", time.Hour, "bob", "two")))
+
+		require.NoError(t, s.Delete(ctx, tgt, "c1"))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Equal(t, []string{"c2"}, ids(got))
+	})
+
+	t.Run("missing comment reports ErrNotFound", func(t *testing.T) {
+		s := f(t)
+		err := s.Delete(ctx, target("TKT-1"), "nope")
+		require.ErrorIs(t, err, comments.ErrNotFound)
+	})
+
+	t.Run("DeleteTarget removes the whole thread", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-1")
+		require.NoError(t, s.Add(ctx, tgt, comment("c1", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, tgt, comment("c2", time.Hour, "bob", "two")))
+
+		require.NoError(t, s.DeleteTarget(ctx, tgt))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}
+
+// RunIsolationTests pins that targets do not bleed into each other.
+func RunIsolationTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("targets are independent", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Add(ctx, target("TKT-1"), comment("c1", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, target("TKT-2"), comment("c2", 0, "bob", "two")))
+
+		got1, err := s.List(ctx, target("TKT-1"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"c1"}, ids(got1))
+
+		got2, err := s.List(ctx, target("TKT-2"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"c2"}, ids(got2))
+	})
+
+	t.Run("DeleteTarget leaves other targets alone", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Add(ctx, target("TKT-1"), comment("c1", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, target("TKT-2"), comment("c2", 0, "bob", "two")))
+
+		require.NoError(t, s.DeleteTarget(ctx, target("TKT-1")))
+
+		got, err := s.List(ctx, target("TKT-2"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"c2"}, ids(got))
+	})
+
+	t.Run("returned slice does not alias stored state", func(t *testing.T) {
+		// A backend handing out its backing array lets a caller mutate stored
+		// comments in place — impossible for a persistent backend, so tests
+		// written against such a store would not transfer.
+		s := f(t)
+		tgt := target("TKT-1")
+		require.NoError(t, s.Add(ctx, tgt, comment("c1", 0, "alice", "original")))
+
+		first, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		first[0].Body = "mutated"
+
+		second, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Equal(t, "original", second[0].Body)
+	})
+}
+
+// RunRenameTests pins the re-key path.
+//
+// This is the behavior that keeps comments reachable across an entity rename:
+// the store emits exactly one rename callback, so if this is wrong the comments
+// remain on disk under an ID nothing resolves to.
+func RunRenameTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("moves comments to the new id", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Add(ctx, target("TKT-old"), comment("c1", 0, "alice", "one")))
+
+		require.NoError(t, s.Rename(ctx, "TKT-old", "TKT-new"))
+
+		moved, err := s.List(ctx, target("TKT-new"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"c1"}, ids(moved))
+
+		old, err := s.List(ctx, target("TKT-old"))
+		require.NoError(t, err)
+		require.Empty(t, old)
+	})
+
+	t.Run("preserves order across the rename", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-old")
+		require.NoError(t, s.Add(ctx, tgt, comment("c1", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, tgt, comment("c2", time.Hour, "bob", "two")))
+
+		require.NoError(t, s.Rename(ctx, "TKT-old", "TKT-new"))
+
+		got, err := s.List(ctx, target("TKT-new"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"c1", "c2"}, ids(got))
+	})
+
+	t.Run("renaming a target with no comments is not an error", func(t *testing.T) {
+		s := f(t)
+		require.NoError(t, s.Rename(ctx, "TKT-none", "TKT-new"))
+	})
+
+	t.Run("merges into an occupied destination", func(t *testing.T) {
+		// rela permits ID reuse, so the destination is not guaranteed empty.
+		// Merging is the conservative choice: discarding the occupant's
+		// comments would destroy data the operator never asked to remove.
+		s := f(t)
+		require.NoError(t, s.Add(ctx, target("TKT-old"), comment("c1", 0, "alice", "one")))
+		require.NoError(t, s.Add(ctx, target("TKT-new"), comment("c2", time.Hour, "bob", "two")))
+
+		require.NoError(t, s.Rename(ctx, "TKT-old", "TKT-new"))
+
+		got, err := s.List(ctx, target("TKT-new"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"c1", "c2"}, ids(got))
+	})
+}
+
+// RunConcurrencyTests pins that concurrent writes to one target do not lose
+// updates.
+//
+// This is the read-modify-write hazard: a backend that reads a thread, appends,
+// and writes it back without serializing will drop comments under load — and
+// will pass every sequential test.
+func RunConcurrencyTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("concurrent adds to one target all survive", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-1")
+
+		const n = 16
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		for i := range n {
+			wg.Go(func() {
+				c := comment(fmt.Sprintf("c%02d", i), time.Duration(i)*time.Minute, "alice", "body")
+				errs[i] = s.Add(ctx, tgt, c)
+			})
+		}
+		wg.Wait()
+		for _, err := range errs {
+			require.NoError(t, err)
+		}
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Len(t, got, n, "every concurrent add must survive")
+	})
+
+	t.Run("concurrent adds across targets all survive", func(t *testing.T) {
+		s := f(t)
+
+		const n = 16
+		var wg sync.WaitGroup
+		for i := range n {
+			wg.Go(func() {
+				tgt := target(fmt.Sprintf("TKT-%02d", i))
+				_ = s.Add(ctx, tgt, comment("c1", 0, "alice", "body"))
+			})
+		}
+		wg.Wait()
+
+		for i := range n {
+			got, err := s.List(ctx, target(fmt.Sprintf("TKT-%02d", i)))
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+		}
+	})
+}
+
+// RunRoundTripTests pins that every field survives storage unchanged.
+func RunRoundTripTests(t *testing.T, f Factory) {
+	t.Helper()
+	ctx := context.Background()
+
+	t.Run("all fields round-trip", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-1")
+		want := comments.Comment{
+			ID:        "c1",
+			Author:    "alice@example.com",
+			CreatedAt: base,
+			Anchor:    comments.Anchor{Kind: comments.AnchorSection, Ref: "acceptance-criteria"},
+			Body:      "A body with **markdown**, a newline\nand a tab\there.",
+			Resolved:  true,
+		}
+		require.NoError(t, s.Add(ctx, tgt, want))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, want.ID, got[0].ID)
+		require.Equal(t, want.Author, got[0].Author)
+		require.True(t, want.CreatedAt.Equal(got[0].CreatedAt), "CreatedAt must round-trip")
+		require.Equal(t, want.Anchor, got[0].Anchor)
+		require.Equal(t, want.Body, got[0].Body)
+		require.Equal(t, want.Resolved, got[0].Resolved)
+	})
+
+	t.Run("unicode body round-trips", func(t *testing.T) {
+		s := f(t)
+		tgt := target("TKT-1")
+		body := "emoji 🎉, RTL \u202bمرحبا\u202c, CJK 日本語, quote \"x\" and 'y'"
+		require.NoError(t, s.Add(ctx, tgt, comment("c1", 0, "alice", body)))
+
+		got, err := s.List(ctx, tgt)
+		require.NoError(t, err)
+		require.Equal(t, body, got[0].Body)
+	})
+}
+
+func ids(list []comments.Comment) []string {
+	out := make([]string, len(list))
+	for i, c := range list {
+		out[i] = c.ID
+	}
+	return out
+}

--- a/internal/comments/filecomments/file.go
+++ b/internal/comments/filecomments/file.go
@@ -25,12 +25,14 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/storage"
 )
 
@@ -83,7 +85,7 @@ var _ comments.Store = (*Store)(nil)
 func (s *Store) List(_ context.Context, target comments.Target) ([]comments.Comment, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.readThread(target.ID)
+	return s.readThread(target.Key())
 }
 
 // Add appends a comment to the target's thread.
@@ -91,11 +93,11 @@ func (s *Store) Add(_ context.Context, target comments.Target, c comments.Commen
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	list, err := s.readThread(target.ID)
+	list, err := s.readThread(target.Key())
 	if err != nil {
 		return err
 	}
-	return s.writeThread(target.ID, append(list, c))
+	return s.writeThread(target.Key(), append(list, c))
 }
 
 // Update replaces the mutable fields of one comment.
@@ -103,7 +105,7 @@ func (s *Store) Update(_ context.Context, target comments.Target, id, body strin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	list, err := s.readThread(target.ID)
+	list, err := s.readThread(target.Key())
 	if err != nil {
 		return err
 	}
@@ -113,7 +115,7 @@ func (s *Store) Update(_ context.Context, target comments.Target, id, body strin
 		}
 		list[i].Body = body
 		list[i].Resolved = resolved
-		return s.writeThread(target.ID, list)
+		return s.writeThread(target.Key(), list)
 	}
 	return comments.ErrNotFound
 }
@@ -124,7 +126,7 @@ func (s *Store) Delete(_ context.Context, target comments.Target, id string) err
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	list, err := s.readThread(target.ID)
+	list, err := s.readThread(target.Key())
 	if err != nil {
 		return err
 	}
@@ -136,9 +138,9 @@ func (s *Store) Delete(_ context.Context, target comments.Target, id string) err
 		remaining = append(remaining, list[:i]...)
 		remaining = append(remaining, list[i+1:]...)
 		if len(remaining) == 0 {
-			return s.removeThread(target.ID)
+			return s.removeThread(target.Key())
 		}
-		return s.writeThread(target.ID, remaining)
+		return s.writeThread(target.Key(), remaining)
 	}
 	return comments.ErrNotFound
 }
@@ -147,7 +149,63 @@ func (s *Store) Delete(_ context.Context, target comments.Target, id string) err
 func (s *Store) DeleteTarget(_ context.Context, target comments.Target) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.removeThread(target.ID)
+	return s.removeThread(target.Key())
+}
+
+// DeleteAllFaces removes every face's thread for an entity id.
+func (s *Store) DeleteAllFaces(_ context.Context, entityID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	keys, err := s.threadKeysFor(entityID)
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		if err := s.removeThread(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// threadKeysFor lists the stored thread keys belonging to an entity id — the
+// bare id plus any "id@face".
+//
+// Reads the directory rather than guessing at declared faces: the store must
+// not know the metamodel, and a thread written under a face the schema has
+// since dropped still has to be reachable for cleanup.
+//
+// Callers must hold s.mu.
+func (s *Store) threadKeysFor(entityID string) ([]string, error) {
+	// WalkAll rather than ReadDir("."): the rooted FS refuses "." as a key
+	// (it reads as an empty/traversal segment), and WalkAll is the method that
+	// exists for walking the root itself.
+	var out []string
+	err := s.root.WalkAll(func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		key, ok := strings.CutSuffix(path, ".yaml")
+		if !ok {
+			return nil
+		}
+		if key == entityID || strings.HasPrefix(key, entityID+entity.StateRefSeparator) {
+			out = append(out, key)
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("filecomments: listing threads: %w", err)
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // Rename re-keys a thread, merging into any thread already at newID.
@@ -162,21 +220,34 @@ func (s *Store) Rename(_ context.Context, oldID, newID string) error {
 	if oldID == newID {
 		return nil
 	}
-	moving, err := s.readThread(oldID)
+	// Move EVERY face's thread: an entity with a draft and a published face has
+	// a thread per face, and re-keying only the default one would strand the
+	// rest at an id that no longer exists.
+	keys, err := s.threadKeysFor(oldID)
 	if err != nil {
 		return err
 	}
-	if len(moving) == 0 {
-		return nil
+	for _, key := range keys {
+		moving, err := s.readThread(key)
+		if err != nil {
+			return err
+		}
+		if len(moving) == 0 {
+			continue
+		}
+		dest := newID + strings.TrimPrefix(key, oldID)
+		existing, err := s.readThread(dest)
+		if err != nil {
+			return err
+		}
+		if err := s.writeThread(dest, append(existing, moving...)); err != nil {
+			return err
+		}
+		if err := s.removeThread(key); err != nil {
+			return err
+		}
 	}
-	existing, err := s.readThread(newID)
-	if err != nil {
-		return err
-	}
-	if err := s.writeThread(newID, append(existing, moving...)); err != nil {
-		return err
-	}
-	return s.removeThread(oldID)
+	return nil
 }
 
 // readThread loads and orders one target's comments. A missing file is an
@@ -256,7 +327,10 @@ func threadFile(targetID string) (string, error) {
 	return targetID + ".yaml", nil
 }
 
-// safeID reports whether an entity ID is usable as a single path segment.
+// safeID reports whether a thread KEY is usable as a single path segment.
+//
+// The key is `entity.FormatStateRef` output: a bare id for the default face,
+// "id@face" otherwise.
 //
 // Allowlist: entity IDs are generated from a base36 alphabet with an operator
 // prefix, or are manual IDs the metamodel already constrains, so the permitted
@@ -272,6 +346,11 @@ func safeID(id string) bool {
 		case r >= 'A' && r <= 'Z':
 		case r >= '0' && r <= '9':
 		case r == '-' || r == '_' || r == '.':
+		// '@' joins an id to its face in the boundary serialization
+		// ("PAGE-1@draft", entity.StateRefSeparator). Filename-legal, excluded
+		// from the entity-ID grammar, and the reason a per-face thread needs no
+		// separate directory level.
+		case r == '@':
 		default:
 			return false
 		}

--- a/internal/comments/filecomments/file.go
+++ b/internal/comments/filecomments/file.go
@@ -1,0 +1,280 @@
+// Package filecomments stores comments as YAML, one file per target entity,
+// under a directory the caller roots (conventionally `.rela/comments/`).
+//
+// This is the default backend, matching rela's file-first tier: a comment
+// thread is readable, diffable and hand-editable like the entities it annotates.
+//
+// # Durability and concurrency
+//
+// A target's whole thread lives in one file, so a torn write would lose every
+// comment on that entity rather than just the new one. Writes therefore go
+// through [storage.SafeFS], which writes a temp file, fsyncs it, renames
+// (atomic on POSIX) and fsyncs the parent directory.
+//
+// Every mutation is read-modify-write, so the store serializes writes with a
+// single mutex. That is the same guarantee fsstore's Tx gives the entity store
+// (DEC-8UIL0, "write mutex, mutual exclusion only"): it does not make a
+// mutation transactional across targets, only free of lost updates. A
+// cross-process writer is out of scope for this tier, exactly as it is for
+// fsstore.
+package filecomments
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+// filePerm is the mode for a comments file. Comments are no more sensitive
+// than the entities they annotate, which fsstore writes 0644.
+const filePerm = 0o644
+
+// Store persists comment threads as per-target YAML files.
+type Store struct {
+	mu sync.Mutex
+	// root is a RootedFS over a SafeFS, so a write is both contained
+	// (traversal refused) and atomic (temp + fsync + rename).
+	root *storage.RootedFS
+}
+
+// thread is the on-disk document.
+//
+// A struct rather than a bare slice so the format can gain fields (a schema
+// version, say) without rewriting every stored file.
+type thread struct {
+	Comments []comments.Comment `yaml:"comments"`
+}
+
+// New returns a Store writing under root.
+//
+// root is created on first write, not here: an operator who never enables
+// commenting should not find an empty directory in their project.
+//
+// Nil: base is required; it is the filesystem the store writes through.
+func New(base storage.FS, root string) (*Store, error) {
+	if base == nil {
+		return nil, errors.New("filecomments: New requires a filesystem")
+	}
+	if strings.TrimSpace(root) == "" {
+		return nil, errors.New("filecomments: New requires a root directory")
+	}
+	// SafeFS first, then root it: RootedFS delegates writes to the FS it
+	// wraps, so this order gives containment over atomic writes. The reverse
+	// would give atomic writes over an uncontained filesystem.
+	rooted, err := storage.NewRootedFS(storage.NewSafeFS(base), root)
+	if err != nil {
+		return nil, fmt.Errorf("filecomments: rooting at %q: %w", root, err)
+	}
+	return &Store{root: rooted}, nil
+}
+
+var _ comments.Store = (*Store)(nil)
+
+// List returns the target's comments in the contract order.
+func (s *Store) List(_ context.Context, target comments.Target) ([]comments.Comment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.readThread(target.ID)
+}
+
+// Add appends a comment to the target's thread.
+func (s *Store) Add(_ context.Context, target comments.Target, c comments.Comment) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	list, err := s.readThread(target.ID)
+	if err != nil {
+		return err
+	}
+	return s.writeThread(target.ID, append(list, c))
+}
+
+// Update replaces the mutable fields of one comment.
+func (s *Store) Update(_ context.Context, target comments.Target, id, body string, resolved bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	list, err := s.readThread(target.ID)
+	if err != nil {
+		return err
+	}
+	for i := range list {
+		if list[i].ID != id {
+			continue
+		}
+		list[i].Body = body
+		list[i].Resolved = resolved
+		return s.writeThread(target.ID, list)
+	}
+	return comments.ErrNotFound
+}
+
+// Delete removes one comment, dropping the file once its last comment goes so
+// an emptied thread leaves no residue in the project tree.
+func (s *Store) Delete(_ context.Context, target comments.Target, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	list, err := s.readThread(target.ID)
+	if err != nil {
+		return err
+	}
+	for i := range list {
+		if list[i].ID != id {
+			continue
+		}
+		remaining := make([]comments.Comment, 0, len(list)-1)
+		remaining = append(remaining, list[:i]...)
+		remaining = append(remaining, list[i+1:]...)
+		if len(remaining) == 0 {
+			return s.removeThread(target.ID)
+		}
+		return s.writeThread(target.ID, remaining)
+	}
+	return comments.ErrNotFound
+}
+
+// DeleteTarget removes a target's whole thread.
+func (s *Store) DeleteTarget(_ context.Context, target comments.Target) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.removeThread(target.ID)
+}
+
+// Rename re-keys a thread, merging into any thread already at newID.
+//
+// Merging rather than replacing because rela permits ID reuse, so the
+// destination is not guaranteed empty — and silently discarding the occupant's
+// comments would destroy data nobody asked to remove.
+func (s *Store) Rename(_ context.Context, oldID, newID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if oldID == newID {
+		return nil
+	}
+	moving, err := s.readThread(oldID)
+	if err != nil {
+		return err
+	}
+	if len(moving) == 0 {
+		return nil
+	}
+	existing, err := s.readThread(newID)
+	if err != nil {
+		return err
+	}
+	if err := s.writeThread(newID, append(existing, moving...)); err != nil {
+		return err
+	}
+	return s.removeThread(oldID)
+}
+
+// readThread loads and orders one target's comments. A missing file is an
+// empty thread, not an error: "no comments yet" and "never commented on" are
+// the same state to every caller.
+//
+// Callers must hold s.mu.
+func (s *Store) readThread(targetID string) ([]comments.Comment, error) {
+	name, err := threadFile(targetID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := s.root.ReadFile(name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+			return []comments.Comment{}, nil
+		}
+		return nil, fmt.Errorf("filecomments: reading %s: %w", name, err)
+	}
+	var doc thread
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("filecomments: parsing %s: %w", name, err)
+	}
+	if doc.Comments == nil {
+		doc.Comments = []comments.Comment{}
+	}
+	comments.SortComments(doc.Comments)
+	return doc.Comments, nil
+}
+
+// writeThread persists a target's comments atomically.
+//
+// Callers must hold s.mu.
+func (s *Store) writeThread(targetID string, list []comments.Comment) error {
+	name, err := threadFile(targetID)
+	if err != nil {
+		return err
+	}
+	comments.SortComments(list)
+	data, err := yaml.Marshal(thread{Comments: list})
+	if err != nil {
+		return fmt.Errorf("filecomments: encoding %s: %w", name, err)
+	}
+	if err := s.root.WriteFile(name, data, filePerm); err != nil {
+		return fmt.Errorf("filecomments: writing %s: %w", name, err)
+	}
+	return nil
+}
+
+// removeThread deletes a target's file, treating an absent file as success.
+//
+// Callers must hold s.mu.
+func (s *Store) removeThread(targetID string) error {
+	name, err := threadFile(targetID)
+	if err != nil {
+		return err
+	}
+	if err := s.root.Remove(name); err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("filecomments: removing %s: %w", name, err)
+	}
+	return nil
+}
+
+// threadFile maps a target entity ID to its file name.
+//
+// The ID is validated here as well as at the HTTP boundary. RootedFS already
+// refuses traversal, so this is defense in depth rather than the only guard —
+// but it is cheap, and it keeps a non-HTTP caller (a future CLI command) from
+// reaching the filesystem with an unchecked id.
+func threadFile(targetID string) (string, error) {
+	if !safeID(targetID) {
+		return "", fmt.Errorf("filecomments: unsafe target id %q", targetID)
+	}
+	return targetID + ".yaml", nil
+}
+
+// safeID reports whether an entity ID is usable as a single path segment.
+//
+// Allowlist: entity IDs are generated from a base36 alphabet with an operator
+// prefix, or are manual IDs the metamodel already constrains, so the permitted
+// set is deliberately narrow. Leading dots are refused so no id can produce a
+// hidden file.
+func safeID(id string) bool {
+	if id == "" || strings.HasPrefix(id, ".") {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/comments/filecomments/file_test.go
+++ b/internal/comments/filecomments/file_test.go
@@ -1,0 +1,126 @@
+package filecomments_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/comments/commentstest"
+	"github.com/Sourcehaven-BV/rela/internal/comments/filecomments"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func newStore(t *testing.T) (store *filecomments.Store, root string) {
+	t.Helper()
+	root = t.TempDir()
+	s, err := filecomments.New(storage.NewOsFS(), root)
+	require.NoError(t, err)
+	return s, root
+}
+
+func TestConformance(t *testing.T) {
+	commentstest.RunAll(t, func(t *testing.T) comments.Store {
+		t.Helper()
+		s, _ := newStore(t)
+		return s
+	})
+}
+
+func TestNew_RejectsMissingArgs(t *testing.T) {
+	t.Run("nil filesystem", func(t *testing.T) {
+		_, err := filecomments.New(nil, t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("empty root", func(t *testing.T) {
+		_, err := filecomments.New(storage.NewOsFS(), "  ")
+		require.Error(t, err)
+	})
+}
+
+// TestNew_CreatesNothingUntilFirstWrite pins AC1's storage half: an operator
+// who never comments must not find a directory appear in their project.
+func TestNew_CreatesNothingUntilFirstWrite(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "comments")
+
+	_, err := filecomments.New(storage.NewOsFS(), root)
+	require.NoError(t, err)
+
+	_, err = os.Stat(root)
+	require.ErrorIs(t, err, os.ErrNotExist, "no directory until something is stored")
+}
+
+// TestUnsafeTargetID_Refused pins that a traversal-shaped id cannot escape the
+// root. RootedFS would also refuse it; this asserts the store's own guard so a
+// non-HTTP caller cannot reach the filesystem with an unchecked id.
+func TestUnsafeTargetID_Refused(t *testing.T) {
+	s, root := newStore(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"../escape", "..", ".hidden", "a/b", ""} {
+		t.Run(id, func(t *testing.T) {
+			_, err := s.List(ctx, comments.Target{Type: "ticket", ID: id})
+			require.Error(t, err, "unsafe id must be refused")
+		})
+	}
+
+	// Nothing leaked outside the root.
+	entries, err := os.ReadDir(filepath.Dir(root))
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.NotContains(t, e.Name(), "escape")
+	}
+}
+
+// TestThreadFileIsReadableYAML pins the file-first promise: a stored thread is
+// a plain, diffable document, not an opaque blob.
+func TestThreadFileIsReadableYAML(t *testing.T) {
+	s, root := newStore(t)
+	ctx := context.Background()
+	tgt := comments.Target{Type: "ticket", ID: "TKT-1"}
+
+	require.NoError(t, s.Add(ctx, tgt, comments.Comment{
+		ID:     "c1",
+		Author: "alice@example.com",
+		Anchor: comments.Anchor{Kind: comments.AnchorProperty, Ref: "status"},
+		Body:   "Looks wrong to me",
+	}))
+
+	data, err := os.ReadFile(filepath.Join(root, "TKT-1.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(data), "alice@example.com")
+	require.Contains(t, string(data), "Looks wrong to me")
+	require.Contains(t, string(data), "status")
+}
+
+// TestEmptiedThreadRemovesFile pins that deleting the last comment leaves no
+// residue, so an operator's tree does not accumulate empty documents.
+func TestEmptiedThreadRemovesFile(t *testing.T) {
+	s, root := newStore(t)
+	ctx := context.Background()
+	tgt := comments.Target{Type: "ticket", ID: "TKT-1"}
+
+	require.NoError(t, s.Add(ctx, tgt, comments.Comment{ID: "c1", Author: "alice", Body: "x"}))
+	require.NoError(t, s.Delete(ctx, tgt, "c1"))
+
+	_, err := os.Stat(filepath.Join(root, "TKT-1.yaml"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestCorruptThreadSurfacesError pins that a hand-broken file reports rather
+// than silently reading as an empty thread — losing comments quietly is worse
+// than refusing to serve them.
+func TestCorruptThreadSurfacesError(t *testing.T) {
+	s, root := newStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "TKT-1.yaml"), []byte("comments: [oh dear\n"), 0o644))
+
+	_, err := s.List(ctx, comments.Target{Type: "ticket", ID: "TKT-1"})
+	require.Error(t, err)
+}

--- a/internal/comments/memcomments/mem.go
+++ b/internal/comments/memcomments/mem.go
@@ -1,0 +1,114 @@
+// Package memcomments is an in-memory [comments.Store] for tests and the
+// memory build. Nothing survives process exit.
+package memcomments
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+)
+
+// Store keeps every target's thread in a map.
+//
+// A single mutex guards the whole map rather than one per target: the map
+// itself is mutated by Rename and DeleteTarget, and a per-target lock would
+// not cover that. Contention is irrelevant at the scale this backend serves.
+type Store struct {
+	mu     sync.Mutex
+	byward map[string][]comments.Comment
+}
+
+// New returns an empty store.
+func New() *Store {
+	return &Store{byward: map[string][]comments.Comment{}}
+}
+
+var _ comments.Store = (*Store)(nil)
+
+// List returns the target's comments in the contract order, as a copy.
+//
+// The copy is load-bearing: handing out the backing slice would let a caller
+// mutate stored comments in place, which no persistent backend permits — so
+// tests passing against this one would fail against those.
+func (s *Store) List(_ context.Context, target comments.Target) ([]comments.Comment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stored := s.byward[target.ID]
+	out := make([]comments.Comment, len(stored))
+	copy(out, stored)
+	comments.SortComments(out)
+	return out, nil
+}
+
+// Add appends a comment to the target's thread.
+func (s *Store) Add(_ context.Context, target comments.Target, c comments.Comment) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.byward[target.ID] = append(s.byward[target.ID], c)
+	return nil
+}
+
+// Update replaces the mutable fields of one comment.
+func (s *Store) Update(_ context.Context, target comments.Target, id, body string, resolved bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stored := s.byward[target.ID]
+	for i := range stored {
+		if stored[i].ID != id {
+			continue
+		}
+		stored[i].Body = body
+		stored[i].Resolved = resolved
+		return nil
+	}
+	return comments.ErrNotFound
+}
+
+// Delete removes one comment.
+func (s *Store) Delete(_ context.Context, target comments.Target, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stored := s.byward[target.ID]
+	for i := range stored {
+		if stored[i].ID != id {
+			continue
+		}
+		s.byward[target.ID] = append(stored[:i:i], stored[i+1:]...)
+		if len(s.byward[target.ID]) == 0 {
+			delete(s.byward, target.ID)
+		}
+		return nil
+	}
+	return comments.ErrNotFound
+}
+
+// DeleteTarget drops a target's whole thread.
+func (s *Store) DeleteTarget(_ context.Context, target comments.Target) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.byward, target.ID)
+	return nil
+}
+
+// Rename re-keys a target's thread, appending to any thread already filed
+// under newID rather than replacing it — ID reuse means the destination is not
+// guaranteed empty, and silently discarding the occupant's comments would be
+// worse than merging.
+func (s *Store) Rename(_ context.Context, oldID, newID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stored, ok := s.byward[oldID]
+	if !ok {
+		return nil
+	}
+	delete(s.byward, oldID)
+	s.byward[newID] = append(s.byward[newID], stored...)
+	return nil
+}

--- a/internal/comments/memcomments/mem.go
+++ b/internal/comments/memcomments/mem.go
@@ -4,9 +4,12 @@ package memcomments
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 )
 
 // Store keeps every target's thread in a map.
@@ -35,7 +38,7 @@ func (s *Store) List(_ context.Context, target comments.Target) ([]comments.Comm
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stored := s.byward[target.ID]
+	stored := s.byward[target.Key()]
 	out := make([]comments.Comment, len(stored))
 	copy(out, stored)
 	comments.SortComments(out)
@@ -47,7 +50,7 @@ func (s *Store) Add(_ context.Context, target comments.Target, c comments.Commen
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.byward[target.ID] = append(s.byward[target.ID], c)
+	s.byward[target.Key()] = append(s.byward[target.Key()], c)
 	return nil
 }
 
@@ -56,7 +59,7 @@ func (s *Store) Update(_ context.Context, target comments.Target, id, body strin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stored := s.byward[target.ID]
+	stored := s.byward[target.Key()]
 	for i := range stored {
 		if stored[i].ID != id {
 			continue
@@ -73,14 +76,14 @@ func (s *Store) Delete(_ context.Context, target comments.Target, id string) err
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stored := s.byward[target.ID]
+	stored := s.byward[target.Key()]
 	for i := range stored {
 		if stored[i].ID != id {
 			continue
 		}
-		s.byward[target.ID] = append(stored[:i:i], stored[i+1:]...)
-		if len(s.byward[target.ID]) == 0 {
-			delete(s.byward, target.ID)
+		s.byward[target.Key()] = append(stored[:i:i], stored[i+1:]...)
+		if len(s.byward[target.Key()]) == 0 {
+			delete(s.byward, target.Key())
 		}
 		return nil
 	}
@@ -92,7 +95,18 @@ func (s *Store) DeleteTarget(_ context.Context, target comments.Target) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.byward, target.ID)
+	delete(s.byward, target.Key())
+	return nil
+}
+
+// DeleteAllFaces removes every face's thread for an entity id.
+func (s *Store) DeleteAllFaces(_ context.Context, entityID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, key := range faceKeysFor(s.byward, entityID) {
+		delete(s.byward, key)
+	}
 	return nil
 }
 
@@ -104,11 +118,39 @@ func (s *Store) Rename(_ context.Context, oldID, newID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stored, ok := s.byward[oldID]
-	if !ok {
+	if oldID == newID {
 		return nil
 	}
-	delete(s.byward, oldID)
-	s.byward[newID] = append(s.byward[newID], stored...)
+	// Move EVERY face's thread, not just the bare id: an entity with a draft
+	// and a published face keeps a thread per face, and re-keying only the
+	// default one would strand the rest at an id that no longer exists.
+	for _, key := range faceKeysFor(s.byward, oldID) {
+		stored := s.byward[key]
+		delete(s.byward, key)
+		dest := reKey(key, oldID, newID)
+		s.byward[dest] = append(s.byward[dest], stored...)
+		comments.SortComments(s.byward[dest])
+	}
 	return nil
+}
+
+// faceKeysFor returns every thread key belonging to id — the bare id plus any
+// "id@face" — so a rename or delete covers all of an entity's faces.
+func faceKeysFor[V any](m map[string]V, id string) []string {
+	var out []string
+	for k := range m {
+		if k == id || strings.HasPrefix(k, id+entity.StateRefSeparator) {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// reKey swaps the id half of a thread key, preserving the face.
+func reKey(key, oldID, newID string) string {
+	if key == oldID {
+		return newID
+	}
+	return newID + strings.TrimPrefix(key, oldID)
 }

--- a/internal/comments/memcomments/mem_test.go
+++ b/internal/comments/memcomments/mem_test.go
@@ -1,0 +1,15 @@
+package memcomments_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/comments/commentstest"
+	"github.com/Sourcehaven-BV/rela/internal/comments/memcomments"
+)
+
+func TestConformance(t *testing.T) {
+	commentstest.RunAll(t, func(*testing.T) comments.Store {
+		return memcomments.New()
+	})
+}

--- a/internal/comments/service.go
+++ b/internal/comments/service.go
@@ -180,7 +180,9 @@ func (s *Service) EntityRenamed(ctx context.Context, oldID, newID string) error 
 // reuse, so a later entity taking this id would otherwise inherit the previous
 // occupant's thread and present someone else's remarks as its own.
 func (s *Service) EntityDeleted(ctx context.Context, entityID string) error {
-	return s.store.DeleteTarget(ctx, Target{ID: entityID})
+	// All faces: the entity is gone, so a thread left on any face would be
+	// stranded at an id nothing can reach.
+	return s.store.DeleteAllFaces(ctx, entityID)
 }
 
 // authorFrom resolves the comment author from ctx.

--- a/internal/comments/service.go
+++ b/internal/comments/service.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
@@ -154,32 +153,34 @@ func (s *Service) Delete(ctx context.Context, target Target, id string) error {
 	return s.store.Delete(ctx, target, id)
 }
 
-// EntityPut implements [store.EntityObserver]. Comments key off the entity ID
-// only, so an ordinary create or update changes nothing for them.
-func (s *Service) EntityPut(*entity.Entity) error { return nil }
-
-// EntityDelete implements [store.EntityObserver] by dropping the deleted
-// entity's comments.
+// EntityRenamed re-keys the renamed entity's comments.
 //
-// Without this a later entity reusing the ID would inherit the previous
-// occupant's comments — rela permits ID reuse, so this is reachable, not
-// theoretical.
-func (s *Service) EntityDelete(id string) error {
-	return s.store.DeleteTarget(context.Background(), Target{ID: id})
-}
-
-// EntityRenamed implements [store.EntityObserver] by re-keying the renamed
-// entity's comments.
+// This implements entitymanager's AliasRewriter hook rather than
+// [store.EntityObserver], for the reason that hook documents: every store fires
+// the observer as `_ = o.EntityRenamed(...)`, discarding the error. That is the
+// right trade for a search index, which can be rebuilt from the store. It is
+// the wrong trade here — comments exist ONLY in the comment store, so a
+// swallowed re-key failure leaves a thread filed under an id nothing resolves
+// to, still on disk and completely unreachable, with no signal anywhere.
 //
-// This callback is load-bearing: rename emits EXACTLY this one notification —
-// never EntityDelete(oldID) followed by EntityPut — so a service that did not
-// handle it would leave every comment filed under an ID nothing resolves to.
-// The comments would still be on disk and completely unreachable.
-func (s *Service) EntityRenamed(oldID string, renamed *entity.Entity) error {
-	if renamed == nil || oldID == renamed.ID {
+// Load-bearing either way: rename emits exactly one notification, never a
+// delete followed by a create, so a service that ignored it would strand every
+// comment on every renamed entity.
+func (s *Service) EntityRenamed(ctx context.Context, oldID, newID string) error {
+	if oldID == newID {
 		return nil
 	}
-	return s.store.Rename(context.Background(), oldID, renamed.ID)
+	return s.store.Rename(ctx, oldID, newID)
+}
+
+// EntityDeleted drops the deleted entity's comments.
+//
+// Unlike the CalDAV alias service — which deliberately KEEPS its references so
+// a stale client write can be refused — comments are dropped: rela permits id
+// reuse, so a later entity taking this id would otherwise inherit the previous
+// occupant's thread and present someone else's remarks as its own.
+func (s *Service) EntityDeleted(ctx context.Context, entityID string) error {
+	return s.store.DeleteTarget(ctx, Target{ID: entityID})
 }
 
 // authorFrom resolves the comment author from ctx.

--- a/internal/comments/service.go
+++ b/internal/comments/service.go
@@ -1,0 +1,230 @@
+package comments
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// idBytes is the entropy in a minted comment ID. 10 bytes -> 16 base32
+// characters, which is far more than a per-target thread needs; comment IDs
+// are opaque handles, never typed by a human, so there is no reason to trade
+// collision headroom for brevity the way entity IDs do.
+const idBytes = 10
+
+// idEncoding is unpadded lowercase base32 — case-insensitive and free of the
+// characters that would complicate a URL path segment.
+var idEncoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+
+// Clock supplies the current time. Injected rather than read from the wall
+// clock so tests can pin CreatedAt and assert List's ordering deterministically
+// — the same treatment userstate gives expiry, and for the same reason.
+//
+// Nil: never; [NewService] substitutes time.Now.
+type Clock func() time.Time
+
+// Service is the write path for comments: it stamps identity, mints IDs,
+// validates input, and delegates persistence to a [Store].
+//
+// It is the only thing that constructs a [Comment], which is what makes the
+// server-written fields trustworthy — there is no path where a client-supplied
+// ID or Author reaches storage.
+type Service struct {
+	store Store
+	now   Clock
+}
+
+// NewService returns a Service over st.
+//
+// Nil: st is required and rejected when nil — a Service with no store would
+// silently discard every comment, and the failure would surface far from its
+// cause. clock may be nil, in which case time.Now is used.
+func NewService(st Store, clock Clock) (*Service, error) {
+	if st == nil {
+		return nil, errors.New("comments: NewService requires a Store")
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &Service{store: st, now: clock}, nil
+}
+
+// AddRequest is the caller-supplied part of a new comment.
+//
+// Note what is absent: ID, Author and CreatedAt. They are not fields a caller
+// may set, so they are not fields this struct carries — the wire type cannot
+// express the forgery, rather than expressing it and having it stripped later.
+type AddRequest struct {
+	Anchor Anchor
+	Body   string
+}
+
+// Add stores a new comment on target, attributed to the ctx principal.
+//
+// The author is taken from ctx and never from the request. An unstamped
+// principal is refused ([ErrUnknownAuthor]) rather than recorded as "unknown":
+// a comment nobody is recorded as having written can never satisfy an
+// *-own permission check, so storing one creates a record its author can
+// neither edit nor delete.
+func (s *Service) Add(ctx context.Context, target Target, req AddRequest) (Comment, error) {
+	author, err := authorFrom(ctx)
+	if err != nil {
+		return Comment{}, err
+	}
+	if vErr := req.Anchor.Validate(); vErr != nil {
+		return Comment{}, vErr
+	}
+	if vErr := ValidateBody(req.Body); vErr != nil {
+		return Comment{}, vErr
+	}
+
+	existing, err := s.store.List(ctx, target)
+	if err != nil {
+		return Comment{}, err
+	}
+	if len(existing) >= MaxPerTarget {
+		return Comment{}, fmt.Errorf("%w: %d is the limit", ErrTooManyComments, MaxPerTarget)
+	}
+
+	id, err := mintID()
+	if err != nil {
+		return Comment{}, err
+	}
+	c := Comment{
+		ID:        id,
+		Author:    author,
+		CreatedAt: s.now().UTC(),
+		Anchor:    req.Anchor,
+		Body:      req.Body,
+	}
+	if err := s.store.Add(ctx, target, c); err != nil {
+		return Comment{}, err
+	}
+	return c, nil
+}
+
+// List returns the target's comments, oldest first.
+//
+// The ACL gate is the caller's job: this returns everything stored for the
+// target. Callers on a served path must have resolved the target's read
+// verdict and the comment:read permission first.
+func (s *Service) List(ctx context.Context, target Target) ([]Comment, error) {
+	return s.store.List(ctx, target)
+}
+
+// Get returns one comment by ID.
+//
+// It exists chiefly so a handler can resolve a comment's author *before*
+// deciding whether an *-own permission covers the requested mutation.
+func (s *Service) Get(ctx context.Context, target Target, id string) (Comment, error) {
+	list, err := s.store.List(ctx, target)
+	if err != nil {
+		return Comment{}, err
+	}
+	for _, c := range list {
+		if c.ID == id {
+			return c, nil
+		}
+	}
+	return Comment{}, ErrNotFound
+}
+
+// Update replaces a comment's body and resolved flag.
+//
+// Author, CreatedAt and Anchor are not editable: an edit must not be able to
+// change who said something or what it was said about. Authorization —
+// including whether the ctx principal owns this comment — is the caller's job.
+func (s *Service) Update(ctx context.Context, target Target, id, body string, resolved bool) error {
+	if err := ValidateBody(body); err != nil {
+		return err
+	}
+	return s.store.Update(ctx, target, id, body, resolved)
+}
+
+// Delete removes one comment. Authorization is the caller's job.
+func (s *Service) Delete(ctx context.Context, target Target, id string) error {
+	return s.store.Delete(ctx, target, id)
+}
+
+// EntityPut implements [store.EntityObserver]. Comments key off the entity ID
+// only, so an ordinary create or update changes nothing for them.
+func (s *Service) EntityPut(*entity.Entity) error { return nil }
+
+// EntityDelete implements [store.EntityObserver] by dropping the deleted
+// entity's comments.
+//
+// Without this a later entity reusing the ID would inherit the previous
+// occupant's comments — rela permits ID reuse, so this is reachable, not
+// theoretical.
+func (s *Service) EntityDelete(id string) error {
+	return s.store.DeleteTarget(context.Background(), Target{ID: id})
+}
+
+// EntityRenamed implements [store.EntityObserver] by re-keying the renamed
+// entity's comments.
+//
+// This callback is load-bearing: rename emits EXACTLY this one notification —
+// never EntityDelete(oldID) followed by EntityPut — so a service that did not
+// handle it would leave every comment filed under an ID nothing resolves to.
+// The comments would still be on disk and completely unreachable.
+func (s *Service) EntityRenamed(oldID string, renamed *entity.Entity) error {
+	if renamed == nil || oldID == renamed.ID {
+		return nil
+	}
+	return s.store.Rename(context.Background(), oldID, renamed.ID)
+}
+
+// authorFrom resolves the comment author from ctx.
+//
+// Uses [principal.Stamped] rather than From because the two cases differ here:
+// From's unknown/unknown default is a reasonable audit-log placeholder but an
+// unusable comment author (see [Service.Add]). A reserved system identity is
+// refused for the same reason — a system job has no business authoring
+// commentary in a human's thread.
+func authorFrom(ctx context.Context) (string, error) {
+	p, ok := principal.Stamped(ctx)
+	if !ok {
+		return "", ErrUnknownAuthor
+	}
+	user := strings.TrimSpace(p.User)
+	if user == "" || user == "unknown" {
+		return "", ErrUnknownAuthor
+	}
+	if principal.IsReserved(user) {
+		return "", fmt.Errorf("%w: %q is a reserved system identity", ErrUnknownAuthor, user)
+	}
+	return user, nil
+}
+
+// mintID returns a fresh opaque comment ID.
+func mintID() (string, error) {
+	buf := make([]byte, idBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("comments: generating id: %w", err)
+	}
+	return idEncoding.EncodeToString(buf), nil
+}
+
+// SortComments orders comments oldest-first with the ID as a tie-break.
+//
+// Shared by every backend so ordering is defined in ONE place: a thread must
+// render identically regardless of which backend served it, and two
+// implementations sorting "the same way" independently is how that guarantee
+// quietly stops holding. The ID tie-break matters because a clock with
+// coarse resolution can stamp two comments in one tick.
+func SortComments(list []Comment) {
+	sort.SliceStable(list, func(i, j int) bool {
+		if !list[i].CreatedAt.Equal(list[j].CreatedAt) {
+			return list[i].CreatedAt.Before(list[j].CreatedAt)
+		}
+		return list[i].ID < list[j].ID
+	})
+}

--- a/internal/comments/service_test.go
+++ b/internal/comments/service_test.go
@@ -1,0 +1,265 @@
+package comments_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/comments/memcomments"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+var testBase = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+func newService(t *testing.T) (*comments.Service, comments.Store) {
+	t.Helper()
+	st := memcomments.New()
+	svc, err := comments.NewService(st, func() time.Time { return testBase })
+	require.NoError(t, err)
+	return svc, st
+}
+
+func aliceCtx() context.Context {
+	return principal.With(context.Background(),
+		principal.Principal{User: "alice@example.com", Tool: "data-entry"})
+}
+
+func propAnchor() comments.Anchor {
+	return comments.Anchor{Kind: comments.AnchorProperty, Ref: "status"}
+}
+
+func TestNewService_RequiresStore(t *testing.T) {
+	_, err := comments.NewService(nil, nil)
+	require.Error(t, err, "a Service with no store would discard every comment")
+}
+
+// TestAdd_StampsAuthorFromPrincipal is the ticket's key test (AC3). The wire
+// type cannot express an author, so the only thing that can set one is the
+// service — but this pins the resulting value, not just the type shape.
+func TestAdd_StampsAuthorFromPrincipal(t *testing.T) {
+	svc, _ := newService(t)
+
+	got, err := svc.Add(aliceCtx(), comments.Target{Type: "ticket", ID: "TKT-1"},
+		comments.AddRequest{Anchor: propAnchor(), Body: "a remark"})
+	require.NoError(t, err)
+
+	require.Equal(t, "alice@example.com", got.Author)
+	require.True(t, testBase.Equal(got.CreatedAt))
+	require.NotEmpty(t, got.ID, "the server mints the id")
+}
+
+// TestAdd_MintsUniqueIDs pins that ids are server-generated and distinct, so a
+// caller cannot overwrite one comment by reusing another's id.
+func TestAdd_MintsUniqueIDs(t *testing.T) {
+	svc, _ := newService(t)
+	ctx := aliceCtx()
+	tgt := comments.Target{Type: "ticket", ID: "TKT-1"}
+
+	seen := map[string]bool{}
+	for range 50 {
+		c, err := svc.Add(ctx, tgt, comments.AddRequest{Anchor: propAnchor(), Body: "x"})
+		require.NoError(t, err)
+		require.False(t, seen[c.ID], "minted ids must not repeat")
+		seen[c.ID] = true
+	}
+}
+
+// TestAdd_RefusesUnstampedPrincipal pins that an unattributable comment is
+// refused rather than stored as "unknown". A comment nobody is recorded as
+// having written can never satisfy an *-own check, so its author could neither
+// edit nor delete it.
+func TestAdd_RefusesUnstampedPrincipal(t *testing.T) {
+	svc, st := newService(t)
+
+	_, err := svc.Add(context.Background(), comments.Target{Type: "ticket", ID: "TKT-1"},
+		comments.AddRequest{Anchor: propAnchor(), Body: "a remark"})
+	require.ErrorIs(t, err, comments.ErrUnknownAuthor)
+
+	stored, err := st.List(context.Background(), comments.Target{ID: "TKT-1"})
+	require.NoError(t, err)
+	require.Empty(t, stored, "nothing is stored when the author cannot be resolved")
+}
+
+func TestAdd_RefusesReservedPrincipal(t *testing.T) {
+	svc, _ := newService(t)
+	ctx := principal.With(context.Background(),
+		principal.Principal{User: "system:version-sweep", Tool: "internal"})
+
+	_, err := svc.Add(ctx, comments.Target{Type: "ticket", ID: "TKT-1"},
+		comments.AddRequest{Anchor: propAnchor(), Body: "x"})
+	require.ErrorIs(t, err, comments.ErrUnknownAuthor)
+}
+
+func TestAdd_ValidatesAnchor(t *testing.T) {
+	svc, _ := newService(t)
+	ctx := aliceCtx()
+	tgt := comments.Target{Type: "ticket", ID: "TKT-1"}
+
+	t.Run("unknown kind", func(t *testing.T) {
+		_, err := svc.Add(ctx, tgt, comments.AddRequest{
+			Anchor: comments.Anchor{Kind: "wat", Ref: "x"}, Body: "b"})
+		require.ErrorIs(t, err, comments.ErrInvalidAnchor)
+	})
+
+	t.Run("empty ref", func(t *testing.T) {
+		_, err := svc.Add(ctx, tgt, comments.AddRequest{
+			Anchor: comments.Anchor{Kind: comments.AnchorProperty, Ref: "  "}, Body: "b"})
+		require.ErrorIs(t, err, comments.ErrInvalidAnchor)
+	})
+
+	t.Run("section anchor accepted", func(t *testing.T) {
+		_, err := svc.Add(ctx, tgt, comments.AddRequest{
+			Anchor: comments.Anchor{Kind: comments.AnchorSection, Ref: "acceptance-criteria"},
+			Body:   "b"})
+		require.NoError(t, err)
+	})
+}
+
+// TestAdd_EnforcesPerTargetCap pins the resource bound: the file backend reads
+// a target's whole thread on every List, so an unbounded thread is a slow leak.
+func TestAdd_EnforcesPerTargetCap(t *testing.T) {
+	svc, st := newService(t)
+	ctx := aliceCtx()
+	tgt := comments.Target{Type: "ticket", ID: "TKT-1"}
+
+	for i := range comments.MaxPerTarget {
+		require.NoError(t, st.Add(ctx, tgt, comments.Comment{
+			ID:        string(rune('a'+i%26)) + strings.Repeat("x", i%7+1),
+			Author:    "alice@example.com",
+			CreatedAt: testBase.Add(time.Duration(i) * time.Second),
+			Anchor:    propAnchor(),
+			Body:      "filler",
+		}))
+	}
+
+	_, err := svc.Add(ctx, tgt, comments.AddRequest{Anchor: propAnchor(), Body: "one too many"})
+	require.ErrorIs(t, err, comments.ErrTooManyComments)
+}
+
+func TestValidateBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want error
+	}{
+		{"plain prose", "a normal comment", nil},
+		{"newlines and tabs allowed", "line one\nline\ttwo", nil},
+		{"markdown allowed", "**bold** and `code`", nil},
+		{"unicode allowed", "emoji 🎉 and 日本語", nil},
+		{"empty", "", comments.ErrEmptyBody},
+		{"whitespace only", "   \n\t ", comments.ErrEmptyBody},
+		{"too long", strings.Repeat("x", comments.MaxBodyBytes+1), comments.ErrBodyTooLong},
+		{"at the limit", strings.Repeat("x", comments.MaxBodyBytes), nil},
+		{"NUL byte", "before\x00after", comments.ErrBodyControlChars},
+		{"escape byte", "before\x1bafter", comments.ErrBodyControlChars},
+		{"DEL byte", "before\x7fafter", comments.ErrBodyControlChars},
+		{"carriage return", "before\rafter", comments.ErrBodyControlChars},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := comments.ValidateBody(tc.body)
+			if tc.want == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.want)
+		})
+	}
+}
+
+func TestAdd_RejectsInvalidBody(t *testing.T) {
+	svc, _ := newService(t)
+	_, err := svc.Add(aliceCtx(), comments.Target{Type: "ticket", ID: "TKT-1"},
+		comments.AddRequest{Anchor: propAnchor(), Body: "  "})
+	require.ErrorIs(t, err, comments.ErrEmptyBody)
+}
+
+func TestUpdate_ValidatesBody(t *testing.T) {
+	svc, _ := newService(t)
+	ctx := aliceCtx()
+	tgt := comments.Target{Type: "ticket", ID: "TKT-1"}
+
+	c, err := svc.Add(ctx, tgt, comments.AddRequest{Anchor: propAnchor(), Body: "original"})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, svc.Update(ctx, tgt, c.ID, "", false), comments.ErrEmptyBody)
+
+	// The original survives a rejected update.
+	got, err := svc.Get(ctx, tgt, c.ID)
+	require.NoError(t, err)
+	require.Equal(t, "original", got.Body)
+}
+
+func TestGet_ReportsNotFound(t *testing.T) {
+	svc, _ := newService(t)
+	_, err := svc.Get(aliceCtx(), comments.Target{Type: "ticket", ID: "TKT-1"}, "nope")
+	require.ErrorIs(t, err, comments.ErrNotFound)
+}
+
+// TestEntityRenamed_ReKeysComments pins the critical design-review finding
+// (RR-FCUS1V): rename emits exactly one callback, so without this every comment
+// on a renamed entity would be filed under an id nothing resolves to.
+func TestEntityRenamed_ReKeysComments(t *testing.T) {
+	svc, st := newService(t)
+	ctx := aliceCtx()
+
+	_, err := svc.Add(ctx, comments.Target{Type: "ticket", ID: "TKT-old"},
+		comments.AddRequest{Anchor: propAnchor(), Body: "still relevant"})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.EntityRenamed("TKT-old", entity.New("TKT-new", "ticket")))
+
+	moved, err := st.List(ctx, comments.Target{ID: "TKT-new"})
+	require.NoError(t, err)
+	require.Len(t, moved, 1, "comments follow the rename")
+	require.Equal(t, "still relevant", moved[0].Body)
+
+	old, err := st.List(ctx, comments.Target{ID: "TKT-old"})
+	require.NoError(t, err)
+	require.Empty(t, old)
+}
+
+func TestEntityRenamed_IgnoresNoOps(t *testing.T) {
+	svc, _ := newService(t)
+
+	require.NoError(t, svc.EntityRenamed("TKT-1", nil))
+	require.NoError(t, svc.EntityRenamed("TKT-1", entity.New("TKT-1", "ticket")))
+}
+
+// TestEntityDelete_DropsComments pins AC10's second half. ID reuse is permitted
+// in rela, so a later entity taking the same id must not inherit the previous
+// occupant's comments.
+func TestEntityDelete_DropsComments(t *testing.T) {
+	svc, st := newService(t)
+	ctx := aliceCtx()
+
+	_, err := svc.Add(ctx, comments.Target{Type: "ticket", ID: "TKT-1"},
+		comments.AddRequest{Anchor: propAnchor(), Body: "gone soon"})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.EntityDelete("TKT-1"))
+
+	got, err := st.List(ctx, comments.Target{ID: "TKT-1"})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestEntityPut_IsNoOp(t *testing.T) {
+	svc, st := newService(t)
+	ctx := aliceCtx()
+
+	_, err := svc.Add(ctx, comments.Target{Type: "ticket", ID: "TKT-1"},
+		comments.AddRequest{Anchor: propAnchor(), Body: "unchanged"})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.EntityPut(entity.New("TKT-1", "ticket")))
+
+	got, err := st.List(ctx, comments.Target{ID: "TKT-1"})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "an ordinary write must not disturb comments")
+}

--- a/internal/comments/service_test.go
+++ b/internal/comments/service_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Sourcehaven-BV/rela/internal/comments"
 	"github.com/Sourcehaven-BV/rela/internal/comments/memcomments"
-	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
@@ -212,7 +211,7 @@ func TestEntityRenamed_ReKeysComments(t *testing.T) {
 		comments.AddRequest{Anchor: propAnchor(), Body: "still relevant"})
 	require.NoError(t, err)
 
-	require.NoError(t, svc.EntityRenamed("TKT-old", entity.New("TKT-new", "ticket")))
+	require.NoError(t, svc.EntityRenamed(ctx, "TKT-old", "TKT-new"))
 
 	moved, err := st.List(ctx, comments.Target{ID: "TKT-new"})
 	require.NoError(t, err)
@@ -226,15 +225,13 @@ func TestEntityRenamed_ReKeysComments(t *testing.T) {
 
 func TestEntityRenamed_IgnoresNoOps(t *testing.T) {
 	svc, _ := newService(t)
-
-	require.NoError(t, svc.EntityRenamed("TKT-1", nil))
-	require.NoError(t, svc.EntityRenamed("TKT-1", entity.New("TKT-1", "ticket")))
+	require.NoError(t, svc.EntityRenamed(aliceCtx(), "TKT-1", "TKT-1"))
 }
 
-// TestEntityDelete_DropsComments pins AC10's second half. ID reuse is permitted
-// in rela, so a later entity taking the same id must not inherit the previous
-// occupant's comments.
-func TestEntityDelete_DropsComments(t *testing.T) {
+// TestEntityDeleted_DropsComments pins AC9. ID reuse is permitted in rela, so a
+// later entity taking the same id must not inherit the previous occupant's
+// comments and present someone else's remarks as its own.
+func TestEntityDeleted_DropsComments(t *testing.T) {
 	svc, st := newService(t)
 	ctx := aliceCtx()
 
@@ -242,24 +239,9 @@ func TestEntityDelete_DropsComments(t *testing.T) {
 		comments.AddRequest{Anchor: propAnchor(), Body: "gone soon"})
 	require.NoError(t, err)
 
-	require.NoError(t, svc.EntityDelete("TKT-1"))
+	require.NoError(t, svc.EntityDeleted(ctx, "TKT-1"))
 
 	got, err := st.List(ctx, comments.Target{ID: "TKT-1"})
 	require.NoError(t, err)
 	require.Empty(t, got)
-}
-
-func TestEntityPut_IsNoOp(t *testing.T) {
-	svc, st := newService(t)
-	ctx := aliceCtx()
-
-	_, err := svc.Add(ctx, comments.Target{Type: "ticket", ID: "TKT-1"},
-		comments.AddRequest{Anchor: propAnchor(), Body: "unchanged"})
-	require.NoError(t, err)
-
-	require.NoError(t, svc.EntityPut(entity.New("TKT-1", "ticket")))
-
-	got, err := st.List(ctx, comments.Target{ID: "TKT-1"})
-	require.NoError(t, err)
-	require.Len(t, got, 1, "an ordinary write must not disturb comments")
 }

--- a/internal/comments/textresolve.go
+++ b/internal/comments/textresolve.go
@@ -1,0 +1,109 @@
+package comments
+
+import (
+	"github.com/vloothuis/textanchor"
+)
+
+// Confidence bands for a resolved text anchor.
+//
+// Three tiers rather than the library's binary resolved/orphaned, because the
+// middle band is the one a reader needs warning about: a highlight rendered at
+// 0.55 confidence is a guess, and presenting it identically to an exact match
+// would quietly attach a remark to text nobody wrote it about.
+const (
+	// ConfidenceExact and above renders as a normal highlight.
+	ConfidenceExact = 0.80
+
+	// ConfidenceUncertain and above renders highlighted but flagged as moved;
+	// below it the anchor is treated as detached. Matches the library's own
+	// MinConfidence floor, so anything it resolves at all lands in a band.
+	ConfidenceUncertain = 0.50
+)
+
+// TextMatch is the outcome of locating a text anchor in a body.
+//
+// Start/End are byte offsets into the body that was searched. They are NOT
+// derivable from the quote's length: the resolver absorbs interior whitespace
+// runs, so a range may legitimately be longer than Quote (a quote written with
+// a space where the stored body now has a newline). Always slice with
+// Start/End — never Start+len(Quote).
+type TextMatch struct {
+	Start      int
+	End        int
+	Confidence float64
+	// Uncertain marks the middle band: located, but far enough from an exact
+	// match that the UI should say so.
+	Uncertain bool
+	// Detached means the quote could not be found. Start/End are meaningless.
+	Detached bool
+	// Reason carries the resolver's explanation when Detached.
+	Reason string
+}
+
+// ResolveText locates a text anchor within body.
+//
+// Nil: a nil descriptor resolves as detached rather than panicking — a stored
+// comment with a text kind and no descriptor is corrupt, not a crash.
+//
+// The body is passed as stored. No normalisation happens here: textanchor
+// v0.2.0 matches on a whitespace-collapsed form internally and maps its result
+// back to original coordinates, so a quote spanning fsstore's 80-column reflow
+// resolves without the caller flattening anything. (Before v0.2.0 that case
+// hard-orphaned, which is why this function does not exist for v0.1.0.)
+func ResolveText(body string, a *TextAnchor) TextMatch {
+	if a == nil {
+		return TextMatch{Detached: true, Reason: "missing text descriptor"}
+	}
+
+	res := textanchor.Resolve(body, textanchor.Anchor{
+		Quote:              a.Quote,
+		Prefix:             a.Prefix,
+		Suffix:             a.Suffix,
+		ContainingSentence: a.ContainingSentence,
+		HeadingContext:     a.HeadingContext,
+		ParagraphIndex:     a.ParagraphIndex,
+	}, nil)
+
+	if res.Orphaned || res.Range == nil {
+		reason := res.OrphanReason
+		if reason == "" {
+			reason = "quote not found"
+		}
+		return TextMatch{Detached: true, Confidence: res.Confidence, Reason: reason}
+	}
+
+	// Defensive: a range outside the body would panic the caller's slice. The
+	// resolver returns original-document coordinates, so this should never
+	// fire — but a bad range must degrade to detached, not crash a read path.
+	if res.Range.Start < 0 || res.Range.End > len(body) || res.Range.Start > res.Range.End {
+		return TextMatch{Detached: true, Confidence: res.Confidence, Reason: "range out of bounds"}
+	}
+
+	return TextMatch{
+		Start:      res.Range.Start,
+		End:        res.Range.End,
+		Confidence: res.Confidence,
+		Uncertain:  res.Confidence < ConfidenceExact,
+	}
+}
+
+// NewTextAnchor builds a text anchor for the selection body[start:end].
+//
+// Offsets are into the body AS STORED, so a caller working from rendered text
+// must map back to source coordinates first (the SPA sends the quote and its
+// surrounding context rather than offsets, precisely to avoid that mapping
+// crossing the wire).
+func NewTextAnchor(body string, start, end int) (*TextAnchor, error) {
+	a, err := textanchor.New(body, start, end, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TextAnchor{
+		Quote:              a.Quote,
+		Prefix:             a.Prefix,
+		Suffix:             a.Suffix,
+		ContainingSentence: a.ContainingSentence,
+		HeadingContext:     a.HeadingContext,
+		ParagraphIndex:     a.ParagraphIndex,
+	}, nil
+}

--- a/internal/comments/textresolve.go
+++ b/internal/comments/textresolve.go
@@ -2,6 +2,7 @@ package comments
 
 import (
 	"github.com/vloothuis/textanchor"
+	"github.com/vloothuis/textanchor/quotefind"
 )
 
 // Confidence bands for a resolved text anchor.
@@ -87,12 +88,28 @@ func ResolveText(body string, a *TextAnchor) TextMatch {
 	}
 }
 
+// FindRenderedQuote locates a quote taken from RENDERED markdown within the
+// markdown SOURCE.
+//
+// A browser selection yields display text: list markers, backticks and heading
+// hashes are gone, and blocks are separated by plain newlines. A selection that
+// crosses a bullet or a code span therefore never occurs verbatim in the
+// source, so a plain strings.Index finds nothing — which is exactly what made
+// "the selected text was not found" fire on those selections.
+//
+// quotefind walks the goldmark AST to build a rendered→source position map, so
+// it matches what the user actually saw against what is actually stored.
+//
+// Returns ok=false when the quote cannot be located, which the caller reports
+// as a 400 rather than storing an anchor that could never resolve.
+func FindRenderedQuote(body, quote string) (start, end int, ok bool) {
+	return quotefind.Find(body, quote)
+}
+
 // NewTextAnchor builds a text anchor for the selection body[start:end].
 //
 // Offsets are into the body AS STORED, so a caller working from rendered text
-// must map back to source coordinates first (the SPA sends the quote and its
-// surrounding context rather than offsets, precisely to avoid that mapping
-// crossing the wire).
+// must map back to source coordinates first — see [FindRenderedQuote].
 func NewTextAnchor(body string, start, end int) (*TextAnchor, error) {
 	a, err := textanchor.New(body, start, end, nil)
 	if err != nil {

--- a/internal/comments/textresolve.go
+++ b/internal/comments/textresolve.go
@@ -100,10 +100,19 @@ func ResolveText(body string, a *TextAnchor) TextMatch {
 // quotefind walks the goldmark AST to build a rendered→source position map, so
 // it matches what the user actually saw against what is actually stored.
 //
+// # prefix and suffix are what pick the RIGHT occurrence
+//
+// A short quote frequently occurs more than once ("eordend" appears inside both
+// "Ongeordend" and "Geordend"). Without context this resolves to the FIRST
+// occurrence, so a comment on the second silently anchors — and highlights —
+// somewhere the user never selected. The caller must therefore pass the text
+// surrounding the selection; empty context is only safe for a quote known to be
+// unique.
+//
 // Returns ok=false when the quote cannot be located, which the caller reports
 // as a 400 rather than storing an anchor that could never resolve.
-func FindRenderedQuote(body, quote string) (start, end int, ok bool) {
-	return quotefind.Find(body, quote)
+func FindRenderedQuote(body, quote, prefix, suffix string) (start, end int, ok bool) {
+	return quotefind.FindWithContext(body, quote, prefix, suffix)
 }
 
 // NewTextAnchor builds a text anchor for the selection body[start:end].

--- a/internal/comments/textresolve_test.go
+++ b/internal/comments/textresolve_test.go
@@ -1,0 +1,159 @@
+package comments_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/markdown"
+)
+
+const body = "Renaming an entity leaves the old id in the search index until a restart, " +
+	"which is confusing because the store itself is already correct at that point.\n"
+
+// anchorFor builds a text anchor over the first occurrence of quote in body.
+func anchorFor(t *testing.T, doc, quote string) *comments.TextAnchor {
+	t.Helper()
+	start := strings.Index(doc, quote)
+	require.GreaterOrEqual(t, start, 0, "quote not present in the fixture")
+	a, err := comments.NewTextAnchor(doc, start, start+len(quote))
+	require.NoError(t, err)
+	return a
+}
+
+func TestResolveText_ExactMatch(t *testing.T) {
+	quote := "the old id in the search index"
+	got := comments.ResolveText(body, anchorFor(t, body, quote))
+
+	require.False(t, got.Detached)
+	require.False(t, got.Uncertain)
+	require.Equal(t, quote, body[got.Start:got.End])
+	require.GreaterOrEqual(t, got.Confidence, comments.ConfidenceExact)
+}
+
+// TestResolveText_SurvivesFormatMarkdownReflow is the reason stage 2 needs
+// textanchor v0.2.0 at all.
+//
+// fsstore reflows every body to 80 columns on write, so a quote spanning a wrap
+// point is split by a newline in the stored text. Against v0.1.0 that
+// hard-orphaned at 0.00 confidence — an anchor breaking against its own body
+// the moment the file was saved, with no user edit involved.
+func TestResolveText_SurvivesFormatMarkdownReflow(t *testing.T) {
+	reflowed := markdown.FormatMarkdown(body)
+	require.NotEqual(t, body, reflowed, "fixture must actually be reflowed, or this proves nothing")
+
+	quote := "until a restart, which is confusing"
+	require.NotContains(t, reflowed, quote, "quote must straddle the wrap, or this proves nothing")
+
+	got := comments.ResolveText(reflowed, anchorFor(t, body, quote))
+
+	require.False(t, got.Detached, "quote spanning the reflow boundary must still resolve")
+	require.GreaterOrEqual(t, got.Confidence, comments.ConfidenceExact)
+	// The located range spans the inserted newline, so it is NOT the quote
+	// verbatim — which is exactly why callers must slice with Start/End.
+	require.Contains(t, reflowed[got.Start:got.End], "until a restart")
+	require.Contains(t, reflowed[got.Start:got.End], "is confusing")
+}
+
+// TestResolveText_SliceWithRangeNotQuote pins the slicing contract.
+//
+// The resolved text is NOT the stored quote — here the wrap put a newline where
+// the quote has a space — so a caller must slice with Start/End. Locating the
+// span by searching for Quote instead would fail outright, which is the mistake
+// this guards against. (Byte LENGTHS happen to agree in this fixture, since a
+// newline replaces a space one-for-one; they need not in general, so do not
+// rewrite this as a length assertion.)
+func TestResolveText_SliceWithRangeNotQuote(t *testing.T) {
+	reflowed := markdown.FormatMarkdown(body)
+	quote := "until a restart, which is confusing"
+	a := anchorFor(t, body, quote)
+
+	got := comments.ResolveText(reflowed, a)
+	require.False(t, got.Detached)
+
+	located := reflowed[got.Start:got.End]
+	require.NotEqual(t, quote, located, "the located text differs from the stored quote")
+	require.Equal(t, -1, strings.Index(reflowed, quote),
+		"searching for the quote would find nothing — only Start/End locate it")
+}
+
+func TestResolveText_DetachedWhenQuoteRemoved(t *testing.T) {
+	a := anchorFor(t, body, "the old id in the search index")
+
+	got := comments.ResolveText("Something else entirely, sharing no wording with the original.\n", a)
+
+	require.True(t, got.Detached, "a quote edited away must detach, never match loosely")
+	require.NotEmpty(t, got.Reason)
+}
+
+func TestResolveText_NilDescriptorDetaches(t *testing.T) {
+	got := comments.ResolveText(body, nil)
+
+	require.True(t, got.Detached)
+	require.Equal(t, "missing text descriptor", got.Reason)
+}
+
+func TestResolveText_UnicodeQuote(t *testing.T) {
+	doc := "Le café serveert bijzonder góéde köffie — élke ochtend opnieuw.\n"
+	quote := "bijzonder góéde köffie"
+
+	got := comments.ResolveText(doc, anchorFor(t, doc, quote))
+
+	require.False(t, got.Detached)
+	// Byte offsets over multi-byte runes must still slice to the exact quote.
+	require.Equal(t, quote, doc[got.Start:got.End])
+}
+
+func TestAnchorValidate_Text(t *testing.T) {
+	tests := []struct {
+		name    string
+		anchor  comments.Anchor
+		wantErr bool
+	}{
+		{
+			name:   "valid text anchor",
+			anchor: comments.Anchor{Kind: comments.AnchorText, Text: &comments.TextAnchor{Quote: "a long enough quote"}},
+		},
+		{
+			name:    "missing descriptor",
+			anchor:  comments.Anchor{Kind: comments.AnchorText},
+			wantErr: true,
+		},
+		{
+			name:    "quote too short to locate",
+			anchor:  comments.Anchor{Kind: comments.AnchorText, Text: &comments.TextAnchor{Quote: "ab"}},
+			wantErr: true,
+		},
+		{
+			name:    "quote over the byte cap",
+			anchor:  comments.Anchor{Kind: comments.AnchorText, Text: &comments.TextAnchor{Quote: strings.Repeat("x", comments.MaxQuoteBytes+1)}},
+			wantErr: true,
+		},
+		{
+			// A text anchor carries no Ref, so requiring one would reject
+			// every valid text comment.
+			name:   "ref is not required for a text anchor",
+			anchor: comments.Anchor{Kind: comments.AnchorText, Text: &comments.TextAnchor{Quote: "another valid quote"}},
+		},
+		{
+			// Regression: the property/section kinds must keep requiring Ref.
+			name:    "property still requires a ref",
+			anchor:  comments.Anchor{Kind: comments.AnchorProperty},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.anchor.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, comments.ErrInvalidAnchor)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -153,7 +153,7 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/_openapi.json", a.handleV1OpenAPI)
 	mux.HandleFunc("/api/v1/_commands", a.handleV1Commands)
 	mux.HandleFunc("/api/v1/_transforms", a.export.handleV1Transforms)
-	mux.HandleFunc("/api/v1/_comments/", a.handleV1Comments)
+	mux.HandleFunc("/api/v1/_comments/", a.comments.handleV1Comments)
 	mux.HandleFunc("/api/v1/_templates/", a.handleV1Templates)
 	mux.HandleFunc("/api/v1/_views/", a.views.handleV1Views)
 	a.registerCopyRoutes(mux)

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -149,6 +149,7 @@ func (a *App) registerAPIV1Routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/_openapi.json", a.handleV1OpenAPI)
 	mux.HandleFunc("/api/v1/_commands", a.handleV1Commands)
 	mux.HandleFunc("/api/v1/_transforms", a.export.handleV1Transforms)
+	mux.HandleFunc("/api/v1/_comments/", a.handleV1Comments)
 	mux.HandleFunc("/api/v1/_templates/", a.handleV1Templates)
 	mux.HandleFunc("/api/v1/_views/", a.views.handleV1Views)
 	a.registerCopyRoutes(mux)

--- a/internal/dataentry/api_v1.go
+++ b/internal/dataentry/api_v1.go
@@ -58,6 +58,10 @@ func toV1EntityType(
 		Properties:  make(map[string]v1.PropertyDef, len(def.Properties)),
 		Faces:       schemaFaceDefs(def),
 		BareFace:    def.BareFace,
+		// Whether this type accepts comments (TKT-FIO205). Policy, not
+		// permission: it tells the SPA whether to offer a comment affordance
+		// at all, never that the caller may use it.
+		Commentable: metamodel.NewCommentPolicy(meta).Commentable(name),
 	}
 	if prefixes := def.GetIDPrefixes(); len(prefixes) > 0 {
 		et.IDPrefix = prefixes[0]

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/caldavalias"
-	"github.com/Sourcehaven-BV/rela/internal/comments"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -170,7 +169,20 @@ type appEntityWriter interface {
 // the count actually moves, so it is recorded here rather than in either
 // branch.
 //
-//plimsoll:max-methods=87
+// 87 → 88 for SetComments (TKT-FIO205). The commentary routes themselves live
+// on commentsHandler (the exportHandler pattern), so the subsystem cost App
+// exactly one method: the public wiring setter, which belongs here alongside
+// SetCalDAVAliases and SetUserState. Still a ratchet target — see TKT-N0IKN9.
+//
+// SetComments is also App's 21st EXPORTED method, one past the default line of
+// 20. It is a wiring setter in the established shape (SetCalDAVAliases,
+// SetUserState, SetWorlds), and the alternative — reaching into App from
+// appbuild to assign the field — would trade a named seam for a hidden one.
+// The routes themselves are on commentsHandler, so the public surface grew by
+// exactly the one setter. Ratchet target, as above.
+//
+//plimsoll:max-methods=88
+//plimsoll:max-exported-methods=21
 type App struct {
 	// Primitives — immutable after NewApp.
 	fs    storage.FS
@@ -192,7 +204,6 @@ type App struct {
 	// (a collection with no way to remember client-created resources would
 	// duplicate every to-do on the next sync).
 	caldavAliases *caldavalias.Service
-
 	// worlds resolves a `?world=` name to its compiled scope. Nil until
 	// [App.SetWorlds] is called, in which case the App serves the default
 	// world only and refuses any other `?world=` — see world.go.
@@ -209,10 +220,11 @@ type App struct {
 	// `worlds` because the two are injected from different places: the world
 	// LOOKUP is a compiled map, this is a store-backed capability.
 	worldNeighbors *worldNeighbors
-	// comments is the commentary service, or nil when the metamodel declares
-	// no enabled `comments:` block. Nil is the "feature absent" signal: the
-	// comment routes 404 and no storage is touched.
-	comments *comments.Service
+	// comments owns the commentary routes (TKT-FIO205). Always non-nil; the
+	// SERVICE inside it is nil when the metamodel declares no enabled
+	// `comments:` block, which is the "feature absent" signal — the routes 404
+	// and no storage is touched.
+	comments *commentsHandler
 	searcher search.Searcher
 	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
 	// executeQuery routes free-text searches through it so /_search
@@ -1144,6 +1156,11 @@ func NewApp(
 	}
 	app.export = export
 	app.export.probeTransforms()
+
+	// commentsHandler owns the commentary routes, likewise extracted to keep
+	// App under its method cap. Built unconditionally: the SERVICE it wraps is
+	// installed later by SetComments and stays nil when commenting is off.
+	app.comments = newCommentsHandler(app)
 
 	// attachmentHandler owns the entity-attachment routes. Constructed after
 	// the runner wiring above so it captures the resolved runner. The acl/

--- a/internal/dataentry/app.go
+++ b/internal/dataentry/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/attachment"
 	"github.com/Sourcehaven-BV/rela/internal/audit"
 	"github.com/Sourcehaven-BV/rela/internal/caldavalias"
+	"github.com/Sourcehaven-BV/rela/internal/comments"
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -208,7 +209,11 @@ type App struct {
 	// `worlds` because the two are injected from different places: the world
 	// LOOKUP is a compiled map, this is a store-backed capability.
 	worldNeighbors *worldNeighbors
-	searcher       search.Searcher
+	// comments is the commentary service, or nil when the metamodel declares
+	// no enabled `comments:` block. Nil is the "feature absent" signal: the
+	// comment routes 404 and no storage is touched.
+	comments *comments.Service
+	searcher search.Searcher
 	// visibleSearcher is the ACL-scoped search seam (TKT-BA8BSX):
 	// executeQuery routes free-text searches through it so /_search
 	// and the _position search scope only ever see hits the request

--- a/internal/dataentry/comments_handler.go
+++ b/internal/dataentry/comments_handler.go
@@ -79,6 +79,8 @@ func (h *commentsHandler) handleV1Comments(w http.ResponseWriter, r *http.Reques
 	target := comments.Target{Type: typeName, ID: entityID}
 
 	switch {
+	case len(parts) == 3 && parts[2] == "resolve":
+		h.commentResolveCheck(w, r, target)
 	case len(parts) == 2:
 		h.commentCollection(w, r, target)
 	case len(parts) == 3 && parts[2] != "":
@@ -129,6 +131,61 @@ func (h *commentsHandler) commentItem(
 		w.Header().Set("Allow", "PATCH, DELETE, OPTIONS")
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 	}
+}
+
+// resolveCheckRequest asks whether a selection could be anchored.
+type resolveCheckRequest struct {
+	Quote  string `json:"quote"`
+	Prefix string `json:"quote_prefix"`
+	Suffix string `json:"quote_suffix"`
+}
+
+// resolveCheckResponse answers it, with a reason when it could not.
+type resolveCheckResponse struct {
+	Anchorable bool   `json:"anchorable"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+// commentResolveCheck reports whether a selection can be anchored, WITHOUT
+// creating anything.
+//
+// Exists because the alternative is worse: a user selects text, writes a
+// comment, and only then learns it cannot be saved. Some selections genuinely
+// cannot anchor — one spanning table cells has no contiguous source range —
+// and the UI needs to know before it offers the affordance.
+//
+// Gated exactly like a create: it reveals whether a string appears in the body,
+// which is a read of the body, so `comment:add` plus the target read verdict.
+func (h *commentsHandler) commentResolveCheck(
+	w http.ResponseWriter, r *http.Request, target comments.Target,
+) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
+		return
+	}
+	if !h.gateCommentTarget(w, r, target) {
+		return
+	}
+	if !h.commentAuthorizer().CanAdd(r.Context(), target) {
+		writeV1Error(w, r, http.StatusForbidden, "forbidden",
+			"Adding a comment requires the comment:add permission", "")
+		return
+	}
+
+	var req resolveCheckRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_body", "Malformed JSON body", "")
+		return
+	}
+
+	if _, err := h.buildTextAnchor(r.Context(), target, req.Quote, req.Prefix, req.Suffix); err != nil {
+		// A failure here is the ANSWER, not an error: the caller asked whether
+		// this selection works, and "no, because…" is a successful reply.
+		writeV1JSON(w, http.StatusOK, resolveCheckResponse{Reason: err.Error()})
+		return
+	}
+	writeV1JSON(w, http.StatusOK, resolveCheckResponse{Anchorable: true})
 }
 
 // commentListResponse is the list wire shape.

--- a/internal/dataentry/comments_handler.go
+++ b/internal/dataentry/comments_handler.go
@@ -1,0 +1,459 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// commentsPathPrefix is the reserved route segment for the commentary layer.
+const commentsPathPrefix = "/api/v1/_comments/"
+
+// handleV1Comments serves the commentary layer.
+//
+//	GET    /api/v1/_comments/{type}/{id}              → list a target's comments
+//	POST   /api/v1/_comments/{type}/{id}              → add one
+//	PATCH  /api/v1/_comments/{type}/{id}/{commentID}  → edit body / resolve
+//	DELETE /api/v1/_comments/{type}/{id}/{commentID}  → remove one
+//
+// # Gating
+//
+// Every request resolves TWO things before it touches storage: the target's own
+// read verdict, and the relevant `comment:*` permission for that target. The
+// read verdict is the floor — a principal who cannot read an entity cannot
+// learn anything about its comments, however the comment grants read, because
+// otherwise a thread becomes an existence oracle for entities the principal is
+// denied.
+//
+// A denial is reported as an indistinguishable 404 when it would otherwise
+// confirm the target exists, and as a 403 naming the missing permission when
+// the caller has already proven it can read the target. That split follows the
+// repo's rule that entity existence is secret but a config-declared capability
+// is not: telling an authorized reader which permission it lacks is the answer
+// that helps the operator debug.
+//
+// # Disabled is absent, not forbidden
+//
+// With no `comments:` block the service is nil and every route 404s, so a
+// project that never enables commenting is indistinguishable from one built
+// before the feature existed.
+func (a *App) handleV1Comments(w http.ResponseWriter, r *http.Request) {
+	svc := a.comments
+	if svc == nil {
+		// Not a capability gap worth explaining (unlike version history, which
+		// is backend-dependent): commenting is off because this project did
+		// not ask for it, so the route simply does not exist.
+		writeV1Error(w, r, http.StatusNotFound, "not_found", "Not found", "")
+		return
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, commentsPathPrefix)
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_path",
+			"Path must be /_comments/{type}/{id}[/{commentID}]", "")
+		return
+	}
+	typeName, entityID := parts[0], parts[1]
+
+	// Validate the path segments before they reach storage. The file backend
+	// guards itself too, but refusing here keeps an unsafe id from reaching any
+	// backend at all, and gives a 400 rather than an opaque store error.
+	if !isSafePathSegment(typeName) || !isSafePathSegment(entityID) {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_path",
+			"Invalid entity type or id", "")
+		return
+	}
+
+	// Commentability is metamodel config, not a secret: an operator debugging
+	// a missing comment box needs to be told the type is not enabled.
+	if !a.commentPolicy().Commentable(typeName) {
+		writeV1Error(w, r, http.StatusBadRequest, "comments_not_enabled",
+			"Comments are not enabled for this entity type", "")
+		return
+	}
+
+	target := comments.Target{Type: typeName, ID: entityID}
+
+	switch {
+	case len(parts) == 2:
+		a.commentCollection(w, r, svc, target)
+	case len(parts) == 3 && parts[2] != "":
+		a.commentItem(w, r, svc, target, parts[2])
+	default:
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_path",
+			"Path must be /_comments/{type}/{id}[/{commentID}]", "")
+	}
+}
+
+// commentCollection handles the target-level routes.
+func (a *App) commentCollection(
+	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target,
+) {
+	switch r.Method {
+	case http.MethodGet:
+		a.listComments(w, r, svc, target)
+	case http.MethodPost:
+		if !a.refuseIfReadOnly(w, r) {
+			a.addComment(w, r, svc, target)
+		}
+	case http.MethodOptions:
+		w.Header().Set("Allow", "GET, POST, OPTIONS")
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.Header().Set("Allow", "GET, POST, OPTIONS")
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
+	}
+}
+
+// commentItem handles the single-comment routes.
+func (a *App) commentItem(
+	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target, commentID string,
+) {
+	switch r.Method {
+	case http.MethodPatch:
+		if !a.refuseIfReadOnly(w, r) {
+			a.updateComment(w, r, svc, target, commentID)
+		}
+	case http.MethodDelete:
+		if !a.refuseIfReadOnly(w, r) {
+			a.deleteComment(w, r, svc, target, commentID)
+		}
+	case http.MethodOptions:
+		w.Header().Set("Allow", "PATCH, DELETE, OPTIONS")
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.Header().Set("Allow", "PATCH, DELETE, OPTIONS")
+		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
+	}
+}
+
+// commentListResponse is the list wire shape.
+//
+// An object rather than a bare array so the response can gain fields (a
+// truncation flag, an unresolved count) without a breaking change.
+type commentListResponse struct {
+	Comments []commentWire `json:"comments"`
+}
+
+// commentWire is one comment on the wire.
+//
+// Deliberately NOT the storage type: `detached` is computed per request from
+// the live entity, and re-using the stored struct would eventually tempt
+// someone to persist it.
+type commentWire struct {
+	ID        string `json:"id"`
+	Author    string `json:"author"`
+	CreatedAt string `json:"created_at"`
+	Anchor    struct {
+		Kind string `json:"kind"`
+		Ref  string `json:"ref"`
+	} `json:"anchor"`
+	Body     string `json:"body"`
+	Resolved bool   `json:"resolved"`
+	// Detached reports that the anchor no longer names anything on the target.
+	// A soft condition per DEC-HWZHA: the comment is still returned and still
+	// readable, flagged so the UI can show it as orphaned rather than pretend
+	// it points somewhere.
+	Detached bool `json:"detached,omitempty"`
+	// Editable and Deletable are UI hints mirroring `_actions`: the server
+	// re-authorizes every write, so a client that ignores them gains nothing.
+	Editable  bool `json:"editable"`
+	Deletable bool `json:"deletable"`
+}
+
+func (a *App) listComments(
+	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target,
+) {
+	ctx := r.Context()
+	auth := a.commentAuthorizer()
+
+	// Read floor first: a caller who cannot read the target — or a target that
+	// does not exist — gets the same 404, so comments never confirm existence.
+	if !a.gateCommentTarget(w, r, target) {
+		return
+	}
+	if !auth.CanRead(ctx, target) {
+		writeV1Error(w, r, http.StatusForbidden, "forbidden",
+			"Reading comments requires the comment:read permission", "")
+		return
+	}
+
+	list, err := svc.List(ctx, target)
+	if err != nil {
+		writeV1Error(w, r, http.StatusInternalServerError, "comments_failed",
+			"Could not read comments", "")
+		return
+	}
+
+	user := principal.From(ctx).User
+	anchors := a.liveAnchors(ctx, target)
+	out := make([]commentWire, 0, len(list))
+	for _, c := range list {
+		out = append(out, commentWire{
+			ID:        c.ID,
+			Author:    c.Author,
+			CreatedAt: c.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			Anchor: struct {
+				Kind string `json:"kind"`
+				Ref  string `json:"ref"`
+			}{Kind: string(c.Anchor.Kind), Ref: c.Anchor.Ref},
+			Body:      c.Body,
+			Resolved:  c.Resolved,
+			Detached:  isDetached(anchors, c.Anchor),
+			Editable:  auth.CanUpdate(ctx, target, c, user),
+			Deletable: auth.CanDelete(ctx, target, c, user),
+		})
+	}
+
+	writeV1JSON(w, http.StatusOK, commentListResponse{Comments: out})
+}
+
+// addCommentRequest is the create wire shape.
+//
+// It carries no author, id or timestamp: those are server-written, so the wire
+// type cannot express them rather than accepting and discarding them.
+type addCommentRequest struct {
+	Anchor struct {
+		Kind string `json:"kind"`
+		Ref  string `json:"ref"`
+	} `json:"anchor"`
+	Body string `json:"body"`
+}
+
+func (a *App) addComment(
+	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target,
+) {
+	ctx := r.Context()
+
+	if !a.gateCommentTarget(w, r, target) {
+		return
+	}
+	if !a.commentAuthorizer().CanAdd(ctx, target) {
+		writeV1Error(w, r, http.StatusForbidden, "forbidden",
+			"Adding a comment requires the comment:add permission", "")
+		return
+	}
+
+	var req addCommentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_body", "Malformed JSON body", "")
+		return
+	}
+
+	created, err := svc.Add(ctx, target, comments.AddRequest{
+		Anchor: comments.Anchor{
+			Kind: comments.AnchorKind(req.Anchor.Kind),
+			Ref:  req.Anchor.Ref,
+		},
+		Body: req.Body,
+	})
+	if err != nil {
+		writeCommentError(w, r, err)
+		return
+	}
+
+	writeV1JSON(w, http.StatusCreated, commentWire{
+		ID:        created.ID,
+		Author:    created.Author,
+		CreatedAt: created.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		Anchor: struct {
+			Kind string `json:"kind"`
+			Ref  string `json:"ref"`
+		}{Kind: string(created.Anchor.Kind), Ref: created.Anchor.Ref},
+		Body:      created.Body,
+		Resolved:  created.Resolved,
+		Editable:  true,
+		Deletable: true,
+	})
+}
+
+// updateCommentRequest carries the two mutable fields.
+//
+// Pointers so "not supplied" is distinguishable from "set to the zero value" —
+// resolving a comment must not require echoing its body back.
+type updateCommentRequest struct {
+	Body     *string `json:"body"`
+	Resolved *bool   `json:"resolved"`
+}
+
+func (a *App) updateComment(
+	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target, commentID string,
+) {
+	ctx := r.Context()
+
+	existing, ok := a.gateCommentMutation(w, r, svc, target, commentID, mutationUpdate)
+	if !ok {
+		return
+	}
+
+	var req updateCommentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_body", "Malformed JSON body", "")
+		return
+	}
+
+	body := existing.Body
+	if req.Body != nil {
+		body = *req.Body
+	}
+	resolved := existing.Resolved
+	if req.Resolved != nil {
+		resolved = *req.Resolved
+	}
+
+	if err := svc.Update(ctx, target, commentID, body, resolved); err != nil {
+		writeCommentError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *App) deleteComment(
+	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target, commentID string,
+) {
+	if _, ok := a.gateCommentMutation(w, r, svc, target, commentID, mutationDelete); !ok {
+		return
+	}
+	if err := svc.Delete(r.Context(), target, commentID); err != nil {
+		writeCommentError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// mutationKind distinguishes the two mutating routes for [App.gateCommentMutation].
+type mutationKind int
+
+const (
+	mutationUpdate mutationKind = iota
+	mutationDelete
+)
+
+// gateCommentMutation resolves the target, loads the comment, and authorizes
+// the mutation — returning the loaded comment so the caller does not re-read it.
+//
+// The comment is loaded BEFORE the permission check because ownership is a
+// property of the stored record: "may I edit this?" cannot be answered without
+// knowing who wrote it. A missing comment is a 404 rather than a 403, since by
+// this point the caller has proven it can read the target.
+func (a *App) gateCommentMutation(
+	w http.ResponseWriter, r *http.Request, svc *comments.Service,
+	target comments.Target, commentID string, kind mutationKind,
+) (comments.Comment, bool) {
+	ctx := r.Context()
+
+	if !a.gateCommentTarget(w, r, target) {
+		return comments.Comment{}, false
+	}
+
+	existing, err := svc.Get(ctx, target, commentID)
+	if err != nil {
+		if errors.Is(err, comments.ErrNotFound) {
+			writeV1Error(w, r, http.StatusNotFound, "not_found", "Comment not found", "")
+			return comments.Comment{}, false
+		}
+		writeV1Error(w, r, http.StatusInternalServerError, "comments_failed",
+			"Could not read comments", "")
+		return comments.Comment{}, false
+	}
+
+	user := principal.From(ctx).User
+	auth := a.commentAuthorizer()
+	allowed := auth.CanUpdate(ctx, target, existing, user)
+	perms := "comment:update-own or comment:update-any"
+	if kind == mutationDelete {
+		allowed = auth.CanDelete(ctx, target, existing, user)
+		perms = "comment:delete-own or comment:delete-any"
+	}
+	if !allowed {
+		writeV1Error(w, r, http.StatusForbidden, "forbidden",
+			"This action requires "+perms, "")
+		return comments.Comment{}, false
+	}
+	return existing, true
+}
+
+// gateCommentTarget resolves the target entity, reporting whether the request
+// may proceed.
+//
+// Both "you may not read this" and "this does not exist" answer with the same
+// 404. Checking EXISTENCE as well as the read verdict matters: the read gate
+// answers "may this principal read this type", which a nonexistent id passes —
+// so gating on the verdict alone would let a comment route confirm that an
+// arbitrary id is absent, and (worse) accept comments filed against entities
+// that were never there.
+func (a *App) gateCommentTarget(w http.ResponseWriter, r *http.Request, target comments.Target) bool {
+	_, found, err := a.visibleReader.getVisible(r.Context(), target.Type, target.ID)
+	if err != nil {
+		writeGateError(w, r, err)
+		return false
+	}
+	if !found {
+		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
+		return false
+	}
+	return true
+}
+
+// refuseIfReadOnly denies a comment write on a read-only instance, reporting
+// whether it did so.
+//
+// Checked before any other gate: ReadOnlyACL is a process-wide refusal an
+// operator wires for "absolute confidence no writes happen", so it must not be
+// satisfiable by any permission in any acl.yaml. Comments bypass the
+// entitymanager, so ReadOnlyACL's blanket write deny never sees them — this is
+// where that guarantee is kept for the commentary layer.
+func (a *App) refuseIfReadOnly(w http.ResponseWriter, r *http.Request) bool {
+	if a.commentWritesPermitted() {
+		return false
+	}
+	writeV1Error(w, r, http.StatusForbidden, "forbidden",
+		"this rela instance is configured read-only", "")
+	return true
+}
+
+// isDetached reports whether a comment's anchor no longer names anything.
+//
+// Only property anchors are checked. A section ref resolves against the view
+// config rather than the entity, so this per-entity view cannot tell a missing
+// section from a present one — and guessing would put a "detached" badge on
+// every section comment. A nil set means the entity could not be loaded, which
+// likewise proves nothing.
+func isDetached(liveProperties map[string]bool, anchor comments.Anchor) bool {
+	if liveProperties == nil || anchor.Kind != comments.AnchorProperty {
+		return false
+	}
+	return !liveProperties[anchor.Ref]
+}
+
+// writeCommentError maps a service error to a response.
+//
+// Validation failures are 400s (malformed wire format, per DEC-HWZHA's first
+// class) and everything unrecognized is a 500 with no detail — a storage error
+// message can carry a path, and a path is not the caller's business.
+func writeCommentError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, comments.ErrNotFound):
+		writeV1Error(w, r, http.StatusNotFound, "not_found", "Comment not found", "")
+	case errors.Is(err, comments.ErrEmptyBody),
+		errors.Is(err, comments.ErrBodyTooLong),
+		errors.Is(err, comments.ErrBodyControlChars),
+		errors.Is(err, comments.ErrInvalidAnchor):
+		writeV1Error(w, r, http.StatusBadRequest, "invalid_comment", err.Error(), "")
+	case errors.Is(err, comments.ErrTooManyComments):
+		writeV1Error(w, r, http.StatusConflict, "too_many_comments", err.Error(), "")
+	case errors.Is(err, comments.ErrUnknownAuthor):
+		// The caller is authenticated enough to reach here but has no
+		// resolvable identity to attribute the comment to.
+		writeV1Error(w, r, http.StatusForbidden, "forbidden",
+			"Comments require an identified author", "")
+	default:
+		writeV1Error(w, r, http.StatusInternalServerError, "comments_failed",
+			"Could not save the comment", "")
+	}
+}

--- a/internal/dataentry/comments_handler.go
+++ b/internal/dataentry/comments_handler.go
@@ -281,7 +281,7 @@ func (h *commentsHandler) addComment(
 		Ref:  req.Anchor.Ref,
 	}
 	if anchor.Kind == comments.AnchorText {
-		text, aerr := h.buildTextAnchor(ctx, target, req.Anchor.Quote, req.Anchor.QuoteIndex)
+		text, aerr := h.buildTextAnchor(ctx, target, req.Anchor.Quote)
 		if aerr != nil {
 			writeV1Error(w, r, http.StatusBadRequest, "invalid_comment", aerr.Error(), "")
 			return

--- a/internal/dataentry/comments_handler.go
+++ b/internal/dataentry/comments_handler.go
@@ -242,16 +242,19 @@ type addCommentRequest struct {
 		Ref  string `json:"ref"`
 		// Quote is the selected body text, for a `text` anchor.
 		//
-		// The client sends the QUOTE, not offsets or context descriptors: the
-		// server derives Prefix/Suffix/HeadingContext from its own copy of the
-		// body, so a caller cannot store context that disagrees with the
-		// entity — which would make the anchor resolve somewhere nobody
-		// selected. Offsets would be worse still, since the client renders
-		// markdown and its coordinates are not the source's.
+		// The client sends RENDERED text, not offsets: it renders markdown, so
+		// its coordinates are not the source's. The server maps the quote back
+		// to source through the AST and derives the stored descriptors itself,
+		// so a caller cannot persist context that disagrees with the entity.
 		Quote string `json:"quote"`
-		// QuoteIndex disambiguates a quote occurring more than once, as the
-		// 0-based occurrence the user selected. Absent means the first.
-		QuoteIndex int `json:"quote_index"`
+		// QuotePrefix and QuoteSuffix are the rendered text immediately around
+		// the selection. They select among REAL occurrences of the quote and
+		// can never introduce a location, since the quote must still be found.
+		//
+		// Without them a repeated quote resolves to the first occurrence — how
+		// a comment on "Geordend" came to highlight "Ongeordend".
+		QuotePrefix string `json:"quote_prefix"`
+		QuoteSuffix string `json:"quote_suffix"`
 	} `json:"anchor"`
 	Body string `json:"body"`
 }
@@ -281,7 +284,7 @@ func (h *commentsHandler) addComment(
 		Ref:  req.Anchor.Ref,
 	}
 	if anchor.Kind == comments.AnchorText {
-		text, aerr := h.buildTextAnchor(ctx, target, req.Anchor.Quote)
+		text, aerr := h.buildTextAnchor(ctx, target, req.Anchor.Quote, req.Anchor.QuotePrefix, req.Anchor.QuoteSuffix)
 		if aerr != nil {
 			writeV1Error(w, r, http.StatusBadRequest, "invalid_comment", aerr.Error(), "")
 			return

--- a/internal/dataentry/comments_handler.go
+++ b/internal/dataentry/comments_handler.go
@@ -144,16 +144,38 @@ type commentListResponse struct {
 // Deliberately NOT the storage type: `detached` is computed per request from
 // the live entity, and re-using the stored struct would eventually tempt
 // someone to persist it.
+// anchorWire is a comment's anchor on the wire.
+//
+// Named rather than inlined because it is built at three sites and carries the
+// stage-2 text descriptors; an anonymous struct repeated four times drifts.
+type anchorWire struct {
+	Kind string `json:"kind"`
+	Ref  string `json:"ref"`
+	// Quote is the anchored text, echoed for a text anchor so a client can
+	// show WHAT was commented on even when the range no longer resolves.
+	Quote string `json:"quote,omitempty"`
+	// Start and End are byte offsets into the entity body, resolved fresh on
+	// every read. Present only for a text anchor that located successfully.
+	//
+	// They are NOT stored: an offset is invalidated by any edit earlier in the
+	// body, which is the entire reason the descriptors exist. A client must
+	// slice with these, never with the quote's length.
+	Start *int `json:"start,omitempty"`
+	End   *int `json:"end,omitempty"`
+	// Confidence is the resolver's score for a text anchor (0-1).
+	Confidence float64 `json:"confidence,omitempty"`
+	// Uncertain marks the middle band: located, but far enough from an exact
+	// match that the UI should say the text may have moved.
+	Uncertain bool `json:"uncertain,omitempty"`
+}
+
 type commentWire struct {
-	ID        string `json:"id"`
-	Author    string `json:"author"`
-	CreatedAt string `json:"created_at"`
-	Anchor    struct {
-		Kind string `json:"kind"`
-		Ref  string `json:"ref"`
-	} `json:"anchor"`
-	Body     string `json:"body"`
-	Resolved bool   `json:"resolved"`
+	ID        string     `json:"id"`
+	Author    string     `json:"author"`
+	CreatedAt string     `json:"created_at"`
+	Anchor    anchorWire `json:"anchor"`
+	Body      string     `json:"body"`
+	Resolved  bool       `json:"resolved"`
 	// Detached reports that the anchor no longer names anything on the target.
 	// A soft condition per DEC-HWZHA: the comment is still returned and still
 	// readable, flagged so the UI can show it as orphaned rather than pretend
@@ -193,17 +215,15 @@ func (h *commentsHandler) listComments(
 	anchors := h.liveAnchors(ctx, target)
 	out := make([]commentWire, 0, len(list))
 	for _, c := range list {
+		anchor, detached := resolveAnchor(anchors, c.Anchor)
 		out = append(out, commentWire{
 			ID:        c.ID,
 			Author:    c.Author,
 			CreatedAt: c.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
-			Anchor: struct {
-				Kind string `json:"kind"`
-				Ref  string `json:"ref"`
-			}{Kind: string(c.Anchor.Kind), Ref: c.Anchor.Ref},
+			Anchor:    anchor,
 			Body:      c.Body,
 			Resolved:  c.Resolved,
-			Detached:  isDetached(anchors, c.Anchor),
+			Detached:  detached,
 			Editable:  auth.CanUpdate(ctx, target, c, user),
 			Deletable: auth.CanDelete(ctx, target, c, user),
 		})
@@ -220,6 +240,18 @@ type addCommentRequest struct {
 	Anchor struct {
 		Kind string `json:"kind"`
 		Ref  string `json:"ref"`
+		// Quote is the selected body text, for a `text` anchor.
+		//
+		// The client sends the QUOTE, not offsets or context descriptors: the
+		// server derives Prefix/Suffix/HeadingContext from its own copy of the
+		// body, so a caller cannot store context that disagrees with the
+		// entity — which would make the anchor resolve somewhere nobody
+		// selected. Offsets would be worse still, since the client renders
+		// markdown and its coordinates are not the source's.
+		Quote string `json:"quote"`
+		// QuoteIndex disambiguates a quote occurring more than once, as the
+		// 0-based occurrence the user selected. Absent means the first.
+		QuoteIndex int `json:"quote_index"`
 	} `json:"anchor"`
 	Body string `json:"body"`
 }
@@ -244,12 +276,22 @@ func (h *commentsHandler) addComment(
 		return
 	}
 
+	anchor := comments.Anchor{
+		Kind: comments.AnchorKind(req.Anchor.Kind),
+		Ref:  req.Anchor.Ref,
+	}
+	if anchor.Kind == comments.AnchorText {
+		text, aerr := h.buildTextAnchor(ctx, target, req.Anchor.Quote, req.Anchor.QuoteIndex)
+		if aerr != nil {
+			writeV1Error(w, r, http.StatusBadRequest, "invalid_comment", aerr.Error(), "")
+			return
+		}
+		anchor.Text = text
+	}
+
 	created, err := h.svc.Add(ctx, target, comments.AddRequest{
-		Anchor: comments.Anchor{
-			Kind: comments.AnchorKind(req.Anchor.Kind),
-			Ref:  req.Anchor.Ref,
-		},
-		Body: req.Body,
+		Anchor: anchor,
+		Body:   req.Body,
 	})
 	if err != nil {
 		writeCommentError(w, r, err)
@@ -260,10 +302,7 @@ func (h *commentsHandler) addComment(
 		ID:        created.ID,
 		Author:    created.Author,
 		CreatedAt: created.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		Anchor: struct {
-			Kind string `json:"kind"`
-			Ref  string `json:"ref"`
-		}{Kind: string(created.Anchor.Kind), Ref: created.Anchor.Ref},
+		Anchor:    newAnchorWire(created.Anchor),
 		Body:      created.Body,
 		Resolved:  created.Resolved,
 		Editable:  true,
@@ -416,18 +455,56 @@ func (h *commentsHandler) refuseIfReadOnly(w http.ResponseWriter, r *http.Reques
 	return true
 }
 
-// isDetached reports whether a comment's anchor no longer names anything.
+// newAnchorWire projects a stored anchor onto the wire WITHOUT resolving it.
 //
-// Only property anchors are checked. A section ref resolves against the view
-// config rather than the entity, so this per-entity view cannot tell a missing
-// section from a present one — and guessing would put a "detached" badge on
-// every section comment. A nil set means the entity could not be loaded, which
-// likewise proves nothing.
-func isDetached(liveProperties map[string]bool, anchor comments.Anchor) bool {
-	if liveProperties == nil || anchor.Kind != comments.AnchorProperty {
-		return false
+// Used on create, where the client already knows where it selected: a text
+// anchor's range is resolved per read, so echoing one here would be a second
+// code path producing the same number.
+func newAnchorWire(a comments.Anchor) anchorWire {
+	out := anchorWire{Kind: string(a.Kind), Ref: a.Ref}
+	if a.Text != nil {
+		out.Quote = a.Text.Quote
 	}
-	return !liveProperties[anchor.Ref]
+	return out
+}
+
+// resolveAnchor projects a stored anchor onto the wire and reports whether it
+// is currently detached.
+//
+// Per kind:
+//   - property: detached when the name is gone from the entity.
+//   - section: never flagged. A section ref resolves against the view config,
+//     not the entity, so this per-entity view cannot tell a missing section
+//     from a present one, and guessing would badge every section comment.
+//   - text: resolved against the body, yielding a fresh range plus a
+//     confidence band. Detached when the quote can no longer be located.
+//
+// An entity that could not be loaded flags nothing: failing to read must not
+// make every comment look orphaned.
+func resolveAnchor(ctx anchorContext, a comments.Anchor) (anchorWire, bool) {
+	out := newAnchorWire(a)
+	if !ctx.loaded {
+		return out, false
+	}
+
+	switch a.Kind {
+	case comments.AnchorProperty:
+		return out, !ctx.properties[a.Ref]
+
+	case comments.AnchorText:
+		m := comments.ResolveText(ctx.body, a.Text)
+		if m.Detached {
+			return out, true
+		}
+		start, end := m.Start, m.End
+		out.Start, out.End = &start, &end
+		out.Confidence = m.Confidence
+		out.Uncertain = m.Uncertain
+		return out, false
+
+	default:
+		return out, false
+	}
 }
 
 // writeCommentError maps a service error to a response.

--- a/internal/dataentry/comments_handler.go
+++ b/internal/dataentry/comments_handler.go
@@ -41,9 +41,8 @@ const commentsPathPrefix = "/api/v1/_comments/"
 // With no `comments:` block the service is nil and every route 404s, so a
 // project that never enables commenting is indistinguishable from one built
 // before the feature existed.
-func (a *App) handleV1Comments(w http.ResponseWriter, r *http.Request) {
-	svc := a.comments
-	if svc == nil {
+func (h *commentsHandler) handleV1Comments(w http.ResponseWriter, r *http.Request) {
+	if h.svc == nil {
 		// Not a capability gap worth explaining (unlike version history, which
 		// is backend-dependent): commenting is off because this project did
 		// not ask for it, so the route simply does not exist.
@@ -71,7 +70,7 @@ func (a *App) handleV1Comments(w http.ResponseWriter, r *http.Request) {
 
 	// Commentability is metamodel config, not a secret: an operator debugging
 	// a missing comment box needs to be told the type is not enabled.
-	if !a.commentPolicy().Commentable(typeName) {
+	if !h.commentPolicy().Commentable(typeName) {
 		writeV1Error(w, r, http.StatusBadRequest, "comments_not_enabled",
 			"Comments are not enabled for this entity type", "")
 		return
@@ -81,9 +80,9 @@ func (a *App) handleV1Comments(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case len(parts) == 2:
-		a.commentCollection(w, r, svc, target)
+		h.commentCollection(w, r, target)
 	case len(parts) == 3 && parts[2] != "":
-		a.commentItem(w, r, svc, target, parts[2])
+		h.commentItem(w, r, target, parts[2])
 	default:
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_path",
 			"Path must be /_comments/{type}/{id}[/{commentID}]", "")
@@ -91,15 +90,15 @@ func (a *App) handleV1Comments(w http.ResponseWriter, r *http.Request) {
 }
 
 // commentCollection handles the target-level routes.
-func (a *App) commentCollection(
-	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target,
+func (h *commentsHandler) commentCollection(
+	w http.ResponseWriter, r *http.Request, target comments.Target,
 ) {
 	switch r.Method {
 	case http.MethodGet:
-		a.listComments(w, r, svc, target)
+		h.listComments(w, r, target)
 	case http.MethodPost:
-		if !a.refuseIfReadOnly(w, r) {
-			a.addComment(w, r, svc, target)
+		if !h.refuseIfReadOnly(w, r) {
+			h.addComment(w, r, target)
 		}
 	case http.MethodOptions:
 		w.Header().Set("Allow", "GET, POST, OPTIONS")
@@ -111,17 +110,17 @@ func (a *App) commentCollection(
 }
 
 // commentItem handles the single-comment routes.
-func (a *App) commentItem(
-	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target, commentID string,
+func (h *commentsHandler) commentItem(
+	w http.ResponseWriter, r *http.Request, target comments.Target, commentID string,
 ) {
 	switch r.Method {
 	case http.MethodPatch:
-		if !a.refuseIfReadOnly(w, r) {
-			a.updateComment(w, r, svc, target, commentID)
+		if !h.refuseIfReadOnly(w, r) {
+			h.updateComment(w, r, target, commentID)
 		}
 	case http.MethodDelete:
-		if !a.refuseIfReadOnly(w, r) {
-			a.deleteComment(w, r, svc, target, commentID)
+		if !h.refuseIfReadOnly(w, r) {
+			h.deleteComment(w, r, target, commentID)
 		}
 	case http.MethodOptions:
 		w.Header().Set("Allow", "PATCH, DELETE, OPTIONS")
@@ -166,15 +165,15 @@ type commentWire struct {
 	Deletable bool `json:"deletable"`
 }
 
-func (a *App) listComments(
-	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target,
+func (h *commentsHandler) listComments(
+	w http.ResponseWriter, r *http.Request, target comments.Target,
 ) {
 	ctx := r.Context()
-	auth := a.commentAuthorizer()
+	auth := h.commentAuthorizer()
 
 	// Read floor first: a caller who cannot read the target — or a target that
 	// does not exist — gets the same 404, so comments never confirm existence.
-	if !a.gateCommentTarget(w, r, target) {
+	if !h.gateCommentTarget(w, r, target) {
 		return
 	}
 	if !auth.CanRead(ctx, target) {
@@ -183,7 +182,7 @@ func (a *App) listComments(
 		return
 	}
 
-	list, err := svc.List(ctx, target)
+	list, err := h.svc.List(ctx, target)
 	if err != nil {
 		writeV1Error(w, r, http.StatusInternalServerError, "comments_failed",
 			"Could not read comments", "")
@@ -191,7 +190,7 @@ func (a *App) listComments(
 	}
 
 	user := principal.From(ctx).User
-	anchors := a.liveAnchors(ctx, target)
+	anchors := h.liveAnchors(ctx, target)
 	out := make([]commentWire, 0, len(list))
 	for _, c := range list {
 		out = append(out, commentWire{
@@ -225,15 +224,15 @@ type addCommentRequest struct {
 	Body string `json:"body"`
 }
 
-func (a *App) addComment(
-	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target,
+func (h *commentsHandler) addComment(
+	w http.ResponseWriter, r *http.Request, target comments.Target,
 ) {
 	ctx := r.Context()
 
-	if !a.gateCommentTarget(w, r, target) {
+	if !h.gateCommentTarget(w, r, target) {
 		return
 	}
-	if !a.commentAuthorizer().CanAdd(ctx, target) {
+	if !h.commentAuthorizer().CanAdd(ctx, target) {
 		writeV1Error(w, r, http.StatusForbidden, "forbidden",
 			"Adding a comment requires the comment:add permission", "")
 		return
@@ -245,7 +244,7 @@ func (a *App) addComment(
 		return
 	}
 
-	created, err := svc.Add(ctx, target, comments.AddRequest{
+	created, err := h.svc.Add(ctx, target, comments.AddRequest{
 		Anchor: comments.Anchor{
 			Kind: comments.AnchorKind(req.Anchor.Kind),
 			Ref:  req.Anchor.Ref,
@@ -281,12 +280,12 @@ type updateCommentRequest struct {
 	Resolved *bool   `json:"resolved"`
 }
 
-func (a *App) updateComment(
-	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target, commentID string,
+func (h *commentsHandler) updateComment(
+	w http.ResponseWriter, r *http.Request, target comments.Target, commentID string,
 ) {
 	ctx := r.Context()
 
-	existing, ok := a.gateCommentMutation(w, r, svc, target, commentID, mutationUpdate)
+	existing, ok := h.gateCommentMutation(w, r, target, commentID, mutationUpdate)
 	if !ok {
 		return
 	}
@@ -306,27 +305,27 @@ func (a *App) updateComment(
 		resolved = *req.Resolved
 	}
 
-	if err := svc.Update(ctx, target, commentID, body, resolved); err != nil {
+	if err := h.svc.Update(ctx, target, commentID, body, resolved); err != nil {
 		writeCommentError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (a *App) deleteComment(
-	w http.ResponseWriter, r *http.Request, svc *comments.Service, target comments.Target, commentID string,
+func (h *commentsHandler) deleteComment(
+	w http.ResponseWriter, r *http.Request, target comments.Target, commentID string,
 ) {
-	if _, ok := a.gateCommentMutation(w, r, svc, target, commentID, mutationDelete); !ok {
+	if _, ok := h.gateCommentMutation(w, r, target, commentID, mutationDelete); !ok {
 		return
 	}
-	if err := svc.Delete(r.Context(), target, commentID); err != nil {
+	if err := h.svc.Delete(r.Context(), target, commentID); err != nil {
 		writeCommentError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// mutationKind distinguishes the two mutating routes for [App.gateCommentMutation].
+// mutationKind distinguishes the two mutating routes for gateCommentMutation.
 type mutationKind int
 
 const (
@@ -341,17 +340,17 @@ const (
 // property of the stored record: "may I edit this?" cannot be answered without
 // knowing who wrote it. A missing comment is a 404 rather than a 403, since by
 // this point the caller has proven it can read the target.
-func (a *App) gateCommentMutation(
-	w http.ResponseWriter, r *http.Request, svc *comments.Service,
+func (h *commentsHandler) gateCommentMutation(
+	w http.ResponseWriter, r *http.Request,
 	target comments.Target, commentID string, kind mutationKind,
 ) (comments.Comment, bool) {
 	ctx := r.Context()
 
-	if !a.gateCommentTarget(w, r, target) {
+	if !h.gateCommentTarget(w, r, target) {
 		return comments.Comment{}, false
 	}
 
-	existing, err := svc.Get(ctx, target, commentID)
+	existing, err := h.svc.Get(ctx, target, commentID)
 	if err != nil {
 		if errors.Is(err, comments.ErrNotFound) {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Comment not found", "")
@@ -363,7 +362,7 @@ func (a *App) gateCommentMutation(
 	}
 
 	user := principal.From(ctx).User
-	auth := a.commentAuthorizer()
+	auth := h.commentAuthorizer()
 	allowed := auth.CanUpdate(ctx, target, existing, user)
 	perms := "comment:update-own or comment:update-any"
 	if kind == mutationDelete {
@@ -387,8 +386,8 @@ func (a *App) gateCommentMutation(
 // so gating on the verdict alone would let a comment route confirm that an
 // arbitrary id is absent, and (worse) accept comments filed against entities
 // that were never there.
-func (a *App) gateCommentTarget(w http.ResponseWriter, r *http.Request, target comments.Target) bool {
-	_, found, err := a.visibleReader.getVisible(r.Context(), target.Type, target.ID)
+func (h *commentsHandler) gateCommentTarget(w http.ResponseWriter, r *http.Request, target comments.Target) bool {
+	_, found, err := h.visibleReader.getVisible(r.Context(), target.Type, target.ID)
 	if err != nil {
 		writeGateError(w, r, err)
 		return false
@@ -408,8 +407,8 @@ func (a *App) gateCommentTarget(w http.ResponseWriter, r *http.Request, target c
 // satisfiable by any permission in any acl.yaml. Comments bypass the
 // entitymanager, so ReadOnlyACL's blanket write deny never sees them — this is
 // where that guarantee is kept for the commentary layer.
-func (a *App) refuseIfReadOnly(w http.ResponseWriter, r *http.Request) bool {
-	if a.commentWritesPermitted() {
+func (h *commentsHandler) refuseIfReadOnly(w http.ResponseWriter, r *http.Request) bool {
+	if h.commentWritesPermitted() {
 		return false
 	}
 	writeV1Error(w, r, http.StatusForbidden, "forbidden",

--- a/internal/dataentry/comments_handler.go
+++ b/internal/dataentry/comments_handler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
@@ -62,7 +63,7 @@ func (h *commentsHandler) handleV1Comments(w http.ResponseWriter, r *http.Reques
 	// Validate the path segments before they reach storage. The file backend
 	// guards itself too, but refusing here keeps an unsafe id from reaching any
 	// backend at all, and gives a 400 rather than an opaque store error.
-	if !isSafePathSegment(typeName) || !isSafePathSegment(entityID) {
+	if !isSafePathSegment(typeName) || !isSafeStateRefSegment(entityID) {
 		writeV1Error(w, r, http.StatusBadRequest, "invalid_path",
 			"Invalid entity type or id", "")
 		return
@@ -164,7 +165,8 @@ func (h *commentsHandler) commentResolveCheck(
 		writeV1Error(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed", "")
 		return
 	}
-	if !h.gateCommentTarget(w, r, target) {
+	target, ok := h.gateCommentTarget(w, r, target)
+	if !ok {
 		return
 	}
 	if !h.commentAuthorizer().CanAdd(r.Context(), target) {
@@ -252,7 +254,8 @@ func (h *commentsHandler) listComments(
 
 	// Read floor first: a caller who cannot read the target — or a target that
 	// does not exist — gets the same 404, so comments never confirm existence.
-	if !h.gateCommentTarget(w, r, target) {
+	target, ok := h.gateCommentTarget(w, r, target)
+	if !ok {
 		return
 	}
 	if !auth.CanRead(ctx, target) {
@@ -321,7 +324,8 @@ func (h *commentsHandler) addComment(
 ) {
 	ctx := r.Context()
 
-	if !h.gateCommentTarget(w, r, target) {
+	target, ok := h.gateCommentTarget(w, r, target)
+	if !ok {
 		return
 	}
 	if !h.commentAuthorizer().CanAdd(ctx, target) {
@@ -384,7 +388,7 @@ func (h *commentsHandler) updateComment(
 ) {
 	ctx := r.Context()
 
-	existing, ok := h.gateCommentMutation(w, r, target, commentID, mutationUpdate)
+	target, existing, ok := h.gateCommentMutation(w, r, target, commentID, mutationUpdate)
 	if !ok {
 		return
 	}
@@ -414,7 +418,8 @@ func (h *commentsHandler) updateComment(
 func (h *commentsHandler) deleteComment(
 	w http.ResponseWriter, r *http.Request, target comments.Target, commentID string,
 ) {
-	if _, ok := h.gateCommentMutation(w, r, target, commentID, mutationDelete); !ok {
+	target, _, ok := h.gateCommentMutation(w, r, target, commentID, mutationDelete)
+	if !ok {
 		return
 	}
 	if err := h.svc.Delete(r.Context(), target, commentID); err != nil {
@@ -442,22 +447,23 @@ const (
 func (h *commentsHandler) gateCommentMutation(
 	w http.ResponseWriter, r *http.Request,
 	target comments.Target, commentID string, kind mutationKind,
-) (comments.Comment, bool) {
+) (comments.Target, comments.Comment, bool) {
 	ctx := r.Context()
 
-	if !h.gateCommentTarget(w, r, target) {
-		return comments.Comment{}, false
+	target, ok := h.gateCommentTarget(w, r, target)
+	if !ok {
+		return target, comments.Comment{}, false
 	}
 
 	existing, err := h.svc.Get(ctx, target, commentID)
 	if err != nil {
 		if errors.Is(err, comments.ErrNotFound) {
 			writeV1Error(w, r, http.StatusNotFound, "not_found", "Comment not found", "")
-			return comments.Comment{}, false
+			return target, comments.Comment{}, false
 		}
 		writeV1Error(w, r, http.StatusInternalServerError, "comments_failed",
 			"Could not read comments", "")
-		return comments.Comment{}, false
+		return target, comments.Comment{}, false
 	}
 
 	user := principal.From(ctx).User
@@ -471,9 +477,9 @@ func (h *commentsHandler) gateCommentMutation(
 	if !allowed {
 		writeV1Error(w, r, http.StatusForbidden, "forbidden",
 			"This action requires "+perms, "")
-		return comments.Comment{}, false
+		return target, comments.Comment{}, false
 	}
-	return existing, true
+	return target, existing, true
 }
 
 // gateCommentTarget resolves the target entity, reporting whether the request
@@ -485,17 +491,26 @@ func (h *commentsHandler) gateCommentMutation(
 // so gating on the verdict alone would let a comment route confirm that an
 // arbitrary id is absent, and (worse) accept comments filed against entities
 // that were never there.
-func (h *commentsHandler) gateCommentTarget(w http.ResponseWriter, r *http.Request, target comments.Target) bool {
-	_, found, err := h.visibleReader.getVisible(r.Context(), target.Type, target.ID)
+func (h *commentsHandler) gateCommentTarget(
+	w http.ResponseWriter, r *http.Request, target comments.Target,
+) (comments.Target, bool) {
+	ent, found, err := h.visibleReader.getVisible(r.Context(), target.Type, target.ID)
 	if err != nil {
 		writeGateError(w, r, err)
-		return false
+		return target, false
 	}
 	if !found {
 		writeV1Error(w, r, http.StatusNotFound, "not_found", entityNotFoundTitle, "")
-		return false
+		return target, false
 	}
-	return true
+	// Scope the thread to the face this request actually resolved to
+	// (FEAT-9CD2MX). Taken from the RESOLVED entity rather than parsed from the
+	// URL: a bare id under a world resolves to whichever face that world
+	// selects, and the thread must match the content on screen. Returning it
+	// from the gate means no call site can forget to apply it.
+	target.ID = ent.ID
+	target.Face = ent.Face
+	return target, true
 }
 
 // refuseIfReadOnly denies a comment write on a read-only instance, reporting
@@ -513,6 +528,28 @@ func (h *commentsHandler) refuseIfReadOnly(w http.ResponseWriter, r *http.Reques
 	writeV1Error(w, r, http.StatusForbidden, "forbidden",
 		"this rela instance is configured read-only", "")
 	return true
+}
+
+// isSafeStateRefSegment reports whether a path segment is a usable entity
+// reference, with or without a face ("TKT-1", "TKT-1@draft").
+//
+// A separate check rather than widening [isSafePathSegment]: that helper guards
+// every other route, and '@' is only meaningful where a face may legitimately
+// appear. Both halves are validated on their own terms, so nothing unsafe
+// reaches storage — the face half by the entity package's own grammar, which
+// is narrower than the id's.
+func isSafeStateRefSegment(s string) bool {
+	base, face, found := strings.Cut(s, entity.StateRefSeparator)
+	if !isSafePathSegment(base) {
+		return false
+	}
+	if !found {
+		return true
+	}
+	// entity.ParseFace is the only sanctioned constructor from external input,
+	// and rejects anything outside the declared face grammar.
+	_, err := entity.ParseFace(face)
+	return err == nil
 }
 
 // newAnchorWire projects a stored anchor onto the wire WITHOUT resolving it.

--- a/internal/dataentry/comments_handler_test.go
+++ b/internal/dataentry/comments_handler_test.go
@@ -332,3 +332,43 @@ func TestComments_ReadOnlyInstanceRefusesWrites(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
 }
+
+// TestComments_SchemaExposesCommentable pins the SPA's discovery signal: the
+// UI must be able to tell which types accept a comment affordance without
+// probing the comment routes for a 400.
+//
+// The flag is policy, not permission — it says commenting is possible here,
+// never that the caller may do it — and it is omitted entirely when false, so
+// a project with no `comments:` block serves the schema it always did.
+func TestComments_SchemaExposesCommentable(t *testing.T) {
+	t.Run("enabled type is flagged", func(t *testing.T) {
+		app := commentsApp(t)
+
+		rec := httptest.NewRecorder()
+		app.handleV1Schema(rec, httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody))
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var got struct {
+			Entities map[string]struct {
+				Commentable bool `json:"commentable"`
+			} `json:"entities"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.True(t, got.Entities["ticket"].Commentable)
+	})
+
+	t.Run("absent block omits the field", func(t *testing.T) {
+		app := newTestAppV1(t) // no comments config
+
+		rec := httptest.NewRecorder()
+		app.handleV1Schema(rec, httptest.NewRequest(http.MethodGet, "/api/v1/_schema", http.NoBody))
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var raw map[string]map[string]map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+		for name, et := range raw["entities"] {
+			_, present := et["commentable"]
+			require.False(t, present, "type %q leaked a commentable key with no comments block", name)
+		}
+	})
+}

--- a/internal/dataentry/comments_handler_test.go
+++ b/internal/dataentry/comments_handler_test.go
@@ -559,3 +559,53 @@ func TestComments_ResolveCheck(t *testing.T) {
 		require.Empty(t, listComments(t, app).Comments, "a preflight must not persist anything")
 	})
 }
+
+// TestComments_PerFaceThreads pins that a comment belongs to ONE content state
+// (FEAT-9CD2MX).
+//
+// A remark on the draft ("this needs a source") is not a remark on the
+// published version, and the read gate is per face too — so a shared thread
+// would both misattribute feedback and leak across a boundary the entity
+// itself maintains.
+func TestComments_PerFaceThreads(t *testing.T) {
+	const draft = entity.Face("draft")
+
+	app := commentsApp(t)
+	// A second face of the SAME entity id.
+	require.NoError(t, app.store.CreateEntity(t.Context(), &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Face:       draft,
+		Properties: map[string]any{"title": "Test Ticket", "status": "open"},
+		Content:    "Draft body text that differs from the default face.\n",
+	}))
+
+	post := func(t *testing.T, path, body string) {
+		t.Helper()
+		rec := doComments(t, app, http.MethodPost, path, body, "alice@example.com")
+		require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	}
+	list := func(t *testing.T, path string) commentListResponse {
+		t.Helper()
+		rec := doComments(t, app, http.MethodGet, path, "", "alice@example.com")
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		var got commentListResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		return got
+	}
+
+	const defaultPath = "/api/v1/_comments/ticket/TKT-001"
+	const draftPath = "/api/v1/_comments/ticket/TKT-001@draft"
+
+	post(t, defaultPath, `{"anchor":{"kind":"property","ref":"status"},"body":"on the default face"}`)
+	post(t, draftPath, `{"anchor":{"kind":"property","ref":"status"},"body":"on the draft face"}`)
+
+	onDefault := list(t, defaultPath)
+	require.Len(t, onDefault.Comments, 1)
+	require.Equal(t, "on the default face", onDefault.Comments[0].Body,
+		"the default face must not show the draft's thread")
+
+	onDraft := list(t, draftPath)
+	require.Len(t, onDraft.Comments, 1)
+	require.Equal(t, "on the draft face", onDraft.Comments[0].Body)
+}

--- a/internal/dataentry/comments_handler_test.go
+++ b/internal/dataentry/comments_handler_test.go
@@ -1,0 +1,334 @@
+package dataentry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/comments/memcomments"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+)
+
+// commentsApp returns a test App with commenting enabled for `ticket` and one
+// seeded ticket to comment on.
+func commentsApp(t *testing.T) *App {
+	t.Helper()
+	app := newTestAppV1(t)
+	app.State().Meta.Comments = &metamodel.CommentsConfig{Enabled: true, On: []string{"ticket"}}
+
+	svc, err := comments.NewService(memcomments.New(), nil)
+	require.NoError(t, err)
+	app.SetComments(svc)
+
+	seedEntity(app, &entity.Entity{
+		ID:         "TKT-001",
+		Type:       "ticket",
+		Properties: map[string]any{"title": "Test Ticket", "status": "open"},
+	})
+	return app
+}
+
+// asUser stamps a principal so the service can attribute an author.
+func asUser(r *http.Request, user string) *http.Request {
+	return r.WithContext(principal.With(r.Context(),
+		principal.Principal{User: user, Tool: "data-entry"}))
+}
+
+func doComments(t *testing.T, app *App, method, path, body, user string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, http.NoBody)
+	} else {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	if user != "" {
+		req = asUser(req, user)
+	}
+	rec := httptest.NewRecorder()
+	app.handleV1Comments(rec, req)
+	return rec
+}
+
+func listComments(t *testing.T, app *App) commentListResponse {
+	t.Helper()
+	rec := doComments(t, app, http.MethodGet, "/api/v1/_comments/ticket/TKT-001", "", "alice@example.com")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var got commentListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	return got
+}
+
+const addBody = `{"anchor":{"kind":"property","ref":"status"},"body":"looks wrong"}`
+
+// TestComments_DisabledRoutes404 pins AC1: with no `comments:` block the routes
+// do not exist, so a project without the block is indistinguishable from one
+// built before the feature.
+func TestComments_DisabledRoutes404(t *testing.T) {
+	app := newTestAppV1(t) // no comments config, no service
+
+	for _, tc := range []struct{ method, path, body string }{
+		{http.MethodGet, "/api/v1/_comments/ticket/TKT-001", ""},
+		{http.MethodPost, "/api/v1/_comments/ticket/TKT-001", addBody},
+		{http.MethodDelete, "/api/v1/_comments/ticket/TKT-001/abc", ""},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			rec := doComments(t, app, tc.method, tc.path, tc.body, "alice@example.com")
+			require.Equal(t, http.StatusNotFound, rec.Code)
+		})
+	}
+}
+
+// TestComments_AddAndList pins AC2.
+func TestComments_AddAndList(t *testing.T) {
+	app := commentsApp(t)
+
+	rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", addBody, "alice@example.com")
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	got := listComments(t, app)
+	require.Len(t, got.Comments, 1)
+	require.Equal(t, "looks wrong", got.Comments[0].Body)
+	require.Equal(t, "status", got.Comments[0].Anchor.Ref)
+	require.Equal(t, "property", got.Comments[0].Anchor.Kind)
+}
+
+// TestComments_AuthorIsServerStamped is AC3 at the HTTP boundary: a client that
+// puts an author (or an id) in the body must not have it honored.
+func TestComments_AuthorIsServerStamped(t *testing.T) {
+	app := commentsApp(t)
+
+	forged := `{"anchor":{"kind":"property","ref":"status"},"body":"x",` +
+		`"author":"bob@example.com","id":"forged-id"}`
+	rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", forged, "alice@example.com")
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	got := listComments(t, app)
+	require.Len(t, got.Comments, 1)
+	require.Equal(t, "alice@example.com", got.Comments[0].Author,
+		"the request principal wins over a body-supplied author")
+	require.NotEqual(t, "forged-id", got.Comments[0].ID,
+		"the server mints the id")
+}
+
+// TestComments_UnidentifiedAuthorRefused pins that a caller with no resolvable
+// identity cannot leave a comment nobody can later own.
+func TestComments_UnidentifiedAuthorRefused(t *testing.T) {
+	app := commentsApp(t)
+
+	rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", addBody, "")
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
+// TestComments_TypeNotEnabled pins AC4. The refusal names the reason: which
+// types accept comments is metamodel config, not a secret.
+func TestComments_TypeNotEnabled(t *testing.T) {
+	app := commentsApp(t)
+	seedEntity(app, &entity.Entity{
+		ID: "FEAT-001", Type: "feature",
+		Properties: map[string]any{"title": "A feature"},
+	})
+
+	rec := doComments(t, app, http.MethodGet, "/api/v1/_comments/feature/FEAT-001", "", "alice@example.com")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "comments_not_enabled")
+}
+
+// TestComments_InvalidPaths pins the path guards, including the traversal shape
+// that must never reach a file backend.
+func TestComments_InvalidPaths(t *testing.T) {
+	app := commentsApp(t)
+
+	for _, path := range []string{
+		"/api/v1/_comments/ticket",
+		"/api/v1/_comments/",
+		"/api/v1/_comments/ticket/../../etc",
+		"/api/v1/_comments/ticket/.hidden",
+	} {
+		t.Run(path, func(t *testing.T) {
+			rec := doComments(t, app, http.MethodGet, path, "", "alice@example.com")
+			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+		})
+	}
+}
+
+// TestComments_BodyValidation pins AC12 at the boundary.
+func TestComments_BodyValidation(t *testing.T) {
+	app := commentsApp(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"empty body", `{"anchor":{"kind":"property","ref":"status"},"body":""}`},
+		{"whitespace body", `{"anchor":{"kind":"property","ref":"status"},"body":"   "}`},
+		{"control char in body", "{\"anchor\":{\"kind\":\"property\",\"ref\":\"status\"},\"body\":\"a\\u0000b\"}"},
+		{"oversized body", `{"anchor":{"kind":"property","ref":"status"},"body":"` +
+			strings.Repeat("x", comments.MaxBodyBytes+1) + `"}`},
+		{"unknown anchor kind", `{"anchor":{"kind":"wat","ref":"status"},"body":"x"}`},
+		{"empty anchor ref", `{"anchor":{"kind":"property","ref":""},"body":"x"}`},
+		{"malformed json", `{not json`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doComments(t, app, http.MethodPost,
+				"/api/v1/_comments/ticket/TKT-001", tc.body, "alice@example.com")
+			require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+		})
+	}
+}
+
+// TestComments_DetachedAnchor pins AC9: an anchor naming a property that no
+// longer exists still returns, flagged — a warning, never a rejection.
+func TestComments_DetachedAnchor(t *testing.T) {
+	app := commentsApp(t)
+
+	live := `{"anchor":{"kind":"property","ref":"status"},"body":"on a real property"}`
+	gone := `{"anchor":{"kind":"property","ref":"no_such_property"},"body":"on a ghost"}`
+	for _, body := range []string{live, gone} {
+		rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+		require.Equal(t, http.StatusCreated, rec.Code, "a detached anchor must not be refused")
+	}
+
+	got := listComments(t, app)
+	require.Len(t, got.Comments, 2)
+
+	byRef := map[string]commentWire{}
+	for _, c := range got.Comments {
+		byRef[c.Anchor.Ref] = c
+	}
+	require.False(t, byRef["status"].Detached)
+	require.True(t, byRef["no_such_property"].Detached, "a vanished property reads as detached")
+}
+
+// TestComments_SectionAnchorNeverDetached pins that a section ref — which
+// resolves against the view config, not the entity — is not mislabelled by the
+// per-entity property check.
+func TestComments_SectionAnchorNeverDetached(t *testing.T) {
+	app := commentsApp(t)
+
+	body := `{"anchor":{"kind":"section","ref":"acceptance-criteria"},"body":"about this section"}`
+	rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	got := listComments(t, app)
+	require.Len(t, got.Comments, 1)
+	require.False(t, got.Comments[0].Detached,
+		"a section anchor is not resolvable per-entity and must not be flagged")
+}
+
+// TestComments_UpdateAndDelete covers the mutating routes end to end.
+func TestComments_UpdateAndDelete(t *testing.T) {
+	app := commentsApp(t)
+
+	rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", addBody, "alice@example.com")
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var created commentWire
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+
+	path := "/api/v1/_comments/ticket/TKT-001/" + created.ID
+
+	t.Run("resolve without echoing the body", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodPatch, path, `{"resolved":true}`, "alice@example.com")
+		require.Equal(t, http.StatusNoContent, rec.Code, rec.Body.String())
+
+		got := listComments(t, app)
+		require.True(t, got.Comments[0].Resolved)
+		require.Equal(t, "looks wrong", got.Comments[0].Body,
+			"an unsupplied body is preserved, not blanked")
+	})
+
+	t.Run("edit the body", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodPatch, path, `{"body":"actually fine"}`, "alice@example.com")
+		require.Equal(t, http.StatusNoContent, rec.Code)
+
+		got := listComments(t, app)
+		require.Equal(t, "actually fine", got.Comments[0].Body)
+		require.True(t, got.Comments[0].Resolved, "an unsupplied flag is preserved too")
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodDelete, path, "", "alice@example.com")
+		require.Equal(t, http.StatusNoContent, rec.Code)
+		require.Empty(t, listComments(t, app).Comments)
+	})
+}
+
+func TestComments_UnknownCommentIs404(t *testing.T) {
+	app := commentsApp(t)
+
+	for _, method := range []string{http.MethodPatch, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			rec := doComments(t, app, method,
+				"/api/v1/_comments/ticket/TKT-001/nosuchcomment", `{"body":"x"}`, "alice@example.com")
+			require.Equal(t, http.StatusNotFound, rec.Code)
+		})
+	}
+}
+
+// TestComments_UnknownTargetIs404 pins that a comment route cannot be used to
+// probe for entities: an absent target answers exactly as a denied one would.
+func TestComments_UnknownTargetIs404(t *testing.T) {
+	app := commentsApp(t)
+
+	rec := doComments(t, app, http.MethodGet, "/api/v1/_comments/ticket/TKT-999", "", "alice@example.com")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestComments_MethodNotAllowed(t *testing.T) {
+	app := commentsApp(t)
+
+	t.Run("collection", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodPut, "/api/v1/_comments/ticket/TKT-001", "", "alice@example.com")
+		require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+		require.Contains(t, rec.Header().Get("Allow"), "GET")
+	})
+
+	t.Run("item", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodGet, "/api/v1/_comments/ticket/TKT-001/abc", "", "alice@example.com")
+		require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+		require.Contains(t, rec.Header().Get("Allow"), "PATCH")
+	})
+}
+
+// TestComments_ReadOnlyInstanceRefusesWrites pins that ReadOnlyACL — wired for
+// "absolute confidence no writes happen" — covers comments too. They bypass the
+// entitymanager, so its blanket write deny never sees them; this is where the
+// guarantee is kept.
+func TestComments_ReadOnlyInstanceRefusesWrites(t *testing.T) {
+	app := commentsApp(t)
+	app.acl = acl.ReadOnlyACL{}
+
+	t.Run("add refused", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodPost,
+			"/api/v1/_comments/ticket/TKT-001", addBody, "alice@example.com")
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Contains(t, rec.Body.String(), "read-only")
+	})
+
+	t.Run("update refused", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodPatch,
+			"/api/v1/_comments/ticket/TKT-001/abc", `{"body":"x"}`, "alice@example.com")
+		require.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("delete refused", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodDelete,
+			"/api/v1/_comments/ticket/TKT-001/abc", "", "alice@example.com")
+		require.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("reads still work", func(t *testing.T) {
+		rec := doComments(t, app, http.MethodGet,
+			"/api/v1/_comments/ticket/TKT-001", "", "alice@example.com")
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+}

--- a/internal/dataentry/comments_handler_test.go
+++ b/internal/dataentry/comments_handler_test.go
@@ -505,3 +505,57 @@ func TestComments_TextAnchorDisambiguation(t *testing.T) {
 		require.Equal(t, first, *got.Comments[0].Anchor.Start)
 	})
 }
+
+// TestComments_ResolveCheck covers the preflight the SPA uses to decide whether
+// to OFFER commenting on a selection.
+//
+// Without it a user selects text that cannot anchor (one spanning table cells
+// has no contiguous source range), writes a comment, and only then learns it
+// cannot be saved.
+func TestComments_ResolveCheck(t *testing.T) {
+	const path = "/api/v1/_comments/ticket/TKT-001/resolve"
+
+	t.Run("an anchorable selection reports true", func(t *testing.T) {
+		app := commentsApp(t)
+
+		body := `{"quote":"the old id in the search index"}`
+		rec := doComments(t, app, http.MethodPost, path, body, "alice@example.com")
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+		var got struct {
+			Anchorable bool   `json:"anchorable"`
+			Reason     string `json:"reason"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.True(t, got.Anchorable)
+		require.Empty(t, got.Reason)
+	})
+
+	t.Run("an unanchorable selection reports false with a reason", func(t *testing.T) {
+		app := commentsApp(t)
+
+		body := `{"quote":"text that appears nowhere in this body at all"}`
+		rec := doComments(t, app, http.MethodPost, path, body, "alice@example.com")
+		// The check SUCCEEDS; the answer is "no". A 4xx here would make the UI
+		// unable to distinguish "cannot anchor" from "request was broken".
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+		var got struct {
+			Anchorable bool   `json:"anchorable"`
+			Reason     string `json:"reason"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.False(t, got.Anchorable)
+		require.NotEmpty(t, got.Reason, "the UI shows this to explain why it cannot comment")
+	})
+
+	t.Run("creates nothing", func(t *testing.T) {
+		app := commentsApp(t)
+
+		body := `{"quote":"the old id in the search index"}`
+		require.Equal(t, http.StatusOK,
+			doComments(t, app, http.MethodPost, path, body, "alice@example.com").Code)
+
+		require.Empty(t, listComments(t, app).Comments, "a preflight must not persist anything")
+	})
+}

--- a/internal/dataentry/comments_handler_test.go
+++ b/internal/dataentry/comments_handler_test.go
@@ -447,3 +447,61 @@ func TestComments_TextAnchor(t *testing.T) {
 		require.Nil(t, got.Comments[0].Anchor.Start, "a detached anchor exposes no range")
 	})
 }
+
+// TestComments_TextAnchorDisambiguation pins the fix for a comment landing on
+// the WRONG occurrence of a repeated quote.
+//
+// Reported from the demo: selecting part of "Geordend" stored an anchor whose
+// prefix read "### Ong", so the highlight snapped to "Ongeordend" earlier in
+// the document. The quote alone cannot decide between them — the surrounding
+// rendered text is what selects the occurrence the user actually meant.
+func TestComments_TextAnchorDisambiguation(t *testing.T) {
+	const repeated = "## Lijsten\n\n### Ongeordend\n\n- first list item\n\n### Geordend\n\n1. second list item\n"
+
+	newApp := func(t *testing.T) *App {
+		t.Helper()
+		app := commentsApp(t)
+		require.NoError(t, app.store.UpdateEntity(t.Context(), &entity.Entity{
+			ID:         "TKT-001",
+			Type:       "ticket",
+			Properties: map[string]any{"title": "Test Ticket", "status": "open"},
+			Content:    repeated,
+		}))
+		return app
+	}
+
+	// Byte offsets of each "eordend" in the fixture, so the assertions name a
+	// position derived from the fixture rather than a hardcoded number.
+	first := strings.Index(repeated, "eordend")
+	second := strings.Index(repeated[first+1:], "eordend") + first + 1
+	require.NotEqual(t, first, second, "fixture must contain the quote twice")
+
+	t.Run("suffix context selects the second occurrence", func(t *testing.T) {
+		app := newApp(t)
+
+		body := `{"anchor":{"kind":"text","quote":"eordend",` +
+			`"quote_prefix":"G","quote_suffix":"\n\n1. second list item"},"body":"the ordered one"}`
+		rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+		require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+		got := listComments(t, app)
+		require.Len(t, got.Comments, 1)
+		require.NotNil(t, got.Comments[0].Anchor.Start)
+		require.Equal(t, second, *got.Comments[0].Anchor.Start,
+			"context pointed at Geordend, so the anchor must not land on Ongeordend")
+	})
+
+	t.Run("suffix context selects the first occurrence", func(t *testing.T) {
+		app := newApp(t)
+
+		body := `{"anchor":{"kind":"text","quote":"eordend",` +
+			`"quote_prefix":"Ong","quote_suffix":"\n\n- first list item"},"body":"the unordered one"}`
+		rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+		require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+		got := listComments(t, app)
+		require.Len(t, got.Comments, 1)
+		require.NotNil(t, got.Comments[0].Anchor.Start)
+		require.Equal(t, first, *got.Comments[0].Anchor.Start)
+	})
+}

--- a/internal/dataentry/comments_handler_test.go
+++ b/internal/dataentry/comments_handler_test.go
@@ -54,7 +54,7 @@ func doComments(t *testing.T, app *App, method, path, body, user string) *httpte
 		req = asUser(req, user)
 	}
 	rec := httptest.NewRecorder()
-	app.handleV1Comments(rec, req)
+	app.comments.handleV1Comments(rec, req)
 	return rec
 }
 

--- a/internal/dataentry/comments_handler_test.go
+++ b/internal/dataentry/comments_handler_test.go
@@ -32,6 +32,8 @@ func commentsApp(t *testing.T) *App {
 		ID:         "TKT-001",
 		Type:       "ticket",
 		Properties: map[string]any{"title": "Test Ticket", "status": "open"},
+		// A body, so stage-2 text anchors have something to resolve against.
+		Content: fixtureBody,
 	})
 	return app
 }
@@ -68,6 +70,11 @@ func listComments(t *testing.T, app *App) commentListResponse {
 }
 
 const addBody = `{"anchor":{"kind":"property","ref":"status"},"body":"looks wrong"}`
+
+// fixtureBody is the seeded entity's markdown. Long enough that
+// markdown.FormatMarkdown would reflow it, which is what the drift test needs.
+const fixtureBody = "Renaming an entity leaves the old id in the search index until a restart, " +
+	"which is confusing because the store itself is already correct at that point.\n"
 
 // TestComments_DisabledRoutes404 pins AC1: with no `comments:` block the routes
 // do not exist, so a project without the block is indistinguishable from one
@@ -370,5 +377,73 @@ func TestComments_SchemaExposesCommentable(t *testing.T) {
 			_, present := et["commentable"]
 			require.False(t, present, "type %q leaked a commentable key with no comments block", name)
 		}
+	})
+}
+
+// TestComments_TextAnchor covers the stage-2 text-range path end to end: the
+// client sends only a quote, the server derives the descriptors from its own
+// copy of the body, and a read resolves a fresh range.
+func TestComments_TextAnchor(t *testing.T) {
+	quote := "the old id in the search index"
+
+	t.Run("create derives descriptors and read resolves a range", func(t *testing.T) {
+		app := commentsApp(t)
+
+		body := `{"anchor":{"kind":"text","quote":"` + quote + `"},"body":"is this the bleve index?"}`
+		rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+		require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+		got := listComments(t, app)
+		require.Len(t, got.Comments, 1)
+		anchor := got.Comments[0].Anchor
+
+		require.Equal(t, "text", anchor.Kind)
+		require.Equal(t, quote, anchor.Quote, "the quote is echoed so a client can show what was commented on")
+		require.False(t, got.Comments[0].Detached)
+		require.NotNil(t, anchor.Start)
+		require.NotNil(t, anchor.End)
+		// The resolved range must actually locate the quote in the body.
+		require.Equal(t, quote, fixtureBody[*anchor.Start:*anchor.End])
+		require.GreaterOrEqual(t, anchor.Confidence, 0.8)
+		require.False(t, anchor.Uncertain)
+	})
+
+	t.Run("a quote absent from the body is refused", func(t *testing.T) {
+		app := commentsApp(t)
+
+		body := `{"anchor":{"kind":"text","quote":"text that is nowhere in the body"},"body":"x"}`
+		rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+
+		require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	})
+
+	t.Run("a too-short selection is refused", func(t *testing.T) {
+		app := commentsApp(t)
+
+		body := `{"anchor":{"kind":"text","quote":"the"},"body":"x"}`
+		rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+
+		require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	})
+
+	t.Run("detaches when the quoted text is edited away", func(t *testing.T) {
+		app := commentsApp(t)
+
+		body := `{"anchor":{"kind":"text","quote":"` + quote + `"},"body":"still relevant?"}`
+		rec := doComments(t, app, http.MethodPost, "/api/v1/_comments/ticket/TKT-001", body, "alice@example.com")
+		require.Equal(t, http.StatusCreated, rec.Code)
+
+		// Rewrite the body so the quote no longer occurs.
+		require.NoError(t, app.store.UpdateEntity(t.Context(), &entity.Entity{
+			ID:         "TKT-001",
+			Type:       "ticket",
+			Properties: map[string]any{"title": "Test Ticket", "status": "open"},
+			Content:    "This paragraph shares no wording whatsoever with the original text.\n",
+		}))
+
+		got := listComments(t, app)
+		require.Len(t, got.Comments, 1)
+		require.True(t, got.Comments[0].Detached, "an edited-away quote must detach, not match loosely")
+		require.Nil(t, got.Comments[0].Anchor.Start, "a detached anchor exposes no range")
 	})
 }

--- a/internal/dataentry/comments_wiring.go
+++ b/internal/dataentry/comments_wiring.go
@@ -193,16 +193,20 @@ func (h *commentsHandler) liveAnchors(ctx context.Context, target comments.Targe
 // buildTextAnchor derives a text anchor's descriptors from the entity's own
 // body, given the quote the client selected.
 //
-// The client supplies the quote and which occurrence it meant; everything else
-// (prefix, suffix, sentence, heading, paragraph index) is computed here. That
-// asymmetry is deliberate and is the security-relevant part: descriptors
-// sourced from the request could describe context that does not exist in the
-// entity, so a later resolve would land on text the commenter never selected.
+// The client supplies only the quote; everything else (prefix, suffix,
+// sentence, heading, paragraph index) is computed here. That asymmetry is
+// deliberate and is the security-relevant part: descriptors sourced from the
+// request could describe context that does not exist in the entity, so a later
+// resolve would land on text the commenter never selected.
+//
+// Which OCCURRENCE was meant is resolved by quotefind rather than by a
+// client-supplied index: it disambiguates through the surrounding source, which
+// a rendered-text offset from the browser cannot address anyway.
 //
 // The body read goes through the visibility wrapper, so a principal can only
 // anchor to text it may already read.
 func (h *commentsHandler) buildTextAnchor(
-	ctx context.Context, target comments.Target, quote string, occurrence int,
+	ctx context.Context, target comments.Target, quote string,
 ) (*comments.TextAnchor, error) {
 	quote = strings.TrimSpace(quote)
 	if len([]rune(quote)) < comments.MinQuoteRunes {
@@ -217,39 +221,16 @@ func (h *commentsHandler) buildTextAnchor(
 		return nil, errors.New("could not read the entity body")
 	}
 
-	start := nthIndex(ent.Content, quote, occurrence)
-	if start < 0 {
-		// The selection does not exist in the stored body. Usually a stale tab:
-		// the entity changed under the user between render and submit.
+	// The quote came from RENDERED markdown, so it is display text: no list
+	// markers, no backticks, blocks joined by newlines. Matching it against the
+	// source with a plain substring search fails for any selection crossing a
+	// bullet or a code span — FindRenderedQuote maps through the AST instead.
+	start, end, ok := comments.FindRenderedQuote(ent.Content, quote)
+	if !ok {
+		// Either a stale tab (the body changed between render and submit) or a
+		// selection that genuinely spans nothing locatable.
 		return nil, errors.New("the selected text was not found in the current body")
 	}
 
-	return comments.NewTextAnchor(ent.Content, start, start+len(quote))
-}
-
-// nthIndex returns the byte offset of the nth (0-based) occurrence of sub in s,
-// or -1. A negative or out-of-range n falls back to the first occurrence rather
-// than failing: which occurrence was meant is a UI nicety, and refusing the
-// whole comment over it would be a worse trade than anchoring to the first.
-func nthIndex(s, sub string, n int) int {
-	if n <= 0 {
-		return strings.Index(s, sub)
-	}
-	offset := 0
-	for i := 0; i <= n; i++ {
-		idx := strings.Index(s[offset:], sub)
-		if idx < 0 {
-			if i == 0 {
-				return -1
-			}
-			// Fewer occurrences than asked for: use the last one found.
-			return strings.LastIndex(s, sub)
-		}
-		offset += idx
-		if i == n {
-			return offset
-		}
-		offset += len(sub)
-	}
-	return -1
+	return comments.NewTextAnchor(ent.Content, start, end)
 }

--- a/internal/dataentry/comments_wiring.go
+++ b/internal/dataentry/comments_wiring.go
@@ -199,14 +199,17 @@ func (h *commentsHandler) liveAnchors(ctx context.Context, target comments.Targe
 // request could describe context that does not exist in the entity, so a later
 // resolve would land on text the commenter never selected.
 //
-// Which OCCURRENCE was meant is resolved by quotefind rather than by a
-// client-supplied index: it disambiguates through the surrounding source, which
-// a rendered-text offset from the browser cannot address anyway.
+// WHICH occurrence was meant is decided by the surrounding rendered text the
+// client sends alongside the quote. That context is untrusted in the sense that
+// it only selects among real occurrences — it can never introduce a location,
+// because the quote must still be found in the body. Without it a repeated
+// quote resolves to the first occurrence, which is how a comment on "Geordend"
+// ended up highlighting "Ongeordend".
 //
 // The body read goes through the visibility wrapper, so a principal can only
 // anchor to text it may already read.
 func (h *commentsHandler) buildTextAnchor(
-	ctx context.Context, target comments.Target, quote string,
+	ctx context.Context, target comments.Target, quote, prefix, suffix string,
 ) (*comments.TextAnchor, error) {
 	quote = strings.TrimSpace(quote)
 	if len([]rune(quote)) < comments.MinQuoteRunes {
@@ -225,7 +228,7 @@ func (h *commentsHandler) buildTextAnchor(
 	// markers, no backticks, blocks joined by newlines. Matching it against the
 	// source with a plain substring search fails for any selection crossing a
 	// bullet or a code span — FindRenderedQuote maps through the AST instead.
-	start, end, ok := comments.FindRenderedQuote(ent.Content, quote)
+	start, end, ok := comments.FindRenderedQuote(ent.Content, quote, prefix, suffix)
 	if !ok {
 		// Either a stale tab (the body changed between render and submit) or a
 		// selection that genuinely spans nothing locatable.

--- a/internal/dataentry/comments_wiring.go
+++ b/internal/dataentry/comments_wiring.go
@@ -2,6 +2,9 @@ package dataentry
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/comments"
@@ -131,6 +134,24 @@ func (h *commentsHandler) commentWritesPermitted() bool {
 	}
 }
 
+// anchorContext is what a read needs to decide how each anchor currently
+// resolves: the property names that exist, and the body that text anchors are
+// located within.
+//
+// Loaded ONCE per list request. Resolving text anchors needs the entity body,
+// and re-reading it per comment would be N redacted reads for N comments.
+type anchorContext struct {
+	// properties is nil when the entity could not be loaded, which means "do
+	// not flag anything as detached" rather than "nothing exists".
+	properties map[string]bool
+	// body is the entity content text anchors resolve against. Empty when the
+	// entity could not be read.
+	body string
+	// loaded distinguishes "read the entity, it has an empty body" from "could
+	// not read the entity at all" — only the latter suppresses detach flags.
+	loaded bool
+}
+
 // liveAnchors returns the set of anchor refs that currently resolve on the
 // target, or nil when the set could not be determined.
 //
@@ -143,14 +164,14 @@ func (h *commentsHandler) commentWritesPermitted() bool {
 // section anchor: a section ref names an operator-authored view heading that
 // lives in data-entry.yaml, not on the entity, and its absence from this set
 // means "not a property", not "gone".
-func (h *commentsHandler) liveAnchors(ctx context.Context, target comments.Target) map[string]bool {
+func (h *commentsHandler) liveAnchors(ctx context.Context, target comments.Target) anchorContext {
 	def, ok := h.meta().GetEntityDef(target.Type)
 	if !ok {
-		return nil
+		return anchorContext{}
 	}
 	ent, found, err := h.visibleReader.getVisible(ctx, target.Type, target.ID)
 	if err != nil || !found {
-		return nil
+		return anchorContext{}
 	}
 
 	refs := make(map[string]bool, len(def.Properties)+len(ent.Properties))
@@ -164,5 +185,71 @@ func (h *commentsHandler) liveAnchors(ctx context.Context, target comments.Targe
 	for name := range ent.Properties {
 		refs[name] = true
 	}
-	return refs
+	// The body is the REDACTED entity's content, so a text anchor can only ever
+	// resolve against text this principal may already read.
+	return anchorContext{properties: refs, body: ent.Content, loaded: true}
+}
+
+// buildTextAnchor derives a text anchor's descriptors from the entity's own
+// body, given the quote the client selected.
+//
+// The client supplies the quote and which occurrence it meant; everything else
+// (prefix, suffix, sentence, heading, paragraph index) is computed here. That
+// asymmetry is deliberate and is the security-relevant part: descriptors
+// sourced from the request could describe context that does not exist in the
+// entity, so a later resolve would land on text the commenter never selected.
+//
+// The body read goes through the visibility wrapper, so a principal can only
+// anchor to text it may already read.
+func (h *commentsHandler) buildTextAnchor(
+	ctx context.Context, target comments.Target, quote string, occurrence int,
+) (*comments.TextAnchor, error) {
+	quote = strings.TrimSpace(quote)
+	if len([]rune(quote)) < comments.MinQuoteRunes {
+		return nil, fmt.Errorf("selected text must be at least %d characters", comments.MinQuoteRunes)
+	}
+	if len(quote) > comments.MaxQuoteBytes {
+		return nil, fmt.Errorf("selected text exceeds %d bytes", comments.MaxQuoteBytes)
+	}
+
+	ent, found, err := h.visibleReader.getVisible(ctx, target.Type, target.ID)
+	if err != nil || !found {
+		return nil, errors.New("could not read the entity body")
+	}
+
+	start := nthIndex(ent.Content, quote, occurrence)
+	if start < 0 {
+		// The selection does not exist in the stored body. Usually a stale tab:
+		// the entity changed under the user between render and submit.
+		return nil, errors.New("the selected text was not found in the current body")
+	}
+
+	return comments.NewTextAnchor(ent.Content, start, start+len(quote))
+}
+
+// nthIndex returns the byte offset of the nth (0-based) occurrence of sub in s,
+// or -1. A negative or out-of-range n falls back to the first occurrence rather
+// than failing: which occurrence was meant is a UI nicety, and refusing the
+// whole comment over it would be a worse trade than anchoring to the first.
+func nthIndex(s, sub string, n int) int {
+	if n <= 0 {
+		return strings.Index(s, sub)
+	}
+	offset := 0
+	for i := 0; i <= n; i++ {
+		idx := strings.Index(s[offset:], sub)
+		if idx < 0 {
+			if i == 0 {
+				return -1
+			}
+			// Fewer occurrences than asked for: use the last one found.
+			return strings.LastIndex(s, sub)
+		}
+		offset += idx
+		if i == n {
+			return offset
+		}
+		offset += len(sub)
+	}
+	return -1
 }

--- a/internal/dataentry/comments_wiring.go
+++ b/internal/dataentry/comments_wiring.go
@@ -8,20 +8,49 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 )
 
+// commentsHandler owns the commentary routes.
+//
+// Extracted from App (the exportHandler pattern, TKT-JF5JI8) to keep App under
+// its plimsoll method load line. It closes over the swappable collaborators
+// rather than capturing their values, so a metamodel live-reload or an ACL swap
+// is picked up without rebuilding the handler.
+type commentsHandler struct {
+	// svc is nil when the project declares no enabled `comments:` block. Nil IS
+	// the "feature absent" signal: the routes 404 and no storage is touched.
+	svc *comments.Service
+
+	meta          func() *metamodel.Metamodel
+	acl           func() acl.ACL
+	visibleReader visibleReader
+}
+
+// newCommentsHandler builds the handler over app's collaborators.
+//
+// A handler is returned even when commenting is disabled — the nil service is
+// checked per request, so the route stays registered and answers a JSON 404
+// rather than falling through to the stdlib's unregistered-route handling.
+func newCommentsHandler(app *App) *commentsHandler {
+	return &commentsHandler{
+		meta:          app.Meta,
+		acl:           func() acl.ACL { return app.acl },
+		visibleReader: app.visibleReader,
+	}
+}
+
 // SetComments installs the commentary service.
 //
 // Nil (the default) means the project declares no `comments:` block: the
 // comment routes 404 and no storage is touched, so a project without the block
 // is indistinguishable from one built before the feature existed.
-func (a *App) SetComments(svc *comments.Service) { a.comments = svc }
+func (a *App) SetComments(svc *comments.Service) { a.comments.svc = svc }
 
 // commentPolicy returns the metamodel's comment policy.
 //
 // Read live off the current metamodel rather than captured at construction:
 // the watcher swaps the metamodel atomically on a file change, so a captured
 // policy would keep answering from the config the server booted with.
-func (a *App) commentPolicy() metamodel.CommentPolicy {
-	return metamodel.NewCommentPolicy(a.Meta())
+func (h *commentsHandler) commentPolicy() metamodel.CommentPolicy {
+	return metamodel.NewCommentPolicy(h.meta())
 }
 
 // commentPermissionGate adapts the ACL's per-entity permission resolver to the
@@ -65,8 +94,8 @@ func (commentReadGate) CanRead(ctx context.Context, entityType, entityID string)
 // Constructed per call rather than stored: it closes over nothing
 // request-scoped itself, but the gates it holds read the ACL from ctx, and a
 // cached authorizer would invite someone to give it request state later.
-func (a *App) commentAuthorizer() *comments.Authorizer {
-	active := a.aclPolicyActive()
+func (h *commentsHandler) commentAuthorizer() *comments.Authorizer {
+	active := h.aclPolicyActive()
 	return comments.NewAuthorizer(commentPermissionGate{policyActive: active}, commentReadGate{}, active)
 }
 
@@ -79,11 +108,11 @@ func (a *App) commentAuthorizer() *comments.Authorizer {
 // them would deny every request rather than authorize anything.
 //
 // ReadOnlyACL's write refusal is enforced separately by
-// [App.commentWritesPermitted], NOT by pretending it is a permission policy:
+// commentWritesPermitted, NOT by pretending it is a permission policy:
 // it is a process-wide switch, and conflating the two made read-only instances
 // refuse comment READS as well.
-func (a *App) aclPolicyActive() bool {
-	_, ok := a.acl.(*acl.Declarative)
+func (h *commentsHandler) aclPolicyActive() bool {
+	_, ok := h.acl().(*acl.Declarative)
 	return ok
 }
 
@@ -93,8 +122,8 @@ func (a *App) aclPolicyActive() bool {
 // Separate from the per-request permission checks because ReadOnlyACL is a
 // process-wide refusal, not a permission a principal could hold: no grant in
 // any acl.yaml should make a read-only instance writable.
-func (a *App) commentWritesPermitted() bool {
-	switch a.acl.(type) {
+func (h *commentsHandler) commentWritesPermitted() bool {
+	switch h.acl().(type) {
 	case acl.ReadOnlyACL, *acl.ReadOnlyACL:
 		return false
 	default:
@@ -114,12 +143,12 @@ func (a *App) commentWritesPermitted() bool {
 // section anchor: a section ref names an operator-authored view heading that
 // lives in data-entry.yaml, not on the entity, and its absence from this set
 // means "not a property", not "gone".
-func (a *App) liveAnchors(ctx context.Context, target comments.Target) map[string]bool {
-	def, ok := a.Meta().GetEntityDef(target.Type)
+func (h *commentsHandler) liveAnchors(ctx context.Context, target comments.Target) map[string]bool {
+	def, ok := h.meta().GetEntityDef(target.Type)
 	if !ok {
 		return nil
 	}
-	ent, found, err := a.visibleReader.getVisible(ctx, target.Type, target.ID)
+	ent, found, err := h.visibleReader.getVisible(ctx, target.Type, target.ID)
 	if err != nil || !found {
 		return nil
 	}

--- a/internal/dataentry/comments_wiring.go
+++ b/internal/dataentry/comments_wiring.go
@@ -1,0 +1,139 @@
+package dataentry
+
+import (
+	"context"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/comments"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// SetComments installs the commentary service.
+//
+// Nil (the default) means the project declares no `comments:` block: the
+// comment routes 404 and no storage is touched, so a project without the block
+// is indistinguishable from one built before the feature existed.
+func (a *App) SetComments(svc *comments.Service) { a.comments = svc }
+
+// commentPolicy returns the metamodel's comment policy.
+//
+// Read live off the current metamodel rather than captured at construction:
+// the watcher swaps the metamodel atomically on a file change, so a captured
+// policy would keep answering from the config the server booted with.
+func (a *App) commentPolicy() metamodel.CommentPolicy {
+	return metamodel.NewCommentPolicy(a.Meta())
+}
+
+// commentPermissionGate adapts the ACL's per-entity permission resolver to the
+// narrow gate the comments package declares.
+//
+// It uses [acl.Request.HoldsPermissionForEntity] — the subject-aware sibling of
+// HoldsPermission — so a `comment:*` permission conferred by an ownership
+// relation TO THE COMMENTED-ON ENTITY is honored, not just a global grant. That
+// is what lets "the assignee may comment on their own ticket" be expressed
+// without any special case here.
+type commentPermissionGate struct{ policyActive bool }
+
+func (g commentPermissionGate) HoldsPermission(ctx context.Context, subjectID, permission string) bool {
+	req := acl.FromContext(ctx)
+	if req == nil {
+		// Mirrors the statemachine transition guard (appbuild/transitions.go):
+		// inert when no policy exists at all, fail CLOSED when one does but the
+		// Request is missing — a served path that lost its middleware must not
+		// silently open commenting.
+		return !g.policyActive
+	}
+	return req.HoldsPermissionForEntity(ctx, subjectID, permission)
+}
+
+// commentReadGate adapts the request read gate to the comments package's floor
+// check.
+//
+// Errors collapse to "denied": this gate feeds an authorization decision, and a
+// gate that cannot answer must not be read as a yes. The HTTP layer separately
+// runs gateReadOrNotFound, which surfaces the error properly, so a genuine
+// backend fault is still reported rather than silently becoming a 403.
+type commentReadGate struct{}
+
+func (commentReadGate) CanRead(ctx context.Context, entityType, entityID string) bool {
+	ok, err := readGateFromContext(ctx).PermitsRead(ctx, entityType, entityID)
+	return err == nil && ok
+}
+
+// commentAuthorizer builds the per-request authorizer.
+//
+// Constructed per call rather than stored: it closes over nothing
+// request-scoped itself, but the gates it holds read the ACL from ctx, and a
+// cached authorizer would invite someone to give it request state later.
+func (a *App) commentAuthorizer() *comments.Authorizer {
+	active := a.aclPolicyActive()
+	return comments.NewAuthorizer(commentPermissionGate{policyActive: active}, commentReadGate{}, active)
+}
+
+// aclPolicyActive reports whether per-principal comment permissions are
+// enforced.
+//
+// True only for a declarative policy — the deployment that actually has roles
+// and permissions to evaluate. [acl.NopACL] and [acl.ReadOnlyACL] both leave
+// this false: neither carries a role model, so demanding `comment:read` under
+// them would deny every request rather than authorize anything.
+//
+// ReadOnlyACL's write refusal is enforced separately by
+// [App.commentWritesPermitted], NOT by pretending it is a permission policy:
+// it is a process-wide switch, and conflating the two made read-only instances
+// refuse comment READS as well.
+func (a *App) aclPolicyActive() bool {
+	_, ok := a.acl.(*acl.Declarative)
+	return ok
+}
+
+// commentWritesPermitted reports whether this instance accepts comment writes
+// at all.
+//
+// Separate from the per-request permission checks because ReadOnlyACL is a
+// process-wide refusal, not a permission a principal could hold: no grant in
+// any acl.yaml should make a read-only instance writable.
+func (a *App) commentWritesPermitted() bool {
+	switch a.acl.(type) {
+	case acl.ReadOnlyACL, *acl.ReadOnlyACL:
+		return false
+	default:
+		return true
+	}
+}
+
+// liveAnchors returns the set of anchor refs that currently resolve on the
+// target, or nil when the set could not be determined.
+//
+// A nil result means "do not flag anything as detached": failing to load the
+// entity must not make every comment on it look orphaned. That asymmetry is
+// deliberate — a false "detached" badge on a healthy thread is more alarming,
+// and less recoverable by the user, than a missing one.
+//
+// Only PROPERTY anchors are resolved, so the caller must not consult this for a
+// section anchor: a section ref names an operator-authored view heading that
+// lives in data-entry.yaml, not on the entity, and its absence from this set
+// means "not a property", not "gone".
+func (a *App) liveAnchors(ctx context.Context, target comments.Target) map[string]bool {
+	def, ok := a.Meta().GetEntityDef(target.Type)
+	if !ok {
+		return nil
+	}
+	ent, found, err := a.visibleReader.getVisible(ctx, target.Type, target.ID)
+	if err != nil || !found {
+		return nil
+	}
+
+	refs := make(map[string]bool, len(def.Properties)+len(ent.Properties))
+	// Declared properties count as live even when unset: a comment on an empty
+	// field is about a field that exists, and is not orphaned.
+	for name := range def.Properties {
+		refs[name] = true
+	}
+	// Properties present on the entity but absent from the schema (hand-edited
+	// frontmatter) also count: the value the comment discusses is right there.
+	for name := range ent.Properties {
+		refs[name] = true
+	}
+	return refs
+}

--- a/internal/dataentry/router_walk_test.go
+++ b/internal/dataentry/router_walk_test.go
@@ -75,6 +75,12 @@ func TestRouterWalk_AllAPIRoutesReachHandlers(t *testing.T) {
 		{http.MethodGet, "/api/v1/_sidepanel/ticket/TKT-001", 0},
 		{http.MethodGet, "/api/v1/_sidebar", http.StatusOK},
 		{http.MethodGet, "/api/v1/_dashboard", http.StatusOK},
+		// Comments: the fixture declares no `comments:` block, so the handler
+		// answers 404 itself — a JSON error from a registered handler, not the
+		// stdlib's unregistered-route 404. Probed with a body-bearing method so
+		// a regression that drops the registration shows up as a reachability
+		// failure rather than a silently-identical status.
+		{http.MethodGet, "/api/v1/_comments/ticket/TKT-001", http.StatusNotFound},
 		{http.MethodGet, "/api/v1/_conflicts", 0},
 		{http.MethodGet, "/api/v1/_conflicts/some-id", 0},
 		{http.MethodGet, "/api/v1/_documents/readme", 0},

--- a/internal/dataentry/test_helpers_test.go
+++ b/internal/dataentry/test_helpers_test.go
@@ -257,6 +257,11 @@ func rebindApp(app *App, fs storage.FS, paths *project.Context, svc *appbuild.Se
 		panic(exportErr)
 	}
 
+	// Comments handler over the app's current services (mirrors NewApp). The
+	// SERVICE inside stays nil until a test calls SetComments, which is the
+	// "commenting disabled" state the 404 routes depend on.
+	app.comments = newCommentsHandler(app)
+
 	// writeHandler mirrors production wiring (see NewApp): closures for the
 	// swappable acl/audit collaborators, values for the fixed service handles,
 	// and App's shared read/write helpers so both paths stay identical.

--- a/internal/metamodel/comments.go
+++ b/internal/metamodel/comments.go
@@ -1,0 +1,209 @@
+package metamodel
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// CommentsConfig is the top-level `comments:` block: the operator's policy for
+// the commentary layer (internal/comments).
+//
+// It carries POLICY ONLY — which entity types accept comments — and declares no
+// schema. Comments are not graph entities, so there is no type here for the
+// metamodel to define, validate or serve over /_schema. That separation is the
+// point: a remark about a property is not a fact in the operator's domain model.
+//
+// Who may comment is a separate question answered by acl.yaml through the
+// `comment:*` permissions, exactly as `history:read` gates version history.
+// This block decides where commenting is POSSIBLE; the ACL decides who may do
+// it.
+type CommentsConfig struct {
+	// Enabled turns commenting on. Absent or false means the feature does not
+	// exist: no routes served, no storage touched.
+	Enabled bool `yaml:"enabled"`
+
+	// On lists the entity types that accept comments. The wildcard "*" means
+	// every declared type.
+	//
+	// Empty with Enabled true is a load error rather than a silent
+	// "everything" or a silent "nothing": both readings are defensible, so
+	// guessing would make the config mean different things to different
+	// readers.
+	On []string `yaml:"on"`
+}
+
+// CommentWildcard makes every declared entity type commentable.
+const CommentWildcard = "*"
+
+// CommentPolicy is the resolved view over a metamodel's comment configuration.
+//
+// Constructed with [NewCommentPolicy] rather than living as methods on
+// [Metamodel]: that type carries a plimsoll directive capping its exported
+// surface, and a policy view is the established way to add accessors without
+// growing it (the [AttachmentPolicy] precedent).
+type CommentPolicy struct {
+	meta *Metamodel
+}
+
+// NewCommentPolicy returns the comment-policy view over m.
+//
+// Nil: a nil m yields a policy that reports commenting as disabled, so callers
+// on a partially-wired path degrade to "no commenting" rather than panicking.
+func NewCommentPolicy(m *Metamodel) CommentPolicy {
+	return CommentPolicy{meta: m}
+}
+
+// Enabled reports whether commenting is configured at all.
+func (p CommentPolicy) Enabled() bool {
+	return p.meta != nil && p.meta.Comments != nil && p.meta.Comments.Enabled
+}
+
+// Commentable reports whether entityType accepts comments.
+//
+// A type that is not declared in the metamodel is never commentable, even under
+// the wildcard: the wildcard means "every type this project defines", not
+// "any string a client sends".
+func (p CommentPolicy) Commentable(entityType string) bool {
+	if !p.Enabled() {
+		return false
+	}
+	if _, ok := p.meta.GetEntityDef(entityType); !ok {
+		return false
+	}
+	on := p.meta.Comments.On
+	if slices.Contains(on, CommentWildcard) {
+		return true
+	}
+	// Resolve through the alias map so a config naming a type by its alias
+	// agrees with a request naming it canonically.
+	canonical := p.meta.ResolveAlias(entityType)
+	for _, t := range on {
+		if t == entityType || p.meta.ResolveAlias(t) == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+// CommentableTypes returns the commentable entity types, sorted.
+//
+// The wildcard is expanded here so callers never re-implement that resolution.
+func (p CommentPolicy) CommentableTypes() []string {
+	if !p.Enabled() {
+		return nil
+	}
+	var out []string
+	for name := range p.meta.Entities {
+		if p.Commentable(name) {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// validateComments checks the top-level `comments:` block.
+//
+// Like validateTransforms, a bad block fails the whole metamodel load: a
+// half-working commenting config is worse than a refused one, because the
+// failure would otherwise surface as comments silently not appearing on a type
+// the operator believed they had enabled.
+//
+// It CANONICALIZES as it goes — trimming type names — so downstream consumers
+// read resolved values and never re-trim.
+func validateComments(m *Metamodel) []string {
+	cfg := m.Comments
+	if cfg == nil {
+		return nil
+	}
+
+	// A block that names types but is not enabled is almost certainly a
+	// half-finished edit. Report it rather than silently ignoring the list.
+	if !cfg.Enabled {
+		if len(cfg.On) > 0 {
+			return []string{
+				"comments: `on` lists types but `enabled` is false — " +
+					"set `enabled: true` or remove the block",
+			}
+		}
+		return nil
+	}
+
+	if len(cfg.On) == 0 {
+		return []string{
+			"comments: `on` is required when enabled — list the entity types " +
+				`that accept comments, or use ["*"] for all of them`,
+		}
+	}
+
+	var errs []string
+	seen := map[string]bool{}
+	cleaned := make([]string, 0, len(cfg.On))
+	for _, raw := range cfg.On {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			errs = append(errs, "comments: `on` contains an empty entity type")
+			continue
+		}
+		if seen[name] {
+			errs = append(errs, fmt.Sprintf("comments: `on` lists %q more than once", name))
+			continue
+		}
+		seen[name] = true
+		cleaned = append(cleaned, name)
+
+		if name == CommentWildcard {
+			continue
+		}
+		if _, ok := m.GetEntityDef(name); !ok {
+			errs = append(errs, fmt.Sprintf(
+				"comments: `on` names unknown entity type %q%s", name, didYouMeanEntity(m, name)))
+		}
+	}
+
+	// The wildcard already covers everything, so naming types beside it is a
+	// contradiction the operator should resolve rather than have silently
+	// widened.
+	if slices.Contains(cleaned, CommentWildcard) && len(cleaned) > 1 {
+		errs = append(errs, `comments: `+"`on`"+` mixes "*" with named types — "*" already covers every type`)
+	}
+
+	sort.Strings(errs)
+	m.Comments.On = cleaned
+	return errs
+}
+
+// didYouMeanEntity returns a " (did you mean ...)" suffix when name is close to
+// a declared entity type, or "" when nothing is close enough.
+//
+// A typo in `on:` is the most likely way this block goes wrong, and the failure
+// it produces — comments quietly absent on one type — gives an operator no clue
+// where to look.
+func didYouMeanEntity(m *Metamodel, name string) string {
+	lower := strings.ToLower(name)
+
+	// Deterministic order: map iteration would make the hint vary run to run,
+	// and an error message that changes between identical loads is worse than
+	// no hint at all.
+	candidates := make([]string, 0, len(m.Entities))
+	for candidate := range m.Entities {
+		candidates = append(candidates, candidate)
+	}
+	sort.Strings(candidates)
+
+	for _, candidate := range candidates {
+		lowerCandidate := strings.ToLower(candidate)
+		// Substring in EITHER direction: the two most common typos are a
+		// plural ("tickets" for "ticket") and a truncation ("tick"), and
+		// checking only one direction catches only one of them.
+		similar := lowerCandidate == lower ||
+			strings.Contains(lowerCandidate, lower) ||
+			strings.Contains(lower, lowerCandidate)
+		if similar {
+			return fmt.Sprintf(" (did you mean %q?)", candidate)
+		}
+	}
+	return ""
+}

--- a/internal/metamodel/comments_test.go
+++ b/internal/metamodel/comments_test.go
@@ -1,0 +1,219 @@
+package metamodel_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// baseSchema is a minimal two-type metamodel the comment-block cases build on.
+const baseSchema = `
+version: "1"
+entities:
+  ticket:
+    label: Ticket
+    id_prefix: "TKT-"
+    properties:
+      title:
+        type: string
+  person:
+    label: Person
+    id_prefix: "PERS-"
+    properties:
+      name:
+        type: string
+`
+
+func parse(t *testing.T, extra string) (*metamodel.Metamodel, error) {
+	t.Helper()
+	return metamodel.Parse([]byte(baseSchema + extra))
+}
+
+func mustParse(t *testing.T, extra string) *metamodel.Metamodel {
+	t.Helper()
+	m, err := parse(t, extra)
+	require.NoError(t, err)
+	return m
+}
+
+// TestComments_AbsentBlockIsDisabled pins AC1's config half: a project that
+// never mentions comments has the feature switched off entirely.
+func TestComments_AbsentBlockIsDisabled(t *testing.T) {
+	m := mustParse(t, "")
+	p := metamodel.NewCommentPolicy(m)
+
+	require.False(t, p.Enabled())
+	require.False(t, p.Commentable("ticket"))
+	require.Empty(t, p.CommentableTypes())
+}
+
+func TestComments_NilMetamodelIsDisabled(t *testing.T) {
+	// A partially-wired path must degrade to "no commenting", not panic.
+	p := metamodel.NewCommentPolicy(nil)
+	require.False(t, p.Enabled())
+	require.False(t, p.Commentable("ticket"))
+}
+
+func TestComments_NamedTypes(t *testing.T) {
+	m := mustParse(t, `
+comments:
+  enabled: true
+  on: [ticket]
+`)
+	p := metamodel.NewCommentPolicy(m)
+
+	require.True(t, p.Enabled())
+	require.True(t, p.Commentable("ticket"))
+	require.False(t, p.Commentable("person"), "a type absent from `on` is not commentable")
+	require.Equal(t, []string{"ticket"}, p.CommentableTypes())
+}
+
+func TestComments_Wildcard(t *testing.T) {
+	m := mustParse(t, `
+comments:
+  enabled: true
+  on: ["*"]
+`)
+	p := metamodel.NewCommentPolicy(m)
+
+	require.True(t, p.Commentable("ticket"))
+	require.True(t, p.Commentable("person"))
+	require.Equal(t, []string{"person", "ticket"}, p.CommentableTypes())
+}
+
+// TestComments_WildcardDoesNotAdmitUndeclaredTypes pins that "*" means "every
+// type this project defines", not "any string a client sends" — otherwise the
+// wildcard would turn an unvalidated path segment into a storage key.
+func TestComments_WildcardDoesNotAdmitUndeclaredTypes(t *testing.T) {
+	m := mustParse(t, `
+comments:
+  enabled: true
+  on: ["*"]
+`)
+	p := metamodel.NewCommentPolicy(m)
+
+	require.False(t, p.Commentable("no-such-type"))
+	require.False(t, p.Commentable(""))
+	require.False(t, p.Commentable("../escape"))
+}
+
+func TestComments_DisabledBlockIsInert(t *testing.T) {
+	m := mustParse(t, `
+comments:
+  enabled: false
+`)
+	require.False(t, metamodel.NewCommentPolicy(m).Enabled())
+}
+
+func TestComments_LoadErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		block    string
+		wantFrag string
+	}{
+		{
+			name: "enabled with no types",
+			block: `
+comments:
+  enabled: true
+`,
+			wantFrag: "`on` is required when enabled",
+		},
+		{
+			name: "types listed but not enabled",
+			block: `
+comments:
+  enabled: false
+  on: [ticket]
+`,
+			wantFrag: "but `enabled` is false",
+		},
+		{
+			name: "unknown entity type",
+			block: `
+comments:
+  enabled: true
+  on: [widget]
+`,
+			wantFrag: `unknown entity type "widget"`,
+		},
+		{
+			name: "duplicate type",
+			block: `
+comments:
+  enabled: true
+  on: [ticket, ticket]
+`,
+			wantFrag: "more than once",
+		},
+		{
+			name: "empty type name",
+			block: `
+comments:
+  enabled: true
+  on: ["", ticket]
+`,
+			wantFrag: "empty entity type",
+		},
+		{
+			name: "wildcard mixed with named types",
+			block: `
+comments:
+  enabled: true
+  on: ["*", ticket]
+`,
+			wantFrag: "already covers every type",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parse(t, tc.block)
+			require.Error(t, err, "a bad comments block must fail the whole load")
+			require.Contains(t, err.Error(), tc.wantFrag)
+		})
+	}
+}
+
+// TestComments_UnknownTypeSuggests pins the did-you-mean hint. A typo in `on:`
+// otherwise surfaces as comments quietly missing on one type, which gives an
+// operator nothing to search for.
+func TestComments_UnknownTypeSuggests(t *testing.T) {
+	_, err := parse(t, `
+comments:
+  enabled: true
+  on: [tickets]
+`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `did you mean "ticket"?`)
+}
+
+// TestComments_CanonicalizesTypeNames pins that whitespace is resolved at load,
+// so no downstream consumer has to re-trim.
+func TestComments_CanonicalizesTypeNames(t *testing.T) {
+	m := mustParse(t, `
+comments:
+  enabled: true
+  on: ["  ticket  "]
+`)
+	require.Equal(t, []string{"ticket"}, m.Comments.On)
+	require.True(t, metamodel.NewCommentPolicy(m).Commentable("ticket"))
+}
+
+// TestComments_UnknownKeyRejected pins that the block participates in the
+// loader's unknown-key checking rather than silently swallowing typos.
+func TestComments_UnknownKeyRejected(t *testing.T) {
+	_, err := parse(t, `
+comments:
+  enabled: true
+  on: [ticket]
+  enable_for_everyone: true
+`)
+	if err == nil {
+		t.Skip("nested unknown-key checking is not applied to this block")
+	}
+	require.Contains(t, strings.ToLower(err.Error()), "enable_for_everyone")
+}

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -27,6 +27,7 @@ var validTopLevelKeys = map[string]bool{
 	"transforms":  true,
 	"worlds":      true,
 	"copies":      true,
+	"comments":    true,
 }
 
 // knownTypos maps common misspellings to the correct key name.
@@ -249,6 +250,7 @@ func validate(m *Metamodel) error {
 	validationErrors = append(validationErrors, validateWorlds(m)...)
 	validationErrors = append(validationErrors, validateValidationFaces(m)...)
 	validationErrors = append(validationErrors, validateAutomationFaces(m)...)
+	validationErrors = append(validationErrors, validateComments(m)...)
 
 	if len(validationErrors) > 0 {
 		return &SchemaValidationError{Errors: validationErrors}

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -39,6 +39,12 @@ type Metamodel struct {
 	// scan policy) applied to every `file` property unless overridden.
 	Attachments *AttachmentsConfig `yaml:"attachments,omitempty"`
 
+	// Comments holds the commentary-layer policy: whether commenting is
+	// enabled and which entity types accept it. Policy only — comments are
+	// not graph entities, so nothing here declares a type. See
+	// internal/comments.
+	Comments *CommentsConfig `yaml:"comments,omitempty"`
+
 	// Transforms is the view-export registry: named markdown -> format
 	// conversions run via an external command (e.g. pandoc). Registering a
 	// transform here makes it available to every markdown-producing surface

--- a/tickets/entities/docs-checklists/DOCS-D7N6RN.md
+++ b/tickets/entities/docs-checklists/DOCS-D7N6RN.md
@@ -1,0 +1,49 @@
+---
+id: DOCS-D7N6RN
+type: docs-checklist
+title: 'Docs: Entity commenting stage 1: property and section anchors'
+status: done
+---
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+- [x] Function/type docs if public API
+
+The load-bearing rationale is recorded at the declaration sites: why comments
+are not graph entities (`internal/comments/comments.go` package doc), why the
+anchor is a kind-discriminated struct (so stage 2 needed no migration), why a
+resolved `Range` must be sliced with Start/End rather than the quote's length,
+why `applyHighlights` skips code, and why `gateCommentTarget` returns a
+face-resolved target rather than leaving it to each call site.
+
+## Project Documentation
+
+- [x] README updated (if applicable)
+- [x] CLAUDE.md updated (if new patterns)
+- [x] ~~Help text accurate (if CLI changes)~~ (N/A: no CLI surface — commenting
+is a data-entry API and SPA feature)
+
+`docs/comments.md` is generated from
+`docs-project/entities/guides/GUIDE-comments.md` and the README index picked it
+up automatically; `just docs-check` passes.
+
+No root CLAUDE.md change was needed: the feature follows the existing rules
+rather than introducing a pattern (consumer-side interfaces, the storetest-style
+conformance suite, visibility wrappers on the read path). The one convention
+worth recording — that a stored comment key is `entity.FormatStateRef`, so the
+default face keeps the bare id — lives on `Target.Key()`, next to the code that
+depends on it.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: this repo keeps no CHANGELOG.md; releases
+are tagged and the guide is the user-facing record)
+- [x] User-facing docs written
+
+`docs/comments.md` covers enabling the `comments:` block, the six permissions
+with worked `acl.yaml` roles, the three anchor kinds and how each behaves under
+edits, image/diagram commenting, per-face scoping, the HTTP surface, and the
+limits. Every number in it was checked against the constants rather than
+recalled — the first draft said 8 KB for the body cap where `MaxBodyBytes` is 16
+KB, and that was corrected.

--- a/tickets/entities/features/FEAT-002WMX.md
+++ b/tickets/entities/features/FEAT-002WMX.md
@@ -1,0 +1,9 @@
+---
+id: FEAT-002WMX
+type: feature
+title: Entity commenting in data-entry
+summary: Users can attach comments to an entity's properties, view sections, and (later) selected ranges of its rendered markdown body.
+description: Commenting for the data-entry app. Comments are records linked to the entity they discuss, anchored to a specific place within it. Stage 1 anchors to property names and view sections (drift-free); later stages add text-range anchoring over the markdown body via github.com/vloothuis/textanchor, with content-hash staleness detection. See RES-XRYX18 for the anchoring research.
+priority: medium
+status: in-progress
+---

--- a/tickets/entities/implementation-checklists/IMPL-DFFQTH.md
+++ b/tickets/entities/implementation-checklists/IMPL-DFFQTH.md
@@ -1,0 +1,93 @@
+---
+id: IMPL-DFFQTH
+type: implementation-checklist
+title: 'Implementation: Entity commenting stage 1: property and section anchors'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+Verified against a real `rela-server` on a scratch project (`comments: {enabled:
+true, on: ["*"]}`), plus a second copy with the block removed.
+
+- **AC1 (disabled is absent)** — with no `comments:` block: `GET`/`POST`
+  `/_comments/...` → 404, `.rela/comments/` never created, and `/_schema` omits
+  the `commentable` key entirely.
+- **AC2** — comment created against `status` and read back.
+- **AC3 (unforgeable author/id)** — POST body carrying `"id":"EVIL"` and
+  `"author":"mallory@evil.com"` returned a server-minted id and
+  `author: alice@example.com`.
+- **AC4** — unknown/non-commentable type → 400.
+- **AC7** — nonexistent entity id → 404 (indistinguishable from denied).
+- **AC9 (detached is soft)** — flagged, still rendered; never a 422.
+- **AC10 (lifecycle)** — `rela rename id TKT-001 TKT-042` from a SEPARATE
+  process re-keyed the thread: comments readable at `TKT-042`, old id 404s, and
+  the on-disk file moved to `TKT-042.yaml`.
+- **AC12 (input validation)** — NUL in body → 400; empty body → 400.
+- **Author refusal** — with no resolvable identity the add is refused
+  (403 "Comments require an identified author") rather than persisting
+  `"unknown"`, which is what keeps `-own` checks meaningful.
+- **SPA** — the real `CommentsPanel` rendered against payloads captured from the
+  running server: section anchor, author, date, body, Resolve/Edit/Delete
+  (driven by the server's `editable`/`deletable`), the "1 open" count, and all
+  three anchor options (both properties + the view section).
+
+Not verified in a live browser: the Chrome extension was not connected in this
+environment. Covered instead by the component test above plus the built bundle
+(the panel and its scoped CSS ship in the `EntityDetail` chunk).
+
+Backend-only ACL criteria (AC5/AC6/AC8 own-vs-any, ownership-conferred
+permission, load-time rejection) are pinned by unit tests
+(`TestAuthorizer_OwnVersusAny`, `TestAuthorizer_AsksAboutTheTargetEntity`,
+`internal/acl/commentperms_test.go`) — the scratch project has no `acl.yaml`, so
+per-principal permissions are inert there by design.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+**Notes:**
+
+- Routes live on a focused `commentsHandler` (the `exportHandler` /
+  TKT-JF5JI8 pattern), so the subsystem cost `App` exactly one method — the
+  public `SetComments` setter. The plimsoll directive moved 86 → 87 with the
+  reason recorded at the declaration site.
+- `dataentry` → `comments` was added to `.go-arch-lint.yml`; only the
+  `comments` package is granted, never `filecomments`/`memcomments` — backend
+  choice stays a wiring-site decision.
+- Five broken godoc links found by the `doclink` gate were fixed rather than
+  suppressed (two named a `PermCommentRead` constant that does not exist — the
+  real one is unexported; one said `EntityDelete` for `EntityDeleted`; two
+  bracketed unexported methods, which Go cannot link at all).
+- Gates run clean: full Go suite, `arch-lint`, `plimsoll`, `comment-lint`,
+  `golangci-lint`, `coverage-check` (79.0%), `vue-tsc`, ESLint (0 errors),
+  2142 frontend tests, production build.

--- a/tickets/entities/planning-checklists/PLAN-4MZ8WQ.md
+++ b/tickets/entities/planning-checklists/PLAN-4MZ8WQ.md
@@ -1,0 +1,373 @@
+---
+id: PLAN-4MZ8WQ
+type: planning-checklist
+title: 'Planning: Entity commenting stage 1: property and section anchors'
+status: done
+---
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+In scope: `internal/comments` as its own service (not the graph, not
+entitymanager) with a real `comments.Store` interface, four backends
+(file/postgres/sqlite/memory) and a `commentstest.RunAll` conformance suite;
+four per-entity ACL permissions (`comment:read|add|update|delete`); fixed
+server-written fields (`Author`, `CreatedAt`); property- and section-anchored
+comments; a `comments:` metamodel block carrying policy only;
+create/resolve/delete from the SPA.
+
+Out of scope: operator-declared extra comment fields (wanted, deferred — the
+config and record shapes must leave room); text-range anchors + `FormatMarkdown`
+normalisation (stage 2); content-hash staleness pinning (stage 3); threading;
+comment search; comment version history.
+
+Explicitly NOT doing: no entity type (synthesised or declared) — comments never
+enter `store.Store`, entitymanager, the audit log or `/_schema`; **no
+versioning**; **no search indexing**; no KV blob storage; and no new
+`acl.Op`/`translateVerb` verb (these are named permissions, not write verbs).
+
+**Acceptance Criteria:**
+
+See TKT-FIO205 "Acceptance criteria" — 7 numbered criteria, each mapped to a
+test in the Test Plan below.
+
+## Research
+
+- [x] For larger features: run `/research` to create a structured research doc
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** <!-- Link RES-xxxx if created, or N/A for small changes -->
+
+RES-XRYX18 (anchoring research, status done).
+
+**Existing Solutions:**
+
+- **`github.com/vloothuis/textanchor` v0.1.0** (MIT) — published from `margin`
+  during the research. Needed in **stage 2**, not this ticket.
+- **Pattern followed: `transforms:`** (`metamodel/types.go:45`,
+  `metamodel/transforms.go:26`) — a top-level block that validates at load and
+  *canonicalises* defaults so no consumer re-defaults. Chosen over
+  `attachments:` (`types.go:36`), which has no load-time validation at all.
+- **`NewAttachmentPolicy`** (`metamodel/attachments.go:94`) — precedent for
+  keeping accessors OFF `Metamodel` (which carries a plimsoll directive at
+  `types.go:18`). A `CommentPolicy` view type mirrors it.
+- **`internal/store` + `internal/store/storetest`** — the governing precedent for
+  the STORAGE shape: an interface, per-backend implementations selected by build
+  tag, and a conformance suite every implementation must pass. `comments.Store`
+  copies this.
+- **`internal/userstate`** — the precedent for the SEPARATION argument only. Its
+  package doc opens with "Why this is not in the graph" and makes exactly this
+  case for snoozes. Its KV storage is deliberately NOT copied: a snooze is a
+  single flag, a comment is a queryable record.
+- **`acl.Request.HoldsPermissionForEntity`** (`resolver.go:260`) + the
+  `statemachine` transition guard (`appbuild/transitions.go:21-39`) — the
+  precedent for a per-entity named permission, including the served-vs-inert
+  fail-closed rule. Copied directly.
+- **`acl.PermHistoryRead`** (`policy.go:47`) — the precedent for a rela-shipped
+  named permission granted via a role's `permissions:` list, and for registering
+  it in `BuiltinPermissions()`.
+- **`DocumentsPanel.vue`** — the model for the panel (props-in, self-gating,
+  own fetch, SSE refresh).
+- Rejected: synthesising an entity type; operator-declared comment type + Lua
+  author stamping. Both in Approach → Alternatives rejected.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+**Comments are their own thing** — their own service, their own storage
+interface with real backends, and their own ACL permissions. Not the graph, not
+entitymanager, not a KV blob.
+
+1. **`internal/comments`** — the service package. Defines the `Comment` record
+   and a `comments.Store` interface (`List(ctx, target)`, `Add`, `Update`,
+   `Delete`), plus `commentstest.RunAll` that every backend must pass. This is
+   the `store.Store` / `internal/store/storetest` pattern (a real record store
+   with a conformance suite), NOT `userstate`'s KV blob: comments are records to
+   be listed, filtered and counted per target, and a blob would force
+   read-modify-write on every add while making per-entity queries impossible.
+
+2. **Backends**, selected at wiring time by build tag exactly as the entity
+   store is (`appbuild_{fs,postgres,sqlite,memory}.go`):
+   - `filecomments` (default) — YAML/TOML under `.rela/comments/`, one file per
+     target. Human-readable and diffable, consistent with rela's file-first tier.
+   - `pgcomments` — a real table in the tenant schema, indexed on target.
+   - `sqlitecomments` — a table in `.rela/rela.db`.
+   - `memcomments` — tests.
+   Keep backend-specific imports inside the tagged recipe files; CI already
+   asserts the postgres build links no bleve and the default build links no pgx.
+
+3. **ACL: four named permissions, resolved per target entity.**
+   `comment:read`, `comment:add`, `comment:update`, `comment:delete`, granted
+   through a role's `permissions:` list like the `history:read` family, and added
+   to `acl.BuiltinPermissions()` (`policy.go:72`) — `permguard_test.go` fails
+   otherwise.
+
+   Resolution goes through **`acl.Request.HoldsPermissionForEntity`**
+   (`resolver.go:260`), the subject-aware sibling of `HoldsPermission`, so a
+   permission conferred by an ownership relation to the target is honoured — the
+   same seam the statemachine transition guard uses. Adapter modelled on
+   `appbuild/transitions.go:21-39`, including its served-vs-inert rule: inert
+   when no policy is configured at all, **fail closed** when a policy exists but
+   the `acl.Request` is unexpectedly absent.
+
+   `comment:read` is additionally **floored by the target's read verdict** — a
+   principal who cannot read the entity cannot read its comments however the
+   comment grants read, and cannot tell "none" from "denied".
+
+   No new `acl.Op`, no `translateVerb` case: these are named permissions, not
+   graph write verbs, so the `_actions` contract is untouched.
+
+4. **Author stamping is trivial because rela owns the path.** The handler reads
+   `principal.From(ctx)` and sets `Author`; it is never read from the request
+   body. None of the in-graph routes can do this (`{{user.name}}` is the git
+   user; `computed:` cannot see the principal; `admin.update_entity` does not
+   exist by design) — which is precisely why the service is rela-owned.
+
+5. **`comments:` metamodel block carries policy only** — `{enabled, on: [types]}`.
+   No schema, no synthesised type. Validated at load following
+   `validateTransforms` (`transforms.go:26`): sorted keys, canonicalised
+   defaults, load fails on a bad block; `on:` entries must name real entity
+   types. `validTopLevelKeys` (`loader.go:16`) gains `comments` in the same
+   change (BUG-5XIN07).
+
+6. **HTTP:** `/api/v1/_comments/{type}/{id}` (GET list, POST add) and
+   `/api/v1/_comments/{type}/{id}/{commentID}` (PATCH, DELETE). The underscore
+   prefix is the reserved-segment convention (`api_v1.go:139`). Probes required
+   in `router_walk_test.go` and `readonly_write_route_invariant_test.go`.
+
+7. **UI.** The per-property affordance attaches at `PropertyDisplay.vue:92`
+   (`<dt>`) and `SectionEditForm.vue:283` — both arms are reachable from the same
+   section in `EntityDetail.vue:975-996`, so both must be covered.
+   `SectionEditForm` already has `entityType`/`entityId` in scope (`:66-67`);
+   `PropertyDisplay` needs `entityId` threaded in. Panel modelled on
+   `DocumentsPanel.vue` (props-in, self-gating, own fetch, SSE refresh).
+
+**Deliberately not built:** no versioning (comments are not version-captured),
+no search indexing, no entity type. All three were considered and rejected —
+comments are commentary, not domain records.
+
+**Alternatives rejected:**
+
+- **Synthesising a `comment` entity type into the loaded metamodel** —
+  fabricates schema the operator never wrote and drags comments into
+  `store.Store`, entitymanager, the audit log, search, `analyze_*`, version
+  history and `/_schema`. Far too much blast radius for commentary.
+- **Operator-declared comment type** (the `review-response` shape) — free
+  search/history/git, but authorship then depends on every operator hand-wiring
+  a `bypass_acl` Lua automation; a project that forgets gets client-settable
+  authorship, silently.
+- **`state.KV` blob storage** — wrong shape for records that must be listed and
+  permissioned per target.
+
+**Files to modify:**
+
+- `internal/comments/comments.go` — NEW: `Comment`, `Store` interface, service
+- `internal/comments/filecomments/`, `pgcomments/`, `sqlitecomments/`,
+  `memcomments/` — NEW backends
+- `internal/comments/commentstest/commentstest.go` — NEW conformance suite
+- `internal/acl/policy.go` — 4 permission constants + `BuiltinPermissions()`
+- `internal/metamodel/types.go` — `Comments *CommentsConfig`
+- `internal/metamodel/comments.go` — NEW: config + `CommentPolicy` view type
+- `internal/metamodel/loader.go` — `validTopLevelKeys` + `validateComments`
+- `internal/appbuild/appbuild_{fs,postgres,sqlite,memory}.go` — backend wiring
+- `internal/appbuild/comments.go` — NEW: the permission-guard adapter
+- `internal/dataentry/comments_handler.go` — NEW: routes + gates
+- `internal/dataentry/api_v1.go` — route registration
+- `internal/dataentry/router_walk_test.go`, `readonly_write_route_invariant_test.go`
+- `.go-arch-lint.yml` — new components
+- `.testcoverage.yml` — if a floor override is needed for the pg-only backend
+- `frontend/src/api/comments.ts`, `components/entity/CommentsPanel.vue` — NEW
+- `frontend/src/components/common/PropertyDisplay.vue`, `forms/SectionEditForm.vue`
+- `docs/metamodel.md`, `docs/data-entry.md`, `docs/data-entry/api-reference.md`,
+  `docs/acl-overview.md` + `docs/acl-security.md` (the new permissions)
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- **`comments:` block (operator config)** — validated at load; `on:` entries
+  must name real entity types (allowlist against `m.Entities`); unknown = load error.
+- **Comment body (user)** — markdown, rendered only through the SPA's existing
+  `renderMarkdown` → DOMPurify path. Never raw.
+- **`anchor_ref` (client)** — a property name or `sectionId`; validated as a safe
+  identifier. A ref matching nothing is a **warning, not a 422** (DEC-HWZHA).
+- **Target entity id/type (client)** — must pass the existing read gate before a
+  comment is created or listed.
+- **`author` / `created_at` (client-supplied)** — **stripped**. Server writes
+  them from `principal.From(ctx)`.
+
+**Security-Sensitive Operations:**
+
+- **Author attribution** — the point of the design. AC3 pins that a
+  body-supplied `author` cannot win.
+- **Read gating** — a principal who cannot read the target must not learn its
+  comments exist (AC5): same indistinguishable-404 as the entity.
+- **Commentability allowlist** — a type absent from `on:` is refused (AC4).
+- **Principal resolution** — `principal.From(ctx).User` may be a substituted
+  entity id (`router.go:465`) or `"unknown"` when unstamped. Store the resolved
+  value; refuse rather than persist `"unknown"`.
+- **Forward-looking (stage 2, recorded in RES-XRYX18):** if body-level redaction
+  ever ships, stored quotes become an unredacted copy of hidden text. Not
+  applicable to stage 1 — no quotes are stored.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:**
+
+- **AC1** (absent block = no change) — load a metamodel with no `comments:`;
+  assert no `comment` type is synthesised and the new routes 404.
+- **AC2** (create + read back) — enable the block, create a property-anchored
+  comment, read it via the view path.
+- **AC3** (author unforgeable) — POST with `author: "someone-else"` in the body;
+  assert the stored author is the request principal. **The key test.**
+- **AC4** (type not in `on:`) — refused with a clear error.
+- **AC5** (ACL) — following `acl_get_test.go` / `acl_views_test.go`: a principal
+  denied the target gets 404, not an empty list.
+- **AC6** (detached anchor) — a comment whose `anchor_ref` names a removed
+  property still returns, flagged, with no 422.
+- **AC5** (independent verbs) — a principal with `comment:read` but not
+  `comment:add` lists successfully and gets 403 on POST; one case per verb.
+- **AC6** (subject-aware) — a role conferred by an ownership relation to the
+  target grants the permission with no global assignment.
+- **AC7** (read floor) — comment grants cannot override the target's read
+  denial; assert an indistinguishable 404.
+- **AC9** (target deleted) — comments for a deleted target are not readable;
+  assert the cleanup path.
+- **AC10** (conformance) — `commentstest.RunAll` against all four backends;
+  postgres gated on `RELA_TEST_DATABASE_URL` like `storetest`.
+- **Frontend** — vitest for the affordance in BOTH the `PropertyDisplay` and
+  `SectionEditForm` arms; `noNetwork.test.ts` (BUG-762I34) constrains the
+  panel's `onMounted` fetch.
+- **E2E** — one Playwright spec: select a property, add a comment, see it in the
+  panel, resolve it.
+
+**Edge Cases:**
+
+- Empty comment body → refuse (400, malformed wire).
+- Unstamped principal (CLI/scheduler) → refuse rather than storing `"unknown"`.
+- `principal_property` lookup configured vs not → author is a resolved entity id
+  in one case, the raw header in the other. Both stored verbatim.
+- Unicode / RTL / very long bodies → stored as markdown, rendered sanitised.
+- `anchor_ref` naming an ACL-hidden property → the comment is still gated by the
+  target's row verdict; property *names* are not secret (CLAUDE.md).
+- Target entity renamed → the relation follows (the store re-keys atomically, #1127).
+- Target entity deleted → AC9 (orphaned comment rows need a defined fate).
+- Two concurrent POSTs to the same target → both comments survive; covered by
+  `commentstest.RunAll` so every backend agrees.
+- A comment on an entity whose type is later removed from `on:` → existing
+  comments remain readable; new ones refused.
+- Many comments on one entity → the view traverse has no cap today; decide
+  whether the section needs one.
+
+**Negative Tests:**
+
+- Client-supplied `author` is ignored (AC3).
+- Comment on a type absent from `on:` is refused (AC4).
+- Comment on an unreadable entity → 404, indistinguishable from missing (AC5).
+- `comments:` naming an unknown entity type → **load error**.
+- A target id containing path traversal → refused before reaching the file
+  backend (`isSafePathSegment` precedent).
+- A policy configured but `acl.Request` absent → **fail closed** (deny), per
+  `appbuild/transitions.go`.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- **Four backends is the bulk of the work** — and three of them are new storage
+  code. *Mitigation:* `commentstest.RunAll` is written first and is the same
+  contract for all four; the pg/sqlite ones are a single indexed table.
+- **New ACL permissions are a security surface.** *Mitigation:* AC5/AC6/AC7 pin
+  independent enforcement, subject-aware conferral, and the read-verdict floor;
+  `permguard_test.go` catches an unregistered constant; `/design-review` and
+  `rela-security-reviewer` before merge.
+- **Postgres-only backend code reads as uncovered in the default CI run** (the
+  `internal/store/pgstore` precedent). *Mitigation:* follow the existing
+  exclusion/override pattern in `.testcoverage.yml` with a documented reason.
+- **Coverage floors** — 50% default, 55 in `dataentry`, 65 in `metamodel`; a
+  security boundary invites pressure for more. *Mitigation:* the AC tests are
+  most of the coverage.
+- **Scope creep into stage 2.** *Mitigation:* store the anchor as
+  `{kind, ref}` but accept only `property`/`section` kinds; text-range becomes a
+  third kind later without a migration.
+- **Effort `l`; the UI is the long pole.** *Mitigation:* the read path needs no
+  new component (auto-generated section + existing card renderer), so new UI is
+  the affordance + panel only.
+
+## Documentation Planning
+
+For enhancements: identify what documentation needs updating.
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- `docs/metamodel.md` — the `comments:` block, beside `attachments:`/`transforms:`.
+- `docs/data-entry.md` — the commenting UI.
+- `docs/data-entry/api-reference.md` — new routes (required by
+  `internal/dataentry/CLAUDE.md`).
+- `CLAUDE.md` — that comments are deliberately NOT in the graph, why (the
+  `internal/userstate` precedent), and that `author` is server-written.
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:**
+
+Run 2026-09-01. 8 findings — 1 critical, 5 significant, 1 minor, 1 nit.
+
+| ID | Severity | Finding |
+|---|---|---|
+| RR-FCUS1V | critical | Entity rename silently orphans every comment (EntityObserver.EntityRenamed unhandled) |
+| RR-60067I | significant | No coherence rule between the 4 permissions; `comment:delete` without `read` loads fine |
+| RR-1PCQ42 | significant | Comment count is an unfiltered aggregate / existence oracle |
+| RR-7F6NM9 | significant | File-backend concurrency + partial-write durability unspecified |
+| RR-OOPBUZ | significant | Comment body unbounded and unvalidated (size, control chars, per-target cap) |
+| RR-3VSSPM | significant | Comment ID minting, ordering, and the update/delete subject undefined |
+| RR-JT560T | minor | Four backends in one ticket is disproportionate; land file+memory first |
+| RR-17JRWP | nit | AC1 "byte-identical" is untestable as written |
+
+**All 8 addressed** — see each RR's `resolution`. Plan changes: a Lifecycle
+section (EntityObserver rename/delete), mutating permissions requiring
+`comment:read` validated at load, post-gate counts, a stated storage contract
+(server-minted IDs, defined ordering, serialised writes, atomic file writes),
+allowlist input validation, and two backends instead of four.
+
+**Permission vocabulary settled at 6** (RR-3VSSPM): `comment:read`,
+`comment:add`, `comment:update-own`, `comment:update-any`, `comment:delete-own`,
+`comment:delete-any`. The graph's ownership mechanism was evaluated and rejected
+— it is a graph EDGE test (`graph.HasEdge`, `resolver.go:176`), and comments
+have no edge, so reusing it would couple the ACL walker to a non-graph store.
+"Own" is a string comparison of stored `Author` against the principal, inside
+the comment service.

--- a/tickets/entities/researchs/RES-XRYX18.md
+++ b/tickets/entities/researchs/RES-XRYX18.md
@@ -1,0 +1,501 @@
+---
+id: RES-XRYX18
+type: research
+title: How should entity commenting anchor to properties and text ranges in rendered markdown?
+summary: 'Depend on github.com/vloothuis/textanchor v0.1.0 (MIT, extracted from margin: anchor engine + quotefind rendered->source mapping, a superset of the Hypothesis cascade with structural context and uniqueness scoring); normalise via FormatMarkdown to survive fsstore''s 80-col reflow, pin ContentHash for backend-independent staleness detection; ship property/section anchors first; add three-tier confidence and bound the substring search.'
+status: done
+---
+
+## Problem
+
+Users of the data-entry app want to comment on an entity: either on a named
+property, or on a selection of the rendered markdown body. Two questions need
+answering before implementation:
+
+1. **How is a comment anchored** to a point in the entity, such that the anchor
+survives ordinary editing of that entity — and what happens when it cannot?
+2. **Where does commenting live** — an operator-declared schema pattern, a
+built-in feature, or a built-in mechanism with operator-configured policy?
+
+This matters now because the anchoring decision is load-bearing for the storage
+schema. Getting it wrong means either re-migrating stored anchors later, or
+shipping a feature whose comments silently detach from the text they discuss.
+
+## Context
+
+### Storage and write path (verified)
+
+- Entities are markdown files with YAML frontmatter. `entity.Entity` is
+`{ID, Type, Properties, Content, UpdatedAt}` — `Content` is the body
+(`internal/entity/entity.go:54`).
+- `POST /api/v1/{plural}` accepts **inline `relations`**
+(`internal/dataentry/write_handler.go:227`), so a comment entity and its edge
+are created in one request — no orphan window.
+- The view engine already traverses relations into ACL-filtered collections
+(`internal/dataentry/views.go:66`), so comments can ride the existing
+`/api/v1/_views/` response with correct row-gating and no new endpoint.
+- Entity types are entirely schema-driven; the repo's own
+`review-response` type (`tickets/schema.yaml:694`) is already a comment-shaped
+record, attached via `has-review-response` with an `inverse:`.
+
+### The anchoring constraints (the crux)
+
+Three findings, each independently fatal to naive offset anchoring:
+
+1. **fsstore reflows every body on write**, wrapping paragraphs at 80 columns
+(`internal/store/fsstore/markdown.go:188` → `markdown.FormatMarkdown`,
+`internal/markdown/format.go:34`, `DefaultLineWidth = 80`). pgstore stores the
+body raw. So *the same logical content has different byte offsets on different
+backends*, and an offset can shift with no user edit at all.
+2. **Markdown is rendered client-side** (`frontend/src/utils/markdown.ts:58`,
+marked → DOMPurify). DOMPurify runs last with a strict attribute allowlist
+(`ADD_ATTR: ['data-cb-idx']`, `markdown.ts:112`) — any new anchoring attribute
+must be explicitly allowlisted or it is silently stripped.
+3. **The rendered DOM is mutated after render**: mermaid and PlantUML replace
+subtrees via `innerHTML` in a `flush: 'post'` watcher
+(`EntityDetail.vue:222-231`). DOM-coordinate anchors are invalidated by async
+post-processing.
+
+Together these mean anchors must live in a **normalized source-markdown
+coordinate space**, not in raw byte offsets and not in DOM coordinates.
+
+### What already exists to build on
+
+- **`data-cb-idx`** — the checkbox toggle maps a render-time ordinal back to a
+source line (`markdown.ts:99`, `checkboxToggle.ts:31`, `EntityDetail.vue:281`).
+This is the existing render↔source contract and the precedent to extend;
+`checkboxToggle.ts:7` documents the invariant that renderer and mapper must not
+disagree.
+- **Server-side goldmark AST walking on the view path** — `collectMentions`
+parses entity markdown and reads `t.Segment.Value(source)`
+(`internal/dataentry/mentions.go:150-190`), i.e. **the server can already map
+parsed nodes to exact source offsets**, using a parser explicitly configured to
+match what the SPA renders (`mentions.go:195`).
+- **`canonical.HashEntity`** (`internal/canonical/canonical.go:63`) — a
+backend-stable content hash that normalizes through `FormatMarkdown` so
+fsstore's reflowed body and pgstore's raw body converge. A ready-made
+fingerprint for "has this changed since the comment was written", available on
+**all** backends (unlike version history, which is postgres-only). Caveat: it
+covers id + type + properties + body, so a property-only edit also changes it; a
+body-only fingerprint would hash `FormatMarkdown(content)` directly.
+- **`lineDiff`** (`frontend/src/utils/lineDiff.ts`) — an LCS line diff already
+in-tree, with a documented size guard, reusable for re-anchoring.
+- **Playwright e2e** including `checkboxes.spec.ts` — the precedent for testing
+render↔source interaction in a real browser.
+
+### Policy and security constraints
+
+- **Validation policy (DEC-HWZHA):** a stale anchor is a *soft* condition — a
+hand-editor can trivially produce it — so it must warn, never 422 or block a
+save (`internal/dataentry/CLAUDE.md`).
+- **Authorship must be stamped server-side.** The automation template's
+`{{user.name}}` is the **git config user**
+(`internal/automation/template.go:48`), not the request principal — a trap. The
+automation engine has no principal access at all. `rela.principal` *is* exposed
+to Lua as a frozen table (`internal/lua/runtime.go:976`), which is the
+documented route (`docs/lua-scripting.md:414`).
+- **Row-level ownership is not expressible today.** `RoleDef.Create/Update/Delete`
+are plain type-name allowlists (`internal/acl/authz_write.go:138`); the `when:`
+predicate exists only on *field* and *relation* grants. The predicate engine
+already evaluates `current_user` and ships
+`internal/predicate/testdata/accept/03_owner_check.lua` — literally
+`entity.created_by == current_user.id` — so "edit only your own comment" is
+plumbing, but it is a real ACL change needing its own security review.
+- **Body content is not redactable today** (`internal/visibility/policyreader.go:199`,
+`TODO(body-redaction)`). So a stored quote leaks nothing a reader of the target
+couldn't already see — *provided* comments are gated by the same read verdict as
+their target. If body redaction ever ships (`InaccessibleFieldContent` is
+already reserved), stored quotes become an unredacted copy of hidden content.
+This must be recorded as a forward-looking risk.
+- **SSE is type-granular** — the wire payload is `{"type": "..."}` with no id
+(`internal/dataentry/watcher.go:450`). Comments go live for free, but every open
+view refetches on any comment write. Per-id events were considered and
+deliberately rejected (TKT-POT9GQ); don't reopen that casually.
+- On the fs backend (the default build) each comment is **a committed file** in
+`entities/<type>/`, so comment churn lands in git history.
+
+### Implementation constraints for a top-level `comments:` block (verified)
+
+- **The loader has a hand-maintained allowlist.** `validTopLevelKeys`
+(`internal/metamodel/loader.go:16`) must gain a `comments` entry or the loader
+rejects the block it was built for. This exact drift already happened once with
+`attachments:` (BUG-5XIN07); `TestValidTopLevelKeysMatchStruct`
+(`loader_test.go:931`) is the reflection guard that now catches it.
+- **`transforms:` is the better precedent than `attachments:`** — it validates at
+load (`loader.go:243` → `internal/metamodel/transforms.go:26`), sorts keys for
+deterministic errors, and *canonicalizes* defaults so no downstream consumer
+re-defaults. `attachments:` has no load-time validation at all.
+- **Metamodel config must be read live, never captured.** `watcher.go:307`
+swaps the metamodel atomically on file change; a captured pointer or a registry
+built once at construction goes stale.
+- **`Metamodel` carries a plimsoll grandfather directive** (`types.go:18`), so
+new accessors belong on a narrow `CommentPolicy`-style view type, following
+`NewAttachmentPolicy` (`attachments.go:85`).
+- **Includes are a gap to decide explicitly:** neither `attachments:` nor
+`transforms:` is legal in an included file (`include.go:13`), and an include
+declaring one is *silently dropped*.
+- **Config must not ride `/_config`.** That endpoint is served verbatim and must
+not be filtered per principal (TKT-M1AX6P, pinned by
+`TestNavPermission_ConfigUnfiltered`). Comments get their own endpoint — the
+`/_transforms` precedent (`api_v1.go:113`).
+- **A new write verb is a known-hard extension point.** It touches `acl.Op` plus
+four closed switches, `translateVerb` (`affordances.go:42`, which *panics* on
+unknown verbs by design), `perItemVerbs`, docs, and the SPA.
+`dataentry/CLAUDE.md` already defers `transition:*` / `relation:*` for exactly
+this reason. Note `lint_test.go`'s grep guard only walks the **package root**,
+so comment write code in a sub-package would silently escape it.
+- **New-route test probes are mandatory:** `router_walk_test.go` and
+`readonly_write_route_invariant_test.go`.
+- **Coverage:** default package floor 50 (`.testcoverage.yml:18`); 55 inside
+`dataentry`, 65 inside `metamodel`. Security-boundary packages are pinned higher
+by convention (visibility 85), so expect review pressure there.
+- **Frontend:** vitest with happy-dom by default, but `markdown.test.ts` opts
+into jsdom because **happy-dom mis-serializes adjacent block elements under
+DOMPurify** (BUG-SQSV6V). Anything walking rendered markdown must do the same.
+`noNetwork.test.ts` (BUG-762I34) forbids `onMounted` fetches reaching the
+network — the exact shape a comments panel takes.
+
+### A built-in `comment` entity type would be unprecedented
+
+Nothing in rela reserves an **entity type name**. The only reserved-name check
+at load applies to custom *scalar* types (`loader.go:147`, over `m.Types`);
+`validateEntityStructure` has no entity-name check at all. Reserved namespaces
+in rela are the underscore URL segment (`_config`, `_search`) and the `system:`
+principal prefix — not type names. So shipping a built-in `comment` type would
+collide with any existing project that already declares one, and adding a
+reservation check is a breaking change.
+
+### Version pinning is postgres-only — but staleness detection is not
+
+- `versionServiceFor` returns a genuinely-nil service in every non-postgres build
+(`internal/appbuild/versionsweep_nosweep.go:19`); fsstore's substitute is git,
+sqlite has none. The documented degradation pattern is a plainly-stated 501
+capability gap (`history_handler.go:44`), not a silent fallback.
+- Pin on **`ContentHash`, never the `Version` ordinal** — ordinals are computed
+at read time and are purge-fragile, and rela permits id reuse so `(entity_id,
+version)` can cross into an unrelated reclaimed entity
+(`pgstore/version.go:81`).
+- Crucially, `contentHashOf` is just `canonical.HashEntity`
+(`pgstore/version.go:70`), explicitly "matching the live entity hash". That
+function is backend-independent — so **"is this comment stale?" works on every
+backend** even though *retrieving the old version* is postgres-only. This
+decouples staleness detection from version history.
+- There is no `GetVersionByContentHash` today; resolving a hash-pinned anchor to
+a snapshot would need a new store method plus `storetest` conformance.
+- Do **not** add comment config to `RenderProjection` — its hash stability is a
+versioning contract (`shapeprojection.go:19`: "This is a SIBLING … Do not merge
+them").
+
+### Library landscape for text anchoring (surveyed)
+
+Only three projects in this ecosystem are alive; the entire `dom-anchor-*` /
+`annotator.js` / Apache Annotator lineage is dormant, archived, or formally
+retired.
+
+| Project | Licence | State |
+|---|---|---|
+| `hypothesis/client` | BSD-2-Clause | active; vendored anchoring |
+| `@recogito/text-annotator` | BSD-3-Clause | active; the live successor, quote + start/end, W3C-aligned |
+| `approx-string-match` | MIT | stable/complete; the matching primitive |
+| `dom-anchor-text-quote` | — | unmaintained; depends on a third-party `diff-match-patch` fork whose Google upstream is archived (2019) |
+| `annotator.js` | **MIT OR GPL-3.0** | dead since 2015; if adopted, the MIT election must be explicit |
+| `anchorpoint` (Python) | "Free To Use But Restricted" | **not permissive — unusable** |
+| `robertknight/anchor-quote` | none | archived, no licence — unusable |
+
+**There is no Go library for W3C selector anchoring** — a Go implementation is a
+from-scratch port (the Myers bit-parallel matcher plus a scoring cascade),
+though both reference implementations are permissively licensed for reading.
+
+Two in-tree facts matter here:
+
+- **`sergi/go-diff`** (the Go diff-match-patch port) is **already in `go.mod`**
+(line 157, currently indirect) — the fuzzy-matching primitive is effectively
+available without a new direct dependency decision.
+- **rela's existing `fuzzy` is not a locator.** `internal/filter/fuzzy.go:6`
+implements set-based **trigram Jaccard similarity** (order-insensitive,
+position-free). It can *score* a candidate window but cannot *find* the best
+window in a document. Locating a moved quote needs a different algorithm than
+anything currently in-tree — do not assume `fuzzy()` can be reused for it.
+
+### Prior art in-house: `~/Work/margin` (decisive)
+
+`margin` is the user's own MIT-licensed Go tool that solves *exactly* this
+problem — annotating markdown without modifying the source, anchored by fuzzy
+matching so annotations survive edits. It has a working, tested `anchor/`
+package (11 tests, passing) and has been in real use since 2025-12. This is a
+reference implementation, not a sketch, and it supersedes the "no Go library
+exists" conclusion: one exists, it is ours, and it is adoptable.
+
+**`anchor.Anchor` stores five descriptors** (`anchor/anchor.go`), a superset of
+the W3C/Hypothesis selector set:
+
+| Field | Purpose |
+|---|---|
+| `Quote` | the exact selected text |
+| `Prefix` / `Suffix` | ~50 chars either side, for disambiguation |
+| `ContainingSentence` | full sentence, captured **only for quotes < 50 chars** |
+| `HeadingContext` | nearest preceding ATX heading |
+| `ParagraphIndex` | 0-based paragraph index within that section |
+
+The last three are **beyond** what Hypothesis stores, and they directly address
+its two documented weaknesses. `ContainingSentence` is the answer to the
+short-generic-quote pathology (#3919); `HeadingContext` + `ParagraphIndex` give
+a *structural* fallback that survives whole-paragraph rewrites where quote
+matching alone would orphan.
+
+**Resolution** (`anchor/resolve.go`) is a two-phase candidate search — all exact
+quote occurrences first, fuzzy matching only if none — then weighted scoring:
+
+```
+0.40*quote + 0.20*prefix + 0.20*suffix + 0.10*structural + 0.10*uniqueness
+```
+
+with `MinConfidence` 0.5, a 0.8 penalty on fuzzy-derived candidates, and
+structural score itself `0.7*heading + 0.3*paragraph`. Note the **uniqueness
+term (1/occurrences)** — a component absent from Hypothesis's weights that
+directly scores the W3C §4.2.4 ambiguity problem rather than merely mitigating
+it. `ResolveAll` hoists heading/paragraph extraction across anchors so a
+document's whole annotation set resolves in one pass.
+
+**Matching** (`anchor/fuzzy.go`) is length-adaptive: Levenshtein ratio
+(`agnivade/levenshtein`) under 100 chars, token-Jaccard above; a sliding window
+at ±25% of quote length finds the best substring; queries under 5 chars are
+refused outright — the minimum-quote-length guard my research recommended,
+already implemented.
+
+**`internal/web/quotefind.go` solves the render↔source problem I had flagged as
+unsolved.** `extractRenderedTextWithMapping` walks the goldmark AST and builds a
+**per-byte `posMap` from rendered text back to source offsets**, handling soft
+line breaks and block separators. This is the technique rela *has available*
+(`mentions.go:150` already reads `t.Segment`) but has never implemented. It
+exists precisely because a browser selection yields rendered text without
+markdown syntax — the same mismatch rela's SPA would hit.
+
+**What this changes:**
+
+- The Stage-2 matcher is **adoption, not a from-scratch Myers port**. The
+recommendation to reimplement `match-quote.ts` in Go is superseded.
+- `margin`'s design is a **strict superset** of the Hypothesis cascade, with
+structural context and a uniqueness term it lacks.
+- Storage shape is already proven git-friendly (one TOML file per annotation,
+mirroring document paths) — conceptually identical to rela's one-markdown-
+file-per-entity model, which de-risks the "comments as committed files" concern.
+
+**Gaps to close on adoption** (none fundamental):
+
+- **No `FormatMarkdown` normalisation.** margin anchors into raw document text;
+rela must normalise both at store and at match time or fsstore's 80-column
+reflow will orphan anchors. This remains the highest-leverage decision.
+- **Binary orphaned/resolved, not three-tier.** `ResolveResult` has `Orphaned` +
+`Confidence` + `OrphanReason`, so the data for a middle "orphan-with-
+suggestion" band is already present — but the tier logic is not. The
+MSR-TR-2001-107 finding still needs applying.
+- **`bestSubstringMatch` is O(windows x levenshtein)** over a paragraph. Fine
+for margin's scale; needs a bound before it runs per-comment on a server request
+path.
+- Anchors are byte offsets into a `string`; rela is UTF-8 throughout, so
+multi-byte handling needs checking at the boundary.
+
+## Options
+
+Prior art settles the *shape* of the answer: W3C Web Annotation (Rec. 2017)
+defines the selector vocabulary, Hypothesis is the reference re-anchoring
+implementation, GitHub demonstrates version-pinning, and MSR-TR-2001-107 is the
+one study that measured user expectations. The live question is which regime
+rela adopts.
+
+**The architectural fork.** Anchoring splits into two regimes, and the choice is
+structural, not a tuning parameter:
+
+- **Positional / CRDT anchors** (Google Docs, Yjs, Peritext) — the anchor is an
+*identity*, and the system participates in **every** edit.
+- **Re-anchoring** (W3C selectors, Hypothesis) — the anchor *describes* content,
+and the system sees only before-and-after.
+
+**Regime 1 is unavailable to rela in principle.** Entity bodies are edited by
+external tools, git, and other processes; the storage philosophy in `CLAUDE.md`
+guarantees whole-file writes rela never observes. Positional anchors require
+mediating every edit, and that precondition fails. This is a fact about rela's
+design, not a preference — so the options below all sit inside the re-anchoring
+regime.
+
+### Option A — Property/section anchors only
+
+Anchor to a property name or the operator-authored `sectionId`.
+
+- **Pros:** Zero drift — anchors are *names*, not offsets. No new render
+machinery, no matching algorithm, no orphan state. Ships as a schema pattern.
+- **Cons:** Cannot comment on a sentence, which is the stated requirement.
+- **Effort:** Small.
+
+### Option B — Quote-only anchors
+
+Store `exact` plus prefix/suffix; locate by search on render.
+
+- **Pros:** Survives insertion-before, reordering, and (critically for rela)
+the fsstore 80-column reflow, provided text is normalised first.
+- **Cons:** W3C §4.2.4 concedes quote matching is **not guaranteed unique** —
+duplicate text anchors ambiguously. No fast path: every comment searches the
+document on every render. Hypothesis #3919 documents >10s main-thread blocking
+for short quotes in long documents.
+- **Effort:** Medium.
+
+### Option C — Quote + position + context (the Hypothesis cascade)
+
+Store all three selectors. Try position first as a *hint*, then assert the
+resolved text equals the stored quote; fall back to fuzzy search.
+
+- **Pros:** The settled belt-and-braces design. Position gives speed, quote gives
+truth. Hypothesis's `maybeAssertQuote` **rejects a positional hit whose text
+does not match** — so a shifted offset degrades to a search rather than silently
+anchoring the wrong text. Its weighted score (quote 50, prefix 20, suffix 20,
+position 2 — position explicitly a tie-breaker) is a directly reusable starting
+point, as is the error budget `min(256, len(quote)/2)`.
+- **Cons:** Needs an approximate-substring locator, which rela does **not** have
+(`internal/filter/fuzzy.go` is order-insensitive trigram Jaccard — a scorer, not
+a locator). Real orphan rates in the wild are 22–27% (Aturban et al.,
+arXiv:1512.06195), though that measures uncontrolled public web pages and is an
+upper bound, not a prediction for a controlled corpus.
+- **Effort:** Medium-large.
+
+### Option D — Version-pinned anchors (GitHub's model)
+
+Pin each comment to the content it was written against; re-anchor onto the live
+body best-effort; when that fails, display the comment against its pinned
+version rather than orphaning it.
+
+- **Pros:** The pin is **immutable and always resolvable**, so a failed
+re-anchor still renders meaningfully — strictly better than an orphan list. This
+is exactly what GitHub does: `original_commit_id` + `original_line` +
+`diff_hunk` are retained verbatim, and `diff_hunk` is effectively a stored
+`TextQuoteSelector`. W3C §4.3 recommends the same via `TimeState`/`cached`.
+- **Cons:** Retrieving a *pinned snapshot* is postgres-only in rela. Pinning must
+key on `ContentHash`, never the `Version` ordinal (read-time computed,
+purge-fragile, and id-reuse can cross lineages).
+- **Effort:** Medium on top of C; larger if snapshot retrieval is required on
+every backend.
+
+### Option E — Positional / CRDT anchors
+
+Rejected above: rela does not observe the edits. Recorded only so the rejection
+is on the record. Worth noting that on a whole-document rewrite CRDT anchors
+survive *mechanically* to a location whose meaning has changed, flagging nothing
+— arguably worse than an honest orphan.
+
+## Recommendation
+
+**Option C as the mechanism, with Option D's pin as a stored field and Option A
+shipped first.** Concretely, a three-stage delivery:
+
+**Stage 1 — property/section anchors (Option A).** Delivers commenting end to
+end with zero drift risk, and builds the record type, the ACL story, the panel
+UI, and server-side author stamping. Everything here is reusable by later
+stages.
+
+**Stage 2 — text ranges via the Hypothesis cascade (Option C).** Store `exact` +
+prefix/suffix + a position hint + a body fingerprint. Resolve position-first,
+**assert the quote**, fall back to approximate search. Two rela-specific
+requirements fall out of the constraints already recorded:
+
+- **Normalise through `markdown.FormatMarkdown` before storing and before
+matching.** This is what makes the fsstore 80-column reflow a no-op rather than
+a mass-orphaning event, and it is also W3C's own requirement for
+`TextQuoteSelector`. It is the single highest-leverage decision in the design.
+- **Anchor in source-markdown coordinates, not DOM coordinates** — DOMPurify's
+attribute allowlist and the post-render mermaid/PlantUML `innerHTML` rewrites
+make DOM offsets untrustworthy.
+
+**Stage 3 — pinning (Option D).** Store `canonical.HashEntity` (or a body-only
+`FormatMarkdown` hash) at comment creation. Because `contentHashOf` is just
+`canonical.HashEntity`, **staleness detection works on every backend** even
+though snapshot *retrieval* is postgres-only — so "this comment was written
+against different text" is universally available, and pg additionally offers
+"show me that text". Degrade per the `history_handler.go:44` precedent: a
+plainly-stated capability gap, never a silent fallback.
+
+### Where to implement the matcher — adopt `margin/anchor`
+
+Server-side in Go, by depending on **`github.com/vloothuis/textanchor`**
+(v0.1.0, MIT, public) rather than writing a matcher from scratch. The `anchor`
+and `quotefind` packages were extracted from `margin` into that library so rela
+consumes them as a normal dependency instead of copying code between repos.
+`textanchor.New`/`Resolve`/`ResolveAll` are the anchor engine;
+`quotefind.Find`/`FindWithContext`/`RenderedTextWithMapping` map a selection
+over rendered markdown back to source offsets. The `Anchor` struct carries both
+TOML and JSON tags, so it serialises straight into rela's wire types. This
+supersedes the earlier plan to port Myers bit-parallel matching from
+`match-quote.ts`: a working, tested Go implementation already exists, and its
+descriptor set (adding `ContainingSentence`, `HeadingContext`, `ParagraphIndex`,
+and a uniqueness score) is a **strict superset** of the Hypothesis cascade,
+addressing two of Hypothesis's own documented weaknesses.
+
+Port `internal/web/quotefind.go` alongside it: its
+`extractRenderedTextWithMapping` builds a per-byte rendered→source `posMap` from
+the goldmark AST, which is the missing piece for turning a browser selection
+over rendered HTML into source-markdown coordinates. rela already has the same
+primitive available (`mentions.go:150` reads `t.Segment`) but has never used it
+this way.
+
+Rejecting the client-side alternative (`@recogito/text-annotator`) still stands,
+and more strongly now: anchoring belongs on the server side of the sanitiser,
+and the Go code already exists.
+
+**Required adaptations, in priority order:**
+
+1. **Normalise through `markdown.FormatMarkdown`** at store and match time.
+margin anchors into raw text; without this, fsstore's 80-column reflow orphans
+anchors wholesale. Highest-leverage change.
+2. **Add the third confidence tier.** `ResolveResult` already carries
+`Confidence` and `OrphanReason`, so the data exists; only the place-silently /
+suggest / orphan-outright banding is missing.
+3. **Bound `bestSubstringMatch`.** It is O(windows x levenshtein) per paragraph
+— acceptable for a CLI, not for a per-request server path with many comments.
+4. **Verify UTF-8 boundaries.** Anchors are byte offsets; confirm multi-byte
+handling at the API edge.
+
+### Non-negotiables carried from the evidence
+
+1. **Three-tier confidence, not binary.** MSR-TR-2001-107 found that when a
+candidate matched only one keyword, median user rating was **1.0/7
+("terrible")** — *a bad guess is worse than no guess*. Place silently above a
+high threshold; orphan-with-suggestion in the middle band; orphan with **no**
+guess below it. Start conservative.
+2. **Never hide a failed anchor.** Hypothesis originally hid orphans and users
+believed their annotations had vanished; v1.2.0 added an Orphans tab. GitHub
+collapses-and-labels, never deletes. Demote and label, and always show the
+stored quote as context.
+3. **"Failed to anchor" is an explicit state, never an absence** (Hypothesis
+   #954's silent third state is a real bug class) — and per DEC-HWZHA it is a
+**warning, never a 422**.
+4. **Guard pathological search:** enforce a minimum quote length and always pass
+the position hint (Hypothesis #3919).
+5. **Comments use *after*-anchors and must not grow at boundaries** (Peritext).
+
+### Tradeoffs accepted
+
+- Some anchors will orphan. 22–27% is the uncontrolled-web upper bound; a
+controlled corpus with normalisation should do materially better, but the design
+must treat orphaning as normal rather than exceptional.
+- Ambiguous duplicate text may anchor to the wrong instance; prefix/suffix and
+the position tie-breaker reduce this without eliminating it (W3C §4.2.4).
+- Snapshot display is postgres-only.
+
+### Deliberately deferred
+
+- **Row-level "edit only your own comment"** needs `When` on
+`RoleDef.Create/Update/Delete`. The predicate engine already evaluates
+`current_user` and ships `03_owner_check.lua`, so this is plumbing — but it is a
+real ACL change and belongs in its own ticket with its own security review.
+- **A built-in `comment` entity type** — nothing in rela reserves an entity type
+name, so this would collide with existing projects. Prefer rela owning the
+*mechanism* (anchoring, stamping, UI) over rela owning the *type*.
+- **Per-id SSE events** — deliberately rejected (TKT-POT9GQ); do not reopen as
+part of this work.
+
+### Forward-looking risk to record
+
+If body-level redaction ever ships (`InaccessibleFieldContent` is already
+reserved, `visibility/policyreader.go:199`), every stored quote becomes an
+unredacted copy of potentially-hidden body text. Today this is safe because
+bodies are not policy-hideable and comments inherit their target's read verdict.
+It must be re-examined the moment that TODO is actioned.

--- a/tickets/entities/review-checklists/REV-TMEVUT.md
+++ b/tickets/entities/review-checklists/REV-TMEVUT.md
@@ -2,7 +2,7 @@
 id: REV-TMEVUT
 type: review-checklist
 title: 'Review: Entity commenting stage 1: property and section anchors'
-status: in-progress
+status: done
 ---
 
 ## Automated Checks
@@ -12,10 +12,9 @@ status: in-progress
 - [x] Comment lint gate clean (`just comment-lint`)
 - [x] Coverage maintained (`just coverage-check`)
 
-Full Go suite green (exit 0), `golangci-lint` 0 issues on the touched packages,
-`arch-lint` OK, `plimsoll` OK, `comment-lint` clean across 11800 comments,
-coverage 79.0% (both thresholds PASS). Frontend: `vue-tsc` clean, ESLint 0
-errors, 2142 tests pass, production build succeeds.
+Full Go suite exit 0 · 2395 frontend unit tests · **287 e2e** (8 skipped, 0
+failed) · `arch-lint`, `plimsoll`, `comment-lint`, `golangci-lint` all clean ·
+`docs-check` in sync · coverage thresholds satisfied.
 
 The `doclink` gate caught five broken godoc links in the new code. All five were
 **fixed, not suppressed**: two named a `PermCommentRead` constant that does not
@@ -24,60 +23,67 @@ exist (the real one is unexported, which Go cannot link at all), one said
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
 - [x] Self-reviewed the diff for unrelated changes
 
-The eight review-responses linked to this ticket (RR-17JRWP, RR-1PCQ42,
-RR-3VSSPM, RR-60067I, RR-7F6NM9, RR-FCUS1V, RR-JT560T, RR-OOPBUZ) are the
-**design**-review findings, all folded into the ticket's scope before
-implementation. `/code-review` has not yet run against the implemented diff.
+**How the review was actually done, and its limits.** Two attempts to run the
+cranky-code-reviewer agent over this diff stalled without producing findings
+(watchdog timeout, ~600s of no progress, both times). Rather than report a
+review that did not happen, the four highest-risk areas were reviewed directly
+and each claim tested rather than reasoned about:
+
+- **Gate ordering / existence leaks.** All four routes — `listComments`,
+`addComment`, `commentResolveCheck`, `gateCommentMutation` — were read and
+confirmed to gate the target (404) *before* the permission check (403), so a
+denied read is indistinguishable from a missing entity. The newest route, the
+`POST .../resolve` preflight, follows the same order.
+- **Face key collision.** `faceKeysFor` matches `k == id ||
+HasPrefix(k, id+"@")`. A throwaway test confirmed `DeleteAllFaces("TKT-1")`
+leaves `TKT-10@draft` intact — the `@` in the prefix is what prevents the
+collision, and it is load-bearing.
+- **Highlight escaping.** Four adversarial ids were run through
+`applyHighlights`: attribute break-out (`x" onload=…`), tag break-out
+(`x><script>`), ampersand double-decode, and a range landing mid-rune. All four
+are neutralised; the multi-byte case produces no U+FFFD.
+- **Author/id forgery.** The create wire type carries no `id`/`author` fields at
+all, so the forgery is unrepresentable rather than stripped. Pinned by
+`TestComments_TextAnchor` and the AC3 live check.
+
+Residual risk is honest to state: this is self-review plus targeted testing, not
+an independent adversarial pass. A reviewer on the PR should look hardest at
+`buildTextAnchor`'s trust boundary (client-supplied quote + context, descriptors
+derived server-side) and at `applyHighlights`' code-span detection, which is a
+regex heuristic over markdown and is deliberately biased to over-claim.
 
 **Review Responses:** RR-17JRWP, RR-1PCQ42, RR-3VSSPM, RR-60067I, RR-7F6NM9,
-RR-FCUS1V, RR-JT560T, RR-OOPBUZ (all design-stage)
+RR-FCUS1V, RR-JT560T, RR-OOPBUZ (all design-stage, all folded into scope before
+implementation). No new review-response entities were raised: the defects found
+during this work were found by using the feature in a browser, and were fixed
+with regression tests as they surfaced rather than tracked as findings.
 
 ## Acceptance Verification
 
 - [x] Each acceptance criterion tested (reference planning checklist)
 - [x] Test evidence documented in implementation checklist
 
-**Acceptance Status:**
+**Acceptance Status:** all 14 criteria PASS — see IMPL-DFFQTH for the per-AC
+evidence, verified live against a running `rela-server`.
 
-- AC1 (disabled is absent) — **PASS**, live: routes 404, no `.rela/comments/`
-created, `/_schema` omits `commentable`.
-- AC2 (create + read back) — **PASS**, live.
-- AC3 (author/id unforgeable) — **PASS**, live: injected `id`/`author` ignored.
-- AC4 (non-commentable type refused) — **PASS**, live 400.
-- AC5 (permissions independently enforced) — **PASS** by unit test
-(`TestAuthorizer_VerbsAreIndependent`, `TestAuthorizer_OwnVersusAny`).
-- AC6 (ownership-conferred permission honoured) — **PASS** by unit test
-(`TestAuthorizer_AsksAboutTheTargetEntity`).
-- AC7 (read floor, indistinguishable 404) — **PASS**, live 404 +
-`TestAuthorizer_ReadFloor`.
-- AC8 (mutating perm without read fails at load) — **PASS** by
-`internal/acl/commentperms_test.go`.
-- AC9 (detached renders, flagged) — **PASS**, unit + wire `detached` flag.
-- AC10 (rename re-keys, delete removes) — **PASS**, live: cross-process
-`rela rename id` moved the thread to the new id; old id 404s.
-- AC11 (concurrent adds both survive) — **PASS** via `commentstest.RunAll`.
-- AC12 (body cap / control chars) — **PASS**, live 400 for NUL and empty.
-- AC13 (counts post-gate) — **PASS**: the list is authorized before any count,
-and the panel's count derives from the returned rows.
-- AC14 (both backends pass the suite) — **PASS**: `filecomments` and
-`memcomments` both run `commentstest.RunAll`.
+Beyond the original ACs, stage-2 text anchoring and the follow-on UX work were
+verified in a real browser: multi-block and code-spanning selections, occurrence
+disambiguation ("Geordend" vs "Ongeordend"), anchor survival across an edit that
+shifts every byte offset, detachment when the quoted text is deleted, and
+image/diagram commenting.
 
 ## Documentation (enhancements only)
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
-This is an enhancement with a new operator-facing config block (`comments:`),
-six new ACL permissions and a new HTTP surface, so it needs user-facing docs
-before `done`.
-
-**Docs Checklist:** <!-- not yet created -->
+**Docs Checklist:** DOCS-D7N6RN
 
 ## Final Checks
 
@@ -87,4 +93,9 @@ before `done`.
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A: this item cannot
+  be satisfied before it is checked. `/pr` gates on the ticket being `done` and
+  validating clean, and a `done` review-checklist may have no unchecked items,
+  so the PR it asks for does not exist yet — the chicken-and-egg TKT-UFV01M
+  documents in this template. GitHub records the PR and its CI result; the
+  branch and commit messages carry the ticket ID.)

--- a/tickets/entities/review-checklists/REV-TMEVUT.md
+++ b/tickets/entities/review-checklists/REV-TMEVUT.md
@@ -1,0 +1,90 @@
+---
+id: REV-TMEVUT
+type: review-checklist
+title: 'Review: Entity commenting stage 1: property and section anchors'
+status: in-progress
+---
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+Full Go suite green (exit 0), `golangci-lint` 0 issues on the touched packages,
+`arch-lint` OK, `plimsoll` OK, `comment-lint` clean across 11800 comments,
+coverage 79.0% (both thresholds PASS). Frontend: `vue-tsc` clean, ESLint 0
+errors, 2142 tests pass, production build succeeds.
+
+The `doclink` gate caught five broken godoc links in the new code. All five were
+**fixed, not suppressed**: two named a `PermCommentRead` constant that does not
+exist (the real one is unexported, which Go cannot link at all), one said
+`EntityDelete` for `EntityDeleted`, and two bracketed unexported methods.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+The eight review-responses linked to this ticket (RR-17JRWP, RR-1PCQ42,
+RR-3VSSPM, RR-60067I, RR-7F6NM9, RR-FCUS1V, RR-JT560T, RR-OOPBUZ) are the
+**design**-review findings, all folded into the ticket's scope before
+implementation. `/code-review` has not yet run against the implemented diff.
+
+**Review Responses:** RR-17JRWP, RR-1PCQ42, RR-3VSSPM, RR-60067I, RR-7F6NM9,
+RR-FCUS1V, RR-JT560T, RR-OOPBUZ (all design-stage)
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- AC1 (disabled is absent) — **PASS**, live: routes 404, no `.rela/comments/`
+created, `/_schema` omits `commentable`.
+- AC2 (create + read back) — **PASS**, live.
+- AC3 (author/id unforgeable) — **PASS**, live: injected `id`/`author` ignored.
+- AC4 (non-commentable type refused) — **PASS**, live 400.
+- AC5 (permissions independently enforced) — **PASS** by unit test
+(`TestAuthorizer_VerbsAreIndependent`, `TestAuthorizer_OwnVersusAny`).
+- AC6 (ownership-conferred permission honoured) — **PASS** by unit test
+(`TestAuthorizer_AsksAboutTheTargetEntity`).
+- AC7 (read floor, indistinguishable 404) — **PASS**, live 404 +
+`TestAuthorizer_ReadFloor`.
+- AC8 (mutating perm without read fails at load) — **PASS** by
+`internal/acl/commentperms_test.go`.
+- AC9 (detached renders, flagged) — **PASS**, unit + wire `detached` flag.
+- AC10 (rename re-keys, delete removes) — **PASS**, live: cross-process
+`rela rename id` moved the thread to the new id; old id 404s.
+- AC11 (concurrent adds both survive) — **PASS** via `commentstest.RunAll`.
+- AC12 (body cap / control chars) — **PASS**, live 400 for NUL and empty.
+- AC13 (counts post-gate) — **PASS**: the list is authorized before any count,
+and the panel's count derives from the returned rows.
+- AC14 (both backends pass the suite) — **PASS**: `filecomments` and
+`memcomments` both run `commentstest.RunAll`.
+
+## Documentation (enhancements only)
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+This is an enhancement with a new operator-facing config block (`comments:`),
+six new ACL permissions and a new HTTP surface, so it needs user-facing docs
+before `done`.
+
+**Docs Checklist:** <!-- not yet created -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI

--- a/tickets/entities/review-responses/RR-17JRWP.md
+++ b/tickets/entities/review-responses/RR-17JRWP.md
@@ -1,0 +1,9 @@
+---
+id: RR-17JRWP
+type: review-response
+title: AC1 'byte-identical to today' is untestable as written
+finding: 'AC1 says behaviour with no comments: block is ''byte-identical to today — no routes served, no storage touched''. ''Byte-identical'' has a precedent in the repo (readonly_write_route_invariant_test.go asserts a byte-identical store), but here it is asserted about overall behaviour, which no single test can check. Restate as the two things actually verifiable: (a) GET/POST on the /_comments/ routes return 404 when the block is absent, and (b) no comment storage file/table is created. Both map onto existing probe patterns (router_walk_test.go).'
+severity: nit
+resolution: 'AC1 restated as the two verifiable facts: /_comments/ routes return 404 when the block is absent, and no comment storage file is created. Both map onto existing probe patterns (router_walk_test.go).'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-1PCQ42.md
+++ b/tickets/entities/review-responses/RR-1PCQ42.md
@@ -1,0 +1,9 @@
+---
+id: RR-1PCQ42
+type: review-response
+title: Comment count is an unfiltered aggregate and an existence oracle
+finding: 'The plan''s UI shows a per-property comment affordance, which in practice means a count badge, and the panel lists comments — but the plan says only ''decide whether the section needs a cap''. docs/acl-security.md:638 states the rule directly: ''No count from an unfiltered source. Any new aggregate (badge, dashboard card, export count) must derive from the gated set.'' CLAUDE.md''s gantt rule is the worked precedent: gate BEFORE you fold, and compute caps/truncated on the filtered set, because a pre-filter count is an existence oracle. Two concrete requirements the plan currently omits: (1) any comment count must be computed after the comment:read verdict, never from a raw store count; (2) if a cap is applied, ''truncated'' must be post-filter (TestGantt_TruncatedIsPostFilter is the model). Also unaddressed: whether a principal with comment:read but WITHOUT read on the target can infer the target''s existence from a 403-vs-404 divergence — AC7 covers the read floor but not the count surface.'
+severity: significant
+resolution: 'Plan now has a ''Counts are post-gate'' section: any comment count (per-property badge, panel header) is computed after the comment:read verdict, never from a raw store count, per docs/acl-security.md:638. If a cap is applied, truncated is post-filter following TestGantt_TruncatedIsPostFilter. AC13 pins it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3VSSPM.md
+++ b/tickets/entities/review-responses/RR-3VSSPM.md
@@ -1,0 +1,24 @@
+---
+id: RR-3VSSPM
+type: review-response
+title: Comment IDs, ordering and the update/delete authorisation subject are undefined
+finding: 'The record lists an ''ID'' field but the plan never says who mints it, what shape it takes, or whether it is unique globally or only per target. Three consequences left to the implementer: (1) If the client supplies the ID, a caller can overwrite another user''s comment by guessing/reusing an ID — the server must mint it, consistent with the author-stamping rationale. (2) Ordering is unspecified; a comment thread with no defined order will render differently across backends, and commentstest.RunAll cannot assert what the interface does not promise. CreatedAt exists but ties are undefined. (3) Most importantly, comment:update and comment:delete are resolved against the TARGET ENTITY, so any holder can edit or delete ANY comment on that entity, including other people''s. That may be intended for a moderator role, but the plan never states it, and it is the natural place a reader would expect ''edit your own'' — which RES-XRYX18 explicitly defers as needing new ACL machinery. State the intended semantics; if ''own comments only'' is wanted, it needs its own ticket, and if not, say so in the docs so operators are not surprised.'
+severity: significant
+resolution: |-
+    Resolved by splitting the mutating permissions into explicit own/any pairs rather than reusing the graph's ownership mechanism.
+
+    Why not the graph's 'own': there is no `own` primitive in rela's ACL. Ownership is a GRAPH EDGE — `role_relations: {assigned-to: {confers: assignee}}` — and computeForEntity (resolver.go:176) tests `r.d.graph.HasEdge(member, relType, target)`. Since comments are deliberately not in the graph, HasEdge has nothing to test, so reusing that machinery would require teaching the ACL graph walker about a non-graph store — exactly the coupling that motivated separating comments in the first place.
+
+    Final vocabulary (6 permissions, naming follows the history:read-redacted convention):
+      comment:read        — see comments on this entity
+      comment:add         — add a comment
+      comment:update-own  — edit/resolve a comment you authored
+      comment:update-any  — edit/resolve anyone's comment (moderator)
+      comment:delete-own  — delete a comment you authored
+      comment:delete-any  — delete anyone's comment (moderator)
+
+    'Own' is decided by comparing the stored Author against principal.From(ctx) — a string comparison inside the comment service, needing no ACL change. -any implies -own (holding -any satisfies an -own check).
+
+    Also resolved in the same change: the server mints the comment ID (never the client, same rationale as author stamping), and List returns comments ordered by CreatedAt ascending with the minted ID as the deterministic tie-break, pinned by commentstest.RunAll so all backends agree.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-60067I.md
+++ b/tickets/entities/review-responses/RR-60067I.md
@@ -1,0 +1,9 @@
+---
+id: RR-60067I
+type: review-response
+title: No coherence rule between the four comment permissions; delete-without-read loads fine
+finding: 'The plan defines comment:read|add|update|delete as four independent permissions with no relationship. rela already settled this question for entity verbs and enforces it AT BOOT: policy.go:1053-1069 rejects a role granting update or delete on a type without a covering read grant (''a principal must be able to read every type it can update/delete''), with create explicitly EXEMPT (TKT-4LQMWP) because a submitter may create what it cannot read and read it back via a role-conferring relation. That mapping transfers exactly: comment:update and comment:delete should require comment:read, while comment:add stays exempt (write-only commenting is a legitimate posture). Without this, a policy granting comment:delete alone loads successfully and is incoherent — the holder can delete comments it cannot see, which is both a usability trap and an unauditable capability. Add the check to validateComments (or the policy validator) so it fails at load like its entity-verb sibling.'
+severity: significant
+resolution: Mutating comment permissions now require comment:read, validated AT LOAD exactly as policy.go:1053 does for entity update/delete. comment:add is exempt, mirroring the create exemption (TKT-4LQMWP), because write-only commenting is a legitimate posture. AC8 pins that a policy granting a mutating permission without comment:read fails at load.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7F6NM9.md
+++ b/tickets/entities/review-responses/RR-7F6NM9.md
@@ -1,0 +1,9 @@
+---
+id: RR-7F6NM9
+type: review-response
+title: File backend concurrency and durability are unspecified
+finding: 'The plan names filecomments as the DEFAULT backend (''one file per target'') but specifies nothing about concurrent writes or partial writes. Two concrete gaps: (1) Two simultaneous POSTs to the same target both read the file, append, and write — classic lost update. The plan lists this under edge cases (''both comments survive'') but assigns no mechanism. fsstore''s answer is store.Store.Tx as a write mutex (CLAUDE.md, DEC-8UIL0); the comment store needs its own equivalent and it must be stated, because commentstest.RunAll can only pin behaviour the interface actually promises. (2) A crash mid-write truncates the file and loses every comment on that target, not just the new one. The fs tier writes whole files; an atomic write-temp-then-rename is the standard mitigation and should be specified rather than left to the implementer. Note this is more severe than the equivalent risk in fsstore, because one file holds N comments rather than one entity.'
+severity: significant
+resolution: 'The interface contract now states both explicitly: writes to one target are serialised (the store.Store.Tx role, DEC-8UIL0) with AC11 pinning that two concurrent adds both survive, conformance-tested across backends; and the file backend writes atomically via temp-file + rename, because one file holds N comments so a truncated write would lose a whole thread rather than one record.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-FCUS1V.md
+++ b/tickets/entities/review-responses/RR-FCUS1V.md
@@ -1,0 +1,9 @@
+---
+id: RR-FCUS1V
+type: review-response
+title: Entity rename silently orphans every comment on the renamed entity
+finding: 'The plan keys comments by target entity ID but never mentions rename. store.EntityObserver (store.go:981) emits EXACTLY ONE callback on rename — EntityRenamed(oldID, renamed) — and explicitly NOT EntityDelete(oldID)+EntityPut. The godoc names the intended consumers: ''ID-keyed observers (waiver stores, anything that stores references by entity ID) can rewrite those references in one step.'' A comment store is exactly that. Without subscribing, every comment on a renamed entity becomes unreachable — silently, with no error and no orphan state, because the new ID simply has no comments. rela supports rename as a first-class operation (Manager.RenameEntity, manager.go:1165), so this is not a corner case. The plan must subscribe the comment store as an EntityObserver and handle EntityRenamed (re-key) as well as EntityDelete (AC9''s ''cleanup path'', currently undefined).'
+severity: critical
+resolution: 'Plan now has a Lifecycle section: the comment store subscribes as a store.EntityObserver and handles EntityRenamed(oldID, renamed) by re-keying the target''s comments, plus EntityDelete(id) by removing them. AC10 pins both.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JT560T.md
+++ b/tickets/entities/review-responses/RR-JT560T.md
@@ -1,0 +1,9 @@
+---
+id: RR-JT560T
+type: review-response
+title: Four backends in one ticket is disproportionate for stage 1
+finding: The plan's own risk section concedes 'four backends is the bulk of the work, and three are new storage code', and the ticket is already effort:l with a UI half. Three of the four (postgres, sqlite, file) are genuinely new persistence code, each needing migrations or a serialisation format, plus conformance runs — and the postgres one is DB-gated in CI so it reads as uncovered by default. The conformance suite makes adding a backend cheap LATER, which is the argument for landing the interface plus the default file backend and memory (enough to ship the feature and prove the seam), then adding pg/sqlite as a follow-up ticket. This is a sequencing suggestion, not an objection to the design — the interface must still be designed for all four up front so the later ones need no interface change.
+severity: minor
+resolution: Accepted. This ticket now ships two backends — filecomments (default) and memcomments (tests) — with pgcomments/sqlitecomments moved to a follow-up ticket. The interface is still designed for all four so the later ones need no interface change, and commentstest.RunAll is what makes adding them cheap.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-OOPBUZ.md
+++ b/tickets/entities/review-responses/RR-OOPBUZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-OOPBUZ
+type: review-response
+title: Comment body is unbounded and unvalidated; no size or rate limit
+finding: 'The plan''s input-validation section covers anchor_ref, target ids and author, but says of the body only that it is ''markdown, rendered through the SPA''s existing renderMarkdown -> DOMPurify path''. That addresses XSS on the read side and nothing else. Missing: (1) No maximum body length. An authenticated principal with comment:add can write an arbitrarily large body, and on the file backend that means an unbounded file that must be fully read on every subsequent list. rela caps comparable surfaces elsewhere (cmdexec output caps, attachment max). (2) No cap on comments per target — related to RR-1PCQ42''s cap question but distinct: that one is about disclosure, this is about resource exhaustion. (3) Control characters/NUL in the body are unspecified; the file backend serialises to YAML/TOML where a NUL is at best lossy. Specify an allowlist-shaped validation (max length, reject control chars except newline/tab) at the handler, since the handler is the trust boundary.'
+severity: significant
+resolution: 'Plan now has an Input validation section, allowlist-shaped and enforced at the handler (the trust boundary): body non-empty with a max length bounded like cmdexec''s output cap; control characters rejected except newline/tab (the file backend serialises to YAML/TOML where NUL is lossy); a per-target comment cap bounding both file size and list cost; and target path segments validated with isSafePathSegment before reaching the file backend. AC12 pins the body rejections.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-FIO205.md
+++ b/tickets/entities/tickets/TKT-FIO205.md
@@ -1,0 +1,186 @@
+---
+id: TKT-FIO205
+type: ticket
+title: 'Entity commenting stage 1: property and section anchors'
+kind: enhancement
+priority: medium
+effort: l
+status: review
+---
+
+## Description
+
+Stage 1 of entity commenting (FEAT-002WMX), per the anchoring research in
+RES-XRYX18. Design-reviewed 2026-09-01 (8 findings, all addressed below).
+
+Users can attach a comment to a **named property** or a **view section** of an
+entity, and read the resulting thread. These two anchor kinds are deliberately
+drift-free: a property name and an operator-authored `sectionId` are *names*,
+not offsets, so they survive any edit to the entity body.
+
+**Comments are not part of the graph.** A comment is a remark *about* an entity,
+not a fact *in* the operator's domain model. So comments are their own thing:
+their own service, their own storage interface with real backends, and their own
+ACL permissions — outside `store.Store` and `entitymanager`. rela owns the read
+and write path end to end, which is what makes `author` unforgeable: the handler
+writes it from `principal.From(ctx)` and never reads it from the request body.
+
+Text-range anchoring via `github.com/vloothuis/textanchor` and `FormatMarkdown`
+normalisation follow in stage 2 and are **out of scope here** — but the anchor
+field layout must not foreclose them.
+
+## Scope
+
+### Storage — a real interface with real backends
+
+`internal/comments` defines the `Comment` record and a `comments.Store`
+interface (`List`, `Add`, `Update`, `Delete`), plus a conformance suite
+(`commentstest.RunAll`) every backend must pass — the `store.Store` /
+`internal/store/storetest` pattern, not a KV blob. Comments are records to be
+listed and permissioned per target; a blob forces read-modify-write on every add
+and makes per-entity queries impossible.
+
+**This ticket ships two backends** (RR-JT560T): `filecomments` (default,
+YAML/TOML under `.rela/comments/`) and `memcomments` (tests). The interface is
+designed for four; `pgcomments` and `sqlitecomments` are a follow-up ticket that
+must need **no interface change** — the conformance suite is what makes that
+cheap.
+
+**Contract the interface must state explicitly** (RR-7F6NM9, RR-3VSSPM):
+
+- The **server mints the comment ID**; a client-supplied ID is ignored. Same
+rationale as author stamping — otherwise a caller can overwrite another user's
+comment by reusing an ID.
+- `List` returns comments ordered by `CreatedAt` ascending, with the minted ID
+as a deterministic tie-break. Pinned by `commentstest.RunAll` so backends cannot
+disagree.
+- Writes to one target are **serialised** (the `store.Store.Tx` role, DEC-8UIL0).
+Two concurrent adds must both survive; conformance-tested.
+- The file backend writes **atomically** (temp file + rename). One file holds N
+comments, so a truncated write loses a whole thread, not one record.
+
+### ACL — six named permissions, resolved per target entity
+
+`comment:read`, `comment:add`, `comment:update-own`, `comment:update-any`,
+`comment:delete-own`, `comment:delete-any`.
+
+Granted through a role's `permissions:` list like the existing `history:read`
+family, registered in `acl.BuiltinPermissions()` (`policy.go:72`) — a guard test
+(`permguard_test.go`) fails otherwise. Naming follows the
+`history:read-redacted` hyphenated-qualifier convention.
+
+Resolution uses **`acl.Request.HoldsPermissionForEntity`** (`resolver.go:260`),
+so a permission conferred by an ownership relation *to the target entity* is
+honoured, not just a global grant — the seam the statemachine transition guard
+already uses.
+
+**Why own/any are explicit permissions rather than the graph's ownership
+mechanism** (RR-3VSSPM): rela has no `own` primitive. Ownership is a graph edge
+(`role_relations: {assigned-to: {confers: assignee}}`) tested by `graph.HasEdge`
+(`resolver.go:176`). Comments are not in the graph, so there is no edge to test;
+reusing that machinery would mean teaching the ACL graph walker about a
+non-graph store — the exact coupling that separating comments avoided. "Own" is
+instead a string comparison of the stored `Author` against
+`principal.From(ctx)`, inside the comment service, needing no ACL change. `-any`
+implies `-own`.
+
+**Two invariants:**
+
+- `comment:read` is **floored by the target's read verdict**. A principal who
+cannot read the entity cannot read its comments however comment grants read, and
+cannot distinguish "none" from "denied".
+- **Mutating permissions require `comment:read`** (RR-60067I), validated at load
+exactly as `policy.go:1053` rejects entity `update`/`delete` without a covering
+`read`. `comment:add` is **exempt**, mirroring the `create` exemption
+(TKT-4LQMWP): write-only commenting is a legitimate posture.
+
+### Input validation (RR-OOPBUZ)
+
+Enforced at the handler, the trust boundary, allowlist-shaped:
+
+- Body: non-empty, max length (bounded like `cmdexec`'s output cap); control
+characters rejected except `\n`/`\t` — the file backend serialises to YAML/TOML
+where a NUL is lossy.
+- Per-target comment cap, to bound both file size and list cost.
+- Target `{type}`/`{id}` path segments validated with `isSafePathSegment`
+(`middleware_security.go:568`) before reaching the file backend.
+- `anchor_ref`: a safe identifier; one that matches nothing is a **warning, not
+a 422** (DEC-HWZHA).
+
+### Counts are post-gate (RR-1PCQ42)
+
+Any comment count (per-property badge, panel header) is computed **after** the
+`comment:read` verdict, never from a raw store count —
+`docs/acl-security.md:638` ("no count from an unfiltered source"). If a cap is
+applied, `truncated` is computed post-filter, following
+`TestGantt_TruncatedIsPostFilter`.
+
+### Lifecycle (RR-FCUS1V)
+
+The comment store subscribes as a **`store.EntityObserver`**:
+
+- `EntityRenamed(oldID, renamed)` → **re-key** the target's comments. Rename
+emits *only* this callback, never delete+put (`store.go:996`), and the godoc
+names ID-keyed reference stores as the intended consumer. Without this every
+comment on a renamed entity is silently unreachable.
+- `EntityDelete(id)` → remove that target's comments.
+
+### Also in scope
+
+- Fixed, server-written fields: `ID`, `Author`, `CreatedAt`, `Anchor{Kind,Ref}`,
+`Body`, `Resolved`.
+- HTTP surface under `/api/v1/_comments/...`.
+- Creating, resolving and deleting a comment from the SPA, anchored to a
+property or a section.
+- A `comments:` metamodel block carrying policy only (enable + commentable
+types). Declares no schema, synthesises no types.
+
+## Out of scope
+
+Later increments: `pgcomments` / `sqlitecomments` (follow-up ticket);
+operator-declared extra comment fields; text-range anchors + `FormatMarkdown`
+normalisation (stage 2); content-hash staleness pinning (stage 3); threading.
+
+Decided against, permanently: **no entity type** (comments never enter
+`store.Store`, `entitymanager`, the audit log or `/_schema`); **no versioning**;
+**no search indexing**.
+
+## Acceptance criteria
+
+1. With no `comments:` block: `/_comments/` routes 404, and no comment storage
+file is created (RR-17JRWP — restated from "byte-identical").
+2. With the block enabled for a type, a comment can be created against one of
+its properties and read back.
+3. A create request supplying `author` **or** `id` in the body has both ignored;
+the server's principal and minted ID win.
+4. A comment against a type not listed as commentable is refused.
+5. Each permission is independently enforced: `read` without `add` lists but
+cannot create; `update-own` cannot edit another author's comment; `update-any`
+can.
+6. A permission conferred by an ownership relation to the *target* is honoured.
+7. A principal who cannot read the target cannot read its comments, whatever
+their comment grants, and gets an indistinguishable 404.
+8. A policy granting a mutating comment permission without `comment:read` fails
+at load.
+9. A detached `anchor_ref` still renders, flagged — warning, never a 422.
+10. Rename re-keys comments; delete removes them.
+11. Two concurrent adds to one target both survive.
+12. Body exceeding the cap, or containing control characters, is refused.
+13. Comment counts are post-gate.
+14. Both backends pass `commentstest.RunAll`.
+
+## Notes
+
+- Author cannot be stamped from within the graph machinery, which is why rela
+owning the write path matters: `{{user.name}}` is the git config user
+(`automation/template.go:48`); `computed:` cannot see the principal
+(`computed/computed.go:117-121`); `admin.update_entity` does not exist by design
+(`lua/runtime.go:1967`).
+- `principal.From(ctx).User` may be a substituted entity ID
+(`router.go:465`) or `"unknown"` when unstamped. Store the resolved value;
+refuse rather than persist `"unknown"` — note this also makes `-own` checks
+meaningless for unstamped callers, so they must be refused, not defaulted.
+- Served-vs-inert follows `appbuild/transitions.go:21-39`: inert with no policy,
+**fail closed** when a policy exists but the `acl.Request` is absent.
+- `validTopLevelKeys` (`metamodel/loader.go:16`) must gain `comments`
+(BUG-5XIN07).

--- a/tickets/entities/tickets/TKT-FIO205.md
+++ b/tickets/entities/tickets/TKT-FIO205.md
@@ -5,7 +5,7 @@ title: 'Entity commenting stage 1: property and section anchors'
 kind: enhancement
 priority: medium
 effort: l
-status: review
+status: done
 ---
 
 ## Description

--- a/tickets/relations/FEAT-002WMX--has-research--RES-XRYX18.md
+++ b/tickets/relations/FEAT-002WMX--has-research--RES-XRYX18.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-002WMX
+relation: has-research
+to: RES-XRYX18
+---

--- a/tickets/relations/FEAT-002WMX--requires--data-entry-ui.md
+++ b/tickets/relations/FEAT-002WMX--requires--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-002WMX
+relation: requires
+to: data-entry-ui
+---

--- a/tickets/relations/FEAT-002WMX--requires--metamodel-types.md
+++ b/tickets/relations/FEAT-002WMX--requires--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-002WMX
+relation: requires
+to: metamodel-types
+---

--- a/tickets/relations/RES-XRYX18--researches--authorization.md
+++ b/tickets/relations/RES-XRYX18--researches--authorization.md
@@ -1,0 +1,5 @@
+---
+from: RES-XRYX18
+relation: researches
+to: authorization
+---

--- a/tickets/relations/RES-XRYX18--researches--data-entry-ui.md
+++ b/tickets/relations/RES-XRYX18--researches--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: RES-XRYX18
+relation: researches
+to: data-entry-ui
+---

--- a/tickets/relations/RES-XRYX18--researches--metamodel-types.md
+++ b/tickets/relations/RES-XRYX18--researches--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: RES-XRYX18
+relation: researches
+to: metamodel-types
+---

--- a/tickets/relations/TKT-FIO205--affects--data-entry-ui.md
+++ b/tickets/relations/TKT-FIO205--affects--data-entry-ui.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: affects
+to: data-entry-ui
+---

--- a/tickets/relations/TKT-FIO205--affects--metamodel-types.md
+++ b/tickets/relations/TKT-FIO205--affects--metamodel-types.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: affects
+to: metamodel-types
+---

--- a/tickets/relations/TKT-FIO205--has-docs--DOCS-D7N6RN.md
+++ b/tickets/relations/TKT-FIO205--has-docs--DOCS-D7N6RN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-docs
+to: DOCS-D7N6RN
+---

--- a/tickets/relations/TKT-FIO205--has-implementation--IMPL-DFFQTH.md
+++ b/tickets/relations/TKT-FIO205--has-implementation--IMPL-DFFQTH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-implementation
+to: IMPL-DFFQTH
+---

--- a/tickets/relations/TKT-FIO205--has-planning--PLAN-4MZ8WQ.md
+++ b/tickets/relations/TKT-FIO205--has-planning--PLAN-4MZ8WQ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-planning
+to: PLAN-4MZ8WQ
+---

--- a/tickets/relations/TKT-FIO205--has-review--REV-TMEVUT.md
+++ b/tickets/relations/TKT-FIO205--has-review--REV-TMEVUT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review
+to: REV-TMEVUT
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-17JRWP.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-17JRWP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-17JRWP
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-1PCQ42.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-1PCQ42.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-1PCQ42
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-3VSSPM.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-3VSSPM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-3VSSPM
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-60067I.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-60067I.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-60067I
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-7F6NM9.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-7F6NM9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-7F6NM9
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-FCUS1V.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-FCUS1V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-FCUS1V
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-JT560T.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-JT560T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-JT560T
+---

--- a/tickets/relations/TKT-FIO205--has-review-response--RR-OOPBUZ.md
+++ b/tickets/relations/TKT-FIO205--has-review-response--RR-OOPBUZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: has-review-response
+to: RR-OOPBUZ
+---

--- a/tickets/relations/TKT-FIO205--implements--FEAT-002WMX.md
+++ b/tickets/relations/TKT-FIO205--implements--FEAT-002WMX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-FIO205
+relation: implements
+to: FEAT-002WMX
+---


### PR DESCRIPTION
Entity commenting: annotate an entity without changing it — a remark on a
property, a view section, or a selected range of the markdown body.

Implements TKT-FIO205 (stage 1) plus the stage-2 text-range anchoring, which
turned out to be cheap once the anchor record was kind-discriminated.

## Design

**Comments are not graph entities.** A comment is a remark *about* an entity,
not a fact *in* the operator's domain model — so they get their own package,
their own storage interface with two backends, and their own ACL permissions,
outside `store.Store` and `entitymanager`. That separation is what makes the
author unforgeable: rela owns the read and write path end to end, writes the
author from the request principal, and the create wire type has no `author` or
`id` field at all, so the forgery is unrepresentable rather than stripped.

**Anchors re-resolve, they never store offsets.** A property name and a section
id are *names*, so they survive any edit. A text range stores the quote plus
surrounding context and is re-located on every read — an offset would be
invalidated by any edit earlier in the body, and on fsstore by a plain re-save,
since rela reflows markdown to 80 columns on write. A quote that was edited away
reports *detached* rather than silently re-attaching somewhere else.

**Per content state.** A comment belongs to one face: a remark on the draft is
not a remark on the published version. The storage key is
`entity.FormatStateRef`, so the default face keeps the bare id — which is what
makes this migration-free.

## What's here

- `internal/comments` — record, `Store` interface, service, authorizer, text
  resolution; `filecomments` (default) and `memcomments`, both passing
  `commentstest.RunAll`
- Six `comment:*` permissions with an own/any split; `comment:read` is floored
  by the target's read verdict, and a denial is an indistinguishable 404
- `comments:` metamodel block (policy only — no schema, no synthesised types)
- HTTP surface under `/api/v1/_comments/`, plus a `POST .../resolve` preflight
  so the UI never offers to comment on a selection that cannot be anchored
- SPA: per-field indicators, select-to-comment with highlights, threads with
  replies, affordances on images and diagrams, a collapsed catch-all panel for
  comments with no field row
- `docs/comments.md` (operator guide) and 6 e2e specs with a page object

## Dependency

Adds `github.com/vloothuis/textanchor` v0.2.0 (MIT). While building this I found
two defects in v0.1.0 — an exact-match phase comparing raw bytes, and a fuzzy
pre-gate that made the substring fallback unreachable for short quotes — which
together hard-orphaned any quote spanning a line wrap. Fixed upstream and
released before pinning.

## Verification

Full Go suite · 2395 frontend unit tests · 287 e2e (0 failed) · `arch-lint`,
`plimsoll`, `comment-lint`, `golangci-lint`, `docs-check` all clean.

Every acceptance criterion was verified live against a running `rela-server`,
not only in unit tests — including the two that matter most: a create body
carrying `"id":"EVIL"` and `"author":"mallory@evil.com"` has both ignored, and a
cross-process `rela rename id` re-keys the thread while the old id 404s.

## Reviewer notes

Two automated review passes stalled without producing findings, so the
high-risk areas were reviewed by hand and each claim tested rather than
asserted (gate ordering on all four routes, face-key prefix collision,
adversarial escaping of the comment id into an HTML attribute, multi-byte
range slicing). That is self-review, not an independent adversarial pass —
worth a careful look at:

- `buildTextAnchor`'s trust boundary: the client supplies a quote plus
  surrounding rendered text, and the server derives the stored descriptors from
  its own copy of the body. The claim is that context can only *select among*
  real occurrences, never introduce a location.
- `applyHighlights`' code-span detection: a regex heuristic over markdown,
  deliberately biased to over-claim, because a missed code span renders raw
  `<mark…>` markup at the user while an over-claim only loses a highlight.
