### PR TITLE
🌍 feat(worlds): chrome text is the operator's or nothing (TKT-5SZG2L)

### DIFF
--- a/docs-project/entities/guides/GUIDE-content-states.md
+++ b/docs-project/entities/guides/GUIDE-content-states.md
@@ -187,7 +187,7 @@ The following table summarizes the keys a world accepts:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** `exclude` or `default`. What happens to an entity whose type declares faces but that has none the chain names. |
 | `banner` | Optional text the web app shows at the top of every page in this world. Empty shows no announcement. |
-| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. An undeclared entry shows nothing. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here; placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`), `projection` (a list or board note; `{world}` only), `stand_in` (the badge on a row served a stand-in; `{face}`, `{bare_face}`, `{world}`). An undeclared entry shows nothing. |
 | `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face here to that world instead of showing the page. |
 | `primary_for` | Optional. Breaks a tie when two worlds lead with the same face for a type. See the Metamodel Reference. |
 | `edits` | Accepted and validated as a declared face name, but not used yet. |

--- a/docs-project/entities/guides/GUIDE-content-states.md
+++ b/docs-project/entities/guides/GUIDE-content-states.md
@@ -75,7 +75,10 @@ entities:
 `faces:` declares two content states. `bare_face: draft` says that `POL-1` and
 `POL-1@draft` are the same row, so a newly created policy *is* its own draft.
 The `label:` on each face is display text for the web app and has no effect on
-resolution. When you omit it, the face name is shown instead.
+resolution. When you omit it, the face name is shown instead. A face may also
+carry `messages: {read_only: "..."}`, the sentence the web app shows on a page
+or form that reached this face while the reader may not write it; without it
+the page shows no explanation, as for any other permission denial.
 
 `bare_face:` names a row that already exists. Every entity has one row stored
 under its bare id, whether or not the type declares faces, so adding `faces:`
@@ -184,6 +187,8 @@ The following table summarizes the keys a world accepts:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** `exclude` or `default`. What happens to an entity whose type declares faces but that has none the chain names. |
 | `banner` | Optional text the web app shows at the top of every page in this world. Empty shows no announcement. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. An undeclared entry shows nothing. |
+| `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face here to that world instead of showing the page. |
 | `primary_for` | Optional. Breaks a tie when two worlds lead with the same face for a type. See the Metamodel Reference. |
 | `edits` | Accepted and validated as a declared face name, but not used yet. |
 
@@ -397,6 +402,7 @@ The following table lists the keys a copy accepts:
 | `from` | Source face, as `type` or `type@face`. |
 | `to` | Target face. When it names a non-bare face, `guard:` becomes mandatory. |
 | `label` | Display text for the action. Plain text, no interpolation. |
+| `on_success` | Optional. `message:` is the confirmation the web app shows (default: the copy's label; `{face}` names the face written); `landing:` is where it goes afterwards: `written` (default), `stay`, `{world: name}` or `{face: name}`. |
 | `fields` | `all` to copy every property, or a map of target property to source expression. A copy between different types requires an explicit map. |
 | `relations` | A map of relation type to `merge` (add missing edges) or `replace` (swap the target face's edges). Only `scope: content` relation types can be listed. An omitted type is not copied. |
 | `guard.permission` | The permission required on the source entity. **Required** when `to` names a non-bare face. |
@@ -474,14 +480,17 @@ be redirected to a page that says their new policy has no face here.
 that world onto the post-create redirect, so the author lands on the draft they
 made. It must name a declared world.
 
-With these two keys set, the web app behaves as follows in a non-default world:
+With these two keys set, the web app behaves as follows in a non-default world.
+One rule governs every sentence it shows about worlds and faces: **the words are
+the operator's, or there are none.** The app has no text of its own for any of
+this, because "face", "world" and "default" are storage vocabulary a reader
+never chose.
 
 - The world is part of the URL as `?world=<name>`, so a world-bound page is a
   shareable link. Switching worlds resets pagination and adds a history entry.
 - A page shows the world's `banner:` text when one is declared. On a list or
-  board of a type that declares faces, a note explains that entities with no
-  face in this world are not listed; a type without faces has one state in
-  every world, so its lists carry no such note.
+  board of a type that declares faces it also shows the world's
+  `messages.projection`, if declared.
 - Every write goes to the **address** of the row on screen, face included:
   what you look at is what you edit is what you save. A detail page whose
   entity resolved to its published face opens its edit form on
@@ -489,23 +498,28 @@ With these two keys set, the web app behaves as follows in a non-default world:
   a write is offered is the server's `_actions` verdict for that face, so an
   editor looking at an adopted text sees no Edit button (no grant names the
   published face), and the same editor looking at the draft, in whichever
-  world, edits the draft. A note explains a read-only non-bare face; the bare
-  face is one click away through the face switcher.
+  world, edits the draft. A page showing a face the reader may not write
+  carries that face's `messages.read_only` if one is declared, and otherwise
+  nothing; the bare face is one click away through the face switcher.
 - A **View Published** button, or a menu when there are several faces, lets
   the reader switch to the entity's other faces by address, staying in the
   world they are browsing. It renders on every screen that has faces,
   including the default world.
-- A small badge names the face when a world served a **stand-in**: an entity
-  resolved through `otherwise: default`, or through a later entry in the chain
-  than the first. A first-choice hit shows no badge, so the badge marks only
-  what is surprising. The same badge appears on list rows, kanban cards, and
-  each related entity on a detail page.
+- A row or card served a **stand-in** (an entity resolved through
+  `otherwise: default`, or through a later entry in the chain than the first)
+  carries a badge with the world's `messages.stand_in` text, typically
+  `{face}`. A first-choice hit shows no badge, and a world that declares no
+  text shows none at all.
+- An entity that exists but has no face in the world renders its bare face,
+  with the world's `messages.absent` if declared. With `on_absent: {redirect:
+  <world>}` the app navigates to that world instead.
 
 A policy's detail page shows the **Publish** button when the caller holds
 `publish-policy` and the draft is on screen, in whichever world. A caller
 without the permission sees no button rather than a disabled one. After a
-successful publish, the app confirms it in the copy's own label and lands on
-the face it wrote; the draft is then one click away through the face switcher.
+successful publish, the app shows the copy's `on_success.message` (or just its
+label) and lands per `on_success.landing`: on the face it wrote by default,
+so the draft is then one click away through the face switcher.
 
 Two more `data-entry.yaml` surfaces take a world. A next-action source can set
 `source_world` to decide which world its candidate query runs in and

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -4847,15 +4847,19 @@ shown only if the caller may read the target world.
 
 ### What a world-bound page shows
 
-In a non-default world the web app behaves as follows:
+In a non-default world the web app behaves as follows. One rule governs every
+sentence it shows about worlds and faces: **the words are the operator's, or
+there are none.** The app has no text of its own for any of this — "face",
+"world" and "default" are storage vocabulary a reader never chose — so each
+note below appears only when `schema.yaml` declares it.
 
 - The world is part of the URL as `?world=<name>`, so a world-bound page is a
   shareable link that survives a reload. Changing world resets pagination and
   adds a browser history entry.
-- The top of the page shows the world's `banner:` text when the schema declares
-  one. A list or board of a type that declares faces adds a note that entities
-  with no face in this world are not listed; a type without faces has one
-  state in every world, so its lists carry no note.
+- The top of the page shows the world's `banner:` when declared. A list or
+  board of a type that declares faces adds the world's `messages.projection`
+  when declared; a type without faces has one state in every world, so its
+  lists carry no note.
 - Every write goes to the **address** of the row on screen, face included (see
   [Addressing a face directly](#addressing-a-face-directly-idface)). The Edit
   button opens the form on that address, inline edits and checkbox toggles
@@ -4863,25 +4867,30 @@ In a non-default world the web app behaves as follows:
   it. Whether a write is offered is `_actions` on the response, which the
   server computes for the face it served: an entity served at its published
   face reports `update: false` unless a grant names that face, and an entity
-  served at its bare face reports what the bare grant says. A detail page
-  showing a non-bare face the caller may not write explains that edits are
-  made on the bare face.
+  served at its bare face reports what the bare grant says. A detail page or
+  edit form showing a face the caller may not write shows that face's
+  `messages.read_only` when declared, and otherwise looks like any other
+  permission denial.
 - A **View Published** button, or a menu when the entity has several other
   faces, switches to another face by navigating to its address (`_faces[].ref`)
   in the same world. It appears on every screen that has faces, including the
   default world, because an author on the draft wants to see what readers see.
-- A badge names the face when the world served a **stand-in**: a face reached
-  through `otherwise: default`, or through a later entry in the chain than the
-  first. A first-choice hit shows no badge. The badge appears on list rows,
+- A row or card served a **stand-in** (a face reached through
+  `otherwise: default`, or through a later entry in the chain than the first)
+  carries a badge with the world's `messages.stand_in` when declared, typically
+  `{face}`. A first-choice hit shows no badge. The badge appears on list rows,
   kanban cards, and each related entity on a detail page.
-- An entity that exists but has no face in the world renders a page saying so,
-  with a button to the default world, rather than a not-found error.
+- An entity that exists but has no face in the world renders its bare face,
+  with the world's `messages.absent` when declared. With
+  `on_absent: {redirect: <world>}` the app navigates to that world instead.
 
 A detail page shows one button per copy definition whose source is the face on
 screen and that the caller may invoke, for example **Publish** on a draft
 policy, in whichever world the draft is being read. A caller without the guard
 permission sees no button rather than a disabled one. After a successful copy,
-the app confirms it in the copy's own label and lands on the face it wrote.
+the app shows the copy's `on_success.message` (or its label) and lands per
+`on_success.landing`: the face it wrote by default, `stay` to reload in place,
+or a declared world or face.
 
 A kanban board is a projection too. Each card is one entity at the face the
 world resolved, and an entity with no face in the world has no card. Cards
@@ -4951,7 +4960,8 @@ because world names are configuration in your repository rather than secrets.
 }
 ```
 
-Every declared world is listed for every caller. `readable` says whether *this*
+Every declared world is listed for every caller, with its `banner`, `messages`
+and `on_absent` verbatim from the schema. `readable` says whether *this*
 caller may select it. A world you may not read is marked rather than hidden, and
 selecting it anyway returns an empty result rather than an error. The same
 response reports each type's declared faces under `entities.<type>.faces`

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -5067,7 +5067,7 @@ or a cross-entity copy without a `target_id`, is a `422`.
 | `?world=` on a `POST`, `PATCH`, `PUT`, or `DELETE` | `422 world_read_only` |
 | `?world=` on a route that cannot serve a world | `422 world_unsupported` |
 | A declared world the caller may not read | An empty list, or `404` for one entity, identical to a world holding nothing readable |
-| An entity that has no face in the world | Omitted from lists; `404` from the single-entity read; `200` with `_world_absent: true` and `_world_absent_name` from the entity view; `200` with an empty timeline and `world_face_absent: true` from history |
+| An entity that has no face in the world | Omitted from lists; `404` from the single-entity read; `200` with `_world_absent: true` from the entity view; `200` with an empty timeline and `world_face_absent: true` from history |
 
 Writes never take a world. A world can answer a read with a stand-in face, so a
 write riding that indirection would save to a face the caller did not name:

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -1041,7 +1041,7 @@ entities:
 | --- | --- |
 | `faces` | A map from face name to face definition. A type without it has exactly one state, and that state appears in every world. |
 | `faces.<name>.label` | Display text for the web app. Falls back to the face name. It has no effect on resolution. |
-| `faces.<name>.messages.read_only` | The sentence the web app shows on a page or form that reached this face while the reader may not write it. Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. Undeclared shows nothing. |
+| `faces.<name>.messages.read_only` | The sentence the web app shows on a page or form that reached this face while the reader may not write it. Placeholders `{face}` (this face's label), `{bare_face}`, `{world}`, `{title}` (the entity's display title). Undeclared shows nothing. |
 | `bare_face` | The declared face that the bare entity id addresses. It must name a declared face. Omitting it leaves the entity's own row without a name and makes every declared face a separate suffixed row, which is legal but rarely intended. |
 
 `bare_face:` names a row that already exists: every entity has a row under its
@@ -1078,7 +1078,7 @@ worlds:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** What happens to an entity whose type declares faces but that has none the chain names: `exclude` leaves it out of the world, `default` shows its bare face. |
 | `banner` | Optional text the web app shows on every page in this world. Empty shows no announcement. |
-| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note on a faced type), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. The app has no default sentence; an undeclared entry shows nothing. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here; placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`), `projection` (a list or board note on a faced type; `{world}` only, since a list has no single entity), `stand_in` (the badge on a row served a stand-in; `{face}`, `{bare_face}`, `{world}`). A placeholder a surface cannot fill is left as written. The app has no default sentence; an undeclared entry shows nothing. |
 | `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face in this world to that world (or `default`) instead of showing the page. |
 | `primary_for` | Optional. The faces this world is the canonical home of. Needed only when two worlds lead with the same face for a type. See below. |
 | `edits` | Accepted and validated as a declared face name. Not used yet. |
@@ -1123,7 +1123,8 @@ a world:
 - names, in `overrides:`, an unknown type, a type that declares no faces, an
   empty chain, or a face that type does not declare;
 - names a face in `edits:` or `primary_for:` that it does not qualify for;
-- sets `on_absent.redirect` to itself or to a world that is not declared;
+- sets `on_absent.redirect` to a world that is not declared, or to a chain
+  of redirects that returns to a world it has visited (itself included);
 - is called `default` in any capitalization, or has a name outside the face
   grammar.
 
@@ -1227,7 +1228,8 @@ The loader refuses a copy definition that:
 - sets `guard.when`, which is not implemented yet. A condition that is written
   but never evaluated is refused rather than ignored;
 - sets `on_success.landing` to anything but `written`, `stay`, a declared
-  world, or a face the target type declares — or to both a world and a face.
+  world, or a face the target type declares — or to both a world and a face,
+  to an empty mapping, or to a mapping with a key other than `world` or `face`.
 
 A copy runs as one store transaction and is audited after it commits. The
 PostgreSQL backend rolls back a failed copy. On the filesystem and in-memory

--- a/docs-project/entities/guides/GUIDE-metamodel.md
+++ b/docs-project/entities/guides/GUIDE-metamodel.md
@@ -1041,6 +1041,7 @@ entities:
 | --- | --- |
 | `faces` | A map from face name to face definition. A type without it has exactly one state, and that state appears in every world. |
 | `faces.<name>.label` | Display text for the web app. Falls back to the face name. It has no effect on resolution. |
+| `faces.<name>.messages.read_only` | The sentence the web app shows on a page or form that reached this face while the reader may not write it. Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. Undeclared shows nothing. |
 | `bare_face` | The declared face that the bare entity id addresses. It must name a declared face. Omitting it leaves the entity's own row without a name and makes every declared face a separate suffixed row, which is legal but rarely intended. |
 
 `bare_face:` names a row that already exists: every entity has a row under its
@@ -1077,6 +1078,8 @@ worlds:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** What happens to an entity whose type declares faces but that has none the chain names: `exclude` leaves it out of the world, `default` shows its bare face. |
 | `banner` | Optional text the web app shows on every page in this world. Empty shows no announcement. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note on a faced type), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. The app has no default sentence; an undeclared entry shows nothing. |
+| `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face in this world to that world (or `default`) instead of showing the page. |
 | `primary_for` | Optional. The faces this world is the canonical home of. Needed only when two worlds lead with the same face for a type. See below. |
 | `edits` | Accepted and validated as a declared face name. Not used yet. |
 
@@ -1120,6 +1123,7 @@ a world:
 - names, in `overrides:`, an unknown type, a type that declares no faces, an
   empty chain, or a face that type does not declare;
 - names a face in `edits:` or `primary_for:` that it does not qualify for;
+- sets `on_absent.redirect` to itself or to a world that is not declared;
 - is called `default` in any capitalization, or has a name outside the face
   grammar.
 
@@ -1198,6 +1202,8 @@ copies:
 | `from` | The source face, as `type` or `type@face`. |
 | `to` | The target face. When it names a non-bare face, `guard:` is mandatory. |
 | `label` | Display text for the action in the web app. Plain text, no interpolation. Falls back to the definition name. |
+| `on_success.message` | The confirmation the web app shows after the copy. Placeholders as for world messages; `{face}` is the face written. Falls back to the label. |
+| `on_success.landing` | Where the web app goes afterwards: `written` (the face written, the default), `stay` (reload in place), `{world: <name>}` or `{face: <name>}`. |
 | `fields` | `all` to copy every declared property, or a map from target property to source expression using the `{{...}}` interpolation grammar. A copy between different types requires an explicit map. |
 | `relations` | A map from relation type to `merge` (add the edges the target lacks) or `replace` (swap the target face's edges of that type). Only `scope: content` relation types can be listed. An omitted type is not copied. |
 | `guard.permission` | The ACL permission a caller must hold on the source entity. **Required** when `to` names a non-bare face. |
@@ -1219,7 +1225,9 @@ The loader refuses a copy definition that:
 - lists an identity-scoped relation type, because such an edge is shared by
   every face and copying it could duplicate an edge that confers roles;
 - sets `guard.when`, which is not implemented yet. A condition that is written
-  but never evaluated is refused rather than ignored.
+  but never evaluated is refused rather than ignored;
+- sets `on_success.landing` to anything but `written`, `stay`, a declared
+  world, or a face the target type declares — or to both a world and a face.
 
 A copy runs as one store transaction and is audited after it commits. The
 PostgreSQL backend rolls back a failed copy. On the filesystem and in-memory

--- a/docs/content-states.md
+++ b/docs/content-states.md
@@ -181,7 +181,7 @@ The following table summarizes the keys a world accepts:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** `exclude` or `default`. What happens to an entity whose type declares faces but that has none the chain names. |
 | `banner` | Optional text the web app shows at the top of every page in this world. Empty shows no announcement. |
-| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. An undeclared entry shows nothing. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here; placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`), `projection` (a list or board note; `{world}` only), `stand_in` (the badge on a row served a stand-in; `{face}`, `{bare_face}`, `{world}`). An undeclared entry shows nothing. |
 | `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face here to that world instead of showing the page. |
 | `primary_for` | Optional. Breaks a tie when two worlds lead with the same face for a type. See the Metamodel Reference. |
 | `edits` | Accepted and validated as a declared face name, but not used yet. |

--- a/docs/content-states.md
+++ b/docs/content-states.md
@@ -69,7 +69,10 @@ entities:
 `faces:` declares two content states. `bare_face: draft` says that `POL-1` and
 `POL-1@draft` are the same row, so a newly created policy *is* its own draft.
 The `label:` on each face is display text for the web app and has no effect on
-resolution. When you omit it, the face name is shown instead.
+resolution. When you omit it, the face name is shown instead. A face may also
+carry `messages: {read_only: "..."}`, the sentence the web app shows on a page
+or form that reached this face while the reader may not write it; without it
+the page shows no explanation, as for any other permission denial.
 
 `bare_face:` names a row that already exists. Every entity has one row stored
 under its bare id, whether or not the type declares faces, so adding `faces:`
@@ -178,6 +181,8 @@ The following table summarizes the keys a world accepts:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** `exclude` or `default`. What happens to an entity whose type declares faces but that has none the chain names. |
 | `banner` | Optional text the web app shows at the top of every page in this world. Empty shows no announcement. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. An undeclared entry shows nothing. |
+| `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face here to that world instead of showing the page. |
 | `primary_for` | Optional. Breaks a tie when two worlds lead with the same face for a type. See the Metamodel Reference. |
 | `edits` | Accepted and validated as a declared face name, but not used yet. |
 
@@ -391,6 +396,7 @@ The following table lists the keys a copy accepts:
 | `from` | Source face, as `type` or `type@face`. |
 | `to` | Target face. When it names a non-bare face, `guard:` becomes mandatory. |
 | `label` | Display text for the action. Plain text, no interpolation. |
+| `on_success` | Optional. `message:` is the confirmation the web app shows (default: the copy's label; `{face}` names the face written); `landing:` is where it goes afterwards: `written` (default), `stay`, `{world: name}` or `{face: name}`. |
 | `fields` | `all` to copy every property, or a map of target property to source expression. A copy between different types requires an explicit map. |
 | `relations` | A map of relation type to `merge` (add missing edges) or `replace` (swap the target face's edges). Only `scope: content` relation types can be listed. An omitted type is not copied. |
 | `guard.permission` | The permission required on the source entity. **Required** when `to` names a non-bare face. |
@@ -468,14 +474,17 @@ be redirected to a page that says their new policy has no face here.
 that world onto the post-create redirect, so the author lands on the draft they
 made. It must name a declared world.
 
-With these two keys set, the web app behaves as follows in a non-default world:
+With these two keys set, the web app behaves as follows in a non-default world.
+One rule governs every sentence it shows about worlds and faces: **the words are
+the operator's, or there are none.** The app has no text of its own for any of
+this, because "face", "world" and "default" are storage vocabulary a reader
+never chose.
 
 - The world is part of the URL as `?world=<name>`, so a world-bound page is a
   shareable link. Switching worlds resets pagination and adds a history entry.
 - A page shows the world's `banner:` text when one is declared. On a list or
-  board of a type that declares faces, a note explains that entities with no
-  face in this world are not listed; a type without faces has one state in
-  every world, so its lists carry no such note.
+  board of a type that declares faces it also shows the world's
+  `messages.projection`, if declared.
 - Every write goes to the **address** of the row on screen, face included:
   what you look at is what you edit is what you save. A detail page whose
   entity resolved to its published face opens its edit form on
@@ -483,23 +492,28 @@ With these two keys set, the web app behaves as follows in a non-default world:
   a write is offered is the server's `_actions` verdict for that face, so an
   editor looking at an adopted text sees no Edit button (no grant names the
   published face), and the same editor looking at the draft, in whichever
-  world, edits the draft. A note explains a read-only non-bare face; the bare
-  face is one click away through the face switcher.
+  world, edits the draft. A page showing a face the reader may not write
+  carries that face's `messages.read_only` if one is declared, and otherwise
+  nothing; the bare face is one click away through the face switcher.
 - A **View Published** button, or a menu when there are several faces, lets
   the reader switch to the entity's other faces by address, staying in the
   world they are browsing. It renders on every screen that has faces,
   including the default world.
-- A small badge names the face when a world served a **stand-in**: an entity
-  resolved through `otherwise: default`, or through a later entry in the chain
-  than the first. A first-choice hit shows no badge, so the badge marks only
-  what is surprising. The same badge appears on list rows, kanban cards, and
-  each related entity on a detail page.
+- A row or card served a **stand-in** (an entity resolved through
+  `otherwise: default`, or through a later entry in the chain than the first)
+  carries a badge with the world's `messages.stand_in` text, typically
+  `{face}`. A first-choice hit shows no badge, and a world that declares no
+  text shows none at all.
+- An entity that exists but has no face in the world renders its bare face,
+  with the world's `messages.absent` if declared. With `on_absent: {redirect:
+  <world>}` the app navigates to that world instead.
 
 A policy's detail page shows the **Publish** button when the caller holds
 `publish-policy` and the draft is on screen, in whichever world. A caller
 without the permission sees no button rather than a disabled one. After a
-successful publish, the app confirms it in the copy's own label and lands on
-the face it wrote; the draft is then one click away through the face switcher.
+successful publish, the app shows the copy's `on_success.message` (or just its
+label) and lands per `on_success.landing`: on the face it wrote by default,
+so the draft is then one click away through the face switcher.
 
 Two more `data-entry.yaml` surfaces take a world. A next-action source can set
 `source_world` to decide which world its candidate query runs in and

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -4841,15 +4841,19 @@ shown only if the caller may read the target world.
 
 ### What a world-bound page shows
 
-In a non-default world the web app behaves as follows:
+In a non-default world the web app behaves as follows. One rule governs every
+sentence it shows about worlds and faces: **the words are the operator's, or
+there are none.** The app has no text of its own for any of this — "face",
+"world" and "default" are storage vocabulary a reader never chose — so each
+note below appears only when `schema.yaml` declares it.
 
 - The world is part of the URL as `?world=<name>`, so a world-bound page is a
   shareable link that survives a reload. Changing world resets pagination and
   adds a browser history entry.
-- The top of the page shows the world's `banner:` text when the schema declares
-  one. A list or board of a type that declares faces adds a note that entities
-  with no face in this world are not listed; a type without faces has one
-  state in every world, so its lists carry no note.
+- The top of the page shows the world's `banner:` when declared. A list or
+  board of a type that declares faces adds the world's `messages.projection`
+  when declared; a type without faces has one state in every world, so its
+  lists carry no note.
 - Every write goes to the **address** of the row on screen, face included (see
   [Addressing a face directly](#addressing-a-face-directly-idface)). The Edit
   button opens the form on that address, inline edits and checkbox toggles
@@ -4857,25 +4861,30 @@ In a non-default world the web app behaves as follows:
   it. Whether a write is offered is `_actions` on the response, which the
   server computes for the face it served: an entity served at its published
   face reports `update: false` unless a grant names that face, and an entity
-  served at its bare face reports what the bare grant says. A detail page
-  showing a non-bare face the caller may not write explains that edits are
-  made on the bare face.
+  served at its bare face reports what the bare grant says. A detail page or
+  edit form showing a face the caller may not write shows that face's
+  `messages.read_only` when declared, and otherwise looks like any other
+  permission denial.
 - A **View Published** button, or a menu when the entity has several other
   faces, switches to another face by navigating to its address (`_faces[].ref`)
   in the same world. It appears on every screen that has faces, including the
   default world, because an author on the draft wants to see what readers see.
-- A badge names the face when the world served a **stand-in**: a face reached
-  through `otherwise: default`, or through a later entry in the chain than the
-  first. A first-choice hit shows no badge. The badge appears on list rows,
+- A row or card served a **stand-in** (a face reached through
+  `otherwise: default`, or through a later entry in the chain than the first)
+  carries a badge with the world's `messages.stand_in` when declared, typically
+  `{face}`. A first-choice hit shows no badge. The badge appears on list rows,
   kanban cards, and each related entity on a detail page.
-- An entity that exists but has no face in the world renders a page saying so,
-  with a button to the default world, rather than a not-found error.
+- An entity that exists but has no face in the world renders its bare face,
+  with the world's `messages.absent` when declared. With
+  `on_absent: {redirect: <world>}` the app navigates to that world instead.
 
 A detail page shows one button per copy definition whose source is the face on
 screen and that the caller may invoke, for example **Publish** on a draft
 policy, in whichever world the draft is being read. A caller without the guard
 permission sees no button rather than a disabled one. After a successful copy,
-the app confirms it in the copy's own label and lands on the face it wrote.
+the app shows the copy's `on_success.message` (or its label) and lands per
+`on_success.landing`: the face it wrote by default, `stay` to reload in place,
+or a declared world or face.
 
 A kanban board is a projection too. Each card is one entity at the face the
 world resolved, and an entity with no face in the world has no card. Cards
@@ -4945,7 +4954,8 @@ because world names are configuration in your repository rather than secrets.
 }
 ```
 
-Every declared world is listed for every caller. `readable` says whether *this*
+Every declared world is listed for every caller, with its `banner`, `messages`
+and `on_absent` verbatim from the schema. `readable` says whether *this*
 caller may select it. A world you may not read is marked rather than hidden, and
 selecting it anyway returns an empty result rather than an error. The same
 response reports each type's declared faces under `entities.<type>.faces`

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -5061,7 +5061,7 @@ or a cross-entity copy without a `target_id`, is a `422`.
 | `?world=` on a `POST`, `PATCH`, `PUT`, or `DELETE` | `422 world_read_only` |
 | `?world=` on a route that cannot serve a world | `422 world_unsupported` |
 | A declared world the caller may not read | An empty list, or `404` for one entity, identical to a world holding nothing readable |
-| An entity that has no face in the world | Omitted from lists; `404` from the single-entity read; `200` with `_world_absent: true` and `_world_absent_name` from the entity view; `200` with an empty timeline and `world_face_absent: true` from history |
+| An entity that has no face in the world | Omitted from lists; `404` from the single-entity read; `200` with `_world_absent: true` from the entity view; `200` with an empty timeline and `world_face_absent: true` from history |
 
 Writes never take a world. A world can answer a read with a stand-in face, so a
 write riding that indirection would save to a face the caller did not name:

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -1035,6 +1035,7 @@ entities:
 | --- | --- |
 | `faces` | A map from face name to face definition. A type without it has exactly one state, and that state appears in every world. |
 | `faces.<name>.label` | Display text for the web app. Falls back to the face name. It has no effect on resolution. |
+| `faces.<name>.messages.read_only` | The sentence the web app shows on a page or form that reached this face while the reader may not write it. Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. Undeclared shows nothing. |
 | `bare_face` | The declared face that the bare entity id addresses. It must name a declared face. Omitting it leaves the entity's own row without a name and makes every declared face a separate suffixed row, which is legal but rarely intended. |
 
 `bare_face:` names a row that already exists: every entity has a row under its
@@ -1071,6 +1072,8 @@ worlds:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** What happens to an entity whose type declares faces but that has none the chain names: `exclude` leaves it out of the world, `default` shows its bare face. |
 | `banner` | Optional text the web app shows on every page in this world. Empty shows no announcement. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note on a faced type), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. The app has no default sentence; an undeclared entry shows nothing. |
+| `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face in this world to that world (or `default`) instead of showing the page. |
 | `primary_for` | Optional. The faces this world is the canonical home of. Needed only when two worlds lead with the same face for a type. See below. |
 | `edits` | Accepted and validated as a declared face name. Not used yet. |
 
@@ -1114,6 +1117,7 @@ a world:
 - names, in `overrides:`, an unknown type, a type that declares no faces, an
   empty chain, or a face that type does not declare;
 - names a face in `edits:` or `primary_for:` that it does not qualify for;
+- sets `on_absent.redirect` to itself or to a world that is not declared;
 - is called `default` in any capitalization, or has a name outside the face
   grammar.
 
@@ -1192,6 +1196,8 @@ copies:
 | `from` | The source face, as `type` or `type@face`. |
 | `to` | The target face. When it names a non-bare face, `guard:` is mandatory. |
 | `label` | Display text for the action in the web app. Plain text, no interpolation. Falls back to the definition name. |
+| `on_success.message` | The confirmation the web app shows after the copy. Placeholders as for world messages; `{face}` is the face written. Falls back to the label. |
+| `on_success.landing` | Where the web app goes afterwards: `written` (the face written, the default), `stay` (reload in place), `{world: <name>}` or `{face: <name>}`. |
 | `fields` | `all` to copy every declared property, or a map from target property to source expression using the `{{...}}` interpolation grammar. A copy between different types requires an explicit map. |
 | `relations` | A map from relation type to `merge` (add the edges the target lacks) or `replace` (swap the target face's edges of that type). Only `scope: content` relation types can be listed. An omitted type is not copied. |
 | `guard.permission` | The ACL permission a caller must hold on the source entity. **Required** when `to` names a non-bare face. |
@@ -1213,7 +1219,9 @@ The loader refuses a copy definition that:
 - lists an identity-scoped relation type, because such an edge is shared by
   every face and copying it could duplicate an edge that confers roles;
 - sets `guard.when`, which is not implemented yet. A condition that is written
-  but never evaluated is refused rather than ignored.
+  but never evaluated is refused rather than ignored;
+- sets `on_success.landing` to anything but `written`, `stay`, a declared
+  world, or a face the target type declares — or to both a world and a face.
 
 A copy runs as one store transaction and is audited after it commits. The
 PostgreSQL backend rolls back a failed copy. On the filesystem and in-memory

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -1035,7 +1035,7 @@ entities:
 | --- | --- |
 | `faces` | A map from face name to face definition. A type without it has exactly one state, and that state appears in every world. |
 | `faces.<name>.label` | Display text for the web app. Falls back to the face name. It has no effect on resolution. |
-| `faces.<name>.messages.read_only` | The sentence the web app shows on a page or form that reached this face while the reader may not write it. Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. Undeclared shows nothing. |
+| `faces.<name>.messages.read_only` | The sentence the web app shows on a page or form that reached this face while the reader may not write it. Placeholders `{face}` (this face's label), `{bare_face}`, `{world}`, `{title}` (the entity's display title). Undeclared shows nothing. |
 | `bare_face` | The declared face that the bare entity id addresses. It must name a declared face. Omitting it leaves the entity's own row without a name and makes every declared face a separate suffixed row, which is legal but rarely intended. |
 
 `bare_face:` names a row that already exists: every entity has a row under its
@@ -1072,7 +1072,7 @@ worlds:
 | `overrides` | A map from entity type to a chain that replaces `select` for that type. It replaces the chain rather than extending it. |
 | `otherwise` | **Required.** What happens to an entity whose type declares faces but that has none the chain names: `exclude` leaves it out of the world, `default` shows its bare face. |
 | `banner` | Optional text the web app shows on every page in this world. Empty shows no announcement. |
-| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here), `projection` (a list or board note on a faced type), `stand_in` (the badge on a row served a stand-in). Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`. The app has no default sentence; an undeclared entry shows nothing. |
+| `messages` | Optional. The web app's wording for what this world changes on a screen: `absent` (a detail page for an entity with no face here; placeholders `{face}`, `{bare_face}`, `{world}`, `{title}`), `projection` (a list or board note on a faced type; `{world}` only, since a list has no single entity), `stand_in` (the badge on a row served a stand-in; `{face}`, `{bare_face}`, `{world}`). A placeholder a surface cannot fill is left as written. The app has no default sentence; an undeclared entry shows nothing. |
 | `on_absent` | Optional. `redirect: <world>` sends a reader who opens an entity with no face in this world to that world (or `default`) instead of showing the page. |
 | `primary_for` | Optional. The faces this world is the canonical home of. Needed only when two worlds lead with the same face for a type. See below. |
 | `edits` | Accepted and validated as a declared face name. Not used yet. |
@@ -1117,7 +1117,8 @@ a world:
 - names, in `overrides:`, an unknown type, a type that declares no faces, an
   empty chain, or a face that type does not declare;
 - names a face in `edits:` or `primary_for:` that it does not qualify for;
-- sets `on_absent.redirect` to itself or to a world that is not declared;
+- sets `on_absent.redirect` to a world that is not declared, or to a chain
+  of redirects that returns to a world it has visited (itself included);
 - is called `default` in any capitalization, or has a name outside the face
   grammar.
 
@@ -1221,7 +1222,8 @@ The loader refuses a copy definition that:
 - sets `guard.when`, which is not implemented yet. A condition that is written
   but never evaluated is refused rather than ignored;
 - sets `on_success.landing` to anything but `written`, `stay`, a declared
-  world, or a face the target type declares — or to both a world and a face.
+  world, or a face the target type declares — or to both a world and a face,
+  to an empty mapping, or to a mapping with a key other than `world` or `face`.
 
 A copy runs as one store transaction and is audited after it commits. The
 PostgreSQL backend rolls back a failed copy. On the filesystem and in-memory

--- a/frontend/src/api/views.ts
+++ b/frontend/src/api/views.ts
@@ -169,8 +169,6 @@ export interface ViewResponse {
    * world, and that world resolves nothing for this entity.
    */
   _world_absent?: boolean
-  /** The world that has no face for this entity, for naming it in the UI. */
-  _world_absent_name?: string
 }
 
 // Fetch executed view data for an entity. The backend looks up the

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, onUnmounted } from 'vue'
-import { RouterLink, useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
+import { RouterLink, useRoute, useRouter, type RouteLocationRaw, type LocationQueryRaw } from 'vue-router'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { useScopeNavigation } from '@/composables'
 import { useBackTarget } from '@/composables/useBackTarget'
@@ -8,6 +8,7 @@ import { isCancelledFetch } from '@/composables/usePageData'
 import { fetchView, getCommands, getErrorMessage } from '@/api'
 import { useWorld, DEFAULT_WORLD } from '@/composables/useWorld'
 import { entityRef, refBareId, refFace } from '@/utils/entityRef'
+import { worldText, type WorldTextVars } from '@/utils/worldText'
 import type { ViewEntity, ViewResponse, ViewSection, ViewSectionField } from '@/api'
 import type { Entity } from '@/types'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
@@ -107,12 +108,6 @@ const { world, isWorldBound, worldParam, setWorld } = useWorld()
 // bare id, so the ordinary world banner (which announces read-only-ness)
 // must not render alongside it.
 const worldAbsent = computed(() => viewData.value?._world_absent === true)
-
-// The world that has no face here. Falls back to the requested world name, so
-// the banner still reads correctly against a server that omits the field.
-const worldAbsentName = computed(
-  () => viewData.value?._world_absent_name || world.value || '',
-)
 
 // --- The address of the row on screen -------------------------------------
 //
@@ -668,29 +663,21 @@ async function runCopy(offer: CopyOffer) {
   copyBusy.value = true
   try {
     const res = await invokeCopy(offer.name, subject)
-    // The toast speaks the operator's vocabulary: the copy's own label and
-    // the face's declared label, never rela's word "face" (atlas worlds
-    // issue 8). `res.face` is the STORED coordinate the copy wrote; the bare
-    // face is '' and labelled from the type.
-    const written = faceLabel(res.face) || 'default'
-    const outcome = res.created ? 'created' : 'updated'
+    // The toast is the operator's `on_success.message`, or the copy's own
+    // label — the button the reader just pressed — never rela's "Created the
+    // X face" (TKT-5SZG2L). `{face}` here is the face WRITTEN, which
+    // `res.face` reports as a stored coordinate.
+    const message = worldText(offer.onSuccess?.message, {
+      ...textVars.value, face: faceLabel(res.face),
+    }) || label
     if (bareEntityId.value !== subject) {
       // Still worth telling them it succeeded — they asked for it — but name
       // the entity, since the page in front of them is no longer the subject.
-      uiStore.success(`${label}: ${written} ${outcome} for ${subject}`)
+      uiStore.success(`${message} (${subject})`)
       return
     }
-    uiStore.success(`${label}: ${written} ${outcome}`)
-    // Land on what was just written. The copy's target is a face of THIS
-    // entity, and `ID@face` is its address under any world; a copy into the
-    // bare face reloads in place, since the bare address would re-resolve
-    // under a world. Either way the offers recompute: a face that now exists
-    // may no longer be offered.
-    if (res.face) {
-      router.push({ path: `/entity/${props.entityType}/${subject}@${res.face}`, query: { ...route.query } })
-      return
-    }
-    await loadView()
+    uiStore.success(message)
+    await landAfterCopy(offer, subject, res.face)
   } catch (err) {
     // The kernel re-authorizes, so a 403 here is not a contradiction of
     // `allowed` — it is the boundary doing its job on a hint that went stale
@@ -704,32 +691,50 @@ async function runCopy(offer: CopyOffer) {
   }
 }
 
-// --- Leaving a world ----------------------------------------------------
-//
-// The way back returns to the DEFAULT world, which is where writes land: the
-// API refuses `?world=` on a write (422 world_read_only), so a world-bound
-// page is inherently read-only and the editing affordances belong on the
-// default face.
-//
-// Hidden when the principal cannot read the default world. That is a GLOBAL,
-// role-level grant `/_schema`.worlds already reports per world for this
-// caller, so the check costs no request and reads no entity — it is not a
-// per-entity probe and cannot act as an existence oracle. Nor is it a
-// confidentiality measure: a world NAME is schema.yaml config, served to every
-// principal by design. The gate is purely honesty — offering the way back to
-// someone whose default-world request returns an empty result would send them
-// somewhere that looks broken. `worldReadable` answers TRUE for an unknown
-// world, so an older server or an unloaded schema shows the button rather than
-// hiding a working affordance.
-//
-// It cannot fire on today's server: `/_schema` reports the default world's
-// `readable` as a hardcoded `true`, mirroring a request path that
-// short-circuits `default` before any grant check (the pre-existing gap
-// schemaworlds.go documents, pinned by
-// TestSchemaWorlds_DefaultWorldAgreesWithTheRequestPath). Wiring the honest
-// input anyway means that when the enumeration starts asking the gate, this
-// button starts hiding itself with no change here.
-const canReachDefaultWorld = computed(() => schemaStore.worldReadable(''))
+// landAfterCopy navigates per the copy's `on_success.landing`. The default is
+// the face WRITTEN (an editor who adopts a policy usually wants to see the
+// adopted text), addressed as `ID@face` so it is literal under any world; a
+// copy into the bare face reloads in place, since the bare address would
+// re-resolve. `stay` reloads in place; a world lands the bare id in that
+// world; a face lands on that face's address. Either way the offers
+// recompute, since a face that now exists may no longer be offered.
+async function landAfterCopy(offer: CopyOffer, subject: string, writtenFace: string) {
+  const landing = offer.onSuccess?.landing
+  const mode = landing?.mode ?? 'written'
+  const path = `/entity/${props.entityType}/${subject}`
+  switch (mode) {
+    case 'stay':
+      await loadView()
+      return
+    case 'world': {
+      const target = landing?.world ?? ''
+      router.push({ path, query: worldQueryFor(target === DEFAULT_WORLD ? '' : target) })
+      return
+    }
+    case 'face':
+      router.push({ path: `${path}@${landing?.face}`, query: { ...route.query } })
+      return
+    default:
+      if (writtenFace) {
+        router.push({ path: `${path}@${writtenFace}`, query: { ...route.query } })
+        return
+      }
+      await loadView()
+  }
+}
+
+// worldQueryFor spells a world into this page's query the way setWorld
+// does: dropped when it is the deployment's configured default, `default`
+// when the bare faces are wanted under a configured default, the name
+// otherwise. The rest of the query is preserved.
+function worldQueryFor(target: string): LocationQueryRaw {
+  const query = { ...route.query }
+  const norm = (w: string) => (w === DEFAULT_WORLD ? '' : w)
+  if (norm(target) === norm(schemaStore.defaultWorld)) delete query.world
+  else if (norm(target) === '') query.world = DEFAULT_WORLD
+  else query.world = target
+  return query
+}
 
 // The operator's announcement for the world on screen, or '' to announce
 // nothing. Config, not data — served identically to every principal.
@@ -738,45 +743,66 @@ const worldBanner = computed<string>(
 )
 
 
-// The button NAMES A DESTINATION, so it is labelled from the destination
-// rather than from a guess about the project's vocabulary.
+// --- Operator chrome text ------------------------------------------------
 //
-// It used to read the literal string "Go to draft" on every type in every
-// project. A blog post has no draft — its faces are `en`/`nl`/`fr`, a language
-// axis with no lifecycle — so the button was ISMS vocabulary applied to
-// content that has none.
-//
-// The destination is always the type's DEFAULT face (the button returns to the
-// default world, which is where writes land), so its label is a pure schema
-// lookup: `faces.<default>.label` if the operator declared one, else the
-// face name. "Go to draft" still appears on an ISMS — because the operator
-// declared `draft` — and the blog post says "Go to English".
-//
-// "Go to default" is the fallback, not the goal: it is jargon, but it is
-// type-neutral and never wrong, which is the right thing to say when the type
-// declares no name for its default face at all.
-const defaultFaceLabel = computed<string>(
-  () => schemaStore.faceLabel(props.entityType, '') || 'default',
-)
+// The page has NO sentence of its own about worlds or faces. Every one it
+// used to have ("Read-only in this world — edit from Concept", "This entity
+// has no published face yet", "Created the published face") was rela's
+// storage vocabulary shown to a reader who never chose those words. What an
+// operator declares in schema.yaml renders verbatim (placeholders
+// substituted); what they do not declare renders nothing (TKT-5SZG2L).
 
-// A face's display label in the operator's vocabulary, by stored coordinate.
-function faceLabel(face: string): string {
-  return schemaStore.faceLabel(props.entityType, face) || face
+// The declared label of a face, by its DECLARED name (the vocabulary the
+// address and `_world.face` use). '' when the type names none.
+function faceLabelOf(declared: string): string {
+  const faces = typeDef.value?.faces
+  if (!faces) return declared
+  return faces[declared]?.label || declared
 }
 
-// The note for a NON-BARE face the principal may not write: the one case a
-// reader needs telling why there is no Edit, because the bare face — where
-// edits are made — really is elsewhere. A bare face without `update` is an
-// ordinary permission denial and gets no note, as in the default world.
-// A non-bare face WITH `update` (a translator on `nl`) is simply editable.
-//
-// No button: the face menu already offers "View <bare face>", and two
-// controls to one destination with different verbs was its own confusion
-// (atlas worlds issue 5).
+// A face's display label by STORED coordinate ('' is the bare face), for the
+// copy result, which reports what it wrote as stored.
+function faceLabel(stored: string): string {
+  return schemaStore.faceLabel(props.entityType, stored) || stored
+}
+
+const bareFaceLabel = computed<string>(() => schemaStore.faceLabel(props.entityType, ''))
+
+const textVars = computed<WorldTextVars>(() => ({
+  face: faceLabelOf(servedFace.value || (typeDef.value?.bare_face ?? '')),
+  bare_face: bareFaceLabel.value,
+  world: world.value,
+  title: entryTitle.value,
+}))
+
+const worldInfo = computed(() => (world.value ? schemaStore.worlds.get(world.value) : undefined))
+
+// The note for a NON-BARE face the principal may not write, in the
+// operator's words for THAT face (`faces.<name>.messages.read_only`). A bare
+// face without `update` is an ordinary permission denial; a non-bare face
+// WITH `update` (a translator on `nl`) is simply editable; neither gets a
+// note. No button either: the face menu already reaches the bare face.
 const readOnlyNote = computed<string>(() => {
   if (worldAbsent.value || !servedFace.value || mayUpdate.value) return ''
-  return `You are viewing the ${faceLabel(servedFace.value)} face, which is read-only for you. ` +
-    `Edits are made on the ${defaultFaceLabel.value} face.`
+  const declared = typeDef.value?.faces?.[servedFace.value]
+  return worldText(declared?.messages?.read_only, textVars.value)
+})
+
+// The note for an entity with no face in this world, in the world's words.
+const absentNote = computed<string>(() => {
+  if (!worldAbsent.value) return ''
+  return worldText(worldInfo.value?.messages?.absent, textVars.value)
+})
+
+// `on_absent.redirect`: the operator would rather send the reader somewhere
+// than explain an absence. Fires when the view reports the absence; the
+// target is a declared world (validated at load), spelled through setWorld so
+// `default` becomes the right query for this deployment.
+watch(worldAbsent, (absent) => {
+  if (!absent) return
+  const target = worldInfo.value?.on_absent?.redirect
+  if (!target) return
+  setWorld(target === DEFAULT_WORLD ? '' : target)
 })
 
 // --- The header's mobile home ------------------------------------------
@@ -814,10 +840,6 @@ const hasOverflow = computed(
     overflowCopies.value.length > 0 ||
     showHistory.value,
 )
-
-function goToDefaultWorld() {
-  setWorld('')
-}
 
 function backTargetAfterDelete(): string {
   if (backTarget.value) return backTarget.value.to
@@ -1270,42 +1292,28 @@ watch(
         the badge below.
       -->
       <!--
-        No face in the requested world. Distinct from the banner below because
-        the two say opposite things about the page: that one announces a
-        read-only face served BY the world, this one announces that the world
-        served nothing and what is on screen is the DEFAULT face — which is
-        writable, and is where a promote would start from. Rendering both would
-        tell the reader the page is read-only when it is not.
+        No face in the requested world: the page shows the BARE face, which is
+        writable and where a promote starts from, so this banner must not read
+        as read-only. It carries the world's announcement and the operator's
+        `messages.absent` and nothing else — no rela sentence, no button (the
+        face menu reaches every other face by address). With neither declared
+        it does not render at all.
       -->
       <WorldBanner
-        v-if="worldAbsent"
+        v-if="worldAbsent && (worldBanner || absentNote)"
         variant="absent"
-        :label="`Not in the ${worldAbsentName} world`"
+        :label="worldBanner"
       >
-        This entity has no {{ worldAbsentName }} face yet. You are looking at
-        the {{ defaultFaceLabel }} face, which is where edits are saved.
-        <template #actions>
-          <button
-            v-if="canReachDefaultWorld"
-            class="btn btn-secondary"
-            @click="goToDefaultWorld"
-          >
-            Go to {{ defaultFaceLabel }}
-          </button>
-        </template>
+        {{ absentNote }}
       </WorldBanner>
 
       <!--
         The ANNOUNCEMENT is operator config: `banner:` on the world in
-        schema.yaml. "DRAFT — not in force" on an editorial world, nothing on a
-        language world, where announcing "you are reading Dutch" to someone who
-        chose Dutch is noise.
-
-        The NOTE is the one fact the server's affordances leave unexplained: a
-        non-bare face on screen that this principal may not write (see
-        readOnlyNote). A world-bound page that shows the bare face, or a face
-        the principal may write, is simply editable and gets no note — the
-        world no longer makes a page read-only; only a grant does.
+        schema.yaml. The NOTE is the operator's `faces.<name>.messages.read_only`
+        for a non-bare face on screen that this principal may not write (see
+        readOnlyNote). Neither declared: nothing renders — the world does not
+        make a page read-only, only a grant does, and a denial looks like any
+        other denial.
       -->
       <WorldBanner
         v-if="!worldAbsent && ((isWorldBound && worldBanner) || readOnlyNote)"
@@ -1602,7 +1610,7 @@ watch(
                   row, not part of the link's accessible name — folding it in
                   would make the link read "Guide GUIDE-1 nl".
                 -->
-                <WorldBadge :world="ent._world" />
+                <WorldBadge :world="ent._world" :entity-type="ent.type" />
               </header>
               <div
                 v-if="ent.hasContent"
@@ -1637,7 +1645,7 @@ watch(
                   <span class="entity-id">{{ ent.id }}</span>
                 </component>
                 <!-- Per-neighbour provenance; see the first WorldBadge above. -->
-                <WorldBadge :world="ent._world" />
+                <WorldBadge :world="ent._world" :entity-type="ent.type" />
                 <button
                   v-if="ent.editFormId"
                   class="edit-btn"
@@ -1708,7 +1716,7 @@ watch(
                 <span class="entity-id">{{ ent.id }}</span>
               </component>
               <!-- Per-neighbour provenance; see the first WorldBadge above. -->
-              <WorldBadge :world="ent._world" />
+              <WorldBadge :world="ent._world" :entity-type="ent.type" />
               <SectionEditForm
                 v-if="rowShouldRouteToInlineEdit(ent, section.entities?.length ?? 0)"
                 :key="`${ent.type}/${entityRef(ent)}`"

--- a/frontend/src/components/entity/EntityDetail.vue
+++ b/frontend/src/components/entity/EntityDetail.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, onUnmounted } from 'vue'
-import { RouterLink, useRoute, useRouter, type RouteLocationRaw, type LocationQueryRaw } from 'vue-router'
+import { RouterLink, useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
 import { useSchemaStore, useUIStore } from '@/stores'
 import { useScopeNavigation } from '@/composables'
 import { useBackTarget } from '@/composables/useBackTarget'
 import { isCancelledFetch } from '@/composables/usePageData'
 import { fetchView, getCommands, getErrorMessage } from '@/api'
-import { useWorld, DEFAULT_WORLD } from '@/composables/useWorld'
+import { useWorld, worldQuery, DEFAULT_WORLD } from '@/composables/useWorld'
 import { entityRef, refBareId, refFace } from '@/utils/entityRef'
 import { worldText, type WorldTextVars } from '@/utils/worldText'
 import type { ViewEntity, ViewResponse, ViewSection, ViewSectionField } from '@/api'
@@ -698,42 +698,39 @@ async function runCopy(offer: CopyOffer) {
 // re-resolve. `stay` reloads in place; a world lands the bare id in that
 // world; a face lands on that face's address. Either way the offers
 // recompute, since a face that now exists may no longer be offered.
+//
+// The server validates a landing at load, so a `world`/`face` arm with no
+// name is not a state this deployment produces — but a response is data,
+// and the guard is what keeps a hand-crafted or older one from navigating
+// to a literal `ID@undefined`. A mode this build does not know reloads in
+// place rather than passing for `written`: the landing was a declaration,
+// and "written" would be this code inventing one.
 async function landAfterCopy(offer: CopyOffer, subject: string, writtenFace: string) {
   const landing = offer.onSuccess?.landing
-  const mode = landing?.mode ?? 'written'
   const path = `/entity/${props.entityType}/${subject}`
-  switch (mode) {
+  const toFace = (face: string) => router.push({ path: `${path}@${face}`, query: { ...route.query } })
+  switch (landing?.mode ?? 'written') {
+    case 'written':
+      if (writtenFace) toFace(writtenFace)
+      else await loadView()
+      return
     case 'stay':
       await loadView()
       return
-    case 'world': {
-      const target = landing?.world ?? ''
-      router.push({ path, query: worldQueryFor(target === DEFAULT_WORLD ? '' : target) })
+    case 'world':
+      if (landing?.world) {
+        router.push({ path, query: worldQuery(landing.world, route.query, schemaStore.defaultWorld) })
+      } else {
+        await loadView()
+      }
       return
-    }
     case 'face':
-      router.push({ path: `${path}@${landing?.face}`, query: { ...route.query } })
+      if (landing?.face) toFace(landing.face)
+      else await loadView()
       return
     default:
-      if (writtenFace) {
-        router.push({ path: `${path}@${writtenFace}`, query: { ...route.query } })
-        return
-      }
       await loadView()
   }
-}
-
-// worldQueryFor spells a world into this page's query the way setWorld
-// does: dropped when it is the deployment's configured default, `default`
-// when the bare faces are wanted under a configured default, the name
-// otherwise. The rest of the query is preserved.
-function worldQueryFor(target: string): LocationQueryRaw {
-  const query = { ...route.query }
-  const norm = (w: string) => (w === DEFAULT_WORLD ? '' : w)
-  if (norm(target) === norm(schemaStore.defaultWorld)) delete query.world
-  else if (norm(target) === '') query.world = DEFAULT_WORLD
-  else query.world = target
-  return query
 }
 
 // The operator's announcement for the world on screen, or '' to announce
@@ -795,14 +792,31 @@ const absentNote = computed<string>(() => {
 })
 
 // `on_absent.redirect`: the operator would rather send the reader somewhere
-// than explain an absence. Fires when the view reports the absence; the
-// target is a declared world (validated at load), spelled through setWorld so
-// `default` becomes the right query for this deployment.
-watch(worldAbsent, (absent) => {
-  if (!absent) return
-  const target = worldInfo.value?.on_absent?.redirect
+// than explain an absence. Fires on every VIEW the page loads, not on the
+// absent flag: scope-nav from one absent entity to the next keeps the flag
+// true throughout, and a watcher on it would fire for the first entity
+// only. Fires on the schema too, since `worldInfo` is empty until the store
+// has loaded and a redirect must not depend on which fetch won. The target
+// is a declared world, spelled through setWorld so `default` becomes the
+// right query for this deployment.
+//
+// The loader refuses a redirect chain that returns to a visited world, so a
+// loop is not a state this deployment produces. The set below is the
+// client's own guard for a schema it did not validate: every world this
+// page has redirected from or to, for this entity, is never a target again.
+// A loop therefore stops after one hop, a chain `a → b → c` still runs, and
+// a schema reload cannot push the same hop twice.
+const redirectVisited = new Set<string>()
+watch(() => props.entityId, () => redirectVisited.clear())
+watch([viewData, worldInfo], ([, info]) => {
+  if (!worldAbsent.value) return
+  const target = info?.on_absent?.redirect
   if (!target) return
-  setWorld(target === DEFAULT_WORLD ? '' : target)
+  const norm = (w: string) => (w === DEFAULT_WORLD ? '' : w)
+  if (redirectVisited.has(norm(target))) return
+  redirectVisited.add(norm(world.value))
+  redirectVisited.add(norm(target))
+  setWorld(norm(target))
 })
 
 // --- The header's mobile home ------------------------------------------

--- a/frontend/src/components/entity/EntityDetail.world.test.ts
+++ b/frontend/src/components/entity/EntityDetail.world.test.ts
@@ -611,6 +611,56 @@ describe('EntityDetail world binding', () => {
       })
     })
 
+    it('drops the world param when the landing world IS the configured default', async () => {
+      // The branch worldQuery exists for: on a deployment with a configured
+      // default, a bare URL already means that world, and writing the name
+      // would be a second spelling of the same page. The page reset rides
+      // along, since a page of one world is not a page of another.
+      useSchemaStore().defaultWorld = 'published'
+      invokeCopyMock.mockResolvedValue(copyResult())
+      mockRoute.query = { world: 'editorial', page: '3' }
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { landing: { mode: 'world', world: 'published' } } })],
+      }))
+      await clickPromote(w)
+      expect(routerPush).toHaveBeenCalledWith({ path: '/entity/policy/POL-1', query: {} })
+    })
+
+    it('spells the default world explicitly when landing there under a configured default', async () => {
+      useSchemaStore().defaultWorld = 'published'
+      invokeCopyMock.mockResolvedValue(copyResult())
+      mockRoute.query = {}
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { landing: { mode: 'world', world: 'default' } } })],
+      }))
+      await clickPromote(w)
+      expect(routerPush).toHaveBeenCalledWith({ path: '/entity/policy/POL-1', query: { world: 'default' } })
+    })
+
+    it('reloads in place rather than navigating to `@undefined` for a face landing with no face', async () => {
+      // The server validates a landing at load; this is the guard for a
+      // response the client did not validate.
+      invokeCopyMock.mockResolvedValue(copyResult())
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { landing: { mode: 'face' } as never } })],
+      }))
+      const before = fetchViewMock.mock.calls.length
+      await clickPromote(w)
+      expect(routerPush).not.toHaveBeenCalled()
+      expect(fetchViewMock.mock.calls.length).toBeGreaterThan(before)
+    })
+
+    it('reloads in place for a landing mode this build does not know', async () => {
+      invokeCopyMock.mockResolvedValue(copyResult())
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { landing: { mode: 'elsewhere' } as never } })],
+      }))
+      const before = fetchViewMock.mock.calls.length
+      await clickPromote(w)
+      expect(routerPush).not.toHaveBeenCalled()
+      expect(fetchViewMock.mock.calls.length).toBeGreaterThan(before)
+    })
+
     it('reloads in place after a copy INTO the bare face', async () => {
       // A bare address would re-resolve under a world, so a revert stays put
       // and the offers recompute from the reload.
@@ -749,7 +799,6 @@ describe('EntityDetail world binding', () => {
         entry: entry(),
         sections: [],
         _world_absent: true,
-        _world_absent_name: 'published',
       }
     }
 
@@ -822,6 +871,46 @@ describe('EntityDetail world binding', () => {
       const w = await mountDetail(viewResponse())
       rendersProof(w)
       expect(routerPush).not.toHaveBeenCalled()
+    })
+
+    it('redirects when the schema arrives AFTER the view', async () => {
+      // Two fetches race on a cold load. A redirect that only fired when the
+      // schema won would be a redirect that sometimes does not happen.
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(absentResponse())
+      rendersProof(w)
+      expect(routerPush).not.toHaveBeenCalled()
+      useSchemaStore().worlds.set('published', {
+        readable: true, on_absent: { redirect: 'editorial' },
+      } as never)
+      await flushPromises()
+      expect(routerPush).toHaveBeenCalledWith({ query: { world: 'editorial' } })
+    })
+
+    it('never pushes the same hop twice for one entity', async () => {
+      // The loader refuses a redirect loop, so this is the guard for a
+      // schema the client did not validate. The mocked route never moves,
+      // so the second firing here stands in for the hop that would come
+      // back: a target this page has already been sent to is not pushed
+      // again, which is what bounds a loop to one hop.
+      useSchemaStore().worlds.set('published', {
+        readable: true, on_absent: { redirect: 'editorial' },
+      } as never)
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(absentResponse())
+      rendersProof(w)
+      expect(routerPush).toHaveBeenCalledTimes(1)
+      expect(routerPush).toHaveBeenCalledWith({ query: { world: 'editorial' } })
+      useSchemaStore().worlds.set('published', {
+        readable: true, on_absent: { redirect: 'editorial' },
+      } as never)
+      await flushPromises()
+      expect(routerPush).toHaveBeenCalledTimes(1)
+      // A different entity starts over.
+      fetchViewMock.mockResolvedValue(absentResponse())
+      await w.setProps({ entityId: 'POL-2' })
+      await flushPromises()
+      expect(routerPush).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/frontend/src/components/entity/EntityDetail.world.test.ts
+++ b/frontend/src/components/entity/EntityDetail.world.test.ts
@@ -306,29 +306,49 @@ describe('EntityDetail world binding', () => {
       expect(w.find('.world-banner').exists()).toBe(false)
     })
 
-    it('hides Edit and Delete for a stand-in face _actions denies, and says why', async () => {
+    // The words for a read-only non-bare face are the OPERATOR's
+    // (`faces.<name>.messages.read_only`); the app has none of its own. A
+    // page with nothing declared shows a denial the way every denial looks:
+    // no Edit, no explanation (TKT-5SZG2L).
+    function seedReadOnlyText(text: string) {
+      useSchemaStore().entityTypes.set(entityType, {
+        name: entityType,
+        label: 'Policy',
+        properties: { title: { type: 'string', values: null } },
+        faces: { draft: { label: 'Concept' }, published: { label: 'Vastgesteld', messages: { read_only: text } } },
+        bare_face: 'draft',
+      } as never)
+    }
+
+    it('hides Edit and Delete for a stand-in face _actions denies, and says nothing by default', async () => {
       mockRoute.query = { world: 'published' }
       const w = await mountDetail(viewResponse(standIn()))
       rendersProof(w)
       expect(button(w, 'Edit')).toBeUndefined()
       expect(w.find('.btn-danger').exists()).toBe(false)
-      // The one fact the affordances leave unexplained: the bare face — where
-      // edits are made — really is elsewhere. No button: the face menu is the
-      // way there (atlas worlds issue 5).
+      expect(w.find('.world-banner').exists()).toBe(false)
+    })
+
+    it("explains a read-only face in the operator's words, placeholders substituted", async () => {
+      seedReadOnlyText('Dit is {face} van {title}. Bewerken doe je in {bare_face}.')
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse(standIn()))
+      rendersProof(w)
       const banner = w.find('.world-banner')
       expect(banner.exists()).toBe(true)
-      expect(banner.text()).toContain('read-only for you')
-      expect(banner.text()).toContain('Edits are made on the default face')
-      expect(banner.text()).not.toContain('Go to')
+      expect(banner.text()).toBe('Dit is Vastgesteld van Access Control Policy. Bewerken doe je in Concept.')
+      // No button: the face menu is the way to the bare face (issue 5).
+      expect(banner.find('button').exists()).toBe(false)
     })
 
     it('explains the stand-in even without a world in the URL', async () => {
       // `/entity/policy/POL-1@published?world=default` reaches the same row
       // by address; the note is about the face, not the world.
+      seedReadOnlyText('Alleen lezen')
       mockRoute.query = { world: 'default' }
       const w = await mountDetail(viewResponse(standIn()))
       rendersProof(w)
-      expect(w.find('.world-banner').text()).toContain('read-only for you')
+      expect(w.find('.world-banner').text()).toBe('Alleen lezen')
     })
 
     it('gives a bare face without update no note — an ordinary denial', async () => {
@@ -525,11 +545,21 @@ describe('EntityDetail world binding', () => {
       expect(invokeCopyMock).toHaveBeenCalledWith('promote-policy', entityId)
     })
 
-    it('lands on the face it wrote, in the operator vocabulary', async () => {
-      // The written face is one click away otherwise; landing on it is what
-      // an editor who just adopted a policy expects. The toast speaks the
-      // copy's label and the face's label, never rela's word "face" (atlas
-      // worlds issue 8).
+    it('lands on the face it wrote, and the toast is the copy\'s own label', async () => {
+      // With no `on_success` declared: the written face is where an editor
+      // who just adopted a policy expects to be, and the toast says only what
+      // the button said — never rela's "Created the X face" (TKT-5SZG2L).
+      invokeCopyMock.mockResolvedValue(copyResult())
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      await clickPromote(w)
+      expect(routerPush).toHaveBeenCalledWith({
+        path: '/entity/policy/POL-1@published', query: { world: 'published' },
+      })
+      expect(successMock).toHaveBeenCalledWith('Publish this policy')
+    })
+
+    it("toasts the operator's on_success.message with {face} as the face written", async () => {
       useSchemaStore().entityTypes.set(entityType, {
         name: entityType,
         label: 'Policy',
@@ -538,14 +568,47 @@ describe('EntityDetail world binding', () => {
         bare_face: 'draft',
       } as never)
       invokeCopyMock.mockResolvedValue(copyResult())
-      mockRoute.query = { world: 'published' }
-      const w = await mountDetail(viewResponse({ _copies: [promoteOffer()] }))
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { message: '{title} is nu {face}.', landing: { mode: 'written' } } })],
+      }))
+      await clickPromote(w)
+      expect(successMock).toHaveBeenCalledWith('Access Control Policy is nu Vastgesteld.')
+    })
+
+    it('stays in place when landing is `stay`', async () => {
+      invokeCopyMock.mockResolvedValue(copyResult())
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { landing: { mode: 'stay' } } })],
+      }))
+      const before = fetchViewMock.mock.calls.length
+      await clickPromote(w)
+      expect(routerPush).not.toHaveBeenCalled()
+      expect(fetchViewMock.mock.calls.length).toBeGreaterThan(before)
+    })
+
+    it('lands in a declared world when landing names one', async () => {
+      invokeCopyMock.mockResolvedValue(copyResult())
+      mockRoute.query = { from: 'posts' }
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { landing: { mode: 'world', world: 'published' } } })],
+      }))
+      await clickPromote(w)
+      // The bare id in that world, with the rest of the query kept.
+      expect(routerPush).toHaveBeenCalledWith({
+        path: '/entity/policy/POL-1', query: { from: 'posts', world: 'published' },
+      })
+    })
+
+    it('lands on a declared face when landing names one', async () => {
+      invokeCopyMock.mockResolvedValue(copyResult())
+      mockRoute.query = { world: 'editorial' }
+      const w = await mountDetail(viewResponse({
+        _copies: [promoteOffer({ onSuccess: { landing: { mode: 'face', face: 'draft' } } })],
+      }))
       await clickPromote(w)
       expect(routerPush).toHaveBeenCalledWith({
-        path: '/entity/policy/POL-1@published', query: { world: 'published' },
+        path: '/entity/policy/POL-1@draft', query: { world: 'editorial' },
       })
-      expect(successMock).toHaveBeenCalledWith('Publish this policy: Vastgesteld created')
-      expect(successMock.mock.calls[0][0]).not.toMatch(/\bface\b/)
     })
 
     it('reloads in place after a copy INTO the bare face', async () => {
@@ -640,6 +703,7 @@ describe('EntityDetail world binding', () => {
     })
 
     it('distinguishes a real face from a fallback in the SAME section', async () => {
+      useSchemaStore().worlds.set('site-nl', { readable: true, messages: { stand_in: 'vervangend' } } as never)
       mockRoute.query = { world: 'site-nl' }
       const w = await mountDetail(
         withCollection([
@@ -656,7 +720,7 @@ describe('EntityDetail world binding', () => {
       const badges = w.findAll('.world-badge')
       expect(badges).toHaveLength(1)
       expect(badges[0].classes()).toContain('is-fallback')
-      expect(badges[0].text()).toBe('default')
+      expect(badges[0].text()).toBe('vervangend')
       // Anti-vacuity: both neighbours really rendered, so the single badge is
       // a statement about provenance and not about a section that came up
       // empty.
@@ -696,21 +760,27 @@ describe('EntityDetail world binding', () => {
       expect(w.find('.error-state').exists()).toBe(false)
     })
 
-    it('names the world that has no face for it', async () => {
-      mockRoute.query = { world: 'published' }
-      const w = await mountDetail(absentResponse())
-      const banner = w.find('.world-banner--absent')
-      expect(banner.exists()).toBe(true)
-      expect(banner.text()).toContain('published')
-    })
-
-    it('does NOT claim the page is read-only', async () => {
-      // What is on screen is the DEFAULT face, which is exactly where writes
-      // land.
+    it('says nothing about the absence unless the operator declared text', async () => {
+      // The app has no sentence of its own for "no face in this world"; a
+      // page with nothing declared is simply the bare face (TKT-5SZG2L).
       mockRoute.query = { world: 'published' }
       const w = await mountDetail(absentResponse())
       rendersProof(w)
-      expect(w.text()).not.toContain('read-only for you')
+      expect(w.find('.world-banner').exists()).toBe(false)
+      expect(w.text()).not.toContain('Go to')
+    })
+
+    it("renders the world's messages.absent in the operator's words", async () => {
+      useSchemaStore().worlds.set('published', {
+        readable: true, messages: { absent: 'Nog niet vastgesteld: {title}.' },
+      } as never)
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(absentResponse())
+      rendersProof(w)
+      const banner = w.find('.world-banner--absent')
+      expect(banner.exists()).toBe(true)
+      expect(banner.text()).toBe('Nog niet vastgesteld: Access Control Policy.')
+      expect(banner.find('button').exists()).toBe(false)
     })
 
     it('offers Edit and Delete, because the default face IS what is on screen', async () => {
@@ -721,77 +791,37 @@ describe('EntityDetail world binding', () => {
       expect(button(w, 'Delete')).toBeDefined()
     })
 
-    it('offers the way back to the default world', async () => {
+    it('redirects to the declared world when on_absent.redirect names one', async () => {
+      // The operator would rather send the reader to the concept than
+      // explain an absence. `default` is spelled through setWorld, so the
+      // param is dropped here (no configured default world).
+      useSchemaStore().worlds.set('published', {
+        readable: true, on_absent: { redirect: 'default' },
+      } as never)
       mockRoute.query = { world: 'published' }
       const w = await mountDetail(absentResponse())
       rendersProof(w)
-      const back = w.findAll('button').find((b) => b.text().includes('Go to default'))
-      expect(back).toBeDefined()
-      await back!.trigger('click')
-      // Returns to the same id with the world dropped.
       expect(routerPush).toHaveBeenCalledWith({ query: {} })
     })
 
-    it('hides the way back when the principal cannot read the default world', async () => {
-      // A GLOBAL role-level grant, reported per world by `/_schema`.worlds —
-      // no per-entity probe. Offering the button to someone whose
-      // default-world request returns an empty result would send them
-      // somewhere that looks broken.
-      useSchemaStore().worlds.set('default', { readable: false, default: true })
+    it('redirects to a non-default world by name', async () => {
+      useSchemaStore().worlds.set('published', {
+        readable: true, on_absent: { redirect: 'editorial' },
+      } as never)
       mockRoute.query = { world: 'published' }
       const w = await mountDetail(absentResponse())
       rendersProof(w)
-      expect(w.text()).not.toContain('Go to default')
-      expect(w.find('.world-banner--absent').exists()).toBe(true)
+      expect(routerPush).toHaveBeenCalledWith({ query: { world: 'editorial' } })
     })
 
-    // The button NAMES A DESTINATION, so it is labelled from the destination
-    // rather than from a guess about the project's vocabulary: "Go to draft"
-    // on an ISMS because the operator declared `draft`, "Go to English" on a
-    // blog post whose faces are a language axis.
-    describe('the way back is labelled from the destination face', () => {
-      function seedFaces(bareFace: string, faces: Record<string, { label?: string }>) {
-        useSchemaStore().entityTypes.set(entityType, {
-          name: entityType,
-          label: 'Policy',
-          properties: { title: { type: 'string', values: null } },
-          faces,
-          bare_face: bareFace,
-        } as never)
-      }
-
-      it("uses the operator's label for the default face", async () => {
-        seedFaces('draft', { draft: { label: 'the draft' }, published: {} })
-        mockRoute.query = { world: 'published' }
-        const w = await mountDetail(absentResponse())
-        rendersProof(w)
-        expect(w.text()).toContain('Go to the draft')
-      })
-
-      it('reads the language vocabulary on a type with no lifecycle', async () => {
-        seedFaces('en', { en: { label: 'English' }, nl: {} })
-        mockRoute.query = { world: 'published' }
-        const w = await mountDetail(absentResponse())
-        rendersProof(w)
-        expect(w.text()).toContain('Go to English')
-        expect(w.text()).not.toContain('Go to draft')
-      })
-
-      it('falls back to the FACE NAME when the operator declared no label', async () => {
-        seedFaces('draft', { draft: {}, published: {} })
-        mockRoute.query = { world: 'published' }
-        const w = await mountDetail(absentResponse())
-        rendersProof(w)
-        expect(w.text()).toContain('Go to draft')
-      })
-
-      it('falls back to "default" when the type names no bare_face', async () => {
-        seedFaces('', { published: {} })
-        mockRoute.query = { world: 'published' }
-        const w = await mountDetail(absentResponse())
-        rendersProof(w)
-        expect(w.text()).toContain('Go to default')
-      })
+    it('does not redirect when the page is not absent', async () => {
+      useSchemaStore().worlds.set('published', {
+        readable: true, on_absent: { redirect: 'default' },
+      } as never)
+      mockRoute.query = { world: 'published' }
+      const w = await mountDetail(viewResponse())
+      rendersProof(w)
+      expect(routerPush).not.toHaveBeenCalled()
     })
   })
 

--- a/frontend/src/components/entity/WorldBadge.test.ts
+++ b/frontend/src/components/entity/WorldBadge.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import WorldBadge from './WorldBadge.vue'
+import { useSchemaStore } from '@/stores/schema'
 import type { EntityWorld } from '@/types'
 
 // WorldBadge is an EXCEPTION marker: it renders ONLY when the world served a
@@ -8,11 +10,17 @@ import type { EntityWorld } from '@/types'
 // world asked for. A badge on every row is noise, and noise trains people to
 // ignore it — so the presence of the badge is what carries the meaning.
 //
-// The regression these tests exist for (WORLDS-DEMO-ISSUES, blocker 1): a
-// draft-only policy served under `?world=published` reported `via: 'chain'`,
-// byte-identical to a genuine published hit, so the badge said nothing and
-// the page framed draft content as published. `chain_position` carries the
-// missing fact, and a position > 0 must read exactly like `fallback-default`.
+// WHETHER a row is a stand-in is the server's answer (`_world`); WHAT the
+// badge says is the operator's `messages.stand_in` for the world, and with
+// nothing declared nothing renders (TKT-5SZG2L). The badge has no words of
+// its own — the coordinate names and tooltips it used to print were rela's
+// storage vocabulary shown to a reader.
+//
+// The regression the substitute detection exists for (WORLDS-DEMO-ISSUES,
+// blocker 1): a draft-only policy served under `?world=published` reported
+// `via: 'chain'`, byte-identical to a genuine published hit. `chain_position`
+// carries the missing fact, and a position > 0 must read exactly like
+// `fallback-default`.
 
 const world = (over: Partial<EntityWorld>): EntityWorld => ({
   name: 'published',
@@ -21,70 +29,90 @@ const world = (over: Partial<EntityWorld>): EntityWorld => ({
   ...over,
 })
 
-describe('WorldBadge substitute detection', () => {
-  it('renders NOTHING for a first-choice chain hit', () => {
-    // The rule, pinned directly: chain_position 0 is the face the world would
-    // normally give you, so there is nothing to warn about and no badge.
-    const w = mount(WorldBadge, {
-      props: { world: world({ chain_position: 0 }) },
+function seed(standIn?: string) {
+  const store = useSchemaStore()
+  store.worlds.set('published', { readable: true, messages: standIn ? { stand_in: standIn } : undefined } as never)
+  store.entityTypes.set('policy', {
+    name: 'policy',
+    label: 'Policy',
+    properties: {},
+    faces: { draft: { label: 'Concept' }, published: { label: 'Vastgesteld' } },
+    bare_face: 'draft',
+  } as never)
+}
+
+function badge(w: EntityWorld | undefined) {
+  return mount(WorldBadge, { props: { world: w, entityType: 'policy' } })
+}
+
+describe('WorldBadge', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('says only what the operator declared', () => {
+    it('renders NOTHING for a stand-in when the world declares no stand_in text', () => {
+      seed()
+      const w = badge(world({ face: 'draft', chain_position: 1 }))
+      expect(w.find('.world-badge').exists()).toBe(false)
+      expect(w.text()).toBe('')
     })
-    expect(w.find('.world-badge').exists()).toBe(false)
-    expect(w.text()).toBe('')
-  })
 
-  it('flags a WITHIN-CHAIN fallback as a substitute', () => {
-    // THE reported bug: `via` is still 'chain', because the chain did match —
-    // its second element. Only the position separates this from the case
-    // above.
-    const w = mount(WorldBadge, {
-      props: { world: world({ face: 'draft', chain_position: 1 }) },
+    it('renders the declared text with {face} as the served face LABEL', () => {
+      seed('Nog {face}')
+      const w = badge(world({ face: 'draft', chain_position: 1 }))
+      expect(w.find('.world-badge').exists()).toBe(true)
+      expect(w.find('.world-badge').classes()).toContain('is-fallback')
+      expect(w.text()).toBe('Nog Concept')
+      // No tooltip: it was a rela sentence.
+      expect(w.find('.world-badge').attributes('title')).toBeUndefined()
     })
-    expect(w.find('.world-badge').exists()).toBe(true)
-    expect(w.find('.world-badge').classes()).toContain('is-fallback')
-    expect(w.text()).toBe('draft')
-    expect(w.find('.world-badge').attributes('title')).toBe(
-      'No published face exists for this entity — showing draft instead',
-    )
-  })
 
-  it('still flags the otherwise:default arm', () => {
-    const w = mount(WorldBadge, {
-      props: { world: world({ face: '', via: 'fallback-default' }) },
+    it('renders the declared text on the otherwise:default arm too', () => {
+      seed('{bare_face}')
+      const w = badge(world({ face: '', via: 'fallback-default' }))
+      expect(w.text()).toBe('Concept')
     })
-    expect(w.find('.world-badge').exists()).toBe(true)
-    expect(w.find('.world-badge').classes()).toContain('is-fallback')
-    expect(w.text()).toBe('default')
-    expect(w.find('.world-badge').attributes('title')).toBe(
-      'No published face exists for this entity — showing the default state instead',
-    )
   })
 
-  it('treats a missing chain_position as a first-choice hit', () => {
-    // An older server omits the field. `undefined > 0` is false, so the badge
-    // stays quiet rather than inventing a warning it has no evidence for —
-    // the pre-existing behaviour, deliberately unchanged.
-    const w = mount(WorldBadge, { props: { world: world({}) } })
-    expect(w.find('.world-badge').exists()).toBe(false)
-  })
+  describe('substitute detection', () => {
+    // Constant text: the arm under test may serve a face with no label, and
+    // an empty `{face}` would hide the badge for a reason unrelated to
+    // detection.
+    beforeEach(() => seed('stand-in'))
 
-  it('renders nothing for unscoped', () => {
-    const w = mount(WorldBadge, {
-      props: { world: world({ via: 'unscoped', face: '' }) },
+    it('renders NOTHING for a first-choice chain hit', () => {
+      // chain_position 0 is the face the world would normally give you, so
+      // there is nothing to warn about and no badge — even with text declared.
+      const w = badge(world({ chain_position: 0 }))
+      expect(w.find('.world-badge').exists()).toBe(false)
     })
-    expect(w.find('.world-badge').exists()).toBe(false)
-  })
 
-  it('renders nothing with no world at all', () => {
-    const w = mount(WorldBadge, { props: {} })
-    expect(w.find('.world-badge').exists()).toBe(false)
-  })
+    it('flags a WITHIN-CHAIN fallback as a substitute', () => {
+      // THE reported bug: `via` is still 'chain', because the chain did match —
+      // its second element. Only the position separates this from the case
+      // above.
+      const w = badge(world({ face: 'draft', chain_position: 1 }))
+      expect(w.find('.world-badge').classes()).toContain('is-fallback')
+    })
 
-  it('never renders the removed non-substitute state', () => {
-    // `is-chain` styled a quiet first-choice badge and was removed with it.
-    // A reintroduction would put a badge back on every row, which is exactly
-    // what this rule exists to prevent.
-    for (const w of [world({ chain_position: 0 }), world({ chain_position: 3, face: 'draft' })]) {
-      expect(mount(WorldBadge, { props: { world: w } }).find('.is-chain').exists()).toBe(false)
-    }
+    it('still flags the otherwise:default arm', () => {
+      const w = badge(world({ face: '', via: 'fallback-default' }))
+      expect(w.find('.world-badge').classes()).toContain('is-fallback')
+    })
+
+    it('treats a missing chain_position as a first-choice hit', () => {
+      // An older server omits the field. `undefined > 0` is false, so the badge
+      // stays quiet rather than inventing a warning it has no evidence for.
+      expect(badge(world({})).find('.world-badge').exists()).toBe(false)
+    })
+
+    it('renders nothing for unscoped', () => {
+      expect(badge(world({ via: 'unscoped', face: '' })).find('.world-badge').exists()).toBe(false)
+    })
+
+    it('renders nothing with no world at all', () => {
+      expect(badge(undefined).find('.world-badge').exists()).toBe(false)
+    })
   })
 })

--- a/frontend/src/components/entity/WorldBadge.vue
+++ b/frontend/src/components/entity/WorldBadge.vue
@@ -31,8 +31,12 @@ import type { EntityWorld } from '@/types'
 
 const props = defineProps<{
   world?: EntityWorld
-  /** The row's entity type, for the served face's declared label. */
-  entityType?: string
+  /**
+   * The row's entity type, for the served face's declared label. Required:
+   * a call site that forgot it would render `{face}` as the stored
+   * coordinate name — a rela word — with no error anywhere.
+   */
+  entityType: string
 }>()
 
 const schemaStore = useSchemaStore()
@@ -48,13 +52,13 @@ const text = computed(() => {
   const w = props.world
   if (!w || !isSubstitute.value) return ''
   const info = schemaStore.worlds.get(w.name)
-  const faces = props.entityType ? schemaStore.getEntityType(props.entityType)?.faces : undefined
+  const faces = schemaStore.getEntityType(props.entityType)?.faces
   // `_world.face` is the served face's DECLARED name; '' when the type names
   // none, in which case the placeholder renders empty.
   const face = w.face ? faces?.[w.face]?.label || w.face : ''
   return worldText(info?.messages?.stand_in, {
     face,
-    bare_face: props.entityType ? schemaStore.faceLabel(props.entityType, '') : '',
+    bare_face: schemaStore.faceLabel(props.entityType, ''),
     world: w.name,
   })
 })

--- a/frontend/src/components/entity/WorldBadge.vue
+++ b/frontend/src/components/entity/WorldBadge.vue
@@ -1,66 +1,42 @@
 <script setup lang="ts">
 /**
- * Flags that a world served a SUBSTITUTE face for one entity — and names it.
+ * The stand-in badge: marks a row or card whose face is a SUBSTITUTE for the
+ * world's first choice — a within-chain fallback (`chain` at a position past
+ * 0) or an `otherwise: default` substitution.
  *
- * ## Why this exists at all
+ * ## Existence is the server's answer; the wording is the operator's
  *
- * Under a world with `otherwise: default`, "the Dutch page" and "the English
- * page, because no Dutch page exists" come back BYTE-IDENTICALLY — same id,
- * same title, same body. The only thing separating them is `_world.via`. A
- * reader looking at a `site-nl` listing cannot otherwise tell which entries
- * are actually translated, and neither can the editor deciding what to
- * translate next.
+ * Whether a row is a stand-in comes from `_world` on the row (the store
+ * resolved it; this reads the answer back). What the badge SAYS comes from
+ * the world's `messages.stand_in` in schema.yaml — typically `{face}`, the
+ * served face's label — and nothing is rendered when the operator declared
+ * nothing. The badge used to print the coordinate and a tooltip in rela's
+ * own words ("No published face exists for this entity — showing the default
+ * state instead"), which is storage vocabulary shown to a reader who never
+ * chose it (TKT-5SZG2L).
  *
- * ## The badge is an EXCEPTION marker, and renders ONLY for a substitute
+ * ## Only a substitute renders
  *
- * A first-choice hit renders NOTHING. The badge earns attention precisely
- * because its presence is the exception: it means "what you are reading is
- * NOT the face this world would normally give you." A badge on every row is
- * noise, and noise trains people to ignore it — at which point the one row
- * that genuinely needed to be read differently is the one that gets skipped.
- *
- * This component owns that rule so every surface (list table, list mobile
- * card, EntityDetail entry + section rows, RelationPicker) gets it
- * consistently and no future consumer has to remember it. Mounting the
- * component for a non-substitute is harmless; it emits no markup.
- *
- * `unscoped` renders nothing for the same reason from the other end: it means
- * no resolution was applied, which is the default world's answer for
- * everything and carries no information.
- *
- * ## A substitute is not only the `fallback-default` arm
- *
- * `via` has two ways of saying "you are looking at a stand-in", and for a
- * while this component only handled one. `fallback-default` fires when the
- * chain matched NOTHING and the world's `otherwise:` arm supplied the
- * default state. But a chain with several candidates can also substitute
- * WITHIN itself: under `select: [published, draft]` a missing published face
- * resolves to the draft, and that reports `via: 'chain'` — identical to a
- * genuine published hit.
- *
- * That was reported live: a draft-only policy rendered under `?world=published`
- * with a "read-only" framing implying it was the published face. The badge
- * said nothing, because `via` said `chain`.
- *
- * `chain_position` is the missing fact. Position 0 is the world's first
- * choice; anything greater is a stand-in and reads exactly like
- * `fallback-default`, because to a reader they are the same statement.
+ * A first-choice hit shows nothing, so the badge marks only what is
+ * surprising. `_world.via` alone cannot say which: `chain` covers both the
+ * world's first choice and a later candidate standing in for it, so
+ * `chain_position` is the deciding fact. An older server that omits it is
+ * treated as a first-choice hit — the badge does not invent a warning it has
+ * no evidence for.
  */
 import { computed } from 'vue'
+import { useSchemaStore } from '@/stores/schema'
+import { worldText } from '@/utils/worldText'
 import type { EntityWorld } from '@/types'
 
-const props = defineProps<{ world?: EntityWorld }>()
+const props = defineProps<{
+  world?: EntityWorld
+  /** The row's entity type, for the served face's declared label. */
+  entityType?: string
+}>()
 
-/**
- * Whether the reader is looking at a STAND-IN rather than the face the world
- * asked for — true for both substitute shapes (see the component doc).
- *
- * The `> 0` test is deliberately not `!== 0`: an older server omits
- * `chain_position` entirely, and `undefined > 0` is false, so a response that
- * cannot answer the question is treated as a first-choice hit. That is the
- * pre-existing behaviour, unchanged — the badge does not invent a warning it
- * has no evidence for.
- */
+const schemaStore = useSchemaStore()
+
 const isSubstitute = computed(() => {
   const w = props.world
   if (!w) return false
@@ -70,47 +46,26 @@ const isSubstitute = computed(() => {
 
 const text = computed(() => {
   const w = props.world
-  if (!w) return ''
-  switch (w.via) {
-    case 'chain':
-      // The coordinate the world served. Name it, because "published" (or
-      // "draft", when a draft stood in) is more useful to a reader than the
-      // world's own name.
-      //
-      // The `|| w.name` arm should be unreachable: `chain` means a SELECTED
-      // coordinate matched, and the default state is reported as `unscoped`,
-      // never as `chain` with an empty face. It is a display fallback so a
-      // server that broke that invariant renders a world name rather than an
-      // empty badge — not a case to design around.
-      return w.face || w.name
-    case 'fallback-default':
-      return 'default'
-    default:
-      return ''
-  }
-})
-
-const title = computed(() => {
-  const w = props.world
-  if (!w) return ''
-  if (w.via === 'fallback-default') {
-    return `No ${w.name} face exists for this entity — showing the default state instead`
-  }
-  // The within-chain substitute. Naming the served coordinate matters more
-  // than naming the world: "showing the draft" is the fact the reader acts
-  // on, and the reason the page's content may not contain what they expect.
-  return `No ${w.name} face exists for this entity — showing ${w.face} instead`
+  if (!w || !isSubstitute.value) return ''
+  const info = schemaStore.worlds.get(w.name)
+  const faces = props.entityType ? schemaStore.getEntityType(props.entityType)?.faces : undefined
+  // `_world.face` is the served face's DECLARED name; '' when the type names
+  // none, in which case the placeholder renders empty.
+  const face = w.face ? faces?.[w.face]?.label || w.face : ''
+  return worldText(info?.messages?.stand_in, {
+    face,
+    bare_face: props.entityType ? schemaStore.faceLabel(props.entityType, '') : '',
+    world: w.name,
+  })
 })
 </script>
 
 <template>
   <!--
-    ONLY a substitute renders. There is deliberately no non-substitute visual
-    state: an `is-chain` class used to style a quiet first-choice badge, and
-    was removed with the badge itself (see the component doc). Reintroducing
-    one would put a badge back on every row.
+    ONLY a substitute with operator text renders. `.is-fallback` is the hook
+    consumers and tests use to assert "this is the warning state".
   -->
-  <span v-if="isSubstitute" class="world-badge is-fallback" :title="title">
+  <span v-if="text" class="world-badge is-fallback">
     {{ text }}
   </span>
 </template>
@@ -129,11 +84,6 @@ const title = computed(() => {
   color: var(--muted-text);
 }
 
-/* The substitute is the only case that renders, so it is the only case that
-   carries colour. `.is-fallback` is kept as a separate class rather than
-   folded into `.world-badge` because it is the hook consumers and tests use
-   to assert "this is the warning state" — and because a second, quieter
-   state would go here if one ever earns its place again. */
 .is-fallback {
   border-color: color-mix(in srgb, var(--warning-color) 60%, transparent);
   background: color-mix(in srgb, var(--warning-color) 18%, transparent);

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -7,6 +7,7 @@ import { readReturnTo } from '@/utils/returnPath'
 import { useWorld, DEFAULT_WORLD } from '@/composables/useWorld'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { entityRef, refBareId, refFace } from '@/utils/entityRef'
+import { worldText } from '@/utils/worldText'
 import {
   isFieldWritable,
   isPropertyRedacted,
@@ -225,16 +226,23 @@ const loadState = ref<'pending' | 'loaded' | 'error'>('pending')
 // navigation (bookmark, paste) or when the policy tightened after the
 // detail view loaded.
 const notEditable = ref(false)
-// The NON-BARE face the loaded row is, or '' — so the not-editable message
-// can say the true reason when there is one: the address names a face no
-// grant covers, and edits are made on the bare face. A bare row that is not
-// updatable is an ordinary permission denial and keeps the permissions text.
+// The NON-BARE face the loaded row is, or '' — so the refusal can carry the
+// operator's `faces.<name>.messages.read_only` when one is declared. Nothing
+// declared: the ordinary permissions text, which is true either way and
+// speaks no rela vocabulary (TKT-5SZG2L).
 const notEditableFace = ref('')
-const notEditableFaceLabel = computed(() => {
+const notEditableNote = computed(() => {
   const type = formConfig.value?.entity ?? ''
-  return schemaStore.faceLabel(type, notEditableFace.value) || notEditableFace.value
+  const faces = schemaStore.getEntityType(type)?.faces
+  const face = notEditableFace.value
+  if (!face) return ''
+  return worldText(faces?.[face]?.messages?.read_only, {
+    face: faces?.[face]?.label || face,
+    bare_face: schemaStore.faceLabel(type, ''),
+    world: worldParam.value ?? '',
+    title: bareEntityId.value,
+  })
 })
-const bareFaceLabel = computed(() => schemaStore.faceLabel(formConfig.value?.entity ?? '', '') || 'default')
 // The bare id, for the way back and every per-ENTITY surface.
 const bareEntityId = computed(() => (props.entityId ? refBareId(props.entityId) : ''))
 const saveGeneration = ref(0) // Incremented after save to reset RelationCards
@@ -1906,24 +1914,13 @@ defineExpose({
       <div v-else-if="loading" class="form-loading-placeholder" />
 
       <div v-else-if="notEditable" class="not-editable-state">
-        <h2>{{ notEditableFace ? 'This face is not editable' : 'This entity is not editable' }}</h2>
-        <p v-if="notEditableFace">
-          You are looking at the {{ notEditableFaceLabel }} face of
-          <code>{{ bareEntityId }}</code
-          >, which is read-only for you. Edits are made on the {{ bareFaceLabel }} face.
-        </p>
+        <h2>This entity is not editable</h2>
+        <p v-if="notEditableNote">{{ notEditableNote }}</p>
         <p v-else>
           Your current permissions don't allow updating
           <code>{{ entityId }}</code
           >. Return to the entity view to see available actions.
         </p>
-        <router-link
-          v-if="formConfig && entityId && notEditableFace"
-          :to="{ path: `/entity/${formConfig.entity}/${bareEntityId}`, query: { world: 'default' } }"
-          class="btn btn-secondary"
-        >
-          Go to {{ bareFaceLabel }}
-        </router-link>
         <router-link
           v-if="formConfig && entityId"
           :to="`/entity/${formConfig.entity}/${entityId}`"

--- a/frontend/src/components/forms/DynamicForm.vue
+++ b/frontend/src/components/forms/DynamicForm.vue
@@ -6,8 +6,9 @@ import { isCancelledFetch } from '@/composables/usePageData'
 import { readReturnTo } from '@/utils/returnPath'
 import { useWorld, DEFAULT_WORLD } from '@/composables/useWorld'
 import { actionAllowed } from '@/utils/affordancesWarning'
-import { entityRef, refBareId, refFace } from '@/utils/entityRef'
+import { entityRef, refFace } from '@/utils/entityRef'
 import { worldText } from '@/utils/worldText'
+import { entityDisplayTitle } from '@/utils/entityDisplay'
 import {
   isFieldWritable,
   isPropertyRedacted,
@@ -231,6 +232,10 @@ const notEditable = ref(false)
 // declared: the ordinary permissions text, which is true either way and
 // speaks no rela vocabulary (TKT-5SZG2L).
 const notEditableFace = ref('')
+// The loaded row's display title, so `{title}` reads the same here as on
+// the detail page — the same declared sentence must not name the entity
+// one way there and by its id here.
+const notEditableTitle = ref('')
 const notEditableNote = computed(() => {
   const type = formConfig.value?.entity ?? ''
   const faces = schemaStore.getEntityType(type)?.faces
@@ -240,11 +245,9 @@ const notEditableNote = computed(() => {
     face: faces?.[face]?.label || face,
     bare_face: schemaStore.faceLabel(type, ''),
     world: worldParam.value ?? '',
-    title: bareEntityId.value,
+    title: notEditableTitle.value,
   })
 })
-// The bare id, for the way back and every per-ENTITY surface.
-const bareEntityId = computed(() => (props.entityId ? refBareId(props.entityId) : ''))
 const saveGeneration = ref(0) // Incremented after save to reset RelationCards
 const saving = ref(false)
 const dirty = ref(false)
@@ -505,6 +508,7 @@ async function loadEntity(force = false) {
     // only for direct-URL navigation.
     notEditable.value = !actionAllowed(entity, 'update')
     notEditableFace.value = refFace(entityRef(entity))
+    notEditableTitle.value = entityDisplayTitle(entity)
     // Retained hidden values belong to the form state we are about to replace.
     // Carrying them across a reload — or across an entity switch, since this
     // component is not re-keyed per entity — would restore one entity's value

--- a/frontend/src/components/forms/RelationPicker.test.ts
+++ b/frontend/src/components/forms/RelationPicker.test.ts
@@ -443,11 +443,13 @@ describe('RelationPicker incoming label resolution', () => {
 })
 
 // BUG-3: the picker offers entities that may have several faces, and gave no
-// indication which one a row was. The badge names the face — but only when it
-// is a surprise.
+// indication which one a row was. The badge marks a stand-in — but only when
+// it is a surprise, and only in the operator's words (`messages.stand_in`);
+// with nothing declared it renders nothing (TKT-5SZG2L).
 describe('RelationPicker — face badge (BUG-3)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    useSchemaStore().worlds.set('published', { readable: true, messages: { stand_in: 'stand-in' } } as never)
   })
 
   function faced(id: string, world?: Entity['_world']): Entity {

--- a/frontend/src/components/forms/RelationPicker.vue
+++ b/frontend/src/components/forms/RelationPicker.vue
@@ -392,7 +392,7 @@ onBeforeUnmount(() => {
           TRAILING, after the title: the type chip leads and the face badge
           follows, matching how the rest of the app orders the two.
         -->
-        <WorldBadge v-if="showsFaceBadge(entity)" :world="entity._world" />
+        <WorldBadge v-if="showsFaceBadge(entity)" :world="entity._world" :entity-type="entity.type" />
         <button v-if="canRemove" type="button" class="remove-btn" @click="removeEntity(entity.id)">
           &times;
         </button>
@@ -428,7 +428,7 @@ onBeforeUnmount(() => {
         >
           <span class="entity-type">{{ entity.type }}</span>
           <span class="entity-label">{{ formatEntityLabel(entity) }}</span>
-          <WorldBadge v-if="showsFaceBadge(entity)" :world="entity._world" />
+          <WorldBadge v-if="showsFaceBadge(entity)" :world="entity._world" :entity-type="entity.type" />
         </div>
         <div v-if="filteredCandidates.length > 10" class="dropdown-more">
           +{{ filteredCandidates.length - 10 }} more...

--- a/frontend/src/components/lists/EntityList.vue
+++ b/frontend/src/components/lists/EntityList.vue
@@ -15,6 +15,7 @@ import { beginOptimisticRemove, rollbackOptimistic } from '@/queries/optimisticL
 import { toApiOperator, filterStateToApiParams } from '@/utils/filters'
 import { entityDetailHref } from '@/utils/entityRoute'
 import { entityRef, refFace } from '@/utils/entityRef'
+import { worldText } from '@/utils/worldText'
 import { safeInternalHref, shouldDeferToBrowser } from '@/utils/openIntent'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { renderMarkdown } from '@/utils/markdown'
@@ -224,13 +225,19 @@ const { filters, q: searchQuery, writeToQuery } = useUrlFilterSync({ staticFilte
 // internal/dataentry/world.go.
 const { world, isWorldBound, worldParam } = useWorld()
 
-// The world note below the banner is a fact about a FACED type only: a type
-// without faces has exactly one state, present in every world, so nothing on
-// its list is filtered by the world and search drops nothing either. Config
-// from `/_schema`, not a verdict — which faces a type declares is public.
+// The world's projection note, in the operator's words (`messages.projection`)
+// and only on a list of a type that declares faces: a type without faces has
+// one state in every world, so nothing on its list is filtered by the world
+// and the note would be false. Nothing declared, nothing rendered — the app
+// has no sentence of its own for this (TKT-5SZG2L).
 const listTypeHasFaces = computed(() => {
   const def = schemaStore.getEntityType(listConfig.value?.entity ?? '')
   return Object.keys(def?.faces ?? {}).length > 0
+})
+const projectionNote = computed<string>(() => {
+  if (!listTypeHasFaces.value) return ''
+  const info = world.value ? schemaStore.worlds.get(world.value) : undefined
+  return worldText(info?.messages?.projection, { world: world.value })
 })
 
 // The create button's destination — see useCreateTarget for why a create
@@ -983,23 +990,12 @@ watch(searchQuery, () => {
       reads as a designed property rather than a mistake.
     -->
     <!--
-      The ANNOUNCEMENT is operator config (`banner:` on the world), the same
-      split the detail page makes. It replaces a hardcoded "Showing the X
-      world", which on an ISMS `published` list was pure noise: published IS
-      the reader's normal state, so announcing it says nothing.
-
-      The NOTE is not configurable, but it is only TRUE for a type that
-      declares faces: the world filters rows out and search looks at resolved
-      faces. A type without faces has one state, present in every world, so
-      nothing on its list can be filtered and the note would assert two
-      falsehoods (atlas worlds issue 1). Hence the second gate.
+      Both halves are operator config: the ANNOUNCEMENT (`banner:` on the
+      world) and the NOTE (`messages.projection`, rendered only on a list of a
+      faced type). Neither declared: no banner at all.
     -->
-    <WorldBanner v-if="isWorldBound && !loadError && (worldBanner || listTypeHasFaces)" :label="worldBanner">
-      <template v-if="listTypeHasFaces">
-        Each entity is shown as it appears in this world, and entities with no
-        face here are not listed at all — including from search, which looks at
-        the same faces this list does.
-      </template>
+    <WorldBanner v-if="isWorldBound && !loadError && (worldBanner || projectionNote)" :label="worldBanner">
+      {{ projectionNote }}
     </WorldBanner>
 
     <div class="search-row">
@@ -1110,7 +1106,7 @@ watch(searchQuery, () => {
               <!-- Same per-row provenance as the table below, on the card's
                    title. A narrow screen is not a reason to drop the one
                    signal separating a real face from a stand-in. -->
-              <WorldBadge :world="entity._world" />
+              <WorldBadge :world="entity._world" :entity-type="entity.type" />
             </span>
             <button
               v-if="canDelete(entity)"
@@ -1275,7 +1271,7 @@ watch(searchQuery, () => {
                 `_world` is absent entirely), so a typical list shows no badges
                 at all and the ones it does show are the exceptions.
               -->
-              <WorldBadge v-if="isBadgeColumn(column)" :world="entity._world" />
+              <WorldBadge v-if="isBadgeColumn(column)" :world="entity._world" :entity-type="entity.type" />
             </td>
             <td class="actions-cell">
               <button

--- a/frontend/src/components/lists/EntityList.world.test.ts
+++ b/frontend/src/components/lists/EntityList.world.test.ts
@@ -241,18 +241,14 @@ describe('EntityList world binding', () => {
     // The UI half of the same property: the affordance is real, so it is
     // offered. Paired with the default-world control above, which proves the
     // box's presence is not simply unconditional.
-    it('offers the search box and says what it searches', async () => {
+    it('offers the search box, and says nothing about it unless the operator does', async () => {
       const wrapper = await mountList({ faces: true })
       rendersProof(wrapper)
 
       expect(wrapper.findComponent({ name: 'SearchBox' }).exists()).toBe(true)
-      const banner = wrapper.find('.world-banner')
-      expect(banner.exists()).toBe(true)
-      // The banner must still account for the world's effect on results —
-      // rows missing from the list are missing from its search too. Dropping
-      // that sentence would leave a reader with a short result set and no
-      // explanation, which is what the note exists to prevent.
-      expect(banner.text()).toContain('including from search')
+      // No banner: nothing declared for this world. The app has no sentence
+      // of its own about what a world filters (TKT-5SZG2L).
+      expect(wrapper.find('.world-banner').exists()).toBe(false)
     })
 
     // The banner is TWO things with different owners, the same split the
@@ -263,64 +259,63 @@ describe('EntityList world binding', () => {
     // announcing it says nothing. The announcement is now the operator's
     // `banner:` and renders nothing when unset.
     //
-    // The NOTE is not the operator's to suppress, but it is only TRUE for a
-    // type that declares faces: the world really does filter such rows out,
-    // and the search box beside it searches those same faces. A type without
-    // faces has one state in every world, so the note would assert two
-    // falsehoods on its list (atlas worlds issue 1).
-    describe('the banner announcement is operator config; the note is not', () => {
-      it('renders the operator announcement when the world declares one', async () => {
+    // Both halves of the banner are operator config: the ANNOUNCEMENT
+    // (`banner:`) and the NOTE (`messages.projection`). The note is rendered
+    // only on a list of a type that declares faces — a type without faces has
+    // one state in every world, so nothing on its list is filtered by the
+    // world and the note would be false (atlas worlds issue 1).
+    describe('the banner is the operator\'s words or nothing', () => {
+      it('renders the announcement and the projection note when both are declared', async () => {
         useSchemaStore().worlds.set('published', {
           readable: true,
           banner: 'These policies are in force',
+          messages: { projection: 'Only what is in force is listed.' },
         } as never)
         const wrapper = await mountList({ faces: true })
         rendersProof(wrapper)
 
         const banner = wrapper.find('.world-banner')
-        expect(banner.text()).toContain('These policies are in force')
-        expect(banner.text()).toContain('including from search')
+        expect(banner.find('.world-banner__label').text()).toBe('These policies are in force')
+        expect(banner.find('.world-banner__note').text()).toBe('Only what is in force is listed.')
       })
 
       it('renders the announcement alone on a list of a type WITHOUT faces', async () => {
         useSchemaStore().worlds.set('published', {
           readable: true,
           banner: 'These policies are in force',
+          messages: { projection: 'Only what is in force is listed.' },
         } as never)
         const wrapper = await mountList()
         rendersProof(wrapper)
 
         const banner = wrapper.find('.world-banner')
         expect(banner.text()).toContain('These policies are in force')
-        expect(banner.text()).not.toContain('including from search')
+        expect(banner.text()).not.toContain('Only what is in force')
       })
 
-      it('renders no banner at all on a list of a type WITHOUT faces and no announcement', async () => {
+      it('renders the projection note alone when no banner is declared', async () => {
+        useSchemaStore().worlds.set('published', {
+          readable: true,
+          messages: { projection: 'Only what is in force is listed.' },
+        } as never)
+        const wrapper = await mountList({ faces: true })
+        rendersProof(wrapper)
+        expect(wrapper.find('.world-banner__label').exists()).toBe(false)
+        expect(wrapper.find('.world-banner__note').text()).toBe('Only what is in force is listed.')
+      })
+
+      it('renders no banner at all when nothing is declared', async () => {
         useSchemaStore().worlds.set('published', { readable: true } as never)
-        const wrapper = await mountList()
+        const wrapper = await mountList({ faces: true })
         rendersProof(wrapper)
         expect(wrapper.find('.world-banner').exists()).toBe(false)
       })
 
-      it('announces NOTHING when the world declares no banner', async () => {
-        useSchemaStore().worlds.set('published', { readable: true } as never)
-        const wrapper = await mountList({ faces: true })
-        rendersProof(wrapper)
-
-        // The announcement element is absent — not an empty span, which would
-        // still occupy the layout.
-        expect(wrapper.find('.world-banner__label').exists()).toBe(false)
-        // ...and the note survives, which is the half an operator must not be
-        // able to turn off. Without this assertion, deleting the banner block
-        // outright would pass.
-        expect(wrapper.find('.world-banner__note').text()).toContain('including from search')
-      })
-
       it('never announces the world NAME on its own', async () => {
-        // The specific regression: the hardcoded string named the world, so a
+        // The specific regression: a hardcoded string named the world, so a
         // `published` list announced "published" to a reader for whom that is
         // simply the normal state.
-        useSchemaStore().worlds.set('published', { readable: true } as never)
+        useSchemaStore().worlds.set('published', { readable: true, banner: 'In force' } as never)
         const wrapper = await mountList({ faces: true })
         rendersProof(wrapper)
         expect(wrapper.find('.world-banner').text()).not.toContain('published')
@@ -399,14 +394,9 @@ describe('EntityList world binding', () => {
   //
   // A list row that fell back to a later chain candidate is BYTE-IDENTICAL to
   // a first-choice hit — same id, same title, same cells. `_world` is the only
-  // thing separating them, and until now the list rendered none of it, so an
-  // editorial list showing a stand-in looked exactly like one showing the face
-  // the reader asked for.
-  //
-  // The badge is an EXCEPTION marker: it renders ONLY for a stand-in. A
-  // first-choice row is left unmarked, because a badge on every row is noise
-  // that trains the reader to ignore it — so here the badge's PRESENCE is
-  // itself the claim, and the no-badge cases below are what give it meaning.
+  // thing separating them. The badge is an EXCEPTION marker: it renders ONLY
+  // for a stand-in, and only in the operator's words (`messages.stand_in`);
+  // with nothing declared it renders nothing (TKT-5SZG2L).
   describe('per-row world badge', () => {
     const fallbackRow: Entity = {
       id: 'POL-3',
@@ -421,53 +411,52 @@ describe('EntityList world binding', () => {
       _world: { name: 'editorial', face: 'draft', via: 'chain', chain_position: 0 },
     }
 
-    async function mountWith(rows: Entity[]) {
-      seedSchema()
+    async function mountWith(rows: Entity[], standIn?: string) {
+      seedSchema({ faces: true })
+      useSchemaStore().worlds.set('editorial', {
+        readable: true, ...(standIn ? { messages: { stand_in: standIn } } : {}),
+      } as never)
       seedEntities(rows)
       const wrapper = mount(EntityList, {
         props: { listId },
         attachTo: document.body,
         global: { plugins: [pinia, PiniaColada] },
       })
+      mounted.push(wrapper)
       await flushPromises()
       expect(listEntitiesMock).toHaveBeenCalled()
       return wrapper
     }
 
-    it('badges a within-chain fallback row as a substitute, naming the face served', async () => {
+    it('badges a within-chain fallback row in the operator\'s words', async () => {
       mockRoute.query = { world: 'editorial' }
-      const wrapper = await mountWith([fallbackRow])
+      const wrapper = await mountWith([fallbackRow], 'Stand-in: {face}')
       expect(wrapper.text()).toContain('Remote Working Policy')
 
       const badge = wrapper.find('.world-badge')
       expect(badge.exists()).toBe(true)
-      // The face, not the world name: "published" is what the reader is
-      // actually looking at, and the reason the row may not say what they
-      // expect.
-      expect(badge.text()).toBe('published')
-      // Mutation: drop chain_position from isSubstitute and this row stops
-      // rendering a badge at all, i.e. the stand-in becomes indistinguishable
-      // from the world's first choice — the exact bug the badge exists for.
+      expect(badge.text()).toBe('Stand-in: published')
       expect(badge.classes()).toContain('is-fallback')
-      expect(badge.attributes('title')).toContain('No editorial face exists')
+      expect(badge.attributes('title')).toBeUndefined()
+    })
+
+    it('renders NO badge for a stand-in when the world declares no stand_in text', async () => {
+      mockRoute.query = { world: 'editorial' }
+      const wrapper = await mountWith([fallbackRow])
+      expect(wrapper.text()).toContain('Remote Working Policy')
+      expect(wrapper.find('.world-badge').exists()).toBe(false)
     })
 
     it('leaves a chain-position-0 row UNBADGED even inside a world', async () => {
       mockRoute.query = { world: 'editorial' }
-      const wrapper = await mountWith([firstChoiceRow])
-      // Anti-vacuity: the row rendered, and it rendered inside a world — so
-      // the absent badge is the rule and not a list that failed to resolve.
+      const wrapper = await mountWith([firstChoiceRow], '{face}')
       expect(wrapper.text()).toContain('Access Control Policy')
-
-      // The positive control for the test above: without this, badging every
-      // row would pass it.
       expect(wrapper.find('.world-badge').exists()).toBe(false)
     })
 
     it('badges only the stand-in when both kinds share one table', async () => {
-      // The clearest statement of the rule: same list, same world, one badge.
       mockRoute.query = { world: 'editorial' }
-      const wrapper = await mountWith([firstChoiceRow, fallbackRow])
+      const wrapper = await mountWith([firstChoiceRow, fallbackRow], '{face}')
       expect(wrapper.text()).toContain('Access Control Policy')
       expect(wrapper.text()).toContain('Remote Working Policy')
 
@@ -485,48 +474,38 @@ describe('EntityList world binding', () => {
           properties: { title: 'Joiners Policy' },
           _world: { name: 'editorial', face: '', via: 'fallback-default' },
         },
-      ])
+      ], '{bare_face}')
       expect(wrapper.text()).toContain('Joiners Policy')
 
       const badge = wrapper.find('.world-badge')
-      expect(badge.text()).toBe('default')
+      expect(badge.text()).toBe('draft')
       expect(badge.classes()).toContain('is-fallback')
     })
 
     it('renders NO badge under the default world', async () => {
       mockRoute.query = {}
-      const wrapper = await mountWith([policy])
-      // Anti-vacuity: the rows really rendered, so the absence is about the
-      // badge and not about a component that failed to mount.
+      const wrapper = await mountWith([policy], '{face}')
       expect(wrapper.text()).toContain('Access Control Policy')
       expect(wrapper.find('.world-badge').exists()).toBe(false)
     })
 
-    // One badge per ROW, not one per cell. A world verdict is a statement
-    // about the entity, so repeating it in every column would be noise that
-    // also grows with the list's width.
     it('renders exactly one badge per row regardless of column count', async () => {
       mockRoute.query = { world: 'editorial' }
-      seedSchema({ relationColumn: true })
+      seedSchema({ faces: true, relationColumn: true })
+      useSchemaStore().worlds.set('editorial', { readable: true, messages: { stand_in: '{face}' } } as never)
       seedEntities([fallbackRow])
       const wrapper = mount(EntityList, {
         props: { listId },
         attachTo: document.body,
         global: { plugins: [pinia, PiniaColada] },
       })
+      mounted.push(wrapper)
       await flushPromises()
       expect(wrapper.text()).toContain('Remote Working Policy')
-
-      // Two columns are configured; still one badge.
-      expect(wrapper.findAll('th').length).toBeGreaterThan(2)
       expect(wrapper.findAll('.world-badge')).toHaveLength(1)
     })
   })
 
-
-  // TKT-6NCSSC: the row link used to drop the world, so following a row from a
-  // world-bound list landed on the DEFAULT face — of the very entity whose row
-  // the reader had just seen carrying a fallback badge.
   describe('row links carry the world', () => {
     const linkRow: Entity = {
       id: 'POL-3',

--- a/frontend/src/composables/useWorld.ts
+++ b/frontend/src/composables/useWorld.ts
@@ -33,7 +33,7 @@
  * unchanged rather than being silently rewritten.
  */
 import { computed, type Ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter, type LocationQuery, type LocationQueryRaw } from 'vue-router'
 import { useSchemaStore } from '@/stores/schema'
 
 // DEFAULT_WORLD is the reserved name the API accepts as an explicit way to
@@ -133,31 +133,43 @@ export function useWorld(): UseWorld {
   function setWorld(next: string) {
     if (next === world.value) return
     if (!route || !router) return
-    const query = { ...route.query }
-    // Dropping the param lands on the operator's default world, so it is only
-    // the way to reach `next` when `next` IS that default. Otherwise the param
-    // has to be written explicitly — including `?world=default`, which is how
-    // a reader reaches the raw faces on a deployment that configures one.
-    // '' and DEFAULT_WORLD name the SAME world, so normalise before comparing
-    // — otherwise setWorld(DEFAULT_WORLD) on a deployment with no configured
-    // default writes ?world=default instead of dropping the param.
-    const norm = (w: string) => (w === DEFAULT_WORLD ? '' : w)
-    if (norm(next) === norm(schemaStore.defaultWorld)) {
-      delete query.world
-    } else if (norm(next) === '') {
-      query.world = DEFAULT_WORLD
-    } else {
-      query.world = next
-    }
-    // Changing world resets pagination: page 3 of the draft world is not
-    // page 3 of the published world — the published world may hold fewer
-    // entities than that page's offset, landing the user on a silently empty
-    // page that reads as "nothing is published".
-    delete query.page
     // push, not replace: switching world is a deliberate act the back button
     // should undo. See the composable doc.
-    router.push({ query })
+    router.push({ query: worldQuery(next, route.query, schemaStore.defaultWorld) })
   }
 
   return { world, isWorldBound, worldParam, setWorld }
+}
+
+/**
+ * Spells a world into a query, the ONE place that rule lives. `setWorld`
+ * uses it for a same-page switch; a caller that also changes the path (a
+ * copy landing in another world) uses it directly, so the two cannot
+ * drift — the first copy of this logic had already lost the page reset.
+ *
+ * Dropping the param lands on the operator's default world, so it is only
+ * the way to reach `next` when `next` IS that default. Otherwise the param
+ * has to be written explicitly — including `?world=default`, which is how a
+ * reader reaches the raw faces on a deployment that configures one. '' and
+ * DEFAULT_WORLD name the SAME world, so both are normalised before
+ * comparing; otherwise DEFAULT_WORLD on a deployment with no configured
+ * default writes ?world=default instead of dropping the param.
+ *
+ * Changing world resets pagination: page 3 of the draft world is not page 3
+ * of the published world — the published world may hold fewer entities than
+ * that page's offset, landing the user on a silently empty page that reads
+ * as "nothing is published".
+ */
+export function worldQuery(next: string, base: LocationQuery, defaultWorld: string): LocationQueryRaw {
+  const query: LocationQueryRaw = { ...base }
+  const norm = (w: string) => (w === DEFAULT_WORLD ? '' : w)
+  if (norm(next) === norm(defaultWorld)) {
+    delete query.world
+  } else if (norm(next) === '') {
+    query.world = DEFAULT_WORLD
+  } else {
+    query.world = next
+  }
+  delete query.page
+  return query
 }

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -221,6 +221,14 @@ export interface CopyOffer {
   targetFace: string
   allowed: boolean
   reason?: string
+  // The operator's follow-through (TKT-5SZG2L): the toast (absent means the
+  // copy's label) and where to land. Absent means land on the face written.
+  onSuccess?: CopyOnSuccess
+}
+
+export interface CopyOnSuccess {
+  message?: string
+  landing: { mode: 'written' | 'stay' | 'world' | 'face'; world?: string; face?: string }
 }
 
 // AttachmentInfo describes one file attached to a `file`-type property,

--- a/frontend/src/types/schema.ts
+++ b/frontend/src/types/schema.ts
@@ -28,8 +28,15 @@ export interface WorldInfo {
   primary_for?: string[]
   // Operator-authored text announcing this world ("DRAFT — not in force").
   // Empty/absent means announce nothing — a language world needs no banner.
-  // Gates ONLY the announcement: a non-default world is read-only regardless.
   banner?: string
+  // The operator's wording for what this world changes on a screen
+  // (TKT-5SZG2L). Each entry is optional and an absent one renders NOTHING:
+  // the app has no sentence of its own for any of them. Placeholders
+  // `{face}`, `{bare_face}`, `{world}`, `{title}` — see utils/worldText.
+  messages?: WorldMessages
+  // Behaviour for an entity with no face in this world: `redirect` names the
+  // world the app navigates to instead of rendering the page.
+  on_absent?: { redirect?: string }
   // Whether this caller may select the world via `?world=`.
   //
   // A UI HINT about SELECTION, never a boundary: the server re-checks the
@@ -80,6 +87,20 @@ export interface FaceInfo {
   // Absent means fall back to the face name, which is itself
   // operator-authored config and so an honest, if terse, display string.
   label?: string
+  // The operator's chrome text about this face (TKT-5SZG2L). `read_only` is
+  // the note for a page or form showing this face while the reader may not
+  // write it; absent renders nothing.
+  messages?: { read_only?: string }
+}
+
+// WorldMessages mirrors v1.WorldMessages. See WorldInfo.messages.
+export interface WorldMessages {
+  // Detail-page note for an entity with no face in the world.
+  absent?: string
+  // List/board note for a type that declares faces.
+  projection?: string
+  // Badge text for a stand-in row or card; absent means no badge.
+  stand_in?: string
 }
 
 export interface PropertyDef {

--- a/frontend/src/utils/worldText.test.ts
+++ b/frontend/src/utils/worldText.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { worldText } from './worldText'
+
+describe('worldText', () => {
+  it('renders nothing for an undeclared template', () => {
+    expect(worldText(undefined, { face: 'Vastgesteld' })).toBe('')
+    expect(worldText('', { face: 'Vastgesteld' })).toBe('')
+  })
+
+  it('substitutes the allowlisted placeholders', () => {
+    expect(
+      worldText('Je kijkt naar {face} van {title}; bewerken doe je in {bare_face} ({world}).', {
+        face: 'Vastgesteld',
+        bare_face: 'Concept',
+        world: 'actueel',
+        title: 'Toegangsbeleid',
+      }),
+    ).toBe('Je kijkt naar Vastgesteld van Toegangsbeleid; bewerken doe je in Concept (actueel).')
+  })
+
+  it('leaves an unknown placeholder as written', () => {
+    // A typo in the operator's text should show up on screen, not vanish.
+    expect(worldText('{fase} is klaar', { face: 'x' })).toBe('{fase} is klaar')
+  })
+
+  it('substitutes every occurrence', () => {
+    expect(worldText('{face}/{face}', { face: 'nl' })).toBe('nl/nl')
+  })
+})

--- a/frontend/src/utils/worldText.test.ts
+++ b/frontend/src/utils/worldText.test.ts
@@ -27,3 +27,22 @@ describe('worldText', () => {
     expect(worldText('{face}/{face}', { face: 'nl' })).toBe('nl/nl')
   })
 })
+
+describe('worldText: what a missing value means', () => {
+  it('leaves the placeholder as written when the surface has no such fact', () => {
+    // A list has no single title; `{title}` in a projection note is the
+    // operator asking for something this surface cannot say, so it shows.
+    expect(worldText('{title} in {world}', { world: 'actueel' })).toBe('{title} in actueel')
+  })
+
+  it('substitutes an EMPTY value to nothing', () => {
+    // The fact exists and is empty — a face with no declared label. Printing
+    // `{face}` there would put a rela word on screen.
+    expect(worldText('Nog {face}.', { face: '' })).toBe('Nog .')
+  })
+
+  it('never re-scans a substituted value', () => {
+    // A title that happens to contain a placeholder is data, not template.
+    expect(worldText('{title}', { title: '{world}', world: 'x' })).toBe('{world}')
+  })
+})

--- a/frontend/src/utils/worldText.ts
+++ b/frontend/src/utils/worldText.ts
@@ -24,19 +24,24 @@ export interface WorldTextVars {
   title?: string
 }
 
+// The allowlist. internal/metamodel.ChromePlaceholders is the same list on
+// the Go side, and TestChromePlaceholdersInSyncWithFrontend reads this line
+// to pin the two together.
 const KEYS: (keyof WorldTextVars)[] = ['face', 'bare_face', 'world', 'title']
+
+const PLACEHOLDER = new RegExp(`\\{(${KEYS.join('|')})\\}`, 'g')
 
 /**
  * Renders an operator template. Returns '' for an undeclared template, which
  * every caller treats as "render nothing".
+ *
+ * One pass, so a substituted VALUE is never re-scanned for placeholders. A
+ * var the caller did not supply (`undefined`) leaves its placeholder as
+ * written, like an unknown name — the surface has no such fact. A var
+ * supplied as '' substitutes to nothing: the fact exists and is empty (a
+ * face with no label), and printing `{face}` there would be a rela word.
  */
 export function worldText(template: string | undefined, vars: WorldTextVars): string {
   if (!template) return ''
-  let out = template
-  for (const key of KEYS) {
-    const value = vars[key]
-    if (value === undefined) continue
-    out = out.split(`{${key}}`).join(value)
-  }
-  return out
+  return template.replace(PLACEHOLDER, (match, key: keyof WorldTextVars) => vars[key] ?? match)
 }

--- a/frontend/src/utils/worldText.ts
+++ b/frontend/src/utils/worldText.ts
@@ -1,0 +1,42 @@
+/**
+ * Operator-authored chrome text for worlds, faces and copies (TKT-5SZG2L).
+ *
+ * The web app has NO sentence of its own for any of the world chrome — the
+ * read-only note, the absent note, the projection note, the stand-in badge,
+ * the copy toast. Every one it used to have was rela's storage vocabulary
+ * ("face", "world", "bare", "default") shown to a reader who never chose those
+ * words. So: an operator declares the text in schema.yaml and it is rendered
+ * verbatim, or nothing is rendered.
+ *
+ * The one thing the app does to the text is substitute an allowlisted set of
+ * `{placeholders}`. Anything else in braces is left as written — the text is
+ * the operator's, and a typo in a placeholder name should show up on screen
+ * rather than vanish.
+ */
+export interface WorldTextVars {
+  /** The served face's label. */
+  face?: string
+  /** The type's bare face label. */
+  bare_face?: string
+  /** The world's name. */
+  world?: string
+  /** The entity's display title. */
+  title?: string
+}
+
+const KEYS: (keyof WorldTextVars)[] = ['face', 'bare_face', 'world', 'title']
+
+/**
+ * Renders an operator template. Returns '' for an undeclared template, which
+ * every caller treats as "render nothing".
+ */
+export function worldText(template: string | undefined, vars: WorldTextVars): string {
+  if (!template) return ''
+  let out = template
+  for (const key of KEYS) {
+    const value = vars[key]
+    if (value === undefined) continue
+    out = out.split(`{${key}}`).join(value)
+  }
+  return out
+}

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -292,7 +292,9 @@ const backTarget = computed<RouteLocationRaw>(() => ({
 // face's history passed for a published page's.
 const faceLabel = computed(() => {
   if (!world.value) return ''
-  return face.value || 'default'
+  // The operator's label for the face on screen, by declared name; a face
+  // the type does not name renders nothing rather than a rela word.
+  return schemaStore.faceLabel(entityType.value, face.value)
 })
 
 const hasContentChanges = computed(() => contentDiff.value.some((l) => l.op !== 'equal'))
@@ -315,7 +317,7 @@ onMounted(load)
             labelling it would be noise; under a world the label is the whole
             point, because the record on screen is face-specific.
           -->
-          <span v-if="faceLabel" class="history-face"> · {{ faceLabel }} face </span>
+          <span v-if="faceLabel" class="history-face"> · {{ faceLabel }}</span>
         </p>
       </div>
       <RouterLink class="btn btn-secondary" :to="backTarget">Back to entity</RouterLink>

--- a/frontend/src/views/HistoryView.vue
+++ b/frontend/src/views/HistoryView.vue
@@ -292,9 +292,11 @@ const backTarget = computed<RouteLocationRaw>(() => ({
 // face's history passed for a published page's.
 const faceLabel = computed(() => {
   if (!world.value) return ''
-  // The operator's label for the face on screen, by declared name; a face
-  // the type does not name renders nothing rather than a rela word.
-  return schemaStore.faceLabel(entityType.value, face.value)
+  // The operator's label for the face on screen, else its declared NAME —
+  // both are the operator's words, and under a world the coordinate is what
+  // says which record this timeline is. Only the bare face with no label
+  // renders nothing: naming it would take a rela word.
+  return schemaStore.faceLabel(entityType.value, face.value) || face.value
 })
 
 const hasContentChanges = computed(() => contentDiff.value.some((l) => l.op !== 'equal'))

--- a/frontend/src/views/KanbanView.vue
+++ b/frontend/src/views/KanbanView.vue
@@ -20,6 +20,7 @@ import { useBackTarget } from '@/composables/useBackTarget'
 import { useWorld } from '@/composables/useWorld'
 import { actionAllowed } from '@/utils/affordancesWarning'
 import { entityRef } from '@/utils/entityRef'
+import { worldText } from '@/utils/worldText'
 import { entityDisplayTitle } from '@/utils/entityDisplay'
 import { renderMarkdown } from '@/utils/markdown'
 import { hasIcon, resolveIcon } from '@/utils/icons'
@@ -89,6 +90,12 @@ function canUpdate(entity: Entity): boolean {
 const boardTypeHasFaces = computed(() => {
   const def = schemaStore.getEntityType(kanbanConfig.value?.entity ?? '')
   return Object.keys(def?.faces ?? {}).length > 0
+})
+// The operator's `messages.projection` for the world, or nothing.
+const projectionNote = computed<string>(() => {
+  if (!boardTypeHasFaces.value) return ''
+  const info = world.value ? schemaStore.worlds.get(world.value) : undefined
+  return worldText(info?.messages?.projection, { world: world.value })
 })
 
 // Computed
@@ -646,23 +653,17 @@ function createNew() {
       longer claims the board is read-only; a card the principal may not write
       simply refuses the drag through `_actions`, as in the default world.
     -->
-    <div v-if="isWorldBound && !loadError && (worldBanner || boardTypeHasFaces)" class="world-banner">
+    <div v-if="isWorldBound && !loadError && (worldBanner || projectionNote)" class="world-banner">
       <!--
-        The ANNOUNCEMENT is operator config (`banner:` on the world). Absent on
-        a language world, where telling someone who asked for Dutch that they
-        are reading Dutch is noise.
+        Both halves are operator config: the ANNOUNCEMENT (`banner:`) and the
+        NOTE (`messages.projection`, only on a board of a faced type). Neither
+        declared: no banner (TKT-5SZG2L).
       -->
       <span v-if="worldBanner" class="world-banner__label">
         {{ worldBanner }}
       </span>
-      <!--
-        The projection note, only for a type that declares faces: a type
-        without faces has one state in every world, so no card can be missing
-        on the world's account.
-      -->
-      <span v-if="boardTypeHasFaces" class="world-banner__note">
-        Each card shows the face this world resolved, and entities with no
-        face here are not on the board at all.
+      <span v-if="projectionNote" class="world-banner__note">
+        {{ projectionNote }}
       </span>
     </div>
 
@@ -756,7 +757,7 @@ function createNew() {
                 absent entirely — shows nothing at all.
               -->
               <div class="card-title text-wrap-anywhere">
-                {{ getCardTitle(entity) }}<WorldBadge :world="entity._world" />
+                {{ getCardTitle(entity) }}<WorldBadge :world="entity._world" :entity-type="entity.type" />
               </div>
               <CardFieldList
                 :fields="resolvedCardFields(entity)"
@@ -840,7 +841,7 @@ function createNew() {
               <div class="card-id">{{ entity.id }}</div>
               <!-- Face provenance; see the simple board above. -->
               <div class="card-title text-wrap-anywhere">
-                {{ getCardTitle(entity) }}<WorldBadge :world="entity._world" />
+                {{ getCardTitle(entity) }}<WorldBadge :world="entity._world" :entity-type="entity.type" />
               </div>
               <CardFieldList
                 :fields="resolvedCardFields(entity)"

--- a/frontend/src/views/KanbanView.world.test.ts
+++ b/frontend/src/views/KanbanView.world.test.ts
@@ -132,22 +132,25 @@ describe('KanbanView world scoping', () => {
 })
 
 describe('KanbanView per-card world badge', () => {
-  it('badges only the card that resolved to a stand-in', async () => {
+  it('badges only the card that resolved to a stand-in, in the operator\'s words', async () => {
     mockRoute.query = { world: 'site-nl' }
-    const wrapper = await mountBoard([
-      card('PRC-1', 'Herstellen vanaf back-up', {
-        name: 'site-nl',
-        face: 'nl',
-        via: 'chain',
-        chain_position: 0,
-      }),
-      card('PRC-2', "Revoke a leaver's access", {
-        name: 'site-nl',
-        face: 'en',
-        via: 'chain',
-        chain_position: 1,
-      }),
-    ])
+    const store = seedSchema()
+    store.worlds.set('site-nl', { name: 'site-nl', readable: true, messages: { stand_in: '{face}' } } as never)
+    listAllEntitiesMock.mockResolvedValue({
+      data: [
+        card('PRC-1', 'Herstellen vanaf back-up', { name: 'site-nl', face: 'nl', via: 'chain', chain_position: 0 }),
+        card('PRC-2', "Revoke a leaver's access", { name: 'site-nl', face: 'en', via: 'chain', chain_position: 1 }),
+      ],
+      meta: { total: 2, page: 1, per_page: 100, has_more: false },
+      included: {},
+      _actions: { create: true },
+    } as never)
+    const wrapper = mount(KanbanView, {
+      props: { id: KANBAN_ID },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
     // Anti-vacuity: both cards really rendered, so the single badge is a
     // statement about provenance and not about a board that came up short.
     expect(wrapper.text()).toContain('Herstellen vanaf back-up')
@@ -155,8 +158,18 @@ describe('KanbanView per-card world badge', () => {
 
     const badges = wrapper.findAll('.world-badge')
     expect(badges).toHaveLength(1)
-    expect(badges[0].text()).toBe('en')
+    // `{face}` is the served face's LABEL from the type's faces.
+    expect(badges[0].text()).toBe('English')
     expect(badges[0].classes()).toContain('is-fallback')
+  })
+
+  it('renders no badge for a stand-in when the world declares no stand_in text', async () => {
+    mockRoute.query = { world: 'site-nl' }
+    const wrapper = await mountBoard([
+      card('PRC-2', "Revoke a leaver's access", { name: 'site-nl', face: 'en', via: 'chain', chain_position: 1 }),
+    ])
+    expect(wrapper.text()).toContain("Revoke a leaver's access")
+    expect(wrapper.find('.world-badge').exists()).toBe(false)
   })
 
   it('renders no badge under the default world', async () => {
@@ -225,17 +238,31 @@ describe('KanbanView write affordances under a world', () => {
 })
 
 describe('KanbanView world banner', () => {
-  it('explains the projection on a board of a FACED type', async () => {
+  it('renders the operator\'s projection note on a board of a FACED type', async () => {
     // A board under a world is a projection: cards may be missing entirely.
-    // The banner no longer claims the board is read-only, because it is not —
-    // a drag writes the face the card shows.
+    // What that says to a reader is the operator's `messages.projection`;
+    // the app has no sentence of its own (TKT-5SZG2L).
     mockRoute.query = { world: 'site-nl' }
-    const wrapper = await mountBoard([card('PRC-1', 'Herstellen vanaf back-up')])
+    const store = seedSchema()
+    store.worlds.set('site-nl', {
+      name: 'site-nl', readable: true, messages: { projection: 'Alleen vertaalde procedures.' },
+    } as never)
+    listAllEntitiesMock.mockResolvedValue({
+      data: [card('PRC-1', 'Herstellen vanaf back-up')],
+      meta: { total: 1, page: 1, per_page: 100, has_more: false },
+      included: {},
+      _actions: { create: true },
+    } as never)
+    const wrapper = mount(KanbanView, {
+      props: { id: KANBAN_ID },
+      attachTo: document.body,
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    await flushPromises()
     const banner = wrapper.find('.world-banner')
     expect(banner.exists()).toBe(true)
-    expect(banner.text()).toContain('not on the board at all')
+    expect(banner.find('.world-banner__note').text()).toBe('Alleen vertaalde procedures.')
     expect(banner.text()).not.toContain('read-only')
-    expect(banner.text()).not.toContain('cannot be dragged')
   })
 
   it('renders the operator announcement when the world declares one', async () => {
@@ -260,13 +287,13 @@ describe('KanbanView world banner', () => {
     expect(wrapper.find('.world-banner__label').text()).toBe('Dutch site')
   })
 
-  it('announces nothing when the world declares no banner', async () => {
-    // `site-nl` in the seed has no `banner:`. The projection note still
-    // renders for a faced type — it is not the operator's to suppress.
+  it('renders no banner at all when the world declares neither banner nor note', async () => {
+    // `site-nl` in the seed declares nothing, so nothing renders — the app
+    // has no words of its own for a world.
     mockRoute.query = { world: 'site-nl' }
     const wrapper = await mountBoard([card('PRC-1', 'Herstellen vanaf back-up')])
-    expect(wrapper.find('.world-banner__label').exists()).toBe(false)
-    expect(wrapper.find('.world-banner__note').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Herstellen vanaf back-up')
+    expect(wrapper.find('.world-banner').exists()).toBe(false)
   })
 
   it('renders no note on a board of a type WITHOUT faces', async () => {

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -390,6 +390,15 @@ type World struct {
 	// Config, not data: world names and their banners are operator-authored
 	// and public, so this is served identically to every principal.
 	Banner string `json:"banner,omitempty"`
+	// Messages is the operator's wording for what this world changes on a
+	// screen (TKT-5SZG2L). Each entry is optional and an absent one renders
+	// nothing: the web app has no sentence of its own for any of them.
+	// Placeholders `{face}`, `{bare_face}`, `{world}` and `{title}` are
+	// substituted by the client. Mirrors metamodel.WorldMessages.
+	Messages *WorldMessages `json:"messages,omitempty"`
+	// OnAbsent is the behavior for an entity with no face in this world.
+	// Mirrors metamodel.WorldOnAbsent.
+	OnAbsent *WorldOnAbsent `json:"on_absent,omitempty"`
 	// Readable reports whether THIS caller may select the world via
 	// `?world=`. False means a request naming it is served an empty result
 	// rather than a 403 — so a client that respects this flag shows the user
@@ -445,6 +454,33 @@ type EntityType struct {
 	BareFace string `json:"bare_face,omitempty"`
 }
 
+// WorldMessages is the operator's chrome text for one world. See
+// [World.Messages].
+type WorldMessages struct {
+	// Absent is the detail-page note for an entity with no face in the world.
+	Absent string `json:"absent,omitempty"`
+	// Projection is the list/board note for a type that declares faces.
+	Projection string `json:"projection,omitempty"`
+	// StandIn is the badge text for a stand-in row or card; empty means no
+	// badge.
+	StandIn string `json:"stand_in,omitempty"`
+}
+
+// WorldOnAbsent is the behavior for an entity with no face in a world.
+type WorldOnAbsent struct {
+	// Redirect names the world the client navigates to instead of rendering
+	// the absent page. Validated at schema load.
+	Redirect string `json:"redirect,omitempty"`
+}
+
+// FaceMessages is the operator's chrome text for one face. See
+// [FaceDef.Messages].
+type FaceMessages struct {
+	// ReadOnly is the note for a page or form showing this face while the
+	// reader may not write it. Empty renders nothing.
+	ReadOnly string `json:"read_only,omitempty"`
+}
+
 // Face is the JSON representation of one declared content state,
 // mirroring metamodel.FaceDef.
 //
@@ -460,6 +496,9 @@ type FaceDef struct {
 	// face it has not fetched — a "return to the default face" button must
 	// say "Go to English" before it has loaded anything English.
 	Label string `json:"label,omitempty"`
+	// Messages is the operator's chrome text about this face (TKT-5SZG2L).
+	// Nil when none is declared. Mirrors metamodel.FaceMessages.
+	Messages *FaceMessages `json:"messages,omitempty"`
 }
 
 // PropertyDef is the JSON representation of a property definition.
@@ -1109,6 +1148,29 @@ type CopyOffer struct {
 	// Advisory, and never carries content from an entity the caller cannot
 	// read.
 	Reason string `json:"reason,omitempty"`
+	// OnSuccess is the operator's follow-through for this copy: the toast
+	// and where the client lands (TKT-5SZG2L). Nil when nothing is declared,
+	// in which case the client shows the copy's label and lands on the face
+	// written. Mirrors metamodel.CopyOnSuccess.
+	OnSuccess *CopyOnSuccess `json:"onSuccess,omitempty"`
+}
+
+// CopyOnSuccess is the operator's follow-through for a successful copy.
+type CopyOnSuccess struct {
+	// Message is the confirmation toast; empty means the copy's label.
+	Message string `json:"message,omitempty"`
+	// Landing is where the client goes afterwards.
+	Landing CopyLanding `json:"landing"`
+}
+
+// CopyLanding is a copy's landing target, mirroring metamodel.CopyLanding
+// with the default spelled out so a client never has to infer it.
+type CopyLanding struct {
+	// Mode is "written" (the face the copy wrote), "stay" (reload in
+	// place), "world" or "face" (see the field of that name).
+	Mode  string `json:"mode"`
+	World string `json:"world,omitempty"`
+	Face  string `json:"face,omitempty"`
 }
 
 // CopyResult reports what an invoked copy produced.

--- a/internal/apiwire/v1/responses.go
+++ b/internal/apiwire/v1/responses.go
@@ -898,10 +898,6 @@ type ViewResponse struct {
 	// Omitted when false, so an ordinary view response is byte-identical to
 	// what it was before this field existed.
 	WorldAbsent bool `json:"_world_absent,omitempty"`
-	// WorldAbsentName is the world that has no face for this entity, so the
-	// page can name it ("no published face") rather than saying "this world".
-	// Set only alongside WorldAbsent.
-	WorldAbsentName string `json:"_world_absent_name,omitempty"`
 }
 
 // ViewSection represents a section with resolved data.

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -1429,7 +1429,30 @@ func (svc affordanceService) computeCopyOffers(
 			TargetFace: o.TargetFace,
 			Allowed:    o.Allowed,
 			Reason:     o.Reason,
+			OnSuccess:  copyOnSuccessWire(o.OnSuccess),
 		})
 	}
 	return out
+}
+
+// copyOnSuccessWire projects a copy's declared follow-through onto the wire,
+// nil when nothing was declared so an undeclared block is omitted rather than
+// sent as an empty object. The landing's default is spelled out as
+// `written`, so a client never infers it from an absent field.
+func copyOnSuccessWire(s metamodel.CopyOnSuccess) *v1.CopyOnSuccess {
+	if s.Message == "" && s.Landing.IsZero() {
+		return nil
+	}
+	landing := v1.CopyLanding{Mode: metamodel.LandingWritten}
+	switch {
+	case s.Landing.Mode != "":
+		landing.Mode = s.Landing.Mode
+	case s.Landing.World != "":
+		landing.Mode = "world"
+		landing.World = s.Landing.World
+	case s.Landing.Face != "":
+		landing.Mode = "face"
+		landing.Face = s.Landing.Face
+	}
+	return &v1.CopyOnSuccess{Message: s.Message, Landing: landing}
 }

--- a/internal/dataentry/affordances.go
+++ b/internal/dataentry/affordances.go
@@ -1443,16 +1443,22 @@ func copyOnSuccessWire(s metamodel.CopyOnSuccess) *v1.CopyOnSuccess {
 	if s.Message == "" && s.Landing.IsZero() {
 		return nil
 	}
+	// The arms are mutually exclusive by construction — the loader refuses a
+	// landing naming both a world and a face (validateCopyLanding) rather
+	// than resolving it by precedence, and this projection must not quietly
+	// introduce the precedence the loader declined to. So the arms test the
+	// full shape, and an impossible combination falls to `written`.
+	l := s.Landing
 	landing := v1.CopyLanding{Mode: metamodel.LandingWritten}
 	switch {
-	case s.Landing.Mode != "":
-		landing.Mode = s.Landing.Mode
-	case s.Landing.World != "":
+	case l.Mode != "":
+		landing.Mode = l.Mode
+	case l.World != "" && l.Face == "":
 		landing.Mode = "world"
-		landing.World = s.Landing.World
-	case s.Landing.Face != "":
+		landing.World = l.World
+	case l.Face != "" && l.World == "":
 		landing.Mode = "face"
-		landing.Face = s.Landing.Face
+		landing.Face = l.Face
 	}
 	return &v1.CopyOnSuccess{Message: s.Message, Landing: landing}
 }

--- a/internal/dataentry/chromeplaceholders_test.go
+++ b/internal/dataentry/chromeplaceholders_test.go
@@ -1,0 +1,40 @@
+package dataentry
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// TestChromePlaceholdersInSyncWithFrontend pins metamodel.ChromePlaceholders
+// to the SPA's allowlist in frontend/src/utils/worldText.ts (TKT-5SZG2L,
+// RR-VJYG4V). The Go side documents the names an operator may write; the TS
+// side is what substitutes them. A name added to one and not the other
+// renders literally on screen with no failure anywhere, so — like
+// TestAppTokensCSSInSyncWithFrontend — both files are read off disk and
+// compared to each other.
+func TestChromePlaceholdersInSyncWithFrontend(t *testing.T) {
+	t.Parallel()
+	src, err := os.ReadFile(filepath.Join("..", "..", "frontend", "src", "utils", "worldText.ts"))
+	if err != nil {
+		t.Fatalf("read worldText.ts: %v", err)
+	}
+	m := regexp.MustCompile(`const KEYS[^=]*=\s*\[([^\]]*)\]`).FindSubmatch(src)
+	if m == nil {
+		t.Fatalf("worldText.ts no longer declares `const KEYS = [...]`; update this test with it")
+	}
+	var ts []string
+	for k := range strings.SplitSeq(string(m[1]), ",") {
+		if k = strings.Trim(strings.TrimSpace(k), `'"`); k != "" {
+			ts = append(ts, k)
+		}
+	}
+	if got, want := strings.Join(ts, ","), strings.Join(metamodel.ChromePlaceholders, ","); got != want {
+		t.Errorf("placeholder allowlists differ: worldText.ts KEYS = [%s], metamodel.ChromePlaceholders = [%s]",
+			got, want)
+	}
+}

--- a/internal/dataentry/schemamessages_test.go
+++ b/internal/dataentry/schemamessages_test.go
@@ -1,0 +1,74 @@
+package dataentry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+)
+
+// The operator's chrome text rides the schema and the copy offers verbatim,
+// and an undeclared block is OMITTED rather than sent empty (TKT-5SZG2L). A
+// client renders nothing for absence and emptiness alike, so the wire carries
+// only what an operator wrote.
+func TestSchemaWorlds_CarriesOperatorMessages(t *testing.T) {
+	meta := worldsMeta()
+	site := meta.Worlds["site-nl"]
+	site.Messages = metamodel.WorldMessages{Absent: "Nog niet vertaald", StandIn: "{face}"}
+	site.OnAbsent = metamodel.WorldOnAbsent{Redirect: "default"}
+	meta.Worlds["site-nl"] = site
+
+	got := schemaWorlds(context.Background(), meta)
+
+	nl := got["site-nl"]
+	if nl.Messages == nil || nl.Messages.Absent != "Nog niet vertaald" || nl.Messages.StandIn != "{face}" {
+		t.Errorf("site-nl messages = %+v, want the declared text verbatim", nl.Messages)
+	}
+	if nl.Messages != nil && nl.Messages.Projection != "" {
+		t.Errorf("an undeclared entry stays empty; got %q", nl.Messages.Projection)
+	}
+	if nl.OnAbsent == nil || nl.OnAbsent.Redirect != "default" {
+		t.Errorf("site-nl on_absent = %+v, want redirect: default", nl.OnAbsent)
+	}
+	if pub := got["published"]; pub.Messages != nil || pub.OnAbsent != nil {
+		t.Errorf("a world with nothing declared omits both blocks; got %+v / %+v", pub.Messages, pub.OnAbsent)
+	}
+}
+
+func TestSchemaFaces_CarriesOperatorMessages(t *testing.T) {
+	meta := worldsMeta()
+	def := meta.Entities["policy"]
+	def.Faces["published"] = metamodel.FaceDef{Messages: metamodel.FaceMessages{ReadOnly: "Alleen lezen"}}
+
+	got := schemaFaceDefs(def)
+	if got["published"].Messages == nil || got["published"].Messages.ReadOnly != "Alleen lezen" {
+		t.Errorf("published face messages = %+v, want read_only verbatim", got["published"].Messages)
+	}
+	if got["draft"].Messages != nil {
+		t.Errorf("a face with nothing declared omits the block; got %+v", got["draft"].Messages)
+	}
+}
+
+func TestCopyOnSuccessWire(t *testing.T) {
+	t.Parallel()
+	if got := copyOnSuccessWire(metamodel.CopyOnSuccess{}); got != nil {
+		t.Errorf("nothing declared must be omitted; got %+v", got)
+	}
+	for _, tc := range []struct {
+		name string
+		in   metamodel.CopyLanding
+		mode string
+	}{
+		{"message only lands on the face written", metamodel.CopyLanding{}, "written"},
+		{"stay", metamodel.CopyLanding{Mode: "stay"}, "stay"},
+		{"world", metamodel.CopyLanding{World: "actueel"}, "world"},
+		{"face", metamodel.CopyLanding{Face: "concept"}, "face"},
+	} {
+		got := copyOnSuccessWire(metamodel.CopyOnSuccess{Message: "Vastgesteld.", Landing: tc.in})
+		if got == nil || got.Message != "Vastgesteld." || got.Landing.Mode != tc.mode ||
+			got.Landing.World != tc.in.World || got.Landing.Face != tc.in.Face {
+
+			t.Errorf("%s: got %+v", tc.name, got)
+		}
+	}
+}

--- a/internal/dataentry/schemaworlds.go
+++ b/internal/dataentry/schemaworlds.go
@@ -105,6 +105,8 @@ func schemaWorlds(ctx context.Context, meta *metamodel.Metamodel) map[string]v1.
 			// shared by every assembled Services.
 			PrimaryFor: append([]string(nil), def.PrimaryFor...),
 			Banner:     def.Banner,
+			Messages:   worldMessagesWire(def.Messages),
+			OnAbsent:   worldOnAbsentWire(def.OnAbsent),
 			Readable:   readable,
 		}
 	}
@@ -144,7 +146,33 @@ func schemaFaceDefs(def metamodel.EntityDef) map[string]v1.FaceDef {
 	}
 	out := make(map[string]v1.FaceDef, len(def.Faces))
 	for name, p := range def.Faces {
-		out[name] = v1.FaceDef{Label: p.Label}
+		out[name] = v1.FaceDef{Label: p.Label, Messages: faceMessagesWire(p.Messages)}
 	}
 	return out
+}
+
+// The operator's chrome text and behavior, projected verbatim. Each projector
+// returns nil for an undeclared block so the key is omitted, not sent empty —
+// a client treats absence and emptiness alike (render nothing), so the wire
+// need not carry a block that says nothing.
+
+func worldMessagesWire(m metamodel.WorldMessages) *v1.WorldMessages {
+	if m == (metamodel.WorldMessages{}) {
+		return nil
+	}
+	return &v1.WorldMessages{Absent: m.Absent, Projection: m.Projection, StandIn: m.StandIn}
+}
+
+func worldOnAbsentWire(o metamodel.WorldOnAbsent) *v1.WorldOnAbsent {
+	if o.Redirect == "" {
+		return nil
+	}
+	return &v1.WorldOnAbsent{Redirect: o.Redirect}
+}
+
+func faceMessagesWire(m metamodel.FaceMessages) *v1.FaceMessages {
+	if m == (metamodel.FaceMessages{}) {
+		return nil
+	}
+	return &v1.FaceMessages{ReadOnly: m.ReadOnly}
 }

--- a/internal/dataentry/viewworld.go
+++ b/internal/dataentry/viewworld.go
@@ -434,10 +434,9 @@ func (h *viewsHandler) writeWorldAbsentView(
 	m := h.schema().Meta
 	def := m.Entities[e.Type]
 	resp := v1.ViewResponse{
-		Entry:           h.serializer.forWire(ctx, e, rels, m, def.GetPlural(e.Type)),
-		Sections:        []v1.ViewSection{},
-		WorldAbsent:     true,
-		WorldAbsentName: worldFromContext(ctx).name,
+		Entry:       h.serializer.forWire(ctx, e, rels, m, def.GetPlural(e.Type)),
+		Sections:    []v1.ViewSection{},
+		WorldAbsent: true,
 	}
 	writeV1JSON(w, http.StatusOK, resp)
 }

--- a/internal/entitymanager/copylist.go
+++ b/internal/entitymanager/copylist.go
@@ -49,6 +49,10 @@ type CopyOffer struct {
 	// Allowed is true. Advisory: it explains a denial the server already made,
 	// and never carries content from an entity the caller cannot read.
 	Reason string
+	// OnSuccess is the definition's operator-declared follow-through (toast
+	// text and landing), passed through as declared. Display and navigation
+	// only; the kernel never consults it.
+	OnSuccess metamodel.CopyOnSuccess
 }
 
 // CopiesForSource lists the copy definitions whose `from:` addresses the face
@@ -133,6 +137,7 @@ func CopiesForSource(
 			Name:       name,
 			Label:      copyOfferLabel(name, def),
 			TargetFace: def.To,
+			OnSuccess:  def.OnSuccess,
 		}
 		offer.Allowed, offer.Reason = copyInvocable(ctx, m, name, def, sourceID)
 		out = append(out, offer)

--- a/internal/metamodel/copies.go
+++ b/internal/metamodel/copies.go
@@ -166,7 +166,48 @@ func validateCopy(m *Metamodel, name string, def CopyDef) []string {
 
 	errs = append(errs, validateCopyFields(m, name, def, to)...)
 	errs = append(errs, validateCopyRelations(m, name, def, to)...)
+	errs = append(errs, validateCopyLanding(m, name, def, to)...)
 	return errs
+}
+
+// validateCopyLanding checks `on_success.landing`: a scalar must be `written`
+// or `stay`; a world must be declared (or `default`); a face must be one the
+// TARGET type declares, since the page lands on the entity the copy wrote.
+// Naming both a world and a face is refused rather than resolved by a
+// precedence rule nobody would remember.
+func validateCopyLanding(m *Metamodel, name string, def CopyDef, to CopyTarget) []string {
+	l := def.OnSuccess.Landing
+	if l.IsZero() {
+		return nil
+	}
+	bad := func(format string, args ...any) []string {
+		return []string{fmt.Sprintf("copy %q: `on_success.landing` "+format, append([]any{name}, args...)...)}
+	}
+	if l.Mode != "" {
+		if l.Mode != LandingWritten && l.Mode != LandingStay {
+			return bad("must be %q, %q, `{world: <name>}` or `{face: <name>}` (got %q)",
+				LandingWritten, LandingStay, l.Mode)
+		}
+		return nil
+	}
+	if l.World != "" && l.Face != "" {
+		return bad("names both a world and a face — pick one")
+	}
+	if l.World != "" && l.World != DefaultWorldName {
+		if _, ok := m.Worlds[l.World]; !ok {
+			return bad("names world %q, which is not declared", l.World)
+		}
+	}
+	if l.Face != "" {
+		def, ok := m.Entities[to.Type]
+		if !ok {
+			return nil // the endpoint check already reported the type
+		}
+		if _, declared := def.Faces[l.Face]; !declared {
+			return bad("names face %q, which type %q does not declare", l.Face, to.Type)
+		}
+	}
+	return nil
 }
 
 // validateCopyEndpoint checks that a target names a declared type and, when

--- a/internal/metamodel/copies_test.go
+++ b/internal/metamodel/copies_test.go
@@ -243,3 +243,50 @@ func TestCopyDef_IsSameEntity(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateCopies_Landing pins `on_success.landing` (TKT-5SZG2L): the two
+// scalars, a declared world, a face the TARGET type declares — and the
+// refusals for anything else, at load rather than as a dead navigation.
+func TestValidateCopies_Landing(t *testing.T) {
+	t.Parallel()
+	base := func(landing CopyLanding) map[string]CopyDef {
+		return map[string]CopyDef{"publish": {
+			From: "page@draft", To: "page@published", AllFields: true,
+			Guard:     CopyGuard{Permission: "publish"},
+			OnSuccess: CopyOnSuccess{Landing: landing},
+		}}
+	}
+	for _, tc := range []struct {
+		name    string
+		landing CopyLanding
+		wantErr string
+	}{
+		{"undeclared means written", CopyLanding{}, ""},
+		{"written", CopyLanding{Mode: LandingWritten}, ""},
+		{"stay", CopyLanding{Mode: LandingStay}, ""},
+		{"a declared world", CopyLanding{World: "site"}, ""},
+		{"the default world", CopyLanding{World: "default"}, ""},
+		{"a face the target type declares", CopyLanding{Face: "draft"}, ""},
+		{"an unknown scalar", CopyLanding{Mode: "elsewhere"}, `must be "written", "stay"`},
+		{"an undeclared world", CopyLanding{World: "nope"}, `names world "nope"`},
+		{"a face the target type lacks", CopyLanding{Face: "nl"}, `names face "nl"`},
+		{"both a world and a face", CopyLanding{World: "site", Face: "draft"}, "pick one"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := copyFixture(base(tc.landing))
+			m.Worlds = map[string]WorldDef{"site": {Select: []string{"published"}, Otherwise: OtherwiseDefault}}
+			errs := validateCopies(m)
+			joined := strings.Join(errs, "\n")
+			if tc.wantErr == "" {
+				if len(errs) != 0 {
+					t.Fatalf("unexpected errors: %s", joined)
+				}
+				return
+			}
+			if !strings.Contains(joined, tc.wantErr) {
+				t.Fatalf("want an error containing %q, got %q", tc.wantErr, joined)
+			}
+		})
+	}
+}

--- a/internal/metamodel/copydef_unmarshal_test.go
+++ b/internal/metamodel/copydef_unmarshal_test.go
@@ -65,6 +65,13 @@ copies:
       mentions: merge
     guard:
       permission: promote-page
+    on_success:
+      message: "Published {title}"
+      landing: { world: everything }
+worlds:
+  everything:
+    select: published
+    otherwise: default
 `
 	m, err := Parse([]byte(doc))
 	if err != nil {
@@ -88,6 +95,8 @@ copies:
 		// without evaluating the condition you wrote"), so a document setting
 		// it cannot parse. Permission alone proves the Guard struct arrives.
 		"Guard": def.Guard.Permission == "promote-page",
+		"OnSuccess": def.OnSuccess.Message == "Published {title}" &&
+			def.OnSuccess.Landing.World == "everything",
 	}
 	for name, ok := range checks {
 		if !ok {
@@ -179,6 +188,12 @@ worlds:
     edits: draft
     banner: "DRAFT — not in force"
     primary_for: published
+    messages:
+      absent: "Not here yet"
+      projection: "Only what is in force"
+      stand_in: "{face}"
+    on_absent:
+      redirect: default
 `
 	m, err := Parse([]byte(doc))
 	if err != nil {
@@ -199,6 +214,10 @@ worlds:
 		// spelling: `primary_for: published` must decode to a one-element
 		// slice, not be dropped for not being a list.
 		"PrimaryFor": len(def.PrimaryFor) == 1 && def.PrimaryFor[0] == "published",
+		"Messages": def.Messages.Absent == "Not here yet" &&
+			def.Messages.Projection == "Only what is in force" &&
+			def.Messages.StandIn == "{face}",
+		"OnAbsent": def.OnAbsent.Redirect == "default",
 	}
 	for name, ok := range checks {
 		if !ok {
@@ -245,7 +264,7 @@ entities:
     bare_face: en
     faces:
       en: {label: English}
-      nl: {label: Nederlands}
+      nl: {label: Nederlands, messages: {read_only: "Alleen lezen"}}
     properties:
       title: {type: string}
 `
@@ -265,6 +284,7 @@ entities:
 	checks := map[string]bool{
 		"EntityDef.BareFace": def.BareFace == "en",
 		"Label":              def.Faces["en"].Label == "English" && def.Faces["nl"].Label == "Nederlands",
+		"Messages":           def.Faces["nl"].Messages.ReadOnly == "Alleen lezen" && def.Faces["en"].Messages.ReadOnly == "",
 	}
 	for name, ok := range checks {
 		if !ok {

--- a/internal/metamodel/copydef_unmarshal_test.go
+++ b/internal/metamodel/copydef_unmarshal_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestCopyDef_UnmarshalCoversEveryField is the guard [CopyDef.UnmarshalYAML]'s
@@ -360,5 +362,50 @@ entities:
 	}
 	if got := FaceLabel(nil, "page", ""); got != "" {
 		t.Errorf("FaceLabel(nil, page, \"\") = %q, want empty", got)
+	}
+}
+
+// TestCopyLanding_UnmarshalRefusesWhatItCannotMean pins the mapping form of
+// `landing:` (TKT-5SZG2L, RR-51XOG3): a key it does not know, an empty
+// mapping and an empty name are load errors. Decoded into a struct they
+// would all come out as the zero value, which MEANS `written` — the
+// operator's declaration discarded without a word, which is the failure
+// BUG-I0N3YR closed for affordance grants.
+func TestCopyLanding_UnmarshalRefusesWhatItCannotMean(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, yaml string
+		want       CopyLanding
+		wantErr    string
+	}{
+		{"scalar written", "written", CopyLanding{Mode: LandingWritten}, ""},
+		{"scalar stay", "stay", CopyLanding{Mode: LandingStay}, ""},
+		{"a world", "{world: site}", CopyLanding{World: "site"}, ""},
+		{"a face", "{face: draft}", CopyLanding{Face: "draft"}, ""},
+		{"a typo'd key", "{wrold: site}", CopyLanding{}, `unknown key "wrold"`},
+		{"an empty mapping", "{}", CopyLanding{}, "empty mapping"},
+		{"an empty world", `{world: ""}`, CopyLanding{}, "`world` needs a name"},
+		{"a nested value", "{face: [a, b]}", CopyLanding{}, "`face` needs a name"},
+		{"a sequence", "[written]", CopyLanding{}, "want `written`, `stay`"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got struct {
+				Landing CopyLanding `yaml:"landing"`
+			}
+			err := yaml.Unmarshal([]byte("landing: "+tc.yaml), &got)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("want an error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Landing != tc.want {
+				t.Fatalf("got %+v, want %+v", got.Landing, tc.want)
+			}
+		})
 	}
 }

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -793,17 +793,16 @@ func validateWorlds(m *Metamodel) []string {
 
 // validateWorldOnAbsent checks that `on_absent.redirect` names a world a
 // reader can be sent to: a declared one, or the implicit default. A redirect
-// to this same world would loop; a redirect to an undeclared name would be a
-// 400 on arrival — both are load errors, not runtime surprises.
+// to an undeclared name would be a 400 on arrival, and a redirect chain that
+// returns to a world it has already visited would bounce the browser between
+// them for an entity absent from all of them — both are load errors, not
+// runtime surprises. The chain is walked from this world, so `a → b → a`
+// is reported on both `a` and `b`, naming the loop; `default` never
+// redirects, so it ends every chain.
 func validateWorldOnAbsent(m *Metamodel, worldName string, world WorldDef) []string {
 	target := world.OnAbsent.Redirect
 	if target == "" {
 		return nil
-	}
-	if target == worldName {
-		return []string{fmt.Sprintf(
-			"world %q: `on_absent.redirect` names this world itself, which would redirect forever",
-			worldName)}
 	}
 	if target != DefaultWorldName {
 		if _, ok := m.Worlds[target]; !ok {
@@ -811,6 +810,17 @@ func validateWorldOnAbsent(m *Metamodel, worldName string, world WorldDef) []str
 				"world %q: `on_absent.redirect` names world %q, which is not declared (declare it, or use %q)",
 				worldName, target, DefaultWorldName)}
 		}
+	}
+	chain := []string{worldName}
+	seen := map[string]bool{worldName: true}
+	for next := target; next != "" && next != DefaultWorldName; next = m.Worlds[next].OnAbsent.Redirect {
+		chain = append(chain, next)
+		if seen[next] {
+			return []string{fmt.Sprintf(
+				"world %q: `on_absent.redirect` loops (%s), which would redirect forever",
+				worldName, strings.Join(chain, " → "))}
+		}
+		seen[next] = true
 	}
 	return nil
 }

--- a/internal/metamodel/loader.go
+++ b/internal/metamodel/loader.go
@@ -785,9 +785,34 @@ func validateWorlds(m *Metamodel) []string {
 		errs = append(errs, validateWorldChains(m, worldName, world)...)
 		errs = append(errs, validateWorldEdits(m, worldName, world)...)
 		errs = append(errs, validateWorldPrimaryFor(m, worldName, world)...)
+		errs = append(errs, validateWorldOnAbsent(m, worldName, world)...)
 	}
 	errs = append(errs, validateFacePrimacy(m)...)
 	return errs
+}
+
+// validateWorldOnAbsent checks that `on_absent.redirect` names a world a
+// reader can be sent to: a declared one, or the implicit default. A redirect
+// to this same world would loop; a redirect to an undeclared name would be a
+// 400 on arrival — both are load errors, not runtime surprises.
+func validateWorldOnAbsent(m *Metamodel, worldName string, world WorldDef) []string {
+	target := world.OnAbsent.Redirect
+	if target == "" {
+		return nil
+	}
+	if target == worldName {
+		return []string{fmt.Sprintf(
+			"world %q: `on_absent.redirect` names this world itself, which would redirect forever",
+			worldName)}
+	}
+	if target != DefaultWorldName {
+		if _, ok := m.Worlds[target]; !ok {
+			return []string{fmt.Sprintf(
+				"world %q: `on_absent.redirect` names world %q, which is not declared (declare it, or use %q)",
+				worldName, target, DefaultWorldName)}
+		}
+	}
+	return nil
 }
 
 // validateWorldPrimaryFor checks that every face a world claims in

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -369,6 +369,24 @@ type FaceDef struct {
 	// per-face label is forward-compatible with an axis that later groups
 	// them, where a `return_action_label:` on a face would not be.
 	Label string `yaml:"label,omitempty"`
+
+	// Messages is the operator's wording for the web app's chrome about THIS
+	// face. Every entry is optional and an absent one renders NOTHING: rela
+	// has no fallback sentence, because any it wrote would be its storage
+	// vocabulary ("face", "bare", "default") shown to a reader who never
+	// chose those words (TKT-5SZG2L).
+	Messages FaceMessages `yaml:"messages,omitempty"`
+}
+
+// FaceMessages is operator-authored chrome text about one face. See
+// [WorldMessages] for the placeholder grammar; every entry is plain text.
+type FaceMessages struct {
+	// ReadOnly is shown on a detail page or edit form that reached this face
+	// while the reader may not write it — "Dit is de vastgestelde versie.
+	// Bewerken doe je in het concept." Empty shows nothing: a face the
+	// reader may not write then looks like any other permission denial, a
+	// page without an Edit button.
+	ReadOnly string `yaml:"read_only,omitempty"`
 }
 
 // Otherwise is a world's policy for an entity whose type declares
@@ -487,6 +505,51 @@ type WorldDef struct {
 	// across the whole graph). The same face can be reached from worlds
 	// that warrant different text, or none.
 	Banner string `yaml:"banner,omitempty"`
+
+	// Messages is the operator's wording for what this world changes on a
+	// screen. Every entry is optional and an absent one renders NOTHING — the
+	// web app has no sentence of its own for any of these, because every one
+	// it used to have was rela's storage vocabulary shown to a reader
+	// (TKT-5SZG2L).
+	Messages WorldMessages `yaml:"messages,omitempty"`
+
+	// OnAbsent decides what happens when a reader opens an entity that has
+	// no face in this world. Absent: the page shows the bare face, with
+	// [WorldMessages.Absent] if declared. See [WorldOnAbsent].
+	OnAbsent WorldOnAbsent `yaml:"on_absent,omitempty"`
+}
+
+// WorldMessages is operator-authored chrome text about one world.
+//
+// Each string is plain text with an allowlisted set of placeholders the web
+// app substitutes: `{face}` (the served face's label), `{bare_face}` (the
+// type's bare face label), `{world}` (this world's name), `{title}` (the
+// entity's display title). Anything else in braces is left as written. No
+// markup, no conditionals — the text is the operator's sentence, and
+// rendering it is the whole feature.
+type WorldMessages struct {
+	// Absent is shown on a detail page for an entity that has no face in
+	// this world (the page shows the bare face). Empty shows nothing.
+	Absent string `yaml:"absent,omitempty"`
+	// Projection is the note on a list or board of a type that declares
+	// faces — that entities with no face here are not listed. Empty shows
+	// nothing.
+	Projection string `yaml:"projection,omitempty"`
+	// StandIn is the badge text on a row or card whose face is a stand-in
+	// for the world's first choice (a within-chain fallback or an
+	// `otherwise: default` substitution) — typically `{face}`. Empty renders
+	// no badge at all.
+	StandIn string `yaml:"stand_in,omitempty"`
+}
+
+// WorldOnAbsent is the behavior for an entity with no face in a world.
+type WorldOnAbsent struct {
+	// Redirect names a declared world (or `default`) the web app navigates
+	// to instead of rendering the absent page: an ISMS whose adopted world
+	// has no adopted version of a policy yet sends the reader to the
+	// concept rather than to a page explaining that there is nothing here.
+	// Validated at load; empty means no redirect.
+	Redirect string `yaml:"redirect,omitempty"`
 }
 
 // DefaultWorldName is reserved: the default world is implicit and total,
@@ -510,7 +573,9 @@ func (w *WorldDef) UnmarshalYAML(node *yaml.Node) error {
 		Banner    string               `yaml:"banner,omitempty"`
 		// oneOrMany like Select: the common case is a single face, and
 		// `primary_for: nl` should not have to be written as a list.
-		PrimaryFor oneOrMany `yaml:"primary_for,omitempty"`
+		PrimaryFor oneOrMany     `yaml:"primary_for,omitempty"`
+		Messages   WorldMessages `yaml:"messages,omitempty"`
+		OnAbsent   WorldOnAbsent `yaml:"on_absent,omitempty"`
 	}
 	var raw worldDefYAML
 	if err := node.Decode(&raw); err != nil {
@@ -521,6 +586,8 @@ func (w *WorldDef) UnmarshalYAML(node *yaml.Node) error {
 	w.Edits = raw.Edits
 	w.Banner = raw.Banner
 	w.PrimaryFor = raw.PrimaryFor
+	w.Messages = raw.Messages
+	w.OnAbsent = raw.OnAbsent
 	if len(raw.Overrides) > 0 {
 		w.Overrides = make(map[string][]string, len(raw.Overrides))
 		for typ, chain := range raw.Overrides {
@@ -786,6 +853,69 @@ type CopyDef struct {
 	// which is the delegate-X gate on role-relation writes and is checked
 	// globally. "The owner of THIS doc may publish it" needs the former.
 	Guard CopyGuard `yaml:"guard,omitempty"`
+
+	// OnSuccess is what the web app says and where it goes after this copy
+	// runs. Both optional; see [CopyOnSuccess].
+	OnSuccess CopyOnSuccess `yaml:"on_success,omitempty"`
+}
+
+// CopyOnSuccess is the operator's follow-through for a successful copy
+// (TKT-5SZG2L).
+type CopyOnSuccess struct {
+	// Message is the confirmation toast. Empty means the copy's own label
+	// (the button the reader just pressed) — never rela's "Created the X
+	// face". Placeholders as in [WorldMessages], plus `{face}` naming the
+	// face written.
+	Message string `yaml:"message,omitempty"`
+	// Landing is where the web app navigates afterwards. See [CopyLanding];
+	// the zero value is [LandingWritten].
+	Landing CopyLanding `yaml:"landing,omitempty"`
+}
+
+// CopyLanding is where the web app lands after a copy: `written` (the face
+// the copy wrote — the default, since an editor who adopts a policy usually
+// wants to see the adopted text), `stay` (reload in place — a translator
+// wants to stay on the source), or a declared world or face:
+//
+//	landing: stay
+//	landing: { world: actueel }
+//	landing: { face: vastgesteld }
+//
+// Exactly one of the fields is set; [CopyLanding.UnmarshalYAML] accepts the
+// scalar and the mapping forms. The zero value means `written`.
+type CopyLanding struct {
+	// Mode is LandingWritten or LandingStay when a scalar was given.
+	Mode  string `yaml:"-"`
+	World string `yaml:"world,omitempty"`
+	Face  string `yaml:"face,omitempty"`
+}
+
+// The scalar landing modes.
+const (
+	LandingWritten = "written"
+	LandingStay    = "stay"
+)
+
+// IsZero reports whether no landing was declared (which means `written`).
+func (l CopyLanding) IsZero() bool { return l.Mode == "" && l.World == "" && l.Face == "" }
+
+// UnmarshalYAML accepts `landing: stay`, `landing: written`,
+// `landing: {world: name}` and `landing: {face: name}`.
+func (l *CopyLanding) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		l.Mode = node.Value
+		return nil
+	}
+	type landingYAML struct {
+		World string `yaml:"world,omitempty"`
+		Face  string `yaml:"face,omitempty"`
+	}
+	var raw landingYAML
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	l.World, l.Face = raw.World, raw.Face
+	return nil
 }
 
 // CopyGuard is a copy definition's authorization, sharing the statemachine's
@@ -819,12 +949,14 @@ func (c *CopyDef) UnmarshalYAML(unmarshal func(any) error) error {
 		Fields    any               `yaml:"fields,omitempty"`
 		Relations map[string]string `yaml:"relations,omitempty"`
 		Guard     CopyGuard         `yaml:"guard,omitempty"`
+		OnSuccess CopyOnSuccess     `yaml:"on_success,omitempty"`
 	}
 	var r raw
 	if err := unmarshal(&r); err != nil {
 		return err
 	}
 	c.From, c.To, c.Label, c.Relations, c.Guard = r.From, r.To, r.Label, r.Relations, r.Guard
+	c.OnSuccess = r.OnSuccess
 	switch f := r.Fields.(type) {
 	case nil:
 	case string:

--- a/internal/metamodel/types.go
+++ b/internal/metamodel/types.go
@@ -385,7 +385,8 @@ type FaceMessages struct {
 	// while the reader may not write it — "Dit is de vastgestelde versie.
 	// Bewerken doe je in het concept." Empty shows nothing: a face the
 	// reader may not write then looks like any other permission denial, a
-	// page without an Edit button.
+	// page without an Edit button. Substitutes every placeholder: `{face}`
+	// is this face's label, `{title}` the entity's display title.
 	ReadOnly string `yaml:"read_only,omitempty"`
 }
 
@@ -522,25 +523,40 @@ type WorldDef struct {
 // WorldMessages is operator-authored chrome text about one world.
 //
 // Each string is plain text with an allowlisted set of placeholders the web
-// app substitutes: `{face}` (the served face's label), `{bare_face}` (the
-// type's bare face label), `{world}` (this world's name), `{title}` (the
-// entity's display title). Anything else in braces is left as written. No
-// markup, no conditionals — the text is the operator's sentence, and
-// rendering it is the whole feature.
+// app substitutes — [ChromePlaceholders]: `{face}` (the served face's
+// label), `{bare_face}` (the type's bare face label), `{world}` (this
+// world's name), `{title}` (the entity's display title). Anything else in
+// braces is left as written. No markup, no conditionals — the text is the
+// operator's sentence, and rendering it is the whole feature.
+//
+// Not every surface has every value. A list or board has no single entity,
+// so `{face}` and `{title}` are left as written in Projection; a row's badge
+// has no title, so `{title}` is left as written in StandIn. Each field says
+// which it substitutes.
 type WorldMessages struct {
 	// Absent is shown on a detail page for an entity that has no face in
 	// this world (the page shows the bare face). Empty shows nothing.
+	// Substitutes `{face}` (the bare face, which is what is on screen),
+	// `{bare_face}`, `{world}` and `{title}`.
 	Absent string `yaml:"absent,omitempty"`
 	// Projection is the note on a list or board of a type that declares
 	// faces — that entities with no face here are not listed. Empty shows
-	// nothing.
+	// nothing. Substitutes `{world}` only.
 	Projection string `yaml:"projection,omitempty"`
 	// StandIn is the badge text on a row or card whose face is a stand-in
 	// for the world's first choice (a within-chain fallback or an
 	// `otherwise: default` substitution) — typically `{face}`. Empty renders
-	// no badge at all.
+	// no badge at all. Substitutes `{face}`, `{bare_face}` and `{world}`.
 	StandIn string `yaml:"stand_in,omitempty"`
 }
+
+// ChromePlaceholders is the allowlist of `{placeholder}` names the web app
+// substitutes in [WorldMessages] and [FaceMessages] text, and in a copy's
+// `on_success.message`. The SPA holds the same list in
+// frontend/src/utils/worldText.ts; a test in internal/dataentry pins the two
+// to each other, because a name added on one side only renders literally on
+// screen with no failure anywhere.
+var ChromePlaceholders = []string{"face", "bare_face", "world", "title"}
 
 // WorldOnAbsent is the behavior for an entity with no face in a world.
 type WorldOnAbsent struct {
@@ -901,20 +917,40 @@ func (l CopyLanding) IsZero() bool { return l.Mode == "" && l.World == "" && l.F
 
 // UnmarshalYAML accepts `landing: stay`, `landing: written`,
 // `landing: {world: name}` and `landing: {face: name}`.
+//
+// The mapping form is decoded by walking its keys rather than into a struct,
+// because a struct decode drops what it does not recognize: `{wrold: x}` or
+// `{}` would come out as the zero value, which MEANS `written`, and the
+// operator's declaration would be discarded without a word — the failure
+// class BUG-I0N3YR closed for affordance grants. An unknown key, an empty
+// mapping and an empty value are all refused here, at load.
 func (l *CopyLanding) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind == yaml.ScalarNode {
+	const want = "want `written`, `stay`, `{world: <name>}` or `{face: <name>}`"
+	switch node.Kind {
+	case yaml.ScalarNode:
 		l.Mode = node.Value
 		return nil
+	case yaml.MappingNode:
+	default:
+		return fmt.Errorf("landing: %s", want)
 	}
-	type landingYAML struct {
-		World string `yaml:"world,omitempty"`
-		Face  string `yaml:"face,omitempty"`
+	if len(node.Content) == 0 {
+		return fmt.Errorf("landing: empty mapping; %s", want)
 	}
-	var raw landingYAML
-	if err := node.Decode(&raw); err != nil {
-		return err
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key, val := node.Content[i], node.Content[i+1]
+		if val.Kind != yaml.ScalarNode || val.Value == "" {
+			return fmt.Errorf("landing: `%s` needs a name", key.Value)
+		}
+		switch key.Value {
+		case "world":
+			l.World = val.Value
+		case "face":
+			l.Face = val.Value
+		default:
+			return fmt.Errorf("landing: unknown key %q; %s", key.Value, want)
+		}
 	}
-	l.World, l.Face = raw.World, raw.Face
 	return nil
 }
 

--- a/internal/metamodel/worlds_test.go
+++ b/internal/metamodel/worlds_test.go
@@ -355,3 +355,42 @@ func TestOtherwise_IsValid(t *testing.T) {
 		}
 	}
 }
+
+// TestWorlds_OnAbsentRedirectValidated: a redirect target is a declared world
+// or the implicit default, never this world itself and never a name that
+// would 400 on arrival (TKT-5SZG2L).
+func TestWorlds_OnAbsentRedirectValidated(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, target string
+		wantErr      string
+	}{
+		{"default is always a valid target", "default", ""},
+		{"a declared world is a valid target", "editorial", ""},
+		{"self loops", "published", "redirect forever"},
+		{"undeclared world", "nope", `names world "nope", which is not declared`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parse([]byte(worldsSchema(`worlds:
+  editorial:
+    select: draft
+    otherwise: default
+  published:
+    select: published
+    otherwise: exclude
+    on_absent:
+      redirect: ` + tc.target + `
+`)))
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected load error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want load error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/metamodel/worlds_test.go
+++ b/internal/metamodel/worlds_test.go
@@ -357,8 +357,9 @@ func TestOtherwise_IsValid(t *testing.T) {
 }
 
 // TestWorlds_OnAbsentRedirectValidated: a redirect target is a declared world
-// or the implicit default, never this world itself and never a name that
-// would 400 on arrival (TKT-5SZG2L).
+// or the implicit default, never a name that would 400 on arrival, and never
+// a chain that returns to a world it has visited — the self-loop and the
+// two-world round trip alike (TKT-5SZG2L, RR-5TDYWW).
 func TestWorlds_OnAbsentRedirectValidated(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -367,7 +368,9 @@ func TestWorlds_OnAbsentRedirectValidated(t *testing.T) {
 	}{
 		{"default is always a valid target", "default", ""},
 		{"a declared world is a valid target", "editorial", ""},
-		{"self loops", "published", "redirect forever"},
+		{"self loops", "published", "published → published), which would redirect forever"},
+		{"a two-world cycle loops", "roundtrip", "published → roundtrip → published), which would redirect forever"},
+		{"a chain that ends in a declared world is fine", "editorial", ""},
 		{"undeclared world", "nope", `names world "nope", which is not declared`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -376,9 +379,15 @@ func TestWorlds_OnAbsentRedirectValidated(t *testing.T) {
   editorial:
     select: draft
     otherwise: default
+  roundtrip:
+    select: published
+    otherwise: exclude
+    on_absent:
+      redirect: published
   published:
     select: published
     otherwise: exclude
+    primary_for: published
     on_absent:
       redirect: ` + tc.target + `
 `)))

--- a/tickets/entities/docs-checklists/DOCS-NT4GX0.md
+++ b/tickets/entities/docs-checklists/DOCS-NT4GX0.md
@@ -1,0 +1,24 @@
+---
+id: DOCS-NT4GX0
+type: docs-checklist
+title: 'Documentation: operator world chrome messages (TKT-5SZG2L)'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious
+- [x] Function/type docs if public API
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no project-level change)
+- [x] ~~CLAUDE.md updated~~ (N/A: the rule "the words are the operator's or there are none" is recorded on the wire and metamodel types and in the guides)
+- [x] ~~Help text accurate~~ (N/A: no CLI changes)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: the repo keeps no changelog; the PR description carries it)
+- [x] API docs updated: metamodel reference (faces `messages.read_only`, worlds `messages`/`on_absent`, copies `on_success`, both load-check lists), content-states guide (Step 1 faces, Step 2 table, Step 5 table, Step 6 behaviour), data-entry guide (world-bound page, schema discovery); `docs/*.md` regenerated with `just docs`.

--- a/tickets/entities/implementation-checklists/IMPL-3FJKAN.md
+++ b/tickets/entities/implementation-checklists/IMPL-3FJKAN.md
@@ -1,0 +1,57 @@
+---
+id: IMPL-3FJKAN
+type: implementation-checklist
+title: 'Implementation: World chrome speaks the operator''s words or stays silent: messages, on_absent redirect, copy on_success'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
+
+**Verification Evidence:** metamodel: field-coverage tests extended for
+`WorldDef.Messages/OnAbsent`, `FaceDef.Messages`, `CopyDef.OnSuccess`;
+`TestWorlds_OnAbsentRedirectValidated` and `TestValidateCopies_Landing` pin the
+load errors. dataentry: `schemamessages_test.go` pins the wire projection
+(omitted when undeclared). SPA: `worldText` unit tests; WorldBadge, EntityList,
+KanbanView, RelationPicker and EntityDetail world suites rewritten to "silence
+unless declared", plus `on_absent.redirect` and every `landing` mode. Chrome
+walk on the atlas verify project with Dutch messages declared: POLICY-001 shows
+"Dit is de vastgestelde versie. Bewerken doe je in het concept." and nothing
+else; the Beleid list shows the projection note and a "Concept" badge on the
+stand-in row; the Taken list shows no banner; the form refusal carries the same
+Dutch sentence and only "Back to entity"; Vaststellen toasts "Thuiswerkbeleid is
+vastgesteld." and lands on the adopted face. The atlas verify manual passes with
+the extended fixture (19 claims). Go suite, 2361 SPA tests, golangci-lint,
+comment-lint, arch-lint, plimsoll all green.
+
+## Quality
+
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind

--- a/tickets/entities/planning-checklists/PLAN-CX1Z2E.md
+++ b/tickets/entities/planning-checklists/PLAN-CX1Z2E.md
@@ -1,0 +1,137 @@
+---
+id: PLAN-CX1Z2E
+type: planning-checklist
+title: 'Planning: World chrome speaks the operator''s words or stays silent: messages, on_absent redirect, copy on_success'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:** In: remove every rela-authored default sentence from the world chrome
+(read-only note, absent banner + button, list/board notes, form face refusal
+wording, badge text/tooltip, copy toast); operator text per world
+(`messages.absent/projection/stand_in`), per face (`messages.read_only`) and per
+copy (`on_success.message`); `on_absent.redirect` and `on_success.landing`
+behaviour keys; placeholders `{face}` `{bare_face}` `{world}` `{title}`; wire
+projection on `/_schema` and `_copies`; docs. Out: a general UI string table /
+localisation (separate decision), address-grammar hardening (TKT-RJAPG8).
+
+**Acceptance Criteria:**
+1. With no `messages:` declared, a world-bound page, list and board show only the operator `banner:` (if any) and nothing else; the stand-in badge renders nothing; the copy toast is the copy's label.
+2. Declared messages render verbatim with placeholders substituted, on the surface they belong to (atlas verify project as the fixture).
+3. `on_absent: {redirect: default}` lands a reader who opens an entity with no face in the world on the target world silently.
+4. `on_success.landing` `stay` / `{world}` / `{face}` navigates accordingly; `written` (default) lands on the face written.
+5. An undeclared world or face in `on_absent` / `landing` is a load error.
+
+## Research
+
+- [x] ~~For larger features: run `/research`~~ (N/A: design settled in discussion with Jeroen on 2026-09-05)
+- [x] ~~Searched for existing libraries~~ (N/A)
+- [x] Checked codebase for similar patterns or reusable code
+- [x] ~~Looked for reference implementations in other projects~~ (N/A)
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A
+
+**Existing Solutions:** `WorldDef.Banner` already flows operator text to the SPA
+through `/_schema` (schemaworlds.go); `CopyDef.Label` flows through `_copies[]`
+(copylist.go → computeCopyOffers). Both are the pattern to extend. Validation of
+world/face names lives in the metamodel loader (validateWorlds /
+validateCopies).
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:** Add `Messages`/`OnAbsent` to `WorldDef` (and its
+UnmarshalYAML shadow), `Messages` to `FaceDef`, `OnSuccess{Message, Landing}` to
+`CopyDef` with a `Landing` type accepting `written`/`stay` scalars or
+`{world}`/`{face}` maps. Validate targets at load. Project onto `v1.World`,
+`v1.FaceDef`, `v1.CopyOffer`. SPA: a `worldText(template, vars)` util does
+`{key}` substitution; each surface reads the declared text and renders nothing
+when absent; `on_absent.redirect` → `setWorld`; copy landing per offer.
+Alternative rejected: a global `ui.strings` table (the right answer for
+localisation, wrong granularity for per-world/per-copy variation; revisit if a
+Dutch UI is wanted).
+
+**Files to modify:** internal/metamodel/types.go, loader/validation, copies.go;
+internal/apiwire/v1/responses.go; internal/dataentry/schemaworlds.go,
+affordances.go (copy offers); internal/entitymanager/copylist.go; frontend:
+types/schema.ts, types/entity.ts, utils/worldText.ts, EntityDetail.vue,
+EntityList.vue, KanbanView.vue, DynamicForm.vue, WorldBadge.vue,
+stores/schema.ts; docs-project guides.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:** Operator config only (schema.yaml). Messages are
+plain text rendered through Vue interpolation (no v-html); placeholders are a
+fixed allowlist substituted in the SPA. Redirect/landing targets validated
+against declared worlds/faces at load.
+
+**Security-Sensitive Operations:** None. Config names are not secret; no read
+gate or write path changes. The redirect only changes the `?world=` query, which
+the server re-authorizes.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** metamodel: parse + validation tests (undeclared redirect
+world, undeclared landing face, landing scalar/map forms). dataentry: `/_schema`
+carries messages/on_absent/face messages; `_copies[]` carries onSuccess. SPA:
+EntityDetail/EntityList/Kanban/WorldBadge/DynamicForm world suites updated to
+assert silence by default and operator text when declared; redirect and landing
+tests. Atlas verify project updated with Dutch messages as the integration
+fixture.
+
+**Edge Cases:** Placeholder for a face without a declared label (falls back to
+the coordinate name); `{title}` on a row without a title (falls back to id);
+`on_absent.redirect` to a world the reader may not read (server answers empty,
+as any typed URL); redirect loop impossible (target is a declared world, never
+the same page state).
+
+**Negative Tests:** Undeclared world/face targets fail load with a named error;
+unknown placeholder keys are left verbatim.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:** Removing default text removes the only cue on a read-only adopted
+page; accepted by decision (a denial looks like any permission denial; the face
+switcher remains).
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+- [x] docs/metamodel.md - worlds/faces/copies key tables
+- [x] docs/data-entry.md, docs/content-states.md - what a world-bound page shows
+
+## Design Review
+
+- [x] ~~Run `/design-review` before starting implementation~~ (N/A: design reviewed in discussion; three-option comparison recorded on the ticket)
+- [x] ~~All critical/significant findings addressed in plan~~ (N/A)
+
+**Design Review Findings:** N/A

--- a/tickets/entities/review-checklists/REV-AVF3O3.md
+++ b/tickets/entities/review-checklists/REV-AVF3O3.md
@@ -1,0 +1,83 @@
+---
+id: REV-AVF3O3
+type: review-checklist
+title: 'Review: World chrome speaks the operator''s words or stays silent: messages, on_absent redirect, copy on_success'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` on the touched files reports only
+pre-existing findings (restatement on `DefaultMetamodelYAML`/`ListResponse`,
+nil-contract prose on three older `affordances.go` helpers, and the
+`CopyDef`/`planCopy` duplication that predates this ticket). Nothing introduced
+by this diff.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** cranky-code-reviewer and rela-security-reviewer ran in
+parallel on `git diff fix/worlds-face-address...HEAD`. Security found no XSS
+(every operator string lands in a mustache interpolation; `{title}` never
+reaches a `v-html` sink), no open redirect (`landing`/`redirect` write a query
+param or a load-validated face), no disclosure (the new wire fields are
+`schema.yaml` text) and no ACL change; its one finding was the redirect cycle,
+merged into RR-5TDYWW at the higher severity. All fourteen addressed in commit
+d730bd5a: RR-51XOG3 (critical: `landing:` unknown keys silently dropped),
+RR-5TDYWW (critical: two-world redirect cycle), RR-SKDOFD, RR-Q8SWR6, RR-XTHMDD,
+RR-4F65WN, RR-3Y3UR6 (significant), RR-S1QJT8, RR-7W31ZO, RR-BENZ9Z, RR-3UR6T2,
+RR-VJYG4V, RR-D00YBI (minor), RR-LMOCE6 (nit).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+- No rela-authored chrome sentence on any surface: PASS. Detail note, absent banner and its "Go to" button, list/board projection notes, form refusal, stand-in badge text and tooltip, "Created the X face" toast all removed; SPA suites assert silence with nothing declared (EntityDetail.world, EntityList.world, KanbanView.world, WorldBadge, RelationPicker).
+- Operator text per world/face/copy with placeholder substitution: PASS. Go: field-coverage tests, `schemamessages_test.go`, `TestCopyOnSuccessWire`; SPA: `worldText` unit tests plus the per-surface suites; Chrome walk on the atlas verify project showed the Dutch read-only note, the projection note, the "Concept" badge, the form refusal and the toast "Thuiswerkbeleid is vastgesteld." landing on `POLICY-002@vastgesteld`.
+- `on_absent.redirect` and `on_success.landing` validated at load: PASS. `TestWorlds_OnAbsentRedirectValidated` (undeclared, self-loop, two-world cycle, legitimate chain), `TestValidateCopies_Landing`, `TestCopyLanding_UnmarshalRefusesWhatItCannotMean`.
+- Placeholder allowlist pinned across Go and TS: PASS. `TestChromePlaceholdersInSyncWithFrontend`.
+- Atlas verify manual still passes against the extended fixture (19 claims).
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-NT4GX0
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A: PR opened and watched directly per the standing instruction: 🌍 title, auto-merge, reviewer tschmits)
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-3UR6T2.md
+++ b/tickets/entities/review-responses/RR-3UR6T2.md
@@ -1,0 +1,9 @@
+---
+id: RR-3UR6T2
+type: review-response
+title: HistoryView drops the face indicator entirely for a face with no declared label
+finding: HistoryView.vue faceLabel now comes from schemaStore.faceLabel, which is '' for an unlabelled coordinate, and the v-if hides the indicator. Under a world the coordinate identifies which record is being diffed; the face NAME is operator config, not rela vocabulary, so falling back to it is defensible.
+severity: minor
+resolution: HistoryView falls back to the declared face NAME when no label exists; only the unlabelled bare face renders nothing, since naming it would take a rela word.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3Y3UR6.md
+++ b/tickets/entities/review-responses/RR-3Y3UR6.md
@@ -1,0 +1,9 @@
+---
+id: RR-3Y3UR6
+type: review-response
+title: _world_absent_name is shipped on the wire and typed on the client with no consumer left
+finding: The only consumer (EntityDetail worldAbsentName) was removed. internal/apiwire/v1/responses.go still computes and ships `_world_absent_name`, frontend/src/api/views.ts still types it, and one test fixture sets it without asserting. Either document a consumer or remove it deliberately.
+severity: significant
+resolution: 'Removed end to end: the wire field, its producer in viewworld.go, the client type, the test fixture and the data-entry guide''s mention. It was introduced on the still-unmerged TKT-SLFURL branch, so no released API carried it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-4F65WN.md
+++ b/tickets/entities/review-responses/RR-4F65WN.md
@@ -1,0 +1,9 @@
+---
+id: RR-4F65WN
+type: review-response
+title: WorldBadge entityType is optional, so a forgotten prop renders the raw face name silently
+finding: 'WorldBadge.vue now consumes the schema store and takes `entityType?: string`. A call site that omits it gets `{face}` substituted with the coordinate name instead of the label, with no error. Make the prop required so omission is a type error.'
+severity: significant
+resolution: WorldBadge's entityType prop is required (every call site already passes it), so a forgotten prop is a type error rather than a raw coordinate on screen.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-51XOG3.md
+++ b/tickets/entities/review-responses/RR-51XOG3.md
@@ -1,0 +1,9 @@
+---
+id: RR-51XOG3
+type: review-response
+title: 'landing: map with a typo''d or empty key is silently discarded'
+finding: 'CopyLanding.UnmarshalYAML (internal/metamodel/types.go) decodes `landing: {wrold: actueel}`, `landing: {}` and `landing: {world: ""}` to the zero value; IsZero() is true, validateCopyLanding returns nil, and the copy silently lands on `written`. The operator''s declaration is discarded without a load error, the exact class BUG-I0N3YR fixed for affordance grants.'
+severity: critical
+resolution: 'CopyLanding.UnmarshalYAML walks the mapping''s keys: an unknown key, an empty mapping, an empty or non-scalar value, and a non-scalar non-mapping node are all load errors naming the accepted forms. TestCopyLanding_UnmarshalRefusesWhatItCannotMean pins nine shapes. The metamodel guide''s copy load-check list names the new refusals.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5TDYWW.md
+++ b/tickets/entities/review-responses/RR-5TDYWW.md
@@ -1,0 +1,9 @@
+---
+id: RR-5TDYWW
+type: review-response
+title: on_absent.redirect only rejects the one-hop self-loop; a→b→a loops the browser forever
+finding: validateWorldOnAbsent (internal/metamodel/loader.go) rejects `a → a` only. Two worlds redirecting to each other pass load; in EntityDetail.vue the worldAbsent watcher pushes a route per hop, so the SPA bounces between them indefinitely and floods history. Needs a cycle walk at load and a client-side guard.
+severity: critical
+resolution: '[security] validateWorldOnAbsent walks the redirect chain with a visited set and refuses any return to a visited world (self-loop included), naming the loop (`published → roundtrip → published`); `default` ends every chain. TestWorlds_OnAbsentRedirectValidated covers the two-world cycle and a legitimate chain. Client belt-and-braces in EntityDetail: a per-entity visited set of redirect sources and targets bounds a loop to one hop and suppresses a duplicate push on schema reload; the watcher now fires per loaded view (not on the absent flag), so scope-nav between two absent entities also redirects.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-7W31ZO.md
+++ b/tickets/entities/review-responses/RR-7W31ZO.md
@@ -1,0 +1,9 @@
+---
+id: RR-7W31ZO
+type: review-response
+title: Redirect watcher depends on the schema being loaded when the view resolves
+finding: EntityDetail.vue watch(worldAbsent) reads worldInfo at fire time; if the schema is still loading, target is undefined and the redirect silently never happens. Watch both sources or state the degradation.
+severity: minor
+resolution: The watcher observes [viewData, worldInfo], so a schema that lands after the view still triggers the redirect. Pinned by the 'redirects when the schema arrives AFTER the view' test.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-BENZ9Z.md
+++ b/tickets/entities/review-responses/RR-BENZ9Z.md
@@ -1,0 +1,9 @@
+---
+id: RR-BENZ9Z
+type: review-response
+title: copyOnSuccessWire encodes a mode>world>face precedence the validator forbids
+finding: internal/dataentry/affordances.go copyOnSuccessWire's ordered switch resolves the world+face case the validator rejects, a silent divergence waiting for the validator to be relaxed. Mirror the mutual exclusion explicitly.
+severity: minor
+resolution: copyOnSuccessWire's world and face arms each require the other field empty, mirroring the loader's mutual exclusion; the impossible both-set shape falls to written, and the comment says why.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-D00YBI.md
+++ b/tickets/entities/review-responses/RR-D00YBI.md
@@ -1,0 +1,9 @@
+---
+id: RR-D00YBI
+type: review-response
+title: No test for landing {world} against a configured default_world
+finding: 'EntityDetail.world.test.ts covers landing {world: published} with no defaultWorld set. The branch worldQueryFor exists for (drop the param when the target is the configured default) is untested.'
+severity: minor
+resolution: 'Two EntityDetail tests: landing in the configured default world drops the param (and the page), and landing on `default` under a configured default spells `?world=default`.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LMOCE6.md
+++ b/tickets/entities/review-responses/RR-LMOCE6.md
@@ -1,0 +1,9 @@
+---
+id: RR-LMOCE6
+type: review-response
+title: worldText substitutes with four split/join passes; empty vs undefined var behaviour is undecided
+finding: frontend/src/utils/worldText.ts allocates five arrays per call, per badge, per row. One regex pass is cheaper and makes the unknown-placeholder rule structural. An undefined var leaves {face} written while an empty var substitutes to nothing; WorldBadge.test.ts works around this instead of the code deciding it.
+severity: nit
+resolution: 'worldText is one regex pass over the allowlist. Decided and documented: an undefined var leaves the placeholder as written (the surface has no such fact), an empty var substitutes to nothing (the fact is empty); a substituted value is never re-scanned. Three new unit tests pin each.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Q8SWR6.md
+++ b/tickets/entities/review-responses/RR-Q8SWR6.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q8SWR6
+type: review-response
+title: landing face arm pushes `@undefined` when the face is missing; unknown modes fall to written
+finding: 'EntityDetail.vue landAfterCopy `case ''face''` pushes `${path}@${landing?.face}` unguarded; a hand-crafted or older response with `mode: face` and no face navigates to `ID@undefined`. The switch has no `written` arm so an unknown mode silently behaves as written. Guard the face and make the arms explicit.'
+severity: significant
+resolution: landAfterCopy has explicit written/stay/world/face arms; a world or face arm with no name, and an unknown mode, reload in place rather than navigating to `@undefined` or passing for written. Two EntityDetail tests pin the guard and the unknown mode.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-S1QJT8.md
+++ b/tickets/entities/review-responses/RR-S1QJT8.md
@@ -1,0 +1,9 @@
+---
+id: RR-S1QJT8
+type: review-response
+title: Per-surface placeholder availability is undocumented
+finding: absentNote/readOnlyNote/projectionNote/notEditableNote each assemble their own vars; list and board pass only {world}, so {title} in a projection string renders literally there but substitutes on the detail page. The WorldMessages godoc implies every placeholder works everywhere. Document which placeholders each message key supports.
+severity: minor
+resolution: 'WorldMessages and FaceMessages godoc state per field which placeholders substitute (absent: all four; projection: {world}; stand_in: {face},{bare_face},{world}; read_only: all four) and that a placeholder a surface cannot fill is left as written; the metamodel and content-states guides say the same.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SKDOFD.md
+++ b/tickets/entities/review-responses/RR-SKDOFD.md
@@ -1,0 +1,9 @@
+---
+id: RR-SKDOFD
+type: review-response
+title: worldQueryFor duplicates setWorld's normalisation and drops the page reset
+finding: EntityDetail.vue worldQueryFor re-implements useWorld.setWorld's world-query spelling (norm helper copied verbatim) but keeps `page`, which setWorld deletes on purpose. Two copies of one rule, one already diverged. Export the spelling from useWorld and use it from both.
+severity: significant
+resolution: 'useWorld exports worldQuery(next, base, defaultWorld): the one place the spelling and the page reset live. setWorld and landAfterCopy both call it; worldQueryFor is gone. The existing setWorld tests cover the rule; the new EntityDetail landing test asserts the page reset on the copy path.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-VJYG4V.md
+++ b/tickets/entities/review-responses/RR-VJYG4V.md
@@ -1,0 +1,9 @@
+---
+id: RR-VJYG4V
+type: review-response
+title: No test pins the placeholder allowlist across the Go docs and the TS implementation
+finding: The four placeholder names live in worldText.ts KEYS and in the WorldMessages godoc with nothing enforcing agreement. The repo pins cross-boundary contracts by reading both files (TestAppTokensCSSInSyncWithFrontend); a placeholder added on one side renders literally with no failure.
+severity: minor
+resolution: metamodel.ChromePlaceholders is the Go-side allowlist; TestChromePlaceholdersInSyncWithFrontend (internal/dataentry) reads worldText.ts's KEYS line off disk and compares, the TestAppTokensCSSInSyncWithFrontend pattern.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-XTHMDD.md
+++ b/tickets/entities/review-responses/RR-XTHMDD.md
@@ -1,0 +1,9 @@
+---
+id: RR-XTHMDD
+type: review-response
+title: '{title} is the display title on the detail page but the raw id in the form'
+finding: EntityDetail.vue textVars sets title from entityDisplayTitle; DynamicForm.vue notEditableNote sets title to bareEntityId. The same `messages.read_only` string renders differently on the two surfaces. WorldMessages godoc defines {title} as the display title, so the form is wrong.
+severity: significant
+resolution: DynamicForm records entityDisplayTitle(entity) when it loads the row and substitutes that for {title}; the bareEntityId computed had no other reader and is removed.
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-5SZG2L.md
+++ b/tickets/entities/tickets/TKT-5SZG2L.md
@@ -1,56 +1,74 @@
 ---
 id: TKT-5SZG2L
 type: ticket
-title: 'Operator-configurable world chrome: note text and where "go to" leads'
+title: 'World chrome speaks the operator''s words or stays silent: messages, on_absent redirect, copy on_success'
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: done
 ---
 
 Atlas worlds issue 6 (`atlas-world/docs/rela-worlds-issues.md`). After
-TKT-SLFURL the web app's world chrome is small: the operator `banner:`, a note
-on lists/boards of faced types, a note on a detail page showing a non-bare face
-the caller may not write, and the "no face in this world" banner with its "Go to
-<bare face>" button. All of the fixed text is rela-internal wording ("face",
-"world", "default") and reads as jargon to an ISMS reader.
+TKT-SLFURL the web app still shows rela's own vocabulary to readers: the
+"read-only face" note, the "no face in this world" banner and its "Go to
+Concept" button, the list/board projection notes, the form's face refusal, the
+stand-in badge, and the copy toast. "Face", "world", "bare", "default" are the
+storage model leaking onto the screen. A reader who cannot edit an adopted
+policy needs no explanation, any more than a reader without update permission
+does.
 
-## Requirement
+## Decision (2026-09-05)
 
-1. Per world, operator-declared templates replacing the fixed notes, with
-placeholders (`{face}`, `{bare_face}`, `{world}`); empty means no note; rela's
-text stays as the fallback.
+**Silence by default, operator text where the operator wants it, behaviour keys
+for the two things that are not text.** No rela-authored fallback sentence
+anywhere; an undeclared message renders nothing.
 
-   ```yaml
-   worlds:
-     actueel:
-       select: [vastgesteld, concept]
-       otherwise: default
-       messages:
-         read_only: 'Dit is de vastgestelde versie. Bewerken doe je in het concept.'
-         absent:    'Dit item heeft nog geen vastgestelde versie.'
-   ```
+```yaml
+worlds:
+  actueel:
+    select: [vastgesteld, concept]
+    otherwise: default
+    banner: 'Actueel beleid'              # existing
+    messages:
+      absent: 'Dit item heeft nog geen vastgestelde versie.'   # detail page, no face in this world
+      projection: 'Alleen vastgestelde items.'                 # list and board note
+      stand_in: '{face}'                                       # badge on a stand-in row/card
+    on_absent:
+      redirect: default                   # a declared world; lands the reader there instead of the note
 
-2. An operator-declared target for the absent case: another world or a
-specific face, as a button or an automatic redirect (`on_absent: { redirect:
-default }`).
+entities:
+  beleid:
+    faces:
+      vastgesteld:
+        messages:
+          read_only: 'Dit is de vastgestelde versie. Bewerken doe je in het concept.'  # detail note + form refusal
 
-3. Per copy definition, an optional `on_success.message` and landing
-(`world:` / `face:` / `stay`), replacing the default "land on the face written"
-rule where the workflow wants otherwise (a translator stays on the source).
+copies:
+  vaststellen:
+    on_success:
+      message: 'Beleid vastgesteld.'      # toast; default is the copy's own label
+      landing: written                    # written (default) | stay | { world: name } | { face: name }
+```
 
-Keep the safety argument: an operator who declares nothing gets today's
-behaviour.
+Placeholders, substituted client-side: `{face}` (served face label),
+`{bare_face}` (bare face label), `{world}` (world name), `{title}` (entity
+title).
 
-## Address-grammar hardening carried over from the TKT-SLFURL review
+What goes: the read-only note default, the absent banner default and its "Go to"
+button (the face switcher already reaches the bare face by address), the
+list/board note defaults, the badge's default text and tooltip, and the "Created
+the X face" toast (default becomes the copy label alone).
 
-- Parse the address ONCE in `handleV1DynamicRoutes` and pass `entityRef`
-(not `string`) to every entity handler, so a handler cannot forget to parse
-(RR-X2GBWJ). Add a guard test over `store.GetEntity` / `reader.getEntity` call
-sites and a round-trip test over every emitted address (`_self`, `_faces[].ref`,
-`_attachments[].href`).
-- Export of a non-bare face (`/_export` on `ID@face`) — today the uniform
-not-found; the redacting `visibility.Reader.Get` reads by bare id.
-- `/_documents/{name}/{id}` rejects `@` with a 400 while addresses 404
-elsewhere; documents are per entity, decide whether to accept the address and
-strip it or keep refusing uniformly.
+## Surfaces
+
+- metamodel: `WorldDef.Messages`, `WorldDef.OnAbsent`, `FaceDef.Messages`,
+`CopyDef.OnSuccess`; validation: `on_absent.redirect` and `landing.world` must
+name declared worlds, `landing.face` a declared face of the copy's type.
+- wire: `/_schema` worlds gain `messages` + `on_absent`, faces gain `messages`;
+`_copies[]` gains `onSuccess`.
+- SPA: EntityDetail, EntityList, KanbanView, DynamicForm, WorldBadge, copy
+landing.
+- docs: content-states guide Step 6, data-entry guide worlds section,
+metamodel reference tables.
+
+Address-grammar hardening moved to its own ticket.

--- a/tickets/entities/tickets/TKT-RJAPG8.md
+++ b/tickets/entities/tickets/TKT-RJAPG8.md
@@ -1,0 +1,25 @@
+---
+id: TKT-RJAPG8
+type: ticket
+title: Parse the entity address once in the dispatcher; face export; /_documents address shape
+kind: refactor
+priority: low
+effort: m
+status: backlog
+---
+
+Hardening carried over from the TKT-SLFURL review (RR-X2GBWJ, RR-X9P7MW).
+
+- Parse the address ONCE in `handleV1DynamicRoutes` and pass `entityRef`
+(not `string`) to every entity handler, so a handler cannot forget to parse it.
+On fsstore a raw `ID@face` string happens to hit the right index key while on
+pgstore it 404s, which masks the omission locally.
+- Add a guard test over `store.GetEntity` / `reader.getEntity` call sites in
+`internal/dataentry` (allowlist style, like `TestNavFilterStaysPresentational`)
+and a round-trip test over every emitted address (`_self`, `_faces[].ref`,
+`_attachments[].href`).
+- Export of a non-bare face (`/_export` on `ID@face`): today the uniform
+not-found, because `visibility.Reader.Get` reads by bare id.
+- `/_documents/{name}/{id}` rejects `@` with a 400 while addresses 404
+elsewhere; documents are per entity, so either accept and strip the face or
+refuse uniformly.

--- a/tickets/relations/TKT-5SZG2L--has-docs--DOCS-NT4GX0.md
+++ b/tickets/relations/TKT-5SZG2L--has-docs--DOCS-NT4GX0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-docs
+to: DOCS-NT4GX0
+---

--- a/tickets/relations/TKT-5SZG2L--has-implementation--IMPL-3FJKAN.md
+++ b/tickets/relations/TKT-5SZG2L--has-implementation--IMPL-3FJKAN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-implementation
+to: IMPL-3FJKAN
+---

--- a/tickets/relations/TKT-5SZG2L--has-planning--PLAN-CX1Z2E.md
+++ b/tickets/relations/TKT-5SZG2L--has-planning--PLAN-CX1Z2E.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-planning
+to: PLAN-CX1Z2E
+---

--- a/tickets/relations/TKT-5SZG2L--has-review--REV-AVF3O3.md
+++ b/tickets/relations/TKT-5SZG2L--has-review--REV-AVF3O3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review
+to: REV-AVF3O3
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-3UR6T2.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-3UR6T2.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-3UR6T2
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-3Y3UR6.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-3Y3UR6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-3Y3UR6
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-4F65WN.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-4F65WN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-4F65WN
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-51XOG3.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-51XOG3.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-51XOG3
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-5TDYWW.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-5TDYWW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-5TDYWW
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-7W31ZO.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-7W31ZO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-7W31ZO
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-BENZ9Z.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-BENZ9Z.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-BENZ9Z
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-D00YBI.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-D00YBI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-D00YBI
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-LMOCE6.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-LMOCE6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-LMOCE6
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-Q8SWR6.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-Q8SWR6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-Q8SWR6
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-S1QJT8.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-S1QJT8.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-S1QJT8
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-SKDOFD.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-SKDOFD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-SKDOFD
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-VJYG4V.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-VJYG4V.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-VJYG4V
+---

--- a/tickets/relations/TKT-5SZG2L--has-review-response--RR-XTHMDD.md
+++ b/tickets/relations/TKT-5SZG2L--has-review-response--RR-XTHMDD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-5SZG2L
+relation: has-review-response
+to: RR-XTHMDD
+---

--- a/tickets/relations/TKT-RJAPG8--affects--rest-api.md
+++ b/tickets/relations/TKT-RJAPG8--affects--rest-api.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RJAPG8
+relation: affects
+to: rest-api
+---

--- a/tickets/relations/TKT-RJAPG8--implements--FEAT-9CD2MX.md
+++ b/tickets/relations/TKT-RJAPG8--implements--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RJAPG8
+relation: implements
+to: FEAT-9CD2MX
+---


### PR DESCRIPTION
Atlas worlds issue 6 (TKT-5SZG2L). After TKT-SLFURL the web app still spoke rela's storage vocabulary to readers: "read-only face", "no face in this world", "Go to Concept", the list/board projection notes, the form's face refusal, the stand-in badge and the "Created the X face" toast. Those words belong to the operator or to nobody.

## The rule

**The chrome text is the operator's, or there is none.** No rela-authored fallback sentence anywhere; an undeclared message renders nothing. Placeholders `{face}`, `{bare_face}`, `{world}`, `{title}` are substituted client-side; a placeholder a surface cannot fill is left as written.

```yaml
worlds:
  actueel:
    select: [vastgesteld, concept]
    otherwise: default
    messages:
      absent: 'Dit item heeft nog geen vastgestelde versie.'
      projection: 'Alleen vastgestelde items.'
      stand_in: '{face}'
    on_absent:
      redirect: default
entities:
  beleid:
    faces:
      vastgesteld:
        messages:
          read_only: 'Dit is de vastgestelde versie. Bewerken doe je in het concept.'
copies:
  vaststellen:
    on_success:
      message: '{title} is vastgesteld.'
      landing: written   # written | stay | {world: name} | {face: name}
```

## What changed

- **metamodel**: `WorldDef.Messages`/`OnAbsent`, `FaceDef.Messages`, `CopyDef.OnSuccess{Message, Landing}`. Load checks: `on_absent.redirect` must name a declared world or `default` and must not form a cycle; `landing` must be `written`/`stay`/a declared world/a face the target type declares, never both, and a mapping with an unknown key, an empty mapping or an empty name is refused rather than silently read as `written`.
- **wire**: `/_schema` worlds carry `messages` + `on_absent`, faces carry `messages`, `_copies[]` carries `onSuccess` (landing mode spelled out). Blocks are omitted when undeclared. The never-released `_world_absent_name` field from the TKT-SLFURL branch is dropped.
- **SPA**: every default sentence, button and tooltip removed from EntityDetail, EntityList, KanbanView, DynamicForm, WorldBadge, HistoryView. `utils/worldText.ts` does the substitution (one pass, allowlisted). `useWorld.worldQuery` is the one place the world-query spelling lives, shared by `setWorld` and the copy landing. The redirect watcher fires per loaded view and never repeats a hop for one entity.
- **docs**: content-states, metamodel and data-entry guides.
- **tests**: field-coverage tests extended; `TestWorlds_OnAbsentRedirectValidated`, `TestValidateCopies_Landing`, `TestCopyLanding_UnmarshalRefusesWhatItCannotMean`, `schemamessages_test.go`, `TestChromePlaceholdersInSyncWithFrontend` (pins the Go and TS allowlists to each other); SPA world suites rewritten to "silence unless declared" plus redirect and every landing mode.

## Review

cranky-code-reviewer and rela-security-reviewer: 14 findings, all addressed in the second commit (two critical: unknown `landing:` keys silently discarded, two-world redirect cycle). Security found no XSS, no open redirect, no disclosure and no ACL change.

## Verification

Go suite, golangci-lint, comment-lint, arch-lint, plimsoll, coverage floors; 2370 SPA tests, typecheck, lint. Atlas verify manual passes its 19 claims against the extended fixture. Chrome walk on the atlas project: Dutch read-only note on the adopted policy, projection note and "Concept" badge on the list, silent task list, form refusal in the operator's words, toast "Thuiswerkbeleid is vastgesteld." landing on the adopted face.

Stacked on #1527 (`fix/worlds-face-address`); retargets to `develop` when that merges.

https://claude.ai/code/session_01RFLjSpabTeht5eDRMG4E4h
