### PR TITLE
feat(config): widen the Loader seam with List and a disk-first layered loader (TKT-RAT7U3)

### DIFF
--- a/internal/appbuild/scheduled_mail_test.go
+++ b/internal/appbuild/scheduled_mail_test.go
@@ -17,6 +17,10 @@ type staticConfig map[string][]byte
 
 func (c staticConfig) Load(_ context.Context, name string) ([]byte, error) { return c[name], nil }
 
+// List reports no directory-shaped config: these tests exercise the
+// mail-template path, which reads named files only.
+func (c staticConfig) List(_ context.Context, _ string) ([]string, error) { return nil, nil }
+
 func TestRunScheduledTemplateSendsRenderedRecipientMessage(t *testing.T) {
 	t.Parallel()
 	st := memstore.New()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,10 @@ package config
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -21,6 +24,27 @@ type Loader interface {
 	// Load returns the raw bytes for the named file. Implementations
 	// return an os.IsNotExist-compatible error when the file is absent.
 	Load(ctx context.Context, name string) ([]byte, error)
+
+	// List returns the file names directly under dir, sorted, without the
+	// dir prefix and without subdirectory entries. It is how the
+	// directory-shaped parts of a project — scripts/, actions/,
+	// validations/, migrations/, templates/, custom/, apps/ — are read
+	// through this seam rather than through the filesystem directly.
+	//
+	// An ABSENT directory lists empty with a nil error; every other
+	// failure surfaces, a path that exists but is not a directory
+	// included. That asymmetry is deliberate and matches
+	// datamigration.LoadDir: a project legitimately has no scripts/, but
+	// an unreadable one reported as "nothing here" would silently drop
+	// operator-authored config.
+	//
+	// Only regular files are listed.
+	//
+	// Non-recursive by design. Every consumer wants one directory's worth
+	// of files, and a recursive walk would make the two backends differ:
+	// a filesystem has real subdirectories, while a database has flat
+	// keys that merely contain slashes.
+	List(ctx context.Context, dir string) ([]string, error)
 }
 
 // Subscriber is the optional change-notification interface on a Loader.
@@ -59,6 +83,58 @@ func (l *FSLoader) Load(_ context.Context, name string) ([]byte, error) {
 		return nil, err
 	}
 	return l.fs.ReadFile(filepath.Join(l.root, name))
+}
+
+// List returns the sorted names of the regular files directly under dir.
+//
+// A missing directory is an empty list, not an error — see the interface
+// doc for why only that case is forgiven. The absent check is an explicit
+// Stat rather than an errors.Is on ReadDir's error, because the two
+// storage.FS implementations disagree there: OsFS reports ENOTDIR for a
+// path that exists but is a file, while MemFS reports os.ErrNotExist for
+// anything absent from its directory map. Reading the distinction off
+// ReadDir would therefore forgive a not-a-directory on MemFS and surface it
+// on OsFS — the exact "silently drop operator-authored config" case the
+// asymmetry exists to prevent, made dependent on which FS happens to be
+// installed.
+//
+// Entries that are not regular files are skipped, symlinks included. A
+// symlink is not a directory, so it would otherwise be listed as an
+// ordinary config file while pointing anywhere the process can read —
+// .rela/secrets.yaml among them. Containment for the dir argument is
+// validateName's job; this is the containment the ENTRIES need, and it is
+// the duty this seam inherits from the os.OpenRoot call sites it replaces.
+func (l *FSLoader) List(_ context.Context, dir string) ([]string, error) {
+	if err := validateName(dir); err != nil {
+		return nil, err
+	}
+	full := filepath.Join(l.root, dir)
+	switch info, err := l.fs.Stat(full); {
+	case errors.Is(err, os.ErrNotExist):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	case !info.IsDir():
+		return nil, fmt.Errorf("config: %s is not a directory", dir)
+	}
+
+	entries, err := l.fs.ReadDir(full)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	// storage.FS.ReadDir is documented as sorted, but sort here anyway: the
+	// order is part of this method's contract (a script chain's execution
+	// order depends on it), so it must not rest on a promise made by
+	// whichever FS implementation happens to be installed.
+	slices.Sort(names)
+	return names, nil
 }
 
 // Subscribe watches the named file for changes and invokes onChange for

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/config"
@@ -111,4 +112,119 @@ func TestFSLoader_Subscribe(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 	stop()
+}
+
+func TestFSLoader_List(t *testing.T) {
+	t.Parallel()
+	fs := storage.NewMemFS()
+	for _, p := range []string{"/project/scripts", "/project/scripts/nested"} {
+		if err := fs.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Deliberately written out of order: List sorts.
+	for _, n := range []string{"zeta.lua", "alpha.lua", "mid.lua"} {
+		if err := fs.WriteFile("/project/scripts/"+n, []byte("-- x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fs.WriteFile("/project/scripts/nested/deep.lua", []byte("-- y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := config.NewFSLoader(fs, "/project")
+
+	got, err := l.List(context.Background(), "scripts")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Sorted, subdirectory entries dropped, and NOT recursive: deep.lua sits
+	// one level down and must not appear under any name.
+	want := []string{"alpha.lua", "mid.lua", "zeta.lua"}
+	if !slices.Equal(got, want) {
+		t.Errorf("List = %v, want %v (sorted, no subdirectories, non-recursive)", got, want)
+	}
+	for _, unwanted := range []string{"nested", "deep.lua", "nested/deep.lua"} {
+		if slices.Contains(got, unwanted) {
+			t.Errorf("List returned %q; directories and nested files must be excluded", unwanted)
+		}
+	}
+}
+
+func TestFSLoader_List_NotADirectoryIsAnError(t *testing.T) {
+	t.Parallel()
+	fs := storage.NewMemFS()
+	if err := fs.MkdirAll("/project", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// scripts exists, but as a regular file.
+	if err := fs.WriteFile("/project/scripts", []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l := config.NewFSLoader(fs, "/project")
+
+	// Reporting this as "no scripts" would silently drop operator-authored
+	// config — the case the absent-is-empty asymmetry deliberately excludes.
+	if _, err := l.List(context.Background(), "scripts"); err == nil {
+		t.Error("List of a non-directory should surface an error, not report empty")
+	}
+}
+
+func TestFSLoader_List_SkipsSymlinks(t *testing.T) {
+	t.Parallel()
+	// Needs a real filesystem: MemFS has no symlink support.
+	root := t.TempDir()
+	scripts := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scripts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secret.yaml"), []byte("token: x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scripts, "real.lua"), []byte("-- x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "secret.yaml"), filepath.Join(scripts, "evil.lua")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	l := config.NewFSLoader(storage.NewOsFS(), root)
+	got, err := l.List(context.Background(), "scripts")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// A symlink is not a directory, so without the regular-file check it
+	// would be listed as an ordinary config file pointing outside scripts/.
+	want := []string{"real.lua"}
+	if !slices.Equal(got, want) {
+		t.Errorf("List = %v, want %v (symlinks excluded)", got, want)
+	}
+}
+
+func TestFSLoader_List_MissingDirIsEmpty(t *testing.T) {
+	t.Parallel()
+	fs := storage.NewMemFS()
+	if err := fs.MkdirAll("/project", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	l := config.NewFSLoader(fs, "/project")
+
+	// A project with no scripts/ at all is ordinary, not an error.
+	got, err := l.List(context.Background(), "scripts")
+	if err != nil {
+		t.Fatalf("List of missing dir: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List = %v, want empty", got)
+	}
+}
+
+func TestFSLoader_List_RejectsUnsafeNames(t *testing.T) {
+	t.Parallel()
+	l := config.NewFSLoader(storage.NewMemFS(), "/project")
+	for _, name := range []string{"", "../etc", "/etc", `sub\dir`, "sub/../../etc", "C:dir"} {
+		if _, err := l.List(context.Background(), name); err == nil {
+			t.Errorf("List(%q) should be rejected", name)
+		}
+	}
 }

--- a/internal/config/layered.go
+++ b/internal/config/layered.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"os"
+	"slices"
+)
+
+// layered reads from primary, falling back to secondary when primary does
+// not have the file.
+type layered struct {
+	primary   Loader
+	secondary Loader
+}
+
+var _ Loader = (*layered)(nil)
+
+// NewLayered returns a Loader that serves each name from primary when
+// present and from secondary otherwise.
+//
+// It exists so config baked into a database can back a project whose files
+// still live on disk, with DISK FIRST: a project that has both is a project
+// being edited, and the file the operator just wrote must win over the copy
+// baked in at package time. That ordering is also what makes the migration
+// to a database-backed project safe to do one consumer at a time — with the
+// filesystem in front, a converted call site behaves exactly as it did
+// before until the file is actually removed.
+//
+// The fall-through rule is [Loader.Load]'s; see [layered.Load].
+//
+// Nil: both loaders are rejected when nil. A layered loader is built at a
+// wiring site that already threads errors, so a missing collaborator becomes
+// an actionable startup failure rather than a panic at the first read.
+func NewLayered(primary, secondary Loader) (Loader, error) {
+	if primary == nil || secondary == nil {
+		return nil, errors.New("config: NewLayered requires two non-nil loaders")
+	}
+	return &layered{primary: primary, secondary: secondary}, nil
+}
+
+// Load returns the primary's bytes, or the secondary's when the primary
+// does not have the file.
+//
+// Only os.ErrNotExist falls through. Any other primary error surfaces
+// unchanged, because a permission error or a truncated read is not evidence
+// that the file is absent, and treating it as such would silently serve
+// stale baked config in place of the config the operator is looking at.
+func (l *layered) Load(ctx context.Context, name string) ([]byte, error) {
+	data, err := l.primary.Load(ctx, name)
+	if err == nil {
+		return data, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	return l.secondary.Load(ctx, name)
+}
+
+// List returns the UNION of both layers, deduplicated and sorted.
+//
+// A union rather than [layered.Load]'s precedence rule, because the two
+// answer different questions. Load asks "which of these two files do I
+// read", and exactly one must win. List asks "what is in this directory",
+// and a script present only in the database is genuinely there — shadowing
+// the whole directory because one file of the same name sits on disk would
+// make it invisible. Per-file precedence is preserved anyway: a name in both
+// layers appears once, and the subsequent Load resolves it to the primary's
+// bytes.
+//
+// An error from EITHER layer fails the whole call; there is no partial
+// union. A half-listed directory is the worse failure: a caller cannot tell
+// it from a complete one, so an automation missing because the database
+// hiccuped would look exactly like an automation that was never configured.
+// Failing loudly keeps that diagnosable.
+func (l *layered) List(ctx context.Context, dir string) ([]string, error) {
+	primary, err := l.primary.List(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	secondary, err := l.secondary.List(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	// Built by copying into a fresh map rather than appending secondary onto
+	// primary: primary's backing array belongs to the layer that returned it,
+	// and appending into its spare capacity would write through to a slice
+	// that layer may still be holding.
+	seen := make(map[string]struct{}, len(primary)+len(secondary))
+	for _, n := range primary {
+		seen[n] = struct{}{}
+	}
+	for _, n := range secondary {
+		seen[n] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(seen)), nil
+}
+
+// Subscribe forwards to whichever layer can watch for changes, primary
+// first, and reports no capability when neither can.
+//
+// Without this, wrapping an FSLoader would silently disable live config
+// reload: [Subscriber] is an optional interface consumers type-assert for,
+// so the decorator would fail the assertion with no compile error and no
+// test failure — an operator editing data-entry.yaml would simply see
+// nothing happen. That directly undercuts the disk-first premise, which
+// exists so an operator's edit is the one that takes effect.
+func (l *layered) Subscribe(ctx context.Context, name string, onChange func()) (func(), error) {
+	for _, candidate := range []Loader{l.primary, l.secondary} {
+		if sub, ok := candidate.(Subscriber); ok {
+			return sub.Subscribe(ctx, name, onChange)
+		}
+	}
+	return nil, errors.New("config: no layer supports change notification")
+}

--- a/internal/config/layered_test.go
+++ b/internal/config/layered_test.go
@@ -1,0 +1,267 @@
+package config_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/config"
+)
+
+// mapLoader is a Loader over an in-memory name→bytes map, standing in for
+// either layer. Absent names return an os.ErrNotExist-compatible error,
+// which is the contract the Loader interface documents.
+type mapLoader map[string][]byte
+
+func (m mapLoader) Load(_ context.Context, name string) ([]byte, error) {
+	data, ok := m[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: os.ErrNotExist}
+	}
+	return data, nil
+}
+
+func (m mapLoader) List(_ context.Context, dir string) ([]string, error) {
+	var names []string
+	for name := range m {
+		base, ok := cutDir(name, dir)
+		if ok {
+			names = append(names, base)
+		}
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// cutDir reports the base name of `name` when it sits directly under dir.
+func cutDir(name, dir string) (string, bool) {
+	prefix := dir + "/"
+	if len(name) <= len(prefix) || name[:len(prefix)] != prefix {
+		return "", false
+	}
+	base := name[len(prefix):]
+	if strings.ContainsRune(base, '/') {
+		return "", false
+	}
+	return base, true
+}
+
+// errLoader fails every call with a non-ErrNotExist error, standing in for a
+// permission problem or a truncated read.
+type errLoader struct{ err error }
+
+func (e errLoader) Load(context.Context, string) ([]byte, error)   { return nil, e.err }
+func (e errLoader) List(context.Context, string) ([]string, error) { return nil, e.err }
+
+// mustLayered builds a layered loader, failing the test if construction does.
+func mustLayered(t *testing.T, primary, secondary config.Loader) config.Loader {
+	t.Helper()
+	l, err := config.NewLayered(primary, secondary)
+	if err != nil {
+		t.Fatalf("NewLayered: %v", err)
+	}
+	return l
+}
+
+func TestLayered_Load_PrimaryWins(t *testing.T) {
+	t.Parallel()
+	l := mustLayered(t,
+		mapLoader{"schema.yaml": []byte("from disk")},
+		mapLoader{"schema.yaml": []byte("from database")},
+	)
+	got, err := l.Load(context.Background(), "schema.yaml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Disk-first is the whole point: an operator editing a file must see
+	// their edit, not the copy baked in at package time.
+	if !bytes.Equal(got, []byte("from disk")) {
+		t.Errorf("Load = %q, want the primary layer's bytes", got)
+	}
+}
+
+func TestLayered_Load_FallsBackWhenAbsent(t *testing.T) {
+	t.Parallel()
+	l := mustLayered(t,
+		mapLoader{},
+		mapLoader{"schema.yaml": []byte("from database")},
+	)
+	got, err := l.Load(context.Background(), "schema.yaml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got, []byte("from database")) {
+		t.Errorf("Load = %q, want the secondary layer's bytes", got)
+	}
+}
+
+func TestLayered_Load_MissingInBothIsNotExist(t *testing.T) {
+	t.Parallel()
+	l := mustLayered(t, mapLoader{}, mapLoader{})
+	_, err := l.Load(context.Background(), "schema.yaml")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("error %v is not os.IsNotExist-compatible", err)
+	}
+}
+
+func TestLayered_Load_NonNotExistErrorDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("permission denied")
+	l := mustLayered(t,
+		errLoader{err: boom},
+		mapLoader{"schema.yaml": []byte("from database")},
+	)
+
+	// A permission error is not evidence the file is absent. Falling back
+	// here would silently serve stale baked config in place of the file the
+	// operator is actually looking at.
+	_, err := l.Load(context.Background(), "schema.yaml")
+	if !errors.Is(err, boom) {
+		t.Errorf("Load error = %v, want the primary's error surfaced", err)
+	}
+}
+
+func TestLayered_List_UnionsBothLayers(t *testing.T) {
+	t.Parallel()
+	l := mustLayered(t,
+		mapLoader{"scripts/a.lua": nil, "scripts/shared.lua": []byte("from disk")},
+		mapLoader{"scripts/b.lua": nil, "scripts/shared.lua": []byte("from database")},
+	)
+	got, err := l.List(context.Background(), "scripts")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// A union, not the Load precedence rule: a script present only in the
+	// database is genuinely there, and a same-named file on disk must not
+	// hide the rest of the directory. Duplicates collapse to one entry.
+	want := []string{"a.lua", "b.lua", "shared.lua"}
+	if !slices.Equal(got, want) {
+		t.Errorf("List = %v, want %v", got, want)
+	}
+
+	// The other half of the claim: a name appearing in both layers still
+	// resolves to the primary's bytes on the follow-up Load.
+	data, err := l.Load(context.Background(), "scripts/shared.lua")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(data, []byte("from disk")) {
+		t.Errorf("Load after union = %q, want the primary's bytes", data)
+	}
+}
+
+func TestLayered_List_DoesNotMutateLayerSlices(t *testing.T) {
+	t.Parallel()
+	// A layer's returned slice belongs to that layer. Appending the other
+	// layer's names into its spare capacity would write through to a slice
+	// the layer may still be holding — a corruption that no test would show
+	// until a caching backend retains what it returned.
+	primary := &sliceLoader{names: append(make([]string, 0, 8), "a.lua", "shared.lua")}
+	l := mustLayered(t, primary, &sliceLoader{names: []string{"z.lua"}})
+
+	if _, err := l.List(context.Background(), "scripts"); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	backing := primary.names[:cap(primary.names)]
+	if backing[2] != "" {
+		t.Errorf("List wrote %q into the primary's spare capacity", backing[2])
+	}
+}
+
+// sliceLoader returns a caller-owned slice from List, so aliasing is visible.
+type sliceLoader struct {
+	mapLoader
+	names []string
+}
+
+func (s *sliceLoader) List(context.Context, string) ([]string, error) { return s.names, nil }
+
+func TestLayered_List_SurfacesErrors(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("permission denied")
+	for _, tc := range []struct {
+		name              string
+		primary, fallback config.Loader
+	}{
+		{"primary fails", errLoader{err: boom}, mapLoader{}},
+		{"secondary fails", mapLoader{}, errLoader{err: boom}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l := mustLayered(t, tc.primary, tc.fallback)
+			if _, err := l.List(context.Background(), "scripts"); !errors.Is(err, boom) {
+				t.Errorf("List error = %v, want %v", err, boom)
+			}
+		})
+	}
+}
+
+func TestNewLayered_RejectsNil(t *testing.T) {
+	t.Parallel()
+	// Constructors reject nil required collaborators rather than deferring
+	// the failure to a downstream symptom. An error, not a panic: this is
+	// built at a wiring site that already threads errors.
+	for _, tc := range []struct {
+		name              string
+		primary, fallback config.Loader
+	}{
+		{"nil primary", nil, mapLoader{}},
+		{"nil secondary", mapLoader{}, nil},
+		{"both nil", nil, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l, err := config.NewLayered(tc.primary, tc.fallback)
+			if err == nil {
+				t.Fatal("NewLayered should reject a nil loader")
+			}
+			if l != nil {
+				t.Errorf("NewLayered returned %v alongside an error, want nil", l)
+			}
+		})
+	}
+}
+
+func TestLayered_Subscribe_ForwardsToCapableLayer(t *testing.T) {
+	t.Parallel()
+	// mapLoader is not a Subscriber, so neither layer can watch.
+	l := mustLayered(t, mapLoader{}, mapLoader{})
+	sub, ok := l.(config.Subscriber)
+	if !ok {
+		t.Fatal("layered should satisfy config.Subscriber so the capability is not silently lost")
+	}
+	if _, err := sub.Subscribe(context.Background(), "x.yaml", func() {}); err == nil {
+		t.Error("Subscribe should report that no layer can watch")
+	}
+
+	// With a watching primary, the call is forwarded rather than refused.
+	watcher := &countingSubscriber{}
+	l = mustLayered(t, watcher, mapLoader{})
+	stop, err := l.(config.Subscriber).Subscribe(context.Background(), "x.yaml", func() {})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if watcher.calls != 1 {
+		t.Errorf("primary Subscribe called %d times, want 1", watcher.calls)
+	}
+	stop()
+}
+
+// countingSubscriber is a Loader that also implements Subscriber, so the
+// decorator's forwarding can be observed.
+type countingSubscriber struct {
+	mapLoader
+	calls int
+}
+
+func (c *countingSubscriber) Subscribe(
+	context.Context, string, func(),
+) (func(), error) {
+	c.calls++
+	return func() {}, nil
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -67,6 +67,10 @@ func (c *mockConfig) Load(_ context.Context, name string) ([]byte, error) {
 	return data, nil
 }
 
+// List reports no directory-shaped config: the scheduler reads
+// schedules.yaml by name and nothing else.
+func (c *mockConfig) List(_ context.Context, _ string) ([]string, error) { return nil, nil }
+
 type mockState struct{ m *mockWorkspace }
 
 func (s *mockState) Get(_ context.Context, key string) ([]byte, error) {

--- a/tickets/entities/docs-checklists/DOCS-8J08A1.md
+++ b/tickets/entities/docs-checklists/DOCS-8J08A1.md
@@ -1,0 +1,31 @@
+---
+id: DOCS-8J08A1
+type: docs-checklist
+title: 'Documentation: config.Loader List and layered loader'
+status: done
+---
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the two non-obvious choices carry
+their reasoning: why `List` stats before `ReadDir` (OsFS and MemFS disagree on
+not-a-directory), and why the union copies rather than appends (the primary's
+backing array belongs to the layer that returned it).
+- [x] Function/type docs if public API — `Loader.List`, `NewLayered`,
+`layered.Load`, `layered.List` and `layered.Subscribe` all documented, including
+the fail-closed union decision and why the decorator forwards `Subscribe`.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: `internal/config` is not a user-facing surface)
+- [x] ~~CLAUDE.md updated~~ (N/A: no new pattern — this widens an existing
+seam whose package doc already anticipated additional backends. The pattern
+entry belongs with Phase C, when `db dump`/`db load` make the mode visible.)
+- [x] ~~Help text accurate~~ (N/A: no CLI changes in this ticket)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: internal seam with no behaviour change —
+`FSLoader` is the only implementation, so nothing an operator can observe
+differs. The user-visible change lands in Phase C.)
+- [x] ~~API docs updated~~ (N/A: no HTTP or MCP surface touched)

--- a/tickets/entities/features/FEAT-UP14BT.md
+++ b/tickets/entities/features/FEAT-UP14BT.md
@@ -1,0 +1,68 @@
+---
+id: FEAT-UP14BT
+type: feature
+title: 'Self-contained SQLite: operator config in the database'
+summary: Ship one .db file that is a fully working rela app — schema, config, scripts, templates and data — given only the rela binary
+description: 'Config-in-the-DB as a MODE, not a migration: resolution is disk-first with DB fallback, so a normal project keeps schema.yaml on disk and behaves exactly as today. `rela db dump`/`db load` round-trips config in and out. Delivered per-seam (config.Loader, metamodel.Loader, templating.Templater, a script source, a policy source, state.KV) rather than by faking a filesystem over SQLite.'
+priority: medium
+status: planned
+---
+
+## Goal
+
+One `.db` file that, given only the `rela` binary, is a fully working app —
+schema, data-entry config, ACL, scripts, templates, custom assets, and the
+entity/relation data. Editing config happens via a dump & load round-trip.
+
+## Why this is tractable
+
+Four of the five seams needed already exist and were built anticipating this:
+
+| Seam | Location | Backends today |
+|---|---|---|
+| `config.Loader` | `internal/config/config.go:20` | `FSLoader` |
+| `metamodel.Loader` | `internal/metamodel/loader_service.go:19` | `FSLoader` |
+| `templating.Templater` | `internal/templating/storetemplate.go:42` | `FSTemplater` |
+| `state.KV` | `internal/state/state.go:23` | `FSKV` + `pgstore.StateKV` |
+
+`config.Loader`'s package doc already says *"remote or **embedded** deployments
+plug in by implementing Loader."* `storetemplate.go` is named for a store-backed
+Templater that was planned and never built. `state.KV` is the proof the pattern
+works end to end, including a conformance suite.
+
+The SPA is already `go:embed`-ed and attachments are already blobs in the same
+SQLite database, so neither needs work.
+
+## Bootstrap order
+
+Separating the SQLite *connection* from the *store* removes the apparent
+ordering problem:
+
+```
+1. acquire sidecar process lock       (already in OpenContext)
+2. sql.Open + PRAGMA verify + schema  (already in Store.init)
+   ─── connection now usable ───
+3. load metamodel                     ← may read from the connection
+4. load acl.yaml, data-entry.yaml, …  ← may read from the connection
+5. sqlitestore.New(conn, …) → store.Store
+6. assemble(base, store, …)           (unchanged)
+```
+
+This is the shape `pgstore` already has: `pgstore.New(db DBTX)` takes an
+injected pool and appbuild owns/closes it. `SharedBase` survives — it is
+documented as holding nothing derived from a store, and a `*sql.DB` is not a
+store.
+
+## Not in scope
+
+`.rela/secrets.yaml` stays on disk: it has OS-keychain and systemd-credentials
+integration plus permission warnings, and a credential inside a shippable
+artifact is exactly the leak the "configuration is not a secret; the data is"
+rule prevents. `tenants.yaml` stays on disk for the bootstrap circularity its
+own doc comment describes.
+
+## Supersedes
+
+The scope note at `internal/appbuild/appbuild_sqlite.go:19-24` ("it does not
+swallow operator-authored config"). Reversed deliberately, and narrowly — disk
+stays the default and stays first in resolution order.

--- a/tickets/entities/review-checklists/REV-M1KMP6.md
+++ b/tickets/entities/review-checklists/REV-M1KMP6.md
@@ -1,0 +1,96 @@
+---
+id: REV-M1KMP6
+type: review-checklist
+title: 'Review: config.Loader grows List and a disk-first layered loader'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race` over the affected packages; `just build-check-tags` clean)
+- [x] Lint clean (`just lint`: 0 issues; `just arch-lint`: OK)
+- [x] Comment lint gate clean (`just comment-lint`: no unresolvable doc links)
+- [x] Coverage maintained (internal/config 94.2% vs 87 floor)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (RR-RJ3QYT, RR-5932AS)
+- [x] All significant review-responses addressed (RR-I7OQAW, RR-YASRJM, RR-5X9QPT)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-RJ3QYT, RR-5932AS (critical); RR-I7OQAW, RR-YASRJM,
+RR-5X9QPT (significant); RR-L6VQKI, RR-YV817D (minor, one deferred to
+TKT-S1EVV7).
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] ~~Test evidence documented in implementation checklist~~ (N/A: no implementation checklist; evidence is in the Acceptance Status block below)
+
+**Acceptance Status:**
+
+- PASS — `List` returns names sorted, relative to the prefix, non-recursive:
+  `TestFSLoader_List` asserts the sorted set and that neither `nested` nor
+  `deep.lua` appears.
+- PASS — a missing directory lists empty rather than erroring:
+  `TestFSLoader_List_MissingDirIsEmpty`. The neighbouring case (path exists
+  but is a file) surfaces an error: `TestFSLoader_List_NotADirectoryIsAnError`.
+- PASS — `NewLayered` falls back on `os.ErrNotExist` and only on that:
+  `TestLayered_Load_FallsBackWhenAbsent` and
+  `TestLayered_Load_NonNotExistErrorDoesNotFallBack`.
+- PASS — traversal rejection for both new entry points:
+  `TestFSLoader_List_RejectsUnsafeNames` (10 vectors) plus the pre-existing
+  `TestFSLoader_Load_RejectsUnsafeNames`.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: internal seam, no user-facing surface yet)
+- [x] ~~User-facing documentation updated~~ (N/A: `config.Loader` is internal; the user-facing `db dump`/`db load` commands land in Phase C)
+- [x] ~~Docs-checklist marked as done~~ (N/A: no docs-checklist needed)
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-5932AS.md
+++ b/tickets/entities/review-responses/RR-5932AS.md
@@ -1,0 +1,9 @@
+---
+id: RR-5932AS
+type: review-response
+title: layered.List corrupted the primary layer's slice via append aliasing
+finding: layered.List iterated `append(primary, secondary...)`. The primary slice is returned by another component and its backing array is not ours; when it has spare capacity, append writes the secondary's names into it, mutating a slice the other layer may still hold. FSLoader.List allocates with cap=len(entries) and then filters directories out, so a subdirectory in scripts/ leaves exactly the spare capacity required. Harmless only because FSLoader does not retain what it returns — a caching SQLite lister, the obvious next backend, would be silently corrupted.
+severity: critical
+resolution: Replaced with two explicit loops over a fresh map, returning slices.Sorted(maps.Keys(seen)). Verified empirically that append writes 'z.lua' into backing[2] of a len-2/cap-8 primary. Added TestLayered_List_DoesNotMutateLayerSlices with a sliceLoader that returns a caller-owned slice; confirmed the test fails against the reverted implementation and passes against the fix.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-5X9QPT.md
+++ b/tickets/entities/review-responses/RR-5X9QPT.md
@@ -1,0 +1,9 @@
+---
+id: RR-5X9QPT
+type: review-response
+title: layered dropped the optional Subscriber capability silently
+finding: Subscriber is an optional interface consumers type-assert for (dataentry/watcher.go:147), and FSLoader implements it. Wrapping an FSLoader in NewLayered made the assertion fail, silently disabling live config reload — no compile error, no test failure, just an operator editing data-entry.yaml and seeing nothing happen. That directly undercuts the disk-first premise, which exists so an operator's edit is the one that takes effect.
+severity: significant
+resolution: layered now implements Subscribe, forwarding to the first layer that satisfies Subscriber (primary first) and returning an explanatory error when neither does. Added TestLayered_Subscribe_ForwardsToCapableLayer covering both the no-capable-layer and forwarded cases.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-I7OQAW.md
+++ b/tickets/entities/review-responses/RR-I7OQAW.md
@@ -1,0 +1,9 @@
+---
+id: RR-I7OQAW
+type: review-response
+title: List's not-a-directory behaviour diverged between OsFS and MemFS
+finding: 'FSLoader.List forgave any error matching os.ErrNotExist. What that covers depends on the injected storage.FS: OsFS returns ENOTDIR for a path that exists but is a regular file (surfaces, correct), while MemFS returns os.ErrNotExist for anything absent from its directory map (forgiven, wrong). So ''scripts exists but is a file'' silently reported ''no scripts'' on MemFS — precisely the silently-drop-operator-config failure the absent-is-empty asymmetry exists to prevent, made dependent on which FS happened to be installed.'
+severity: significant
+resolution: The absent check is now an explicit fs.Stat before ReadDir, distinguishing absent (empty, nil error) from exists-but-not-a-directory (error) without relying on either backend's error mapping. Interface doc updated to state the rule. Added TestFSLoader_List_NotADirectoryIsAnError.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-L6VQKI.md
+++ b/tickets/entities/review-responses/RR-L6VQKI.md
@@ -1,0 +1,9 @@
+---
+id: RR-L6VQKI
+type: review-response
+title: Fail-closed on a partial List union was undocumented
+finding: layered.List fails the whole call when either layer errors, so a transient database fault takes down a listing that disk could have served completely. That is defensible for Load, where the layers compete, but weaker for List, where they are additive. The doc explained the union and never said what a partial union means, inviting the next reader to 'fix' it into a partial-success path.
+severity: minor
+resolution: 'Documented the choice and its reasoning on layered.List: there is no partial union because a caller cannot distinguish a half-listed directory from a complete one, so an automation missing because the database hiccuped would look exactly like an automation that was never configured. Behaviour unchanged; the decision is now written down.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-RJ3QYT.md
+++ b/tickets/entities/review-responses/RR-RJ3QYT.md
@@ -1,0 +1,9 @@
+---
+id: RR-RJ3QYT
+type: review-response
+title: NewLayered panicked instead of returning an error
+finding: NewLayered validated its two required collaborators with a panic. CLAUDE.md requires a New* function with required collaborators to return error and validate up front; state.NewValidatedKV and kvstate.New both do. A panic also fails to catch the case that actually occurs in production — a non-nil interface holding a nil pointer — which sails past the nil check and fails at the first read anyway, exactly the deferred failure the rule prevents.
+severity: critical
+resolution: Changed to NewLayered(primary, secondary) (Loader, error) returning an error. Test rewritten to assert an error plus a nil Loader rather than a panic, and extended with a both-nil case. Callers are test-only so far; a mustLayered helper keeps the tests readable.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-YASRJM.md
+++ b/tickets/entities/review-responses/RR-YASRJM.md
@@ -1,0 +1,22 @@
+---
+id: RR-YASRJM
+type: review-response
+title: List returned symlinks, crossing the containment boundary it inherits
+finding: The entry filter was e.IsDir(), which is false for a symlink — including one pointing at a directory. List("scripts") therefore returned a symlink named evil.lua pointing at .rela/secrets.yaml as an ordinary config file. validateName guards the caller-supplied dir string and says nothing about entries. This seam is explicitly replacing os.OpenRoot call sites that DID defend against symlink escape (see the nested-root reasoning in dataentry/custom.go:117-125), so it inherits that duty.
+severity: significant
+resolution: 'Filter changed from !e.IsDir() to !e.Type().IsRegular(), so symlinks, devices and sockets are all skipped; the doc comment names .rela/secrets.yaml as the concrete target. Added TestFSLoader_List_SkipsSymlinks, which runs on a real filesystem (MemFS has no symlink support) and asserts a symlink pointing at a secret outside scripts/ is absent from the listing. Defence in depth rather than the only gate: Load still applies validateName, and a name returned by List is a bare filename — the value is that enumeration no longer advertises a path resolving outside the config tree.'
+status: addressed
+---
+
+Filter changed from `!e.IsDir()` to `!e.Type().IsRegular()`, so symlinks,
+devices and sockets are all skipped. Doc comment states why, naming
+`.rela/secrets.yaml` as the concrete target.
+
+Added `TestFSLoader_List_SkipsSymlinks`, which runs on a real filesystem (MemFS
+has no symlink support) and asserts a symlink to a secret outside `scripts/` is
+absent from the listing.
+
+This is defence in depth rather than the only gate: `Load` still applies
+`validateName`, and a name that came back from `List` is a bare filename. The
+value is that enumeration no longer advertises a path that resolves outside the
+config tree.

--- a/tickets/entities/review-responses/RR-YV817D.md
+++ b/tickets/entities/review-responses/RR-YV817D.md
@@ -1,0 +1,9 @@
+---
+id: RR-YV817D
+type: review-response
+title: No configtest conformance harness for Loader implementations
+finding: internal/config is about to grow a second Loader (SQLite), and the point of the seam is that the two are interchangeable. internal/store/storetest and internal/state/statetest are the established pattern, and CLAUDE.md mandates a conformance suite for new store implementations. A configtest.RunLoaderTests covering absent-dir, not-a-directory, sorting, non-recursion, symlinks and the ErrNotExist contract would have caught the OsFS/MemFS divergence the moment it appeared.
+severity: minor
+reason: Agreed in principle, deferred to TKT-S1EVV7 where the second implementation lands. Writing the harness now would mean designing a cross-implementation contract against exactly one implementation, and the FS-specific cases (symlinks, MemFS's directory map) do not all translate to a table-backed loader — the harness would be shaped by FSLoader's incidentals rather than by the contract. The divergence it would have caught is fixed and pinned by a direct test in the meantime.
+status: deferred
+---

--- a/tickets/entities/tickets/TKT-RAT7U3.md
+++ b/tickets/entities/tickets/TKT-RAT7U3.md
@@ -1,0 +1,47 @@
+---
+id: TKT-RAT7U3
+type: ticket
+title: config.Loader grows List and a disk-first layered loader
+kind: enhancement
+priority: medium
+effort: s
+status: done
+---
+
+## Description
+
+`config.Loader` today reads one named file. Directory-shaped config —
+`scripts/`, `actions/`, `validations/`, `migrations/`, `templates/`, `custom/`,
+`apps/` — has no single name, so every consumer of those trees currently
+bypasses the seam with `os.OpenRoot` or `os.DirFS`.
+
+Two additions, both confined to `internal/config`:
+
+- `List(ctx, prefix) ([]string, error)` on the interface. `FSLoader`
+implements it with `ReadDir`; a later SQLite backend with a prefix scan.
+- `NewLayered(primary, fallback Loader) Loader` — disk-first, DB-fallback.
+
+`NewLayered` is what makes the whole feature a *mode* rather than a migration:
+with disk first, every call site converted in later tickets keeps behaving
+exactly as it does today until someone runs `db load`. That is what lets the
+per-seam conversions land independently and stay independently revertible.
+
+`validateName` (`internal/config/config.go:85`) is already the right validator
+for both backends — it rejects empty names, control characters, backslashes,
+absolute paths, drive letters and `.`/`..` segments — and is reused unchanged.
+
+## Scope
+
+`internal/config/` only. Adding a method to an interface with a single
+implementation is contained; no consumer changes.
+
+## Acceptance
+
+- `List` returns names sorted, relative to the prefix, non-recursive.
+- A missing directory lists empty rather than erroring (mirrors
+`datamigration.LoadDir`, which treats only a *missing* dir as empty and surfaces
+every other error).
+- `NewLayered` falls back on `os.ErrNotExist` and only on that — any other
+primary error surfaces, or a transient disk fault would silently serve stale
+baked config.
+- Traversal rejection covered for both new entry points.

--- a/tickets/entities/tickets/TKT-S1EVV7.md
+++ b/tickets/entities/tickets/TKT-S1EVV7.md
@@ -1,0 +1,65 @@
+---
+id: TKT-S1EVV7
+type: ticket
+title: Split the SQLite connection from the store, add project_files and a migration ladder
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Description
+
+Config living in the database means config must be readable *before* the store
+exists. Separating the SQLite connection from the store is what makes that
+ordering work, and it is a refactor rather than a redesign because
+`sqlitestore.OpenContext` already decomposes along exactly this line: acquire
+the sidecar lock → `sql.Open` → `init(ctx)` (PRAGMA verify + schema).
+
+Three changes:
+
+- Extract `Connect(ctx, Options)` returning a usable handle after `init`.
+- `sqlitestore.New(conn, opts...)` mirroring `pgstore.New(db DBTX)`
+(`internal/store/pgstore/pgstore.go:196`), which already takes an injected pool
+with appbuild owning and closing it. Same shape, second backend.
+- Add the `project_files` table, bump `schemaVersion` to 2, and add the first
+rung of the migration ladder.
+
+## The ladder is required, not optional
+
+`schemaSQL` is `CREATE TABLE IF NOT EXISTS`, which is a silent no-op against an
+existing table of a different shape — the failure lands later, at the first
+query, on user data. `internal/cli/db_sqlite.go` currently documents the ladder
+as deliberately absent because no shipped database exists yet; adding a table is
+exactly the event its comment names as the trigger. `runDBMigrate` and
+`runDBStatus` stop being report-only stubs.
+
+## Table
+
+```sql
+CREATE TABLE IF NOT EXISTS project_files (
+	path       TEXT PRIMARY KEY,   -- 'schema.yaml', 'scripts/foo.lua'
+	content    BLOB NOT NULL,      -- BLOB: custom/ and apps/ carry fonts and images
+	updated_at TEXT NOT NULL
+) STRICT;
+```
+
+Flat path keys, no directory rows — listing is a prefix scan, which is all any
+consumer needs.
+
+## Constraints
+
+- `plimsoll` — `Store` carries `max-methods=53 / max-exported-methods=32`.
+`Connect`/`New` must *replace* `Open`/`OpenContext` rather than add to them, so
+the exported count does not rise.
+- The DSN-PRAGMA rule from DEC-LFSYNY is untouched: PRAGMAs stay in the DSN so
+they apply to every pooled connection, never `db.Exec`.
+- Build tags: nothing but the `sqlite` build may link `modernc.org/sqlite`; CI
+asserts this via `go list -deps`.
+
+## Acceptance
+
+- Conformance suite (`storetest.RunAll` + fuzz) still passes.
+- A database at version 1 migrates forward; one from a newer binary is still
+refused rather than mis-read.
+- `just build-check-tags` clean.

--- a/tickets/relations/FEAT-UP14BT--requires--project-layout.md
+++ b/tickets/relations/FEAT-UP14BT--requires--project-layout.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-UP14BT
+relation: requires
+to: project-layout
+---

--- a/tickets/relations/FEAT-UP14BT--requires--store-backends.md
+++ b/tickets/relations/FEAT-UP14BT--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-UP14BT
+relation: requires
+to: store-backends
+---

--- a/tickets/relations/TKT-RAT7U3--affects--project-layout.md
+++ b/tickets/relations/TKT-RAT7U3--affects--project-layout.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: affects
+to: project-layout
+---

--- a/tickets/relations/TKT-RAT7U3--has-docs--DOCS-8J08A1.md
+++ b/tickets/relations/TKT-RAT7U3--has-docs--DOCS-8J08A1.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-docs
+to: DOCS-8J08A1
+---

--- a/tickets/relations/TKT-RAT7U3--has-review--REV-M1KMP6.md
+++ b/tickets/relations/TKT-RAT7U3--has-review--REV-M1KMP6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review
+to: REV-M1KMP6
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-5932AS.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-5932AS.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review-response
+to: RR-5932AS
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-5X9QPT.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-5X9QPT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review-response
+to: RR-5X9QPT
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-I7OQAW.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-I7OQAW.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review-response
+to: RR-I7OQAW
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-L6VQKI.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-L6VQKI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review-response
+to: RR-L6VQKI
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-RJ3QYT.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-RJ3QYT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review-response
+to: RR-RJ3QYT
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-YASRJM.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-YASRJM.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review-response
+to: RR-YASRJM
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-YV817D.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-YV817D.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: has-review-response
+to: RR-YV817D
+---

--- a/tickets/relations/TKT-RAT7U3--implements--FEAT-UP14BT.md
+++ b/tickets/relations/TKT-RAT7U3--implements--FEAT-UP14BT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+relation: implements
+to: FEAT-UP14BT
+---

--- a/tickets/relations/TKT-S1EVV7--affects--store-backends.md
+++ b/tickets/relations/TKT-S1EVV7--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+relation: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-S1EVV7--implements--FEAT-UP14BT.md
+++ b/tickets/relations/TKT-S1EVV7--implements--FEAT-UP14BT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+relation: implements
+to: FEAT-UP14BT
+---


### PR DESCRIPTION
First step toward shipping a rela project as **one self-contained SQLite file** (FEAT-UP14BT) — a `.db` that, given only the `rela` binary, is a fully working app including schema, config, scripts and templates.

Nothing observable changes yet. `FSLoader` remains the only implementation, so this is purely the seam widening the later per-seam conversions need.

## What this adds

**`Loader.List(ctx, dir)`** — the directory-shaped parts of a project (`scripts/`, `actions/`, `validations/`, `migrations/`, `templates/`, `custom/`, `apps/`) have no single name, which is why every consumer of those trees currently reaches past this package to `os.OpenRoot` or `os.DirFS`. Non-recursive on purpose: a filesystem has real subdirectories while a database has flat keys that merely contain slashes, and a recursive walk would make the two backends disagree about what a directory is.

**`NewLayered(primary, secondary)`** — disk-first resolution with a fallback. This is what makes the whole feature a *mode* rather than a migration: with the filesystem in front, each converted call site keeps behaving exactly as it does today until a file is actually removed, so the conversions land one at a time and stay independently revertible.

## The non-obvious parts

Each is pinned by a test.

- **Only `os.ErrNotExist` falls through.** A permission error or truncated read is not evidence a file is absent; treating it as such would silently serve stale baked config in place of the file the operator is looking at.
- **`List` unions the layers** rather than applying `Load`'s precedence — a script present only in the database is genuinely there. Per-file precedence survives: a shared name appears once and the follow-up `Load` resolves it to the primary's bytes.
- **The union copies rather than appends.** The primary's backing array belongs to the layer that returned it, and `FSLoader` leaves exactly the spare capacity required for an `append` to write through it. Verified empirically, and the regression test fails against the reverted implementation.
- **Absent-directory is an explicit `Stat`.** `OsFS` reports ENOTDIR for a path that exists but is a file; `MemFS` reports `os.ErrNotExist` for anything absent from its directory map. Reading the distinction off `ReadDir` would forgive a not-a-directory on one backend and surface it on the other.
- **`List` skips non-regular files.** A symlink is not a directory, so an `IsDir` filter would list one as ordinary config while it points anywhere the process can read — `.rela/secrets.yaml` included. This seam replaces `os.OpenRoot` call sites that did defend against that.
- **`layered` forwards `Subscribe`.** An optional interface consumers type-assert for; dropping it would disable live config reload with no compile error and no failing test.

## Verification

`just lint` (0 issues) · `just arch-lint` (OK) · `just comment-lint` (clean) · `just build-check-tags` (all four) · `go test -race` over config, appbuild, scheduler, dataentry, cli, mcp · `internal/config` coverage 94.2% vs an 87 floor.

Code review found 2 critical and 3 significant issues; all are fixed and recorded as RR entities (RR-RJ3QYT, RR-5932AS, RR-I7OQAW, RR-YASRJM, RR-5X9QPT). One minor is deferred to TKT-S1EVV7 with reasoning (RR-YV817D).

Refs TKT-RAT7U3