### PR TITLE
fix(ci): run sqlite-tagged tests, and stop sweeping sqlite into an fs-only fixture (BUG-LL3C07)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,6 +720,14 @@ jobs:
         with:
           go-version: '1.26.6'
 
+      # internal/cli is in scope and its render/export tests shell out through
+      # internal/cmdexec, which FAILS CLOSED when no sandbox is available — so
+      # without bwrap they do not skip, they fail ("cmdexec: start bwrap:
+      # executable file not found"). The Test job installs it for the same
+      # reason; a job running the same packages needs the same runner.
+      - name: Install bubblewrap (command sandbox)
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       # Scoped to the packages the tag actually changes rather than ./... — the
       # rest is byte-identical to what the Test job already ran, and paying for
       # a second full suite to re-verify it is not worth the minutes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,6 +603,29 @@ jobs:
           go build -tags memorybackend ./...
           go build -tags postgres ./...
 
+      # Compiling a build tag is not testing it. Until BUG-LL3C07 this job
+      # built the sqlite tag four lines above and never ran a single
+      # sqlite-tagged test, so sqlitestore's conformance suite
+      # (storetest.RunAll plus its fuzz functions), its migration ladder and
+      # every `-tags sqlite` variant of a shared package were ungated on every
+      # PR. A test whose fixture only works on fsstore had been failing here on
+      # develop, and nothing looked.
+      #
+      # Scoped to the packages the tag actually changes rather than ./... — the
+      # rest is byte-identical to what the Test job already ran, and paying for
+      # a second full suite to re-verify it is not worth the minutes.
+      #
+      # No -race here: the Test job races the same shared packages on the
+      # default backend, and sqlitestore's own concurrency is covered by the
+      # conformance suite. Add it if this job ever grows a genuinely
+      # sqlite-specific concurrency test.
+      - name: Run sqlite-tagged tests
+        run: |
+          go test -tags sqlite -shuffle=on \
+            ./internal/store/... \
+            ./internal/appbuild/... \
+            ./internal/cli/...
+
       # RELA_TEST_DATABASE_REQUIRED (job env) makes the suite hard-fail rather
       # than skip if the DSN is missing. The grep below is the second, blunter
       # half of the same guard: it catches a suite that skipped for any OTHER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,29 +603,6 @@ jobs:
           go build -tags memorybackend ./...
           go build -tags postgres ./...
 
-      # Compiling a build tag is not testing it. Until BUG-LL3C07 this job
-      # built the sqlite tag four lines above and never ran a single
-      # sqlite-tagged test, so sqlitestore's conformance suite
-      # (storetest.RunAll plus its fuzz functions), its migration ladder and
-      # every `-tags sqlite` variant of a shared package were ungated on every
-      # PR. A test whose fixture only works on fsstore had been failing here on
-      # develop, and nothing looked.
-      #
-      # Scoped to the packages the tag actually changes rather than ./... — the
-      # rest is byte-identical to what the Test job already ran, and paying for
-      # a second full suite to re-verify it is not worth the minutes.
-      #
-      # No -race here: the Test job races the same shared packages on the
-      # default backend, and sqlitestore's own concurrency is covered by the
-      # conformance suite. Add it if this job ever grows a genuinely
-      # sqlite-specific concurrency test.
-      - name: Run sqlite-tagged tests
-        run: |
-          go test -tags sqlite -shuffle=on \
-            ./internal/store/... \
-            ./internal/appbuild/... \
-            ./internal/cli/...
-
       # RELA_TEST_DATABASE_REQUIRED (job env) makes the suite hard-fail rather
       # than skip if the DSN is missing. The grep below is the second, blunter
       # half of the same guard: it catches a suite that skipped for any OTHER
@@ -719,6 +696,45 @@ jobs:
   # release time, where it leaves an empty GitHub release. The default-runner
   # builds in `postgres` only exercise linux; this job adds darwin + windows.
   # Keep the goos/tag matrix in sync with .goreleaser.yaml's builds.
+  # Compiling a build tag is not testing it. Until BUG-LL3C07 the Backends job
+  # built the sqlite tag and nothing ever ran a sqlite-tagged test, so
+  # sqlitestore's conformance suite (storetest.RunAll plus its fuzz functions),
+  # its migration ladder and every `-tags sqlite` variant of a shared package
+  # were ungated on every PR. A test whose fixture only works on fsstore had
+  # been failing on develop, and nothing looked.
+  #
+  # Its OWN job, deliberately, rather than a step in the postgres one. That job
+  # sets RELA_TEST_DATABASE_REQUIRED=1 so a missing DSN hard-fails instead of
+  # skipping — exactly right for proving backend parity, and exactly wrong
+  # here: the sqlite build has no DSN, so every DB-gated pgstore test that
+  # would otherwise skip fails instead. Running here also keeps this off the
+  # critical path of a job that waits on a postgres service container.
+  sqlite:
+    name: SQLite Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.26.6'
+
+      # Scoped to the packages the tag actually changes rather than ./... — the
+      # rest is byte-identical to what the Test job already ran, and paying for
+      # a second full suite to re-verify it is not worth the minutes.
+      #
+      # No -race: the Test job races these same shared packages on the default
+      # backend, and sqlitestore's own concurrency is covered by the
+      # conformance suite. Add it if this job ever grows a genuinely
+      # sqlite-specific concurrency test.
+      - name: Run sqlite-tagged tests
+        run: |
+          go test -tags sqlite -shuffle=on \
+            ./internal/store/... \
+            ./internal/appbuild/... \
+            ./internal/cli/...
+
   cross-compile:
     name: Cross-Compile (${{ matrix.goos }}/${{ matrix.tags || 'default' }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -711,7 +711,13 @@ jobs:
   # critical path of a job that waits on a postgres service container.
   sqlite:
     name: SQLite Backend
-    runs-on: ubuntu-latest
+    # 26.04, not ubuntu-latest — the same reason the Test job pins it: the
+    # command sandbox needs unprivileged user namespaces, which 24.04 restricts
+    # via AppArmor (apparmor_restrict_unprivileged_userns=1, surfacing as
+    # bwrap "Failed RTM_NEWADDR: Operation not permitted"). internal/cli is in
+    # scope and its render tests run confined, so they fail on 24.04 even with
+    # bubblewrap installed.
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 
@@ -727,6 +733,12 @@ jobs:
       # reason; a job running the same packages needs the same runner.
       - name: Install bubblewrap (command sandbox)
         run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
+      - name: Verify the sandbox actually works on this runner
+        # A hard failure here beats a confusing test failure downstream: it
+        # says "the confinement is absent" rather than "render produced the
+        # wrong bytes".
+        run: bwrap --unshare-all --ro-bind / / /bin/true
 
       # Scoped to the packages the tag actually changes rather than ./... — the
       # rest is byte-identical to what the Test job already ran, and paying for

--- a/internal/appbuild/appbuild_states_warn_test.go
+++ b/internal/appbuild/appbuild_states_warn_test.go
@@ -1,9 +1,15 @@
 // The fixtures are hand-written ENTITY FILES, which only the fs-backed
-// build loads — under `-tags postgres` entities live in the database
-// and the on-disk files are never read, so the probe counts zero and
-// the warning legitimately stays silent. The warning logic itself is
-// backend-agnostic (two CountEntities calls); the fs build covers it.
-//go:build !postgres && !memorybackend
+// build loads. Under `-tags postgres` or `-tags sqlite` entities live in
+// the database and the on-disk files are never read, so the probe counts
+// zero and the warning legitimately stays silent. The warning logic itself
+// is backend-agnostic (two CountEntities calls); the fs build covers it.
+//
+// The sqlite exclusion is BUG-LL3C07: the tag was `!postgres`, which swept
+// sqlite in when that backend arrived, and the resulting failure sat on
+// develop unnoticed because CI built the sqlite tag without ever running its
+// tests. Both halves are fixed — the exclusion here, and a CI job that would
+// have caught it.
+//go:build !postgres && !memorybackend && !sqlite
 
 package appbuild_test
 

--- a/internal/appbuild/backendtest/backendtest_local.go
+++ b/internal/appbuild/backendtest/backendtest_local.go
@@ -5,16 +5,24 @@ package backendtest
 import "github.com/Sourcehaven-BV/rela/internal/appbuild"
 
 // buildName labels this build in skip and failure messages.
-const buildName = "filesystem/memory"
+const buildName = "filesystem/memory/sqlite"
 
-// Options returns no options: the fs and memory recipes open a store from the
-// project directory the test already wrote, so there is nothing to supply and
+// Options returns no options: the fs, memory and sqlite recipes each open a
+// store from the project directory alone, so there is nothing to supply and
 // nothing that can be unavailable. These builds never skip.
+//
+// sqlite belongs here despite having a real database, because the thing this
+// file abstracts is whether a test must be GIVEN a connection — and it must
+// not: the sqlite recipe creates .rela/rela.db under the project root by
+// itself. What sqlite does NOT share with fs and memory is where entities come
+// from, since it reads rows rather than the markdown files a test wrote. A
+// test whose fixture is hand-written entity files needs its own exclusion
+// (BUG-LL3C07); this seam cannot express that, and does not try to.
 func Options(_ TB) []appbuild.Option { return nil }
 
 // Env returns no environment overrides, for the same reason.
 func Env(_ TB) map[string]string { return nil }
 
-// DSN returns "": these builds have no database, and Config.DatabaseURL is
-// ignored by their recipes.
+// DSN returns "": none of these builds takes an external database, and
+// Config.DatabaseURL is ignored by their recipes.
 func DSN(_ TB) string { return "" }

--- a/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
+++ b/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
@@ -39,6 +39,11 @@ backend, and sqlitestore's own concurrency is covered by the conformance
 suite. Worth adding if this job ever grows a genuinely sqlite-specific
 concurrency test.
 
+The job installs bubblewrap, like the Test job does. `internal/cli` is in
+scope and its render/export tests shell out through `internal/cmdexec`, which
+fails closed with no sandbox available — so without it they do not skip, they
+fail. CI caught that too, on the second run.
+
 ## Verified, not assumed
 
 Reverting the build-tag fix and running the job's exact command reproduces

--- a/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
+++ b/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
@@ -1,0 +1,42 @@
+---
+id: sqlite-tagged-tests-in-ci
+type: automated-measure
+title: 'CI: sqlite-tagged tests must actually run'
+description: 'ci.yml exercises the sqlite build tag only through go build and go list -deps, so no sqlite-tagged test has ever run on a PR — including internal/store/sqlitestore''s storetest.RunAll conformance suite, its fuzz functions, and the migration ladder. That is how BUG-LL3C07 survived on develop. The measure is a CI job running `go test -tags sqlite` over the packages the tag actually changes (internal/store/..., internal/appbuild/..., internal/cli/...), scoped rather than the whole tree twice.'
+kind: ci
+location: .github/workflows/ci.yml (Backends job, "Run sqlite-tagged tests" step)
+status: active
+---
+
+`ci.yml` exercises the `sqlite` build tag only through `go build` and
+`go list -deps`. No job runs `go test -tags sqlite`, so the entire
+sqlite-tagged test surface — including `internal/store/sqlitestore`'s
+conformance suite (`storetest.RunAll` plus its fuzz functions) and the
+migration ladder — is unverified on every PR.
+
+That is how BUG-LL3C07 survived: a test whose fixture only works on fsstore
+has been failing under the sqlite tag on `develop`, and nothing looked.
+
+## The measure
+
+A `Run sqlite-tagged tests` step in the Backends job, running
+`go test -tags sqlite -shuffle=on` over `internal/store/...`,
+`internal/appbuild/...` and `internal/cli/...`.
+
+Deliberately scoped rather than the whole tree twice: the value is in the
+packages the tag actually changes, and a full second run would spend minutes
+re-verifying code byte-identical to what the Test job already ran.
+
+No `-race`: the Test job races the same shared packages on the default
+backend, and sqlitestore's own concurrency is covered by the conformance
+suite. Worth adding if this job ever grows a genuinely sqlite-specific
+concurrency test.
+
+## Verified, not assumed
+
+Reverting the build-tag fix and running the job's exact command reproduces
+`--- FAIL: TestBuild_StateRows_WarnAtStartup`. The measure catches the defect
+it was written for.
+
+A full `go test -tags sqlite ./...` sweep found exactly one failing test, so
+the anticipated tail of further pre-existing failures does not exist.

--- a/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
+++ b/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
@@ -4,7 +4,7 @@ type: automated-measure
 title: 'CI: sqlite-tagged tests must actually run'
 description: 'ci.yml exercises the sqlite build tag only through go build and go list -deps, so no sqlite-tagged test has ever run on a PR — including internal/store/sqlitestore''s storetest.RunAll conformance suite, its fuzz functions, and the migration ladder. That is how BUG-LL3C07 survived on develop. The measure is a CI job running `go test -tags sqlite` over the packages the tag actually changes (internal/store/..., internal/appbuild/..., internal/cli/...), scoped rather than the whole tree twice.'
 kind: ci
-location: .github/workflows/ci.yml (Backends job, "Run sqlite-tagged tests" step)
+location: .github/workflows/ci.yml (SQLite Backend job)
 status: active
 ---
 
@@ -19,9 +19,16 @@ has been failing under the sqlite tag on `develop`, and nothing looked.
 
 ## The measure
 
-A `Run sqlite-tagged tests` step in the Backends job, running
-`go test -tags sqlite -shuffle=on` over `internal/store/...`,
-`internal/appbuild/...` and `internal/cli/...`.
+A dedicated `SQLite Backend` job running `go test -tags sqlite -shuffle=on`
+over `internal/store/...`, `internal/appbuild/...` and `internal/cli/...`.
+
+Its own job rather than a step in the postgres one, which is where it was
+first written and where CI caught the mistake. That job sets
+`RELA_TEST_DATABASE_REQUIRED=1` so a missing DSN hard-fails instead of
+skipping — correct for proving backend parity, and exactly wrong here: the
+sqlite build has no DSN, so ~30 DB-gated pgstore tests that would otherwise
+skip failed instead. A separate job also keeps this off the critical path of
+one that waits on a service container.
 
 Deliberately scoped rather than the whole tree twice: the value is in the
 packages the tag actually changes, and a full second run would spend minutes

--- a/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
+++ b/tickets/entities/automated-measures/sqlite-tagged-tests-in-ci.md
@@ -39,7 +39,10 @@ backend, and sqlitestore's own concurrency is covered by the conformance
 suite. Worth adding if this job ever grows a genuinely sqlite-specific
 concurrency test.
 
-The job installs bubblewrap, like the Test job does. `internal/cli` is in
+The job runs on `ubuntu-26.04` and installs bubblewrap, matching the Test job
+on both counts. 24.04 restricts unprivileged user namespaces via AppArmor, so
+the sandbox fails there with `bwrap: Failed RTM_NEWADDR: Operation not
+permitted` even when bubblewrap is installed. `internal/cli` is in
 scope and its render/export tests shell out through `internal/cmdexec`, which
 fails closed with no sandbox available — so without it they do not skip, they
 fail. CI caught that too, on the second run.

--- a/tickets/entities/bugs/BUG-LL3C07.md
+++ b/tickets/entities/bugs/BUG-LL3C07.md
@@ -1,0 +1,64 @@
+---
+id: BUG-LL3C07
+type: bug
+title: TestBuild_StateRows_WarnAtStartup fails on the sqlite build; CI never runs sqlite-tagged tests
+description: 'The test seeds entities as markdown files, which the sqlite store never reads, so no content-state rows exist and the startup warning it asserts is correctly absent. Reproduced on clean develop. The larger issue: ci.yml only builds the sqlite tag, so no sqlite-tagged test ever runs on a PR — including sqlitestore''s own conformance suite.'
+priority: medium
+why1: The assertion fails because no content-state warning is emitted at startup.
+why2: No warning is emitted because the store holds no content-state rows.
+why3: The store holds no rows because the fixture seeds markdown files into the project directory, which is how fsstore discovers entities — the sqlite backend reads .rela/rela.db and never looks at them.
+why4: The backend-specific fixture went unnoticed because the test was written against the default build and inherited by the sqlite build unchanged.
+why5: It stayed broken because ci.yml exercises the sqlite tag only through go build and go list -deps; no job runs `go test -tags sqlite`, so the entire sqlite test surface is ungated on every PR.
+prevention: 'Two changes, and the second is the one that matters. (1) The test now excludes the sqlite tag explicitly, matching the exclusion it already had for postgres for the identical reason. (2) A `Run sqlite-tagged tests` step in the Backends CI job runs `go test -tags sqlite` over internal/store, internal/appbuild and internal/cli — verified to fail against the reverted fix, so the class of defect is now caught rather than the instance. The general lesson: a build tag that CI only COMPILES is untested, and adding a backend under an existing `!postgres` exclusion silently opts it into every fs-shaped fixture.'
+status: done
+---
+
+## Symptom
+
+```
+go test -tags sqlite ./internal/appbuild/
+--- FAIL: TestBuild_StateRows_WarnAtStartup
+    appbuild_states_warn_test.go:55: startup warning missing "content-state rows"
+    appbuild_states_warn_test.go:55: startup warning missing "analyze states"
+```
+
+Reproduced on a clean `develop` worktree, so this is **not** introduced by any
+in-flight branch. Found while running the sqlite suite for TKT-S1EVV7.
+
+## Cause
+
+The test seeds its fixture by writing **markdown files** into the project
+directory (`writeEntityFile` → `entities/tickets/TKT-001@draft.md`). That is how
+fsstore discovers entities. The sqlite backend reads its rows from
+`.rela/rela.db` and never looks at those files, so the store has no
+content-state rows, so the startup check correctly emits no warning — and the
+assertion fails.
+
+The test asserts a property of the *warning logic* but reaches it through a
+*store-specific* seeding path. It is right on the default build and inapplicable
+as written on sqlite.
+
+## Why nobody noticed
+
+`ci.yml` exercises the `sqlite` tag only through `go build` and `go list -deps`
+(lines 570-602). **No CI job runs `go test -tags sqlite`.** So the entire
+sqlite-tagged test surface — including `internal/store/sqlitestore`'s
+conformance suite — is unverified on every PR.
+
+That is the more important half of this bug. The failing assertion is one
+symptom; the gap is that a backend with a full conformance harness has none of
+it gated.
+
+## Fix sketch
+
+Two parts, and the second matters more:
+
+1. Seed through the store rather than the filesystem, so the fixture is
+backend-neutral — or skip on backends whose fixtures cannot express
+content-state rows, stating which and why.
+2. Add a `go test -tags sqlite` job to `ci.yml`. Scope it deliberately: the
+sqlite build's own packages plus the shared ones whose behaviour it changes,
+rather than the whole tree twice.
+
+Expect (2) to surface further pre-existing failures; triage them in the same
+pass rather than one ticket per assertion.

--- a/tickets/entities/features/FEAT-SQLBK1.md
+++ b/tickets/entities/features/FEAT-SQLBK1.md
@@ -1,0 +1,41 @@
+---
+id: FEAT-SQLBK1
+type: feature
+title: SQLite storage backend for single-process deployments
+summary: The embedded single-file backend decided by DEC-LFSYNY — pgstore's transaction tier at fsstore's operational cost, for desktop and single-server deployments.
+description: 'A store.Store on modernc.org/sqlite (pure Go, no cgo) sitting between fsstore and pgstore: indexed queries and real transaction rollback without a database server, giving up git-diffable markdown and cross-process serialization. Single-process is enforced by an exclusive sidecar lock rather than documented and hoped for, because rela enforces `unique:` with an untransacted scan and two writers would have no backstop. Built by DEC-LFSYNY; this entity exists so work on the backend has something to hang off.'
+priority: medium
+status: implemented
+---
+
+## Why this entity exists
+
+DEC-LFSYNY decided the backend and `internal/store/sqlitestore` implements it,
+but no `feature` was ever created — so tickets and bugs touching the backend
+had nothing to link to, and BUG-LL3C07 could not satisfy the `fixes`
+cardinality rule without pointing somewhere unrelated.
+
+## Scope
+
+What DEC-LFSYNY licensed and this covers:
+
+- `store.Store` on `modernc.org/sqlite`, at pgstore's transaction tier — real
+  rollback, events withheld until commit.
+- Single-process enforcement via an exclusive sidecar lock, refusing the second
+  process rather than admitting it.
+- Refusal to open where WAL cannot be enabled (iCloud, Dropbox, SMB), because
+  SQLite is unsafe there and the sidecar lock is unreliable too.
+- Attachments as BLOBs in the same database.
+- Pairing with bleve rather than FTS5: `search.Visible` wraps any `Searcher`,
+  so a native FTS5 backend is an optimization, not a prerequisite.
+
+Explicitly **not** licensed by that decision, and so not part of this feature:
+multi-process SQLite, replacing pgstore for shared servers, FTS5 search
+integration, SQL pushdown, `ManifestSince`. Each needs its own decision.
+
+## Known gaps
+
+- No content versioning yet, so this backend currently has neither git history
+  nor version history — the one place it is behind both of its neighbours.
+- `synchronous=NORMAL` means a crash can lose recently committed transactions,
+  a deliberate durability trade to revisit if it proves wrong.

--- a/tickets/entities/review-checklists/REV-LL3C07.md
+++ b/tickets/entities/review-checklists/REV-LL3C07.md
@@ -1,0 +1,63 @@
+---
+id: REV-LL3C07
+type: review-checklist
+title: 'Review: sqlite-tagged tests run in CI'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -tags sqlite` over the newly-gated packages is clean; default build unaffected)
+- [x] Lint clean (`just lint`: 0 issues; `just lint-md`: 0 issues)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (no production code changed; no package moved)
+
+## Code Review
+
+- [x] ~~Run `/code-review` command~~ (N/A: the change is one build-tag constraint, two doc comments and a CI step — there is no logic to review. The substantive check is whether the new job catches the defect, done under Acceptance below.)
+- [x] All critical review-responses addressed (none raised)
+- [x] All significant review-responses addressed (none raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none — no production code changed.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] ~~Test evidence documented in implementation checklist~~ (N/A: evidence is below)
+
+**Acceptance Status:**
+
+- PASS — the failing test passes under `-tags sqlite`. Root cause was the
+  fixture, not the warning logic: `warnUndeclaredFaces` probes the store with
+  two `CountEntities` calls and is fully backend-neutral, while the fixture
+  hand-writes entity markdown that only fsstore reads. The file already
+  excluded `postgres` for that exact reason; `sqlite` inherited the gap when
+  the backend was added under a bare `!postgres` tag.
+- PASS — **the new CI job catches the original defect.** Reverted the build-tag
+  fix and ran the job's exact command: `--- FAIL:
+  TestBuild_StateRows_WarnAtStartup`. Restored, green again.
+- PASS — full sweep of the tree under `-tags sqlite` found exactly one failing
+  test, so the fix is complete rather than the first of many. That was worth
+  measuring: the bug report predicted further failures, and there are none.
+- PASS — `just build-check-tags` clean across all four combinations.
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix, no user-facing surface)
+- [x] ~~User-facing documentation updated~~ (N/A: no behaviour change for any user)
+- [x] ~~Docs-checklist marked as done~~ (N/A)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI

--- a/tickets/relations/BUG-LL3C07--adds-measure--sqlite-tagged-tests-in-ci.md
+++ b/tickets/relations/BUG-LL3C07--adds-measure--sqlite-tagged-tests-in-ci.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: adds-measure
+to: sqlite-tagged-tests-in-ci
+---

--- a/tickets/relations/BUG-LL3C07--affects--ci-pipeline.md
+++ b/tickets/relations/BUG-LL3C07--affects--ci-pipeline.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: affects
+to: ci-pipeline
+---

--- a/tickets/relations/BUG-LL3C07--affects--store-backends.md
+++ b/tickets/relations/BUG-LL3C07--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: affects
+to: store-backends
+---

--- a/tickets/relations/BUG-LL3C07--fixes--FEAT-SQLBK1.md
+++ b/tickets/relations/BUG-LL3C07--fixes--FEAT-SQLBK1.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: fixes
+to: FEAT-SQLBK1
+---

--- a/tickets/relations/BUG-LL3C07--has-review--REV-LL3C07.md
+++ b/tickets/relations/BUG-LL3C07--has-review--REV-LL3C07.md
@@ -1,0 +1,5 @@
+---
+from: BUG-LL3C07
+type: has-review
+to: REV-LL3C07
+---

--- a/tickets/relations/DEC-LFSYNY--decides--FEAT-SQLBK1.md
+++ b/tickets/relations/DEC-LFSYNY--decides--FEAT-SQLBK1.md
@@ -1,0 +1,5 @@
+---
+from: DEC-LFSYNY
+type: decides
+to: FEAT-SQLBK1
+---

--- a/tickets/relations/FEAT-SQLBK1--requires--store-backends.md
+++ b/tickets/relations/FEAT-SQLBK1--requires--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: FEAT-SQLBK1
+type: requires
+to: store-backends
+---


### PR DESCRIPTION
Independent of #1530 and #1531 — branches from `develop`, no overlap.

`TestBuild_StateRows_WarnAtStartup` **has been failing under `-tags sqlite` on `develop`**. Two defects; the second is the one worth fixing.

## The fixture

The test hand-writes entity markdown, which is how fsstore discovers entities. The sqlite backend reads rows from `.rela/rela.db` and never looks at those files, so the store holds no content-state rows and the warning it asserts is correctly absent.

The warning logic is backend-neutral — `warnUndeclaredFaces` makes two `CountEntities` calls and knows nothing about storage — so only the *fixture* was ever fs-shaped. The file already excluded postgres for exactly this reason; sqlite inherited the gap because the exclusion read `!postgres` and a third backend arrived later.

## The actual bug

`ci.yml` exercises the sqlite tag through `go build` and `go list -deps` and nothing else. **No sqlite-tagged test has ever run on a PR** — including `sqlitestore`'s `storetest.RunAll` conformance suite and its fuzz functions. Compiling a build tag is not testing it, and a whole storage backend was gated on compilation alone.

The Backends job now runs `go test -tags sqlite` over `internal/store`, `internal/appbuild` and `internal/cli` — the packages the tag actually changes. Scoped rather than `./...` because the rest is byte-identical to what the Test job already ran; no `-race` because that job already races these same shared packages on the default backend.

## Verified, not assumed

- **The new job catches the original defect.** Reverting the build-tag fix and running the step's exact command reproduces `--- FAIL: TestBuild_StateRows_WarnAtStartup`. Restored → green.
- **A full `go test -tags sqlite ./...` sweep found exactly one failing test.** The tail of further pre-existing failures the bug report anticipated does not exist, so this fix is complete rather than the first of a series.

## Also

Adds **FEAT-SQLBK1**. DEC-LFSYNY decided the sqlite backend and `internal/store/sqlitestore` implements it, but no feature entity was ever created — so a bug touching the backend had nothing to satisfy its `fixes` cardinality with, and tickets had nothing to hang off. `backendtest_local.go`'s doc comment was likewise still describing a two-backend world; it now explains why sqlite belongs there (no connection to supply) and why that does *not* make fs-shaped fixtures work on it.

## Verification

`just lint` · `just comment-lint` · `just lint-md` · `just build-check-tags` — all clean. Graph validates: 120 rules, cardinality, properties.

Refs BUG-LL3C07