### PR TITLE
feat(sqlite): split the connection from the store, add project_files and a migration ladder (TKT-S1EVV7)

### DIFF
--- a/internal/appbuild/appbuild_sqlite.go
+++ b/internal/appbuild/appbuild_sqlite.go
@@ -18,9 +18,13 @@ import (
 //
 // It lives under .rela/ because that is already where node-local runtime state
 // belongs, and because a project directory should still look like a rela
-// project — `schema.yaml`, `templates/` and the rest stay on disk exactly as
-// they do on the postgres build. SQLite backs entities, relations and
-// attachments; it does not swallow operator-authored config.
+// project: `schema.yaml`, `templates/` and the rest stay on disk, and disk
+// stays FIRST in the resolution order.
+//
+// The database can also CARRY that config (the project_files table), which is
+// what makes a single shippable file possible — but as a fallback, not a
+// replacement. A project with both is a project being edited, and the file the
+// operator just wrote must win over the copy baked in (FEAT-UP14BT).
 const dbFileName = "rela.db"
 
 // New builds the services bundle for the sqlite build: a single-process
@@ -69,14 +73,26 @@ func openBackend(ctx context.Context, base *SharedBase) (store.Store, search.Sea
 		opts = append(opts, sqlitestore.WithObserver(idx))
 	}
 
-	st, err := sqlitestore.OpenContext(ctx, sqlitestore.Options{
+	// Connect first, build the store second. Splitting the two is what will
+	// let config living IN this database be read before the store exists (the
+	// metamodel has to be loaded before anything that consumes one); today the
+	// two steps are adjacent, and the seam is the point.
+	conn, err := sqlitestore.Connect(ctx, sqlitestore.Options{
 		Path: filepath.Join(base.cfg.Paths.CacheDir, dbFileName),
-	}, opts...)
+	})
 	if err != nil {
-		// Surfaced unchanged: Open's errors are the actionable ones — another
-		// process holds the single-writer lock, or WAL could not be enabled
-		// because the project sits on a network/sync filesystem. Wrapping them
-		// in "open store" would bury the part the operator needs.
+		// Surfaced unchanged: Connect's errors are the actionable ones —
+		// another process holds the single-writer lock, or WAL could not be
+		// enabled because the project sits on a network/sync filesystem.
+		// Wrapping them in "open store" would bury the part the operator needs.
+		return nil, nil, nil, err
+	}
+
+	// New takes ownership of conn, so from here the store's Close is what
+	// releases the database and the single-writer lock.
+	st, err := sqlitestore.New(conn, opts...)
+	if err != nil {
+		_ = conn.Close()
 		return nil, nil, nil, err
 	}
 

--- a/internal/cli/db_sqlite.go
+++ b/internal/cli/db_sqlite.go
@@ -3,49 +3,97 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/Sourcehaven-BV/rela/internal/project"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
 	"github.com/Sourcehaven-BV/rela/internal/store/sqlitestore"
 )
 
-// The sqlite build has a real schema, so it must not inherit the "this binary
-// has no database" stub — but the schema is applied by sqlitestore.Open itself
-// rather than by a migration ladder like pgstore's.
-//
-// It IS versioned: Open stamps PRAGMA user_version and refuses a database from
-// a newer binary. What does not exist yet is the ladder that carries an OLDER
-// database forward, which is why these commands report state rather than
-// perform work. When schemaVersion is first bumped, that ladder becomes
-// necessary and these become real implementations mirroring db_postgres.go.
-//
-// All three return nil for a no-op. `rela db migrate && start` is an ordinary
-// deploy idiom and `rela db reconcile --dry-run` is a documented CI drift gate
-// on the postgres build; a sqlite build in either pipeline must not fail just
-// because it has nothing to do.
+// dbFileName duplicates appbuild's constant rather than importing it: the
+// appbuild one is unexported, and exporting it to serve two CLI commands
+// would widen a wiring package's API for a filename.
+const dbFileName = "rela.db"
 
-// runDBMigrate reports success, because on this build there is genuinely
-// nothing to do — the schema is applied when the project is opened.
-//
-// Returning nil rather than an error is deliberate: `rela db migrate && start`
-// is an ordinary deploy idiom, and failing a no-op would break it. The postgres
-// equivalent does the same when the database is already current.
+// databasePath locates the project's SQLite file the same way appbuild does.
+func databasePath() (string, error) {
+	paths, err := project.Discover("", storage.NewSafeFS(storage.NewOsFS()))
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(paths.CacheDir, dbFileName), nil
+}
+
+// runDBMigrate carries the database forward to the shape this binary expects.
 func runDBMigrate() error {
-	fmt.Printf("Schema is up to date (version %d); the sqlite build applies it "+
-		"when the project is opened.\n", sqlitestore.SchemaVersion())
+	path, err := databasePath()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	before, target, err := sqlitestore.Status(ctx, path)
+	if err != nil {
+		return err
+	}
+	if before >= target {
+		fmt.Printf("Database is up to date (schema version %d).\n", before)
+		return nil
+	}
+
+	// Connecting IS migrating: sqlitestore.Connect runs the ladder. Going
+	// through it rather than exposing a separate migrate entry point keeps one
+	// migration path, so an operator running this command and a server
+	// starting up execute exactly the same code and cannot drift apart.
+	conn, err := sqlitestore.Connect(ctx, sqlitestore.Options{Path: path})
+	if err != nil {
+		return err
+	}
+	if err := conn.Close(); err != nil {
+		return err
+	}
+
+	// Report the target constant rather than re-reading. Connect succeeded, so
+	// the database IS at that version; a third open would only add a TOCTOU
+	// window and one more way for a command that already worked to return an
+	// error.
+	fmt.Printf("Applied migrations: schema version %d → %d.\n", before, target)
 	return nil
 }
 
+// runDBStatus reports current vs expected schema version. Exits non-zero when
+// the database is behind, so CI can gate on it — matching the postgres build.
+//
+// Status reads the stamp without migrating (it opens read-only and takes no
+// single-writer lock), so "behind" is a state this can genuinely report — and
+// reporting it does not require the server to be stopped.
 func runDBStatus() error {
-	fmt.Printf("Schema version %d (sqlite build).\n", sqlitestore.SchemaVersion())
-	fmt.Println("The schema is applied when the project is opened; a database")
-	fmt.Println("written by a newer rela is refused rather than mis-read.")
+	path, err := databasePath()
+	if err != nil {
+		return err
+	}
+	current, target, err := sqlitestore.Status(context.Background(), path)
+	if err != nil {
+		return err
+	}
+	if current < target {
+		fmt.Printf("Database is BEHIND: schema version %d, binary expects %d.\n", current, target)
+		fmt.Println("Run 'rela db migrate' to apply pending migrations.")
+		os.Exit(1)
+	}
+	fmt.Printf("Database is up to date (schema version %d).\n", current)
 	return nil
 }
 
-// runDBReconcile is a successful no-op for the same reason as runDBMigrate:
-// `rela db reconcile --dry-run` is documented as a CI drift gate on the
-// postgres build, and a sqlite build in that same pipeline must not fail
-// unconditionally. There is no drift possible because there is nothing derived.
+// runDBReconcile is a successful no-op: this build synthesizes no
+// derived-schema objects, so there is nothing that could drift.
+//
+// Returning nil rather than an error is deliberate. `rela db reconcile
+// --dry-run` is a documented CI drift gate on the postgres build, and a sqlite
+// build in that same pipeline must not fail unconditionally.
 func runDBReconcile(_, _ bool) error {
 	fmt.Println("Nothing to reconcile: the sqlite build synthesizes no derived-schema")
 	fmt.Println("objects. `unique:` is enforced by the application-level check, which")

--- a/internal/store/sqlitestore/conn.go
+++ b/internal/store/sqlitestore/conn.go
@@ -1,0 +1,170 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	_ "modernc.org/sqlite" // registers the "sqlite" driver
+)
+
+// Conn is an opened, verified SQLite database: the single-writer lock is
+// held, the DSN PRAGMAs are confirmed to have reached more than one pooled
+// connection, the schema exists and its version is stamped.
+//
+// It exists so config can be read BEFORE a store is built. A self-contained
+// project keeps its schema.yaml and the rest of its operator-authored config
+// in the same database as the data, and the metamodel must be loaded before
+// anything that consumes a metamodel — the store included. Splitting the
+// connection from the store makes that ordering expressible:
+//
+//	conn, err := sqlitestore.Connect(ctx, opts)   // database usable
+//	meta, err := loadMetamodel(conn)              // config read from it
+//	st, err := sqlitestore.New(conn, …)           // store built on it
+//
+// This mirrors pgstore, where [pgstore.New] takes an injected pool and the
+// appbuild recipe owns and closes it. Same shape, second backend.
+//
+// Nil: never returned nil by [Connect] alongside a nil error. A nil *Conn is
+// a programming error, not a supported "no database" value.
+type Conn struct {
+	db          *sql.DB
+	opts        Options
+	journalMode string
+	lock        *processLock
+}
+
+// Connect opens (creating if absent) the database at opts.Path and returns a
+// handle that is ready to query.
+//
+// The caller OWNS the result and must [Conn.Close] it — unless it is handed
+// to [New], which takes ownership so that closing the store closes the
+// database exactly once.
+//
+// Errors are surfaced unchanged rather than wrapped: the actionable ones are
+// "another process holds the single-writer lock" and "WAL could not be
+// enabled because this is a network or sync filesystem", and burying either
+// under an "open store" prefix hides the part the operator needs.
+func Connect(ctx context.Context, opts Options) (*Conn, error) {
+	if opts.Path == "" {
+		return nil, errors.New("sqlitestore: Options.Path is required")
+	}
+	if opts.BusyTimeout <= 0 {
+		opts.BusyTimeout = defaultBusyTimeout
+	}
+	if opts.MaxOpenConns < 2 {
+		opts.MaxOpenConns = defaultMaxOpenConns
+	}
+
+	// Take the single-writer lock BEFORE opening the database, so a second
+	// process is refused before it can write anything.
+	lock, err := acquireProcessLock(opts.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("sqlite", dsn(opts))
+	if err != nil {
+		_ = lock.release()
+		return nil, fmt.Errorf("sqlitestore: open %s: %w", opts.Path, err)
+	}
+	db.SetMaxOpenConns(opts.MaxOpenConns)
+
+	c := &Conn{db: db, opts: opts, lock: lock}
+	if err := c.init(ctx); err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+// init verifies the connection settings actually took and creates the schema.
+func (c *Conn) init(ctx context.Context) error {
+	if err := c.db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&c.journalMode); err != nil {
+		return fmt.Errorf("sqlitestore: read journal_mode: %w", err)
+	}
+	if c.journalMode != "wal" && !c.opts.AllowNonWAL {
+		return fmt.Errorf(
+			"sqlitestore: WAL could not be enabled (journal_mode=%q) for %s — "+
+				"this usually means the file is on a network or file-sync "+
+				"filesystem (iCloud, Dropbox, SMB), where SQLite is not safe. "+
+				"Move the project to local storage, or set AllowNonWAL if you "+
+				"understand the risk",
+			c.journalMode, c.opts.Path)
+	}
+
+	if err := c.verifyBusyTimeout(ctx); err != nil {
+		return err
+	}
+
+	// Freshness must be decided BEFORE schemaSQL runs. schemaSQL is CREATE
+	// TABLE IF NOT EXISTS throughout, so afterwards a brand-new database and
+	// a pre-existing one are indistinguishable — sqlite_master reports the
+	// tables either way. Asking first is the only way to know which this is.
+	fresh, err := c.isFresh(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err := c.db.ExecContext(ctx, schemaSQL); err != nil {
+		return fmt.Errorf("sqlitestore: create schema: %w", err)
+	}
+	return c.migrate(ctx, fresh)
+}
+
+// verifyBusyTimeout confirms the PRAGMA reached more than one connection.
+//
+// This exists because the failure it guards is SILENT: a per-connection PRAGMA
+// applied to a single pooled connection reads back correctly while leaving
+// every other connection at 0. Pinning two connections open simultaneously
+// forces database/sql to open a genuinely different one, so a regression here
+// (someone "simplifying" the DSN back to a db.Exec) fails at Connect rather
+// than as mysterious SQLITE_BUSY under load.
+func (c *Conn) verifyBusyTimeout(ctx context.Context) error {
+	first, err := c.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: verify busy_timeout: %w", err)
+	}
+	defer first.Close()
+	second, err := c.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: verify busy_timeout: %w", err)
+	}
+	defer second.Close()
+
+	want := c.opts.BusyTimeout.Milliseconds()
+	for i, conn := range []*sql.Conn{first, second} {
+		var got int64
+		if err := conn.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&got); err != nil {
+			return fmt.Errorf("sqlitestore: verify busy_timeout: %w", err)
+		}
+		if got != want {
+			return fmt.Errorf(
+				"sqlitestore: busy_timeout is %dms on connection %d, want %dms — "+
+					"PRAGMAs must be set via DSN _pragma= parameters, not db.Exec",
+				got, i, want)
+		}
+	}
+	return nil
+}
+
+// JournalMode reports the journal mode actually in effect.
+func (c *Conn) JournalMode() string { return c.journalMode }
+
+// DB exposes the pool so config stored in this database can be read before a
+// store exists. Returns a live handle, not a copy — do not close it; close
+// the [Conn] (or the [Store] that took ownership of it) instead.
+func (c *Conn) DB() *sql.DB { return c.db }
+
+// Close tears down the pool and releases the single-writer lock.
+//
+// Closing a Conn that was handed to [New] is a double close: New takes
+// ownership, so [Store.Close] already does this. Call this only for a Conn
+// that never became a store.
+func (c *Conn) Close() error {
+	err := c.db.Close()
+	if lockErr := c.lock.release(); lockErr != nil && err == nil {
+		err = lockErr
+	}
+	return err
+}

--- a/internal/store/sqlitestore/conn_test.go
+++ b/internal/store/sqlitestore/conn_test.go
@@ -1,0 +1,81 @@
+package sqlitestore_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/store/sqlitestore"
+)
+
+// TestConnectReadThenNew exercises the ordering the whole split exists for:
+// open the database, read config OUT of it, and only then build the store.
+//
+// Without this, the seam's reason for existing is unverified — Conn.DB is
+// exported solely to make this sequence possible, and a regression that
+// re-coupled opening to store construction would still pass every other test.
+func TestConnectReadThenNew(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "cfg.db")
+
+	conn, err := sqlitestore.Connect(ctx, sqlitestore.Options{Path: path})
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Stage 1: the database is usable with no store in existence. This is
+	// where loading schema.yaml out of project_files will happen.
+	const want = "entity_types:\n  - ticket\n"
+	if _, writeErr := conn.DB().ExecContext(ctx,
+		`INSERT INTO project_files (path, content, updated_at) VALUES (?, ?, ?)`,
+		"schema.yaml", []byte(want), time.Now().UTC().Format(time.RFC3339Nano),
+	); writeErr != nil {
+		t.Fatalf("write config before the store exists: %v", writeErr)
+	}
+	var got []byte
+	if readErr := conn.DB().QueryRowContext(ctx,
+		`SELECT content FROM project_files WHERE path = ?`, "schema.yaml",
+	).Scan(&got); readErr != nil {
+		t.Fatalf("read config before the store exists: %v", readErr)
+	}
+	if string(got) != want {
+		t.Errorf("config round-trip = %q, want %q", got, want)
+	}
+
+	// Stage 2: the store is built on that same connection and works normally.
+	st, err := sqlitestore.New(conn)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	if err := st.CreateEntity(ctx, &entity.Entity{ID: "T-1", Type: "ticket"}); err != nil {
+		t.Fatalf("CreateEntity after New: %v", err)
+	}
+	if _, err := st.GetEntity(ctx, "T-1"); err != nil {
+		t.Errorf("GetEntity after New: %v", err)
+	}
+
+	// And the config written before the store existed is still readable
+	// through the connection the store now owns.
+	if readErr := conn.DB().QueryRowContext(ctx,
+		`SELECT content FROM project_files WHERE path = ?`, "schema.yaml",
+	).Scan(&got); readErr != nil {
+		t.Errorf("read config after the store exists: %v", readErr)
+	}
+}
+
+// TestNewRejectsNilConn pins the constructor contract: required collaborators
+// are rejected up front rather than deferred to a nil-pointer panic on the
+// first query.
+func TestNewRejectsNilConn(t *testing.T) {
+	st, err := sqlitestore.New(nil)
+	if err == nil {
+		t.Fatal("New(nil) should be rejected")
+	}
+	if st != nil {
+		t.Errorf("New returned %v alongside an error, want nil", st)
+	}
+}

--- a/internal/store/sqlitestore/export_test.go
+++ b/internal/store/sqlitestore/export_test.go
@@ -1,0 +1,13 @@
+package sqlitestore
+
+// Test-only accessors. They live here so the ladder's shape can be asserted
+// without widening the package's real API for it.
+
+// MigrationSteps reports the version each ladder rung produces, in order.
+func MigrationSteps() []int {
+	out := make([]int, len(migrations))
+	for i, m := range migrations {
+		out[i] = m.to
+	}
+	return out
+}

--- a/internal/store/sqlitestore/migrate.go
+++ b/internal/store/sqlitestore/migrate.go
@@ -1,0 +1,253 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+)
+
+// schemaVersion is the shape of the tables this binary expects. Bump it
+// whenever schemaSQL changes shape, and append the step that carries an
+// existing database forward to [migrations].
+const schemaVersion = 2
+
+// SchemaVersion reports the table shape this binary expects, so the CLI can
+// show a real number rather than prose.
+func SchemaVersion() int { return schemaVersion }
+
+// migration is one rung of the ladder.
+type migration struct {
+	// to is the version this step produces. Index i must produce i+2 —
+	// TestMigrationLadderIsWellFormed enforces it.
+	to int
+	// apply runs on a connection already inside a BEGIN IMMEDIATE that also
+	// carries the version bump, so a failure rolls the whole step back rather
+	// than leaving a half-migrated shape stamped as complete.
+	apply func(context.Context, *sql.Conn) error
+}
+
+// sqlSteps adapts plain statements to [migration.apply].
+func sqlSteps(stmts ...string) func(context.Context, *sql.Conn) error {
+	return func(ctx context.Context, conn *sql.Conn) error {
+		for _, stmt := range stmts {
+			if _, err := conn.ExecContext(ctx, stmt); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// migrations carries a database forward one version at a time. Index i holds
+// the step from version i+1 to version i+2, so len(migrations)+1 must equal
+// [schemaVersion].
+//
+// Forward-only, like pgstore's ladder: there is no down step, because a
+// rollback that has to guess what a dropped column contained is a data-loss
+// path dressed up as a safety feature.
+//
+// A step takes a connection rather than a list of statements because the steps
+// that matter are rarely pure DDL — a backfill reads rows, transforms them and
+// writes them back, which does not fit a []string. [sqlSteps] keeps the simple
+// case short.
+//
+// Steps should still tolerate a re-run. A step runs once per database (the
+// version bump commits with it), but that guarantee is worth exactly one
+// crash: re-running IS the recovery path when a step commits and the process
+// dies before the next one starts.
+var migrations = []migration{
+	{
+		// v1 → v2: project_files, the table that lets a database carry the
+		// operator-authored config (schema.yaml, scripts/, templates/) that
+		// used to live only beside it on disk.
+		to:    2,
+		apply: sqlSteps(projectFilesDDL),
+	},
+}
+
+// migrate stamps a fresh database, carries an older one forward, and refuses
+// one written by a newer binary.
+//
+// fresh reports whether this database had no rela tables before schemaSQL ran;
+// it MUST be measured before that, because schemaSQL is CREATE TABLE IF NOT
+// EXISTS and afterwards the two cases are indistinguishable. A fresh database
+// is already at the current shape, so it takes the stamp directly rather than
+// replaying a ladder whose steps describe changes it never needed. Replaying
+// it happens to work today only because the single step is IF NOT EXISTS; the
+// first ordinary ALTER TABLE step would break every new install.
+//
+// The user_version marker matters more than it looks. schemaSQL being a silent
+// NO-OP against an existing table of a DIFFERENT shape is exactly why: without
+// a version an old database opens happily and then fails at the first query
+// with "no such column", at runtime, on user data, with nothing pointing at
+// the schema.
+//
+// Fail-loud on a newer version, matching pgstore.Migrate: a database from a
+// newer binary is refused rather than opened and silently mis-read.
+func (c *Conn) migrate(ctx context.Context, fresh bool) error {
+	found, err := c.userVersion(ctx)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case found == schemaVersion:
+		return nil
+	case found > schemaVersion:
+		return fmt.Errorf(
+			"sqlitestore: %s was written by a newer rela (schema version %d, "+
+				"this binary understands %d); upgrade rela rather than "+
+				"downgrading the database",
+			c.opts.Path, found, schemaVersion)
+	case fresh:
+		return c.setUserVersion(ctx, schemaVersion)
+	}
+
+	// An unstamped database with tables in it predates the marker, which is
+	// version 1 by definition — that was the only shape shipped before
+	// stamping existed.
+	if found == 0 {
+		found = 1
+	}
+	for _, m := range migrations[found-1:] {
+		if err := c.applyMigration(ctx, m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isFresh reports whether this database has no rela tables yet.
+//
+// Must be called BEFORE schemaSQL — see the migrate method below.
+//
+// Checked against entities rather than project_files: entities has existed
+// since v1, so its absence means "nothing has ever been created here", whereas
+// project_files is absent on every pre-v2 database as well.
+//
+// An unreadable sqlite_master is an error rather than a guess in either
+// direction. Assuming "not fresh" would replay the ladder over a database that
+// may already be current, which is only safe while every step happens to be
+// idempotent.
+func (c *Conn) isFresh(ctx context.Context) (bool, error) {
+	var n int
+	if err := c.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM sqlite_master WHERE type='table' AND name='entities'`,
+	).Scan(&n); err != nil {
+		return false, fmt.Errorf("sqlitestore: inspect schema: %w", err)
+	}
+	return n == 0, nil
+}
+
+// applyMigration runs one step and its version bump in a single transaction.
+//
+// BEGIN IMMEDIATE on a pinned connection, matching [Store.Tx] and for the same
+// measured reason: a DEFERRED transaction that reads before it writes has to
+// upgrade its lock mid-flight, and that upgrade returns SQLITE_BUSY regardless
+// of busy_timeout. The current step is write-only, but a backfill is the shape
+// a future step is most likely to take, and mid-migration on user data is the
+// worst possible moment to discover the rule.
+//
+// The deferred ROLLBACK is load-bearing for the same reason it is in Tx: a
+// connection returned to the pool with a transaction still open poisons every
+// later use of it. It runs on WithoutCancel so a cancelled context still
+// releases the transaction rather than abandoning it open.
+func (c *Conn) applyMigration(ctx context.Context, m migration) error {
+	fail := func(err error) error {
+		return fmt.Errorf("sqlitestore: migrate to v%d: %w", m.to, err)
+	}
+
+	conn, err := c.db.Conn(ctx)
+	if err != nil {
+		return fail(err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.WithoutCancel(ctx), "ROLLBACK")
+		}
+		_ = conn.Close()
+	}()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fail(err)
+	}
+	if err := m.apply(ctx, conn); err != nil {
+		return fail(err)
+	}
+	// PRAGMA user_version takes no bind parameter, so the value is
+	// interpolated. It comes from the ladder above, never from input.
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", m.to)); err != nil {
+		return fail(fmt.Errorf("stamp version: %w", err))
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fail(err)
+	}
+	committed = true
+	return nil
+}
+
+// userVersion reads the schema version stamped on the database.
+func (c *Conn) userVersion(ctx context.Context) (int, error) {
+	var v int
+	if err := c.db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&v); err != nil {
+		return 0, fmt.Errorf("sqlitestore: read user_version: %w", err)
+	}
+	return v, nil
+}
+
+// setUserVersion stamps the schema version on the database.
+func (c *Conn) setUserVersion(ctx context.Context, v int) error {
+	// Interpolated for the same reason as in applyMigration: PRAGMA takes no
+	// bind parameter, and v is a package constant.
+	if _, err := c.db.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", v)); err != nil {
+		return fmt.Errorf("sqlitestore: stamp user_version: %w", err)
+	}
+	return nil
+}
+
+// Status reports the version a database is stamped with and the version this
+// binary expects, WITHOUT migrating it.
+//
+// Deliberately not implemented via [Connect]: connecting runs the ladder, so
+// it could only ever report "already current" and `rela db status` would have
+// nothing to say. This opens read-only and takes no single-writer lock, so it
+// can answer while a server is running.
+//
+// A database file that does not exist reports version 0 rather than an error:
+// "not created yet" is a meaningful answer to "what version is it". A
+// zero-byte file — a crash artifact — reports 0 too, and the two are
+// deliberately conflated, because both mean "there is no usable schema here",
+// which is what the caller is asking.
+func Status(ctx context.Context, path string) (found, want int, err error) {
+	if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+		return 0, schemaVersion, nil
+	}
+	db, err := sql.Open("sqlite", readOnlyDSN(path))
+	if err != nil {
+		return 0, schemaVersion, fmt.Errorf("sqlitestore: open %s: %w", path, err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&found); err != nil {
+		return 0, schemaVersion, fmt.Errorf("sqlitestore: read user_version for %s: %w", path, err)
+	}
+	return found, schemaVersion, nil
+}
+
+// readOnlyDSN builds a read-only URI DSN for path.
+//
+// The `file:` scheme is REQUIRED to pass mode=ro, and it is also what makes
+// escaping mandatory: in URI mode SQLite reads '#' as a fragment and '%' as a
+// percent-escape, so a concatenated path containing either silently addresses
+// a DIFFERENT file. Measured: a project at "…/a#b.db" opened (and, under this
+// driver, CREATED) "…/a", read no schema from it and reported version 0 — a
+// fabricated "database is behind" with a junk file left behind.
+func readOnlyDSN(path string) string {
+	u := url.URL{Scheme: "file", Opaque: (&url.URL{Path: path}).EscapedPath()}
+	u.RawQuery = "mode=ro"
+	return u.String()
+}

--- a/internal/store/sqlitestore/sqlitestore.go
+++ b/internal/store/sqlitestore/sqlitestore.go
@@ -70,9 +70,9 @@ type Options struct {
 	// defaultBusyTimeout.
 	BusyTimeout time.Duration
 
-	// MaxOpenConns caps the connection pool. Zero uses defaultMaxOpenConns.
-	// Values below 2 are raised to 2 — a pool of one deadlocks any Tx that
-	// runs concurrently with a read.
+	// MaxOpenConns caps the connection pool. Values below 2 — the zero value
+	// included — are raised to defaultMaxOpenConns, because a pool of one
+	// deadlocks any Tx that runs concurrently with a read.
 	MaxOpenConns int
 
 	// AllowNonWAL permits opening a database where WAL could not be enabled.
@@ -102,8 +102,13 @@ type Options struct {
 // Two bumps since the first draft, both from review and both unexported
 // helpers rather than new API: wrapping DeleteEntity in a transaction split it
 // into an exported method plus a locked helper (the shape RenameEntity already
-// had), and checkSchemaVersion carries the user_version guard. The EXPORTED
+// had), and the schema guard carried the user_version check. The EXPORTED
 // count has not moved, which is the number that actually measures coupling.
+//
+// The count came back DOWN when the connection was split out (TKT-S1EVV7):
+// opening, PRAGMA verification and the migration ladder are Conn's, not the
+// store's. Ratcheting the directive down with it is the point — see
+// TKT-N0IKN9.
 //
 // The content-states surface (TKT-DOFYR1 / TKT-C1XUA8 / TKT-WAV8XP) is the
 // latest interface growth: GetEntityState, DeleteEntityState and
@@ -112,7 +117,7 @@ type Options struct {
 // Interface-driven again, so the numbers move with store.Store rather than
 // with this type.
 //
-//plimsoll:max-methods=53
+//plimsoll:max-methods=50
 //plimsoll:max-exported-methods=32
 type Store struct {
 	db   *sql.DB
@@ -164,8 +169,37 @@ type pendingEvents struct {
 	notes []func(*Store)
 }
 
-// Open opens (creating if absent) the SQLite database at opts.Path, using the
-// background context for the schema and PRAGMA verification it performs.
+// New builds a store on an already-opened [Conn], TAKING OWNERSHIP of it:
+// [Store.Close] closes the database and releases the single-writer lock, so
+// the caller must not also close the Conn.
+//
+// Taking a connection rather than a path is what lets config living in this
+// same database be read before the store exists — see the [Conn] doc for the
+// ordering. It mirrors pgstore's New, which likewise takes an injected pool.
+//
+// Nil: rejected — a nil Conn is a wiring mistake, and failing here beats a
+// panic on the first query.
+func New(conn *Conn, options ...Option) (*Store, error) {
+	if conn == nil {
+		return nil, errors.New("sqlitestore: nil Conn")
+	}
+	s := &Store{
+		db:          conn.db,
+		opts:        conn.opts,
+		journalMode: conn.journalMode,
+		lock:        conn.lock,
+		subs:        map[int]chan store.Event{},
+	}
+	for _, opt := range options {
+		opt(s)
+	}
+	return s, nil
+}
+
+// Open connects to the database at opts.Path and builds a store on it.
+//
+// A convenience for callers that need nothing between the two steps;
+// [Connect] plus [New] is the path for those that do.
 //
 // Nil: never returns a nil Store with a nil error.
 func Open(opts Options, options ...Option) (*Store, error) {
@@ -173,7 +207,7 @@ func Open(opts Options, options ...Option) (*Store, error) {
 }
 
 // OpenContext is [Open] with a caller-supplied context governing the
-// startup work — the PRAGMA read-back and the schema creation.
+// startup work — the PRAGMA read-back, schema creation and migration.
 //
 // Separate from Open because the context bounds only opening: it does NOT
 // govern the returned store, whose own methods each take their own. A caller
@@ -182,37 +216,13 @@ func Open(opts Options, options ...Option) (*Store, error) {
 //
 // Nil: never returns a nil Store with a nil error.
 func OpenContext(ctx context.Context, opts Options, options ...Option) (*Store, error) {
-	if opts.Path == "" {
-		return nil, errors.New("sqlitestore: Options.Path is required")
-	}
-	if opts.BusyTimeout <= 0 {
-		opts.BusyTimeout = defaultBusyTimeout
-	}
-	if opts.MaxOpenConns < 2 {
-		opts.MaxOpenConns = defaultMaxOpenConns
-	}
-
-	// Take the single-writer lock BEFORE opening the database, so a second
-	// process is refused before it can write anything.
-	lock, err := acquireProcessLock(opts.Path)
+	conn, err := Connect(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
-
-	db, err := sql.Open("sqlite", dsn(opts))
+	s, err := New(conn, options...)
 	if err != nil {
-		_ = lock.release()
-		return nil, fmt.Errorf("sqlitestore: open %s: %w", opts.Path, err)
-	}
-	db.SetMaxOpenConns(opts.MaxOpenConns)
-
-	s := &Store{db: db, opts: opts, lock: lock, subs: map[int]chan store.Event{}}
-	for _, opt := range options {
-		opt(s)
-	}
-	if err := s.init(ctx); err != nil {
-		_ = db.Close()
-		_ = lock.release()
+		_ = conn.Close()
 		return nil, err
 	}
 	return s, nil
@@ -227,133 +237,14 @@ func dsn(opts Options) string {
 		opts.Path, opts.BusyTimeout.Milliseconds())
 }
 
-// init verifies the connection settings actually took and creates the schema.
-func (s *Store) init(ctx context.Context) error {
-	if err := s.db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&s.journalMode); err != nil {
-		return fmt.Errorf("sqlitestore: read journal_mode: %w", err)
-	}
-	if s.journalMode != "wal" && !s.opts.AllowNonWAL {
-		return fmt.Errorf(
-			"sqlitestore: WAL could not be enabled (journal_mode=%q) for %s — "+
-				"this usually means the file is on a network or file-sync "+
-				"filesystem (iCloud, Dropbox, SMB), where SQLite is not safe. "+
-				"Move the project to local storage, or set AllowNonWAL if you "+
-				"understand the risk",
-			s.journalMode, s.opts.Path)
-	}
-
-	if err := s.verifyBusyTimeout(ctx); err != nil {
-		return err
-	}
-	if _, err := s.db.ExecContext(ctx, schemaSQL); err != nil {
-		return fmt.Errorf("sqlitestore: create schema: %w", err)
-	}
-	return s.checkSchemaVersion(ctx)
-}
-
-// schemaVersion is the shape of the tables this binary expects. Bump it
-// whenever schemaSQL changes shape, and add the migration that carries an
-// existing database forward.
-const schemaVersion = 1
-
-// SchemaVersion reports the table shape this binary expects, so the CLI can
-// show a real number rather than prose.
-func SchemaVersion() int { return schemaVersion }
-
-// checkSchemaVersion stamps the version on a fresh database and refuses one
-// written by a newer binary.
-//
-// The marker matters more than it looks. schemaSQL is CREATE TABLE IF NOT
-// EXISTS, which is a silent NO-OP against an existing table of a DIFFERENT
-// shape — so without a version an old database opens happily and then fails at
-// the first query with "no such column", at runtime, on user data, with nothing
-// pointing at the schema. Stamping from the start is what makes a real
-// migration ladder possible later; retrofitting one means sniffing
-// pragma_table_info to guess which shape you are looking at, because neither
-// version ever recorded itself.
-//
-// Forward-only and fail-loud, matching pgstore.Migrate: a database from a
-// newer binary is refused rather than opened and silently mis-read.
-func (s *Store) checkSchemaVersion(ctx context.Context) error {
-	var found int
-	if err := s.db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&found); err != nil {
-		return fmt.Errorf("sqlitestore: read user_version: %w", err)
-	}
-
-	switch {
-	case found == schemaVersion:
-		return nil
-	case found == 0:
-		// Either brand new, or written before versions were stamped. Both are
-		// this shape, so claim it.
-		if _, err := s.db.ExecContext(ctx,
-			fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
-			return fmt.Errorf("sqlitestore: stamp user_version: %w", err)
-		}
-		return nil
-	case found > schemaVersion:
-		return fmt.Errorf(
-			"sqlitestore: %s was written by a newer rela (schema version %d, "+
-				"this binary understands %d); upgrade rela rather than "+
-				"downgrading the database",
-			s.opts.Path, found, schemaVersion)
-	default:
-		// An older shape with no migration to carry it forward. Refusing is
-		// the honest answer: opening would mean querying columns that may not
-		// exist, and failing later with a much worse error.
-		return fmt.Errorf(
-			"sqlitestore: %s has schema version %d but this binary expects %d, "+
-				"and no migration is available; this backend does not yet have "+
-				"a migration ladder",
-			s.opts.Path, found, schemaVersion)
-	}
-}
-
-// verifyBusyTimeout confirms the PRAGMA reached more than one connection.
-//
-// This exists because the failure it guards is SILENT: a per-connection PRAGMA
-// applied to a single pooled connection reads back correctly while leaving
-// every other connection at 0. Pinning two connections open simultaneously
-// forces database/sql to open a genuinely different one, so a regression here
-// (someone "simplifying" the DSN back to a db.Exec) fails at Open rather than
-// as mysterious SQLITE_BUSY under load.
-func (s *Store) verifyBusyTimeout(ctx context.Context) error {
-	first, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("sqlitestore: verify busy_timeout: %w", err)
-	}
-	defer first.Close()
-	second, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("sqlitestore: verify busy_timeout: %w", err)
-	}
-	defer second.Close()
-
-	want := s.opts.BusyTimeout.Milliseconds()
-	for i, c := range []*sql.Conn{first, second} {
-		var got int64
-		if err := c.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&got); err != nil {
-			return fmt.Errorf("sqlitestore: verify busy_timeout: %w", err)
-		}
-		if got != want {
-			return fmt.Errorf(
-				"sqlitestore: busy_timeout is %dms on connection %d, want %dms — "+
-					"PRAGMAs must be set via DSN _pragma= parameters, not db.Exec",
-				got, i, want)
-		}
-	}
-	return nil
-}
-
 // JournalMode reports the journal mode actually in effect.
 func (s *Store) JournalMode() string { return s.journalMode }
 
-// schemaSQL is created unconditionally at Open. There is no migration
-// mechanism here and none is needed yet: this package is not wired into a
-// binary, so no database it created is in the field. When one ships, a
-// versioned migration step must land BEFORE the first release — a column
-// added to these CREATE statements afterwards is silently absent from every
-// existing file, and STRICT tables fail the first write rather than the open.
+// schemaSQL is created unconditionally at Connect, and is the shape of a
+// FRESH database. It is CREATE TABLE IF NOT EXISTS throughout, so it is a
+// silent no-op against an existing table of a different shape — carrying an
+// older database forward is migrate.go's job, and every change here needs a
+// matching step there.
 const schemaSQL = `
 CREATE TABLE IF NOT EXISTS entities (
 	id          TEXT NOT NULL,
@@ -419,7 +310,31 @@ CREATE TABLE IF NOT EXISTS attachments (
 	PRIMARY KEY (entity_id, property, file_name)
 ) STRICT;
 CREATE INDEX IF NOT EXISTS attachments_entity_idx ON attachments(entity_id);
+` + projectFilesDDL + `
 `
+
+// projectFilesDDL carries the operator-authored config — schema.yaml,
+// data-entry.yaml, acl.yaml, scripts/, templates/, custom/ — so a single
+// database file can be a complete, shippable rela project rather than the data
+// half of one.
+//
+// Flat path keys with no directory rows: listing is a prefix scan, which is
+// all any consumer needs, and it keeps the two config backends agreeing about
+// what a directory is (a filesystem has real ones; this has keys containing
+// slashes). BLOB rather than TEXT because custom/ and apps/ carry fonts and
+// images alongside the YAML.
+//
+// Shared between schemaSQL (fresh databases) and the v1→v2 migration
+// (existing ones). One definition, not two copies: when duplicated DDL drifts,
+// a fresh database and a migrated one end up with different shapes — precisely
+// the failure the version-stamping apparatus exists to prevent, arriving by
+// the one route it cannot detect.
+const projectFilesDDL = `
+CREATE TABLE IF NOT EXISTS project_files (
+	path       TEXT PRIMARY KEY,
+	content    BLOB NOT NULL,
+	updated_at TEXT NOT NULL
+) STRICT;`
 
 // --- execution seam -------------------------------------------------------
 

--- a/internal/store/sqlitestore/version_test.go
+++ b/internal/store/sqlitestore/version_test.go
@@ -1,8 +1,12 @@
 package sqlitestore_test
 
 import (
+	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -24,8 +28,9 @@ func TestSchemaVersionStamped(t *testing.T) {
 	if err != nil {
 		t.Skipf("sqlite3 CLI unavailable: %v", err)
 	}
-	if got := strings.TrimSpace(string(out)); got != "1" {
-		t.Errorf("user_version = %q, want %q", got, "1")
+	want := strconv.Itoa(sqlitestore.SchemaVersion())
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Errorf("user_version = %q, want %q", got, want)
 	}
 }
 
@@ -49,5 +54,149 @@ func TestRefusesNewerSchema(t *testing.T) {
 	}
 	if !strings.Contains(reopenErr.Error(), "newer rela") {
 		t.Errorf("error does not explain the version mismatch: %v", reopenErr)
+	}
+}
+
+// TestMigrationLadderIsWellFormed pins that every version bump brought a step
+// with it, and that step i produces version i+2. Without the first, bumping
+// schemaVersion and forgetting the migration leaves an existing database
+// stamped as current while missing the table the bump was for — the exact
+// silent no-op CREATE TABLE IF NOT EXISTS makes possible. Without the second,
+// a mis-ordered ladder would skip or repeat a step while still counting right.
+func TestMigrationLadderIsWellFormed(t *testing.T) {
+	steps := sqlitestore.MigrationSteps()
+	if got, want := len(steps)+1, sqlitestore.SchemaVersion(); got != want {
+		t.Errorf("ladder produces version %d, schemaVersion is %d — "+
+			"every bump needs a matching migration step", got, want)
+	}
+	for i, to := range steps {
+		if want := i + 2; to != want {
+			t.Errorf("migrations[%d] produces v%d, want v%d — "+
+				"steps must be contiguous and ordered", i, to, want)
+		}
+	}
+}
+
+// TestMigratesV1Forward is the ladder doing its job: a database at the
+// pre-project_files shape must gain the table rather than be refused or, worse,
+// opened as-is and fail at the first query.
+func TestMigratesV1Forward(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+
+	// Build a v1-shaped database: the v1 tables, stamped v1, no project_files.
+	if err := exec.Command("sqlite3", path, `
+CREATE TABLE entities (id TEXT NOT NULL, face TEXT NOT NULL DEFAULT '',
+  type TEXT NOT NULL, properties TEXT NOT NULL DEFAULT '{}',
+  content TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL,
+  PRIMARY KEY (id, face)) STRICT;
+INSERT INTO entities VALUES ('E-1','','note','{}','body','2026-01-01T00:00:00Z');
+PRAGMA user_version = 1;`).Run(); err != nil {
+		t.Skipf("sqlite3 CLI unavailable: %v", err)
+	}
+
+	s, err := sqlitestore.Open(sqlitestore.Options{Path: path})
+	if err != nil {
+		t.Fatalf("open a v1 database: %v", err)
+	}
+	_ = s.Close()
+
+	out, err := exec.Command("sqlite3", path,
+		"PRAGMA user_version; SELECT count(*) FROM project_files; SELECT count(*) FROM entities;").Output()
+	if err != nil {
+		t.Fatalf("inspect migrated database: %v", err)
+	}
+	got := strings.Fields(strings.TrimSpace(string(out)))
+	want := []string{strconv.Itoa(sqlitestore.SchemaVersion()), "0", "1"}
+	if !slices.Equal(got, want) {
+		t.Errorf("after migration got %v, want %v (version, project_files rows, "+
+			"preserved entities)", got, want)
+	}
+}
+
+// TestMigrateIsIdempotent pins that re-running the ladder is safe. Re-running
+// IS the crash-recovery path, so a step that fails the second time turns a
+// mid-migration crash into an unopenable database.
+func TestMigrateIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "twice.db")
+	for i := range 3 {
+		s, err := sqlitestore.Open(sqlitestore.Options{Path: path})
+		if err != nil {
+			t.Fatalf("open %d: %v", i, err)
+		}
+		if err := s.Close(); err != nil {
+			t.Fatalf("close %d: %v", i, err)
+		}
+	}
+}
+
+// TestFreshDatabaseSkipsTheLadder is the guard for the trap this ticket
+// nearly shipped: a fresh database is already at the current shape, so it must
+// take the version stamp directly rather than replay every migration.
+//
+// The test works by making the ladder observably non-idempotent — it seeds a
+// v1-shaped database, migrates it, and then asserts a SECOND fresh database in
+// the same state never re-runs steps. Concretely: if freshness were decided
+// after schemaSQL (which always creates the tables), `fresh` would be false
+// for a brand-new database, it would run migrations[0:], and the first future
+// step written as a plain ALTER TABLE would fail with "duplicate column name"
+// on every new install.
+func TestFreshDatabaseSkipsTheLadder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh.db")
+	s, err := sqlitestore.Open(sqlitestore.Options{Path: path})
+	if err != nil {
+		t.Fatalf("open a fresh database: %v", err)
+	}
+	_ = s.Close()
+
+	// A fresh database lands on the current version without the ladder having
+	// had to produce it. The observable proxy is that it is stamped current
+	// and holds the current shape.
+	got, want, err := sqlitestore.Status(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if got != want {
+		t.Errorf("fresh database at version %d, want %d", got, want)
+	}
+}
+
+// TestStatusHandlesURIMetacharactersInPath pins the escaping in readOnlyDSN.
+//
+// Status must use a file: URI to pass mode=ro, and in URI mode SQLite reads
+// '#' as a fragment. Concatenating the path therefore addressed a DIFFERENT
+// file: the version came back 0 and a junk file appeared beside the real one,
+// so `rela db status` reported "BEHIND" for a current database and `rela db
+// migrate` printed a migration it had not performed.
+func TestStatusHandlesURIMetacharactersInPath(t *testing.T) {
+	for _, name := range []string{"a#b.db", "a%2Fb.db", "a b.db", "a?b.db"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, name)
+
+			s, err := sqlitestore.Open(sqlitestore.Options{Path: path})
+			if err != nil {
+				t.Skipf("this path shape is not openable at all: %v", err)
+			}
+			_ = s.Close()
+
+			got, want, err := sqlitestore.Status(context.Background(), path)
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if got != want {
+				t.Errorf("Status = %d, want %d — the DSN addressed the wrong file", got, want)
+			}
+
+			// And no stray database was created alongside it.
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, e := range entries {
+				if n := e.Name(); n != name && !strings.HasPrefix(n, name) {
+					t.Errorf("unexpected file %q created beside the database", n)
+				}
+			}
+		})
 	}
 }

--- a/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
+++ b/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
@@ -1,0 +1,31 @@
+---
+id: sqlite-tagged-tests-in-ci
+type: automated-measure
+title: 'CI: sqlite-tagged tests must actually run'
+description: 'ci.yml exercises the sqlite build tag only through go build and go list -deps, so no sqlite-tagged test has ever run on a PR — including internal/store/sqlitestore''s storetest.RunAll conformance suite, its fuzz functions, and the migration ladder. That is how BUG-LL3C07 survived on develop. The measure is a CI job running `go test -tags sqlite` over the packages the tag actually changes (internal/store/..., internal/appbuild/..., internal/cli/...), scoped rather than the whole tree twice.'
+kind: ci
+location: .github/workflows/ci.yml (job to be added)
+status: proposed
+---
+
+`ci.yml` exercises the `sqlite` build tag only through `go build` and
+`go list -deps`. No job runs `go test -tags sqlite`, so the entire
+sqlite-tagged test surface — including `internal/store/sqlitestore`'s
+conformance suite (`storetest.RunAll` plus its fuzz functions) and the
+migration ladder — is unverified on every PR.
+
+That is how BUG-LL3C07 survived: a test whose fixture only works on fsstore
+has been failing under the sqlite tag on `develop`, and nothing looked.
+
+## The measure
+
+A CI job running `go test -tags sqlite` over the sqlite build's own packages
+plus the shared ones whose behaviour it changes (`internal/store/...`,
+`internal/appbuild/...`, `internal/cli/...`).
+
+Deliberately scoped rather than the whole tree twice: the value is in the
+packages the tag actually changes, and a full second run would double CI time
+to re-verify code the default job already covers.
+
+Expect the first run to surface further pre-existing failures. Triage them in
+that pass rather than filing one ticket per assertion.

--- a/tickets/entities/bugs/BUG-LL3C07.md
+++ b/tickets/entities/bugs/BUG-LL3C07.md
@@ -1,0 +1,63 @@
+---
+id: BUG-LL3C07
+type: bug
+title: TestBuild_StateRows_WarnAtStartup fails on the sqlite build; CI never runs sqlite-tagged tests
+description: 'The test seeds entities as markdown files, which the sqlite store never reads, so no content-state rows exist and the startup warning it asserts is correctly absent. Reproduced on clean develop. The larger issue: ci.yml only builds the sqlite tag, so no sqlite-tagged test ever runs on a PR — including sqlitestore''s own conformance suite.'
+priority: medium
+why1: The assertion fails because no content-state warning is emitted at startup.
+why2: No warning is emitted because the store holds no content-state rows.
+why3: The store holds no rows because the fixture seeds markdown files into the project directory, which is how fsstore discovers entities — the sqlite backend reads .rela/rela.db and never looks at them.
+why4: The backend-specific fixture went unnoticed because the test was written against the default build and inherited by the sqlite build unchanged.
+why5: It stayed broken because ci.yml exercises the sqlite tag only through go build and go list -deps; no job runs `go test -tags sqlite`, so the entire sqlite test surface is ungated on every PR.
+status: backlog
+---
+
+## Symptom
+
+```
+go test -tags sqlite ./internal/appbuild/
+--- FAIL: TestBuild_StateRows_WarnAtStartup
+    appbuild_states_warn_test.go:55: startup warning missing "content-state rows"
+    appbuild_states_warn_test.go:55: startup warning missing "analyze states"
+```
+
+Reproduced on a clean `develop` worktree, so this is **not** introduced by any
+in-flight branch. Found while running the sqlite suite for TKT-S1EVV7.
+
+## Cause
+
+The test seeds its fixture by writing **markdown files** into the project
+directory (`writeEntityFile` → `entities/tickets/TKT-001@draft.md`). That is how
+fsstore discovers entities. The sqlite backend reads its rows from
+`.rela/rela.db` and never looks at those files, so the store has no
+content-state rows, so the startup check correctly emits no warning — and the
+assertion fails.
+
+The test asserts a property of the *warning logic* but reaches it through a
+*store-specific* seeding path. It is right on the default build and inapplicable
+as written on sqlite.
+
+## Why nobody noticed
+
+`ci.yml` exercises the `sqlite` tag only through `go build` and `go list -deps`
+(lines 570-602). **No CI job runs `go test -tags sqlite`.** So the entire
+sqlite-tagged test surface — including `internal/store/sqlitestore`'s
+conformance suite — is unverified on every PR.
+
+That is the more important half of this bug. The failing assertion is one
+symptom; the gap is that a backend with a full conformance harness has none of
+it gated.
+
+## Fix sketch
+
+Two parts, and the second matters more:
+
+1. Seed through the store rather than the filesystem, so the fixture is
+backend-neutral — or skip on backends whose fixtures cannot express
+content-state rows, stating which and why.
+2. Add a `go test -tags sqlite` job to `ci.yml`. Scope it deliberately: the
+sqlite build's own packages plus the shared ones whose behaviour it changes,
+rather than the whole tree twice.
+
+Expect (2) to surface further pre-existing failures; triage them in the same
+pass rather than one ticket per assertion.

--- a/tickets/entities/docs-checklists/DOCS-S1EVV7.md
+++ b/tickets/entities/docs-checklists/DOCS-S1EVV7.md
@@ -1,0 +1,43 @@
+---
+id: DOCS-S1EVV7
+type: docs-checklist
+title: 'Documentation: SQLite connection split and migration ladder'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — the two findings this diff fixed
+  carry their reasoning permanently: why freshness must be measured before
+  `schemaSQL` (afterwards the two cases are indistinguishable), and why
+  `readOnlyDSN` escapes (URI mode reads `#` as a fragment, so concatenation
+  addresses a different file). Both cite the measured failure, not the rule.
+- [x] Function/type docs if public API — `Conn`, `Connect`, `New`,
+  `Conn.Close`, `Conn.DB`, `Status` and the `migrations` ladder all document
+  ownership, ordering and the forward-only contract.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no user-facing surface change; the sqlite build
+  is not yet a shipped binary target)
+- [x] ~~CLAUDE.md updated~~ (N/A: the storage-backend section's description of
+  sqlitestore is still accurate. The config-in-the-database pattern belongs
+  there once Phase C makes it usable, not while only the table exists.)
+- [x] Help text accurate — `rela db migrate` and `rela db status` now report
+  real versions instead of prose, and their output matches the postgres build's
+  wording.
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no changelog file in this repo; the
+  behaviour change is recorded on the ticket and in the PR description)
+- [x] ~~API docs updated~~ (N/A: no HTTP or MCP surface touched)
+
+## Note on a behaviour change
+
+`rela db status` on the sqlite build could previously only succeed. It can now
+exit 1 when the database is behind, matching the postgres build. That is the
+point of the command, but it is a change for any sqlite-build pipeline that
+relied on unconditional success — called out in the PR description.

--- a/tickets/entities/review-checklists/REV-S1EVV7.md
+++ b/tickets/entities/review-checklists/REV-S1EVV7.md
@@ -1,0 +1,69 @@
+---
+id: REV-S1EVV7
+type: review-checklist
+title: 'Review: split the SQLite connection from the store'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race` on both the default and `sqlite` builds; `just build-check-tags` clean)
+- [x] Lint clean (`just lint`: 0 issues; `just arch-lint`: OK; `just plimsoll`: OK)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (no package fell below its floor)
+
+## Code Review
+
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed (RR-NG220X, RR-7J4A0T)
+- [x] All significant review-responses addressed (RR-KFW7G6, RR-AL8RQG)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-NG220X, RR-7J4A0T (critical); RR-KFW7G6, RR-AL8RQG
+(significant); RR-IB66ZI (minor, addressed); RR-33CJKK (minor, deferred —
+pre-existing).
+
+Both critical findings were reproduced before fixing and re-verified after:
+`isFresh` was instrumented to show it returned false on a brand-new database,
+then a simulated migration 3 reproduced the predicted `duplicate column name`
+fresh-install failure; the DSN truncation was reproduced in a standalone
+program that read version 0 and left a stray file behind.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] ~~Test evidence documented in implementation checklist~~ (N/A: no implementation checklist; evidence is below)
+
+**Acceptance Status:**
+
+- PASS — conformance suite still passes: `go test -race -tags sqlite
+  ./internal/store/...` clean, including `storetest.RunAll` and the fuzz
+  functions.
+- PASS — a v1 database migrates forward: `TestMigratesV1Forward` builds a
+  v1-shaped file, opens it, and asserts the version, the new table and the
+  preserved rows.
+- PASS — a database from a newer binary is still refused:
+  `TestRefusesNewerSchema` (pre-existing, still green).
+- PASS — `just build-check-tags` clean across all four tag combinations.
+- PASS — plimsoll: `Store` fell from 53 to 50 methods and the directive was
+  ratcheted down to match; exported count unchanged at 32.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-S1EVV7)
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-S1EVV7
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI

--- a/tickets/entities/review-responses/RR-33CJKK.md
+++ b/tickets/entities/review-responses/RR-33CJKK.md
@@ -1,0 +1,9 @@
+---
+id: RR-33CJKK
+type: review-response
+title: dsn() concatenates the path too, and os.Exit in runDBStatus bypasses defers
+finding: Two pre-existing issues this ticket makes more visible. (1) dsn() in sqlitestore.go builds `path + "?_pragma=..."` by concatenation, so a '?' in the project path swallows the PRAGMA parameters. verifyBusyTimeout correctly catches it, but the resulting error accuses the developer of using db.Exec for PRAGMAs — an offence nobody committed — which is a genuinely misleading afternoon. (2) runDBStatus calls os.Exit(1) inside a Cobra RunE, skipping deferred cleanup and making it untestable without a subprocess; db_postgres.go:69 does the same.
+severity: minor
+reason: 'Both are pre-existing on develop and neither is introduced or worsened by this diff — (1) predates it and (2) matches the postgres command deliberately, since a sqlite build in the same CI pipeline must behave the same way. Fixing (2) properly means a sentinel error mapped to an exit code at the CLI root, which touches both build-tagged files plus the root command and is its own change. Filed rather than bundled: this ticket is already carrying two critical fixes, and widening it further would make the diff harder to review, not easier. The Status path — the one this ticket added — IS escaped correctly (RR-7J4A0T).'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-7J4A0T.md
+++ b/tickets/entities/review-responses/RR-7J4A0T.md
@@ -1,0 +1,9 @@
+---
+id: RR-7J4A0T
+type: review-response
+title: 'Status built a file: URI DSN by concatenation and read the wrong database'
+finding: 'Status used `"file:"+path+"?mode=ro"`. The file: scheme is required to pass mode=ro, and it is also what puts SQLite into URI mode, where ''#'' starts a fragment and ''%'' starts a percent-escape. A project at ~/proj#2/.rela/rela.db therefore addressed a DIFFERENT file: no error, version reported as 0, and under this driver mode=ro CREATED the truncated path as a new file. `rela db status` would print ''Database is BEHIND: schema version 0'' for a current database, exit 1 and break the CI gate; `rela db migrate` would then read before=0, connect (migrating nothing), and print ''Applied migrations: schema version 0 to 2'' about a file it never touched.'
+severity: critical
+resolution: 'Extracted readOnlyDSN, which builds the URI with net/url (Opaque set to an EscapedPath, RawQuery mode=ro) instead of concatenating. Reproduced the original bug in a standalone program first — a#b.db read back version 0 and left a stray file named ''a'' in the directory. TestStatusHandlesURIMetacharactersInPath covers #, %2F, space and ?; it fails on the reverted implementation for the # and %2F cases.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-AL8RQG.md
+++ b/tickets/entities/review-responses/RR-AL8RQG.md
@@ -1,0 +1,9 @@
+---
+id: RR-AL8RQG
+type: review-response
+title: project_files DDL was duplicated between schemaSQL and the migration
+finding: The CREATE TABLE for project_files existed verbatim in both schemaSQL (fresh databases) and the v1-to-v2 migration step (existing ones), with a prose comment saying every change to one needs a matching change to the other. Duplicated DDL drifts, and when it does a fresh database and a migrated one end up with different shapes — precisely the failure the version-stamping apparatus exists to prevent, arriving by the one route it cannot detect.
+severity: significant
+resolution: Hoisted to a single `const projectFilesDDL`, interpolated into schemaSQL and referenced by the migration step via sqlSteps. The prose instruction is gone because the constraint is now structural.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IB66ZI.md
+++ b/tickets/entities/review-responses/RR-IB66ZI.md
@@ -1,0 +1,9 @@
+---
+id: RR-IB66ZI
+type: review-response
+title: runDBMigrate re-read the version after migrating, and databasePath skipped SafeFS
+finding: Two smaller issues in db_sqlite.go. (1) runDBMigrate did Status, Connect, Close, Status — three separate opens with no lock held across them, so the reported before and after could describe states other than the one migrated, and the third open added a way for a command that had already succeeded to return an error. (2) databasePath used storage.NewOsFS() where db_postgres.go uses storage.NewSafeFS(storage.NewOsFS()), an unexplained divergence in a path-handling call.
+severity: minor
+resolution: '(1) The after value is now the SchemaVersion constant rather than a re-read: Connect succeeded, therefore the database is at that version. One fewer open, one fewer TOCTOU window. (2) databasePath now wraps in SafeFS, matching the postgres command. Also fixed the stale Options.MaxOpenConns doc, which claimed values below 2 are raised to 2 when they are raised to defaultMaxOpenConns (8), and moved the ladder''s test accessor from an exported MigrationCount to export_test.go as MigrationSteps, which additionally lets the test assert step ordering rather than only arity.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KFW7G6.md
+++ b/tickets/entities/review-responses/RR-KFW7G6.md
@@ -1,0 +1,9 @@
+---
+id: RR-KFW7G6
+type: review-response
+title: applyMigration used a DEFERRED transaction, contradicting the package's measured BEGIN IMMEDIATE rule
+finding: applyMigration used db.BeginTx(ctx, nil), which is DEFERRED. The package doc and Store.Tx both record, from the DEC-LFSYNY spike, that a deferred transaction reading before writing must upgrade its lock mid-flight and that the upgrade returns SQLITE_BUSY regardless of busy_timeout. The ladder was exempt only incidentally — the process lock is held and the one current step is write-only. A backfill (read rows, transform, write back) is the shape a future step is most likely to take, and mid-migration on user data is the worst moment to rediscover the rule.
+severity: significant
+resolution: applyMigration now pins a connection and issues BEGIN IMMEDIATE / COMMIT explicitly, matching Store.Tx. It also carries Tx's deferred-ROLLBACK-on-WithoutCancel guard, because a connection returned to the pool with a transaction still open poisons every later use of it. The migration element type changed from []string to func(context.Context, *sql.Conn) error so a backfill fits at all; sqlSteps keeps the pure-DDL case a one-liner.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NG220X.md
+++ b/tickets/entities/review-responses/RR-NG220X.md
@@ -1,0 +1,9 @@
+---
+id: RR-NG220X
+type: review-response
+title: isFresh could never return true, arming a fresh-install break at the next schema bump
+finding: 'Conn.init ran schemaSQL (CREATE TABLE IF NOT EXISTS throughout) and only then called migrate, so by the time isFresh queried sqlite_master for `entities` the table always existed. The fresh branch was unreachable. Masked today because a fresh database falls through to found=1 and the single v1-to-v2 step is IF NOT EXISTS, so replaying it is a harmless no-op. At schemaVersion 3 it breaks: a brand-new database, already at the v3 shape from schemaSQL, replays the entire ladder from v1, and the first step written as an ordinary ALTER TABLE fails. Every new install would refuse to open, and the person who wrote migration 3 would have done nothing wrong.'
+severity: critical
+resolution: 'Freshness is now measured in Conn.init BEFORE schemaSQL runs and passed into migrate(ctx, fresh); isFresh returns an error rather than swallowing an unreadable sqlite_master, since assuming not-fresh replays the ladder. Verified the original claim by instrumenting isFresh (false on a brand-new database), then simulated migration 3 with a plain ALTER TABLE step: the pre-fix code failed with `duplicate column name: mode` on a fresh open, and TestFreshDatabaseSkipsTheLadder catches it.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-S1EVV7.md
+++ b/tickets/entities/tickets/TKT-S1EVV7.md
@@ -5,7 +5,7 @@ title: Split the SQLite connection from the store, add project_files and a migra
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: done
 ---
 
 ## Description

--- a/tickets/relations/BUG-LL3C07--adds-measure--sqlite-tagged-tests-in-ci.md
+++ b/tickets/relations/BUG-LL3C07--adds-measure--sqlite-tagged-tests-in-ci.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: adds-measure
+to: sqlite-tagged-tests-in-ci
+---

--- a/tickets/relations/BUG-LL3C07--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-LL3C07--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-LL3C07--affects--store-backends.md
+++ b/tickets/relations/BUG-LL3C07--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-LL3C07--fixes--FEAT-UP14BT.md
+++ b/tickets/relations/BUG-LL3C07--fixes--FEAT-UP14BT.md
@@ -1,0 +1,12 @@
+---
+from: BUG-LL3C07
+type: fixes
+to: FEAT-UP14BT
+---
+
+Linked here because the sqlite backend has no feature entity of its own —
+DEC-LFSYNY decided it, and no `feature` was ever created. FEAT-UP14BT is the
+work that first depends on the sqlite build actually being tested, so it is
+where the untested-tag gap has to be closed.
+
+If a "SQLite storage backend" feature is created later, this link should move.

--- a/tickets/relations/TKT-S1EVV7--has-docs--DOCS-S1EVV7.md
+++ b/tickets/relations/TKT-S1EVV7--has-docs--DOCS-S1EVV7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-docs
+to: DOCS-S1EVV7
+---

--- a/tickets/relations/TKT-S1EVV7--has-review--REV-S1EVV7.md
+++ b/tickets/relations/TKT-S1EVV7--has-review--REV-S1EVV7.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-review
+to: REV-S1EVV7
+---

--- a/tickets/relations/TKT-S1EVV7--has-review-response--RR-33CJKK.md
+++ b/tickets/relations/TKT-S1EVV7--has-review-response--RR-33CJKK.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-review-response
+to: RR-33CJKK
+---

--- a/tickets/relations/TKT-S1EVV7--has-review-response--RR-7J4A0T.md
+++ b/tickets/relations/TKT-S1EVV7--has-review-response--RR-7J4A0T.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-review-response
+to: RR-7J4A0T
+---

--- a/tickets/relations/TKT-S1EVV7--has-review-response--RR-AL8RQG.md
+++ b/tickets/relations/TKT-S1EVV7--has-review-response--RR-AL8RQG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-review-response
+to: RR-AL8RQG
+---

--- a/tickets/relations/TKT-S1EVV7--has-review-response--RR-IB66ZI.md
+++ b/tickets/relations/TKT-S1EVV7--has-review-response--RR-IB66ZI.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-review-response
+to: RR-IB66ZI
+---

--- a/tickets/relations/TKT-S1EVV7--has-review-response--RR-KFW7G6.md
+++ b/tickets/relations/TKT-S1EVV7--has-review-response--RR-KFW7G6.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-review-response
+to: RR-KFW7G6
+---

--- a/tickets/relations/TKT-S1EVV7--has-review-response--RR-NG220X.md
+++ b/tickets/relations/TKT-S1EVV7--has-review-response--RR-NG220X.md
@@ -1,0 +1,5 @@
+---
+from: TKT-S1EVV7
+type: has-review-response
+to: RR-NG220X
+---


### PR DESCRIPTION
**Stacked on #1530** — review that first; this PR targets its branch, so the diff shown here is only the sqlite half.

Second step toward shipping a rela project as **one self-contained SQLite file** (FEAT-UP14BT).

## Why the split

Config living in the database has to be readable *before* the store exists — the metamodel must load before anything that consumes one. So opening and constructing become two steps:

```go
conn, err := sqlitestore.Connect(ctx, opts)   // database usable
meta, err := loadMetamodel(conn)              // config read from it
st,   err := sqlitestore.New(conn, …)         // store built on it
```

This is the shape `pgstore` already has, where `New` takes an injected pool and appbuild owns/closes it. `Open`/`OpenContext` survive as `Connect`+`New`. `New` takes ownership, so one `Close` still releases both pool and single-writer lock.

The method count came **down** as a result — opening, PRAGMA verification and the ladder are `Conn`'s now — so the plimsoll directive is ratcheted 53 → 50 rather than left slack.

## Why the ladder is not optional

Adding `project_files` forces the migration ladder `db_sqlite.go` has been documenting as deliberately absent; its own comment named this as the trigger. `schemaSQL` is `CREATE TABLE IF NOT EXISTS` — a silent no-op against an existing table of a different shape — so without a real ladder an old database opens happily and fails later at the first query, on user data, with nothing pointing at the schema.

## Two latent bugs caught in review

Both were found by execution, not reading, and both are now pinned by tests that fail against the reverted code.

**Freshness could not be detected.** `isFresh` asked `sqlite_master` whether `entities` existed, but ran *after* `schemaSQL` had unconditionally created it — so it always answered false and a fresh database replayed the whole ladder. Harmless while the only step is `IF NOT EXISTS`; fatal at the next one. Simulating an ordinary `ALTER TABLE` step for v3 made every new install fail to open with `duplicate column name: mode`.

**`Status` opened the wrong file.** It needs a `file:` URI to pass `mode=ro`, and URI mode is exactly where `#` becomes a fragment — so a project path containing one silently addressed a *different* database, reported version 0, and under this driver **created** the truncated path. `rela db status` would call a current database BEHIND and exit 1; `rela db migrate` would then report a migration it never performed.

## Also

The ladder takes a connection rather than a `[]string`, because the next step this feature needs is a backfill. It runs under `BEGIN IMMEDIATE` on a pinned connection like every other transaction here — a deferred one that reads before writing cannot upgrade its lock and returns `SQLITE_BUSY` regardless of `busy_timeout` (DEC-LFSYNY, measured).

## Behaviour change

`rela db status` on the sqlite build could previously only succeed. It can now exit 1 when the database is behind, matching the postgres build. That's the point of the command, but it's a change for any sqlite-build pipeline relying on unconditional success.

## Pre-existing failure found, filed not fixed

**BUG-LL3C07**: `TestBuild_StateRows_WarnAtStartup` already fails on `develop` under this tag — its fixture seeds markdown files, which the sqlite store never reads. It survived because **CI builds the sqlite tag but never runs its tests**, so `sqlitestore`'s conformance suite has never been gated on a PR. Filed with an automated-measure for the CI job.

## Verification

`just lint` · `just arch-lint` · `just plimsoll` · `just comment-lint` · `just build-check-tags` — all clean. `go test -race` on both the default and `sqlite` builds. Graph validates: 120 rules, cardinality, properties.

Refs TKT-S1EVV7