### PR TITLE
feat(config): read migrations/ through the config seam, not os.DirFS

### DIFF
--- a/internal/cli/migrate_data.go
+++ b/internal/cli/migrate_data.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"time"
 
+	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/datamigration"
 	relaerrors "github.com/Sourcehaven-BV/rela/internal/errors"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -20,8 +21,30 @@ import (
 // command path — bare `rela migrate` stays service-free).
 
 // loadDataMigrations parses the project's migrations/ directory.
-func loadDataMigrations(svc *writeServices) ([]*datamigration.File, error) {
-	return datamigration.LoadDir(os.DirFS(svc.Paths.Root))
+//
+// Reads through the injected [config.Loader] rather than os.DirFS so a project
+// whose config lives somewhere other than the filesystem — a self-contained
+// SQLite file — still has a migration chain.
+func loadDataMigrations(ctx context.Context, svc *writeServices) ([]*datamigration.File, error) {
+	fsys, err := newConfigFS(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+	return datamigration.LoadDir(fsys)
+}
+
+// newConfigFS views the project's config as an fs.FS, bound to ctx.
+//
+// The error is a wiring failure (a nil Config), not a runtime condition, but
+// it is returned rather than panicked on for the reason CLAUDE.md gives: the
+// call sites already thread errors, and a startup error names the problem
+// where a panic only names the symptom.
+func newConfigFS(ctx context.Context, svc *writeServices) (fs.FS, error) {
+	v, err := config.NewFSView(svc.Config)
+	if err != nil {
+		return nil, err
+	}
+	return v.WithContext(ctx)
 }
 
 // migrationLock builds the per-store lock the same way appbuild does, so
@@ -64,7 +87,7 @@ func (c *MigrateStatusCmd) Run(ctx context.Context, svc *writeServices) error {
 			fmt.Printf("  [%s] %s\n", tier, d.Detail)
 		}
 	}
-	files, err := loadDataMigrations(svc)
+	files, err := loadDataMigrations(ctx, svc)
 	if err != nil {
 		return err
 	}
@@ -116,7 +139,7 @@ func (c *MigrateGenCmd) Run(ctx context.Context, svc *writeServices) error {
 	if err != nil {
 		return err
 	}
-	existing, err := loadDataMigrations(svc)
+	existing, err := loadDataMigrations(ctx, svc)
 	if err != nil {
 		return err
 	}
@@ -172,7 +195,7 @@ func (c *MigrateDataCmd) Run(ctx context.Context, svc *writeServices) error {
 	if err != nil {
 		return err
 	}
-	files, err := loadDataMigrations(svc)
+	files, err := loadDataMigrations(ctx, svc)
 	if err != nil {
 		return err
 	}
@@ -191,12 +214,25 @@ func (c *MigrateDataCmd) Run(ctx context.Context, svc *writeServices) error {
 		return nil
 	}
 
+	// Same seam as loadDataMigrations: a `lua:` step's script is
+	// operator-authored config, so it resolves wherever the rest of the
+	// project's config does.
+	//
+	// Bound to ctx, which is the point of doing it here rather than reusing a
+	// background view: the runner already binds a `lua:` step's VM to this
+	// context so a runaway migration is interruptible, and reading the script
+	// through an uncancellable FS would defeat half of that.
+	scriptFS, err := newConfigFS(ctx, svc)
+	if err != nil {
+		return err
+	}
+
 	runner, err := datamigration.NewRunner(datamigration.Deps{
 		Store:    svc.Store,
 		Meta:     svc.Meta,
 		State:    svc.State,
 		Audit:    svc.Audit,
-		ScriptFS: os.DirFS(svc.Paths.Root),
+		ScriptFS: scriptFS,
 		Versions: versionCaptureFor(svc),
 		Lock:     lock,
 	})

--- a/internal/config/fsview.go
+++ b/internal/config/fsview.go
@@ -1,0 +1,280 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"time"
+)
+
+// FSView adapts a [Loader] to the standard [io/fs.FS] interface, so consumers
+// written against fs.FS — [datamigration.LoadDir] and the `lua:` migration
+// step, today — read through the config seam instead of the filesystem
+// directly.
+//
+// It supports exactly what those consumers use: [io/fs.ReadFileFS] and
+// [io/fs.ReadDirFS]. Open returns a reader over the whole file, which is what
+// fs.ReadFile falls back to anyway; there is no seeking and no streaming,
+// because a config file is read whole or not at all.
+//
+// # Not walkable from the root
+//
+// The root ("." ) opens, and lists EMPTY. [Loader] has no enumerate-everything
+// capability — List takes a directory and rejects both "" and "." — so a root
+// listing could only be invented, and an invented one would be wrong the
+// moment a backend held a path this view had not been told about.
+//
+// So fs.WalkDir and fs.Glob over an FSView find nothing, and fstest.TestFS
+// fails it for that reason. Both are working as intended: address the
+// directory you want (ReadDir("migrations")) rather than discovering it. The
+// root is openable only because WalkDir and Glob open it before anything else,
+// and an fs.FS whose root cannot be opened is malformed in a way that breaks
+// callers for no benefit.
+//
+// Nil: rejected — [NewFSView] returns an error rather than deferring to a nil
+// dereference at the first read.
+type FSView struct {
+	loader Loader
+	// ctx is carried on the value because [fs.FS] has no context in any of
+	// its method signatures, so there is nowhere else to put one. The usual
+	// objection to a stored context — that it hides the cancellation seam from
+	// the caller — is answered by [FSView.WithContext] being the only way to
+	// set it: a view is explicitly bound, never implicitly.
+	//
+	//nolint:containedctx // fs.FS's signatures take no ctx; see above.
+	ctx context.Context
+}
+
+var (
+	_ fs.FS         = (*FSView)(nil)
+	_ fs.ReadFileFS = (*FSView)(nil)
+	_ fs.ReadDirFS  = (*FSView)(nil)
+)
+
+// NewFSView wraps a Loader as an fs.FS. Its reads carry
+// context.Background(); bind a real one with [FSView.WithContext].
+func NewFSView(loader Loader) (*FSView, error) {
+	if loader == nil {
+		return nil, errors.New("config: NewFSView requires a non-nil Loader")
+	}
+	return &FSView{loader: loader}, nil
+}
+
+// WithContext returns a view whose reads carry ctx.
+//
+// [fs.FS] has no context in its signature, so a ctx cannot be threaded per
+// call and lives on the value instead. It matters because a Loader's reads can
+// genuinely block — a database-backed one waiting on a locked file — and
+// internal/datamigration deliberately binds a `lua:` step's VM to the run
+// context so a runaway migration is interruptible. Reading that step's script
+// through an uncancellable FS would defeat half of that.
+//
+// Nil: rejected, rather than silently replaced with Background, so a caller
+// who meant to pass a context finds out here.
+func (v *FSView) WithContext(ctx context.Context) (*FSView, error) {
+	if ctx == nil {
+		return nil, errors.New("config: WithContext requires a non-nil context")
+	}
+	return &FSView{loader: v.loader, ctx: ctx}, nil
+}
+
+// context returns the view's context, defaulting to Background.
+func (v *FSView) context() context.Context {
+	if v.ctx == nil {
+		return context.Background()
+	}
+	return v.ctx
+}
+
+// Open returns the named file's contents as a read-only fs.File.
+//
+// The ROOT (".") is the one name that opens as a directory, because
+// [fs.WalkDir] and [fs.Glob] open it before doing anything else and an fs.FS
+// whose root cannot be opened is malformed.
+//
+// Every other name must be a file. A directory fallback for other names is
+// deliberately absent: List reports an absent directory as an empty list, so
+// "list it and see" cannot tell a directory that is empty from one that does
+// not exist. Falling back on that would make Open("typo.yaml") return a
+// successful empty directory instead of an error — an fs.FS contract violation
+// that surfaces as a bizarre failure in whatever wraps this next, rather than
+// as the plain "file not found" the caller asked for. Use [FSView.ReadDir] to
+// list a directory.
+func (v *FSView) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	if name == "." {
+		return &memDir{name: "."}, nil
+	}
+	data, err := v.loader.Load(v.context(), name)
+	if err != nil {
+		return nil, err
+	}
+	return &memFile{name: path.Base(name), data: data}, nil
+}
+
+// ReadFile returns the named file's bytes.
+func (v *FSView) ReadFile(name string) ([]byte, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	return v.loader.Load(v.context(), name)
+}
+
+// ReadDir lists the regular files directly under name.
+//
+// Entries carry a name and a "regular file" mode and nothing else. That is
+// everything [io/fs.ReadDirFS]'s consumers here need — LoadDir filters on
+// IsDir and the extension — and inventing a size or mtime for a row in a
+// database would be fabricating detail the backend does not have.
+func (v *FSView) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+	// The ROOT lists empty rather than enumerating the project.
+	//
+	// Loader has no "list everything" capability — List takes a directory, and
+	// validateName rejects both "" and "." — so a root listing could only be
+	// fabricated. Empty is the honest answer, and it is enough: every consumer
+	// here addresses a named directory (migrations/, scripts/), and the reason
+	// the root is openable at all is that fs.WalkDir and fs.Glob start there.
+	//
+	// The cost is that a WalkDir over this view finds nothing. That is worth
+	// stating rather than discovering: use ReadDir on the directory you want.
+	if name == "." {
+		return nil, nil
+	}
+	names, err := v.loader.List(v.context(), name)
+	if err != nil {
+		// A Loader may report an absent directory either way: FSLoader
+		// returns an empty list, while returning os.ErrNotExist is the
+		// obvious alternative and matches what Load is documented to do.
+		// Both must mean "no such directory", because datamigration.LoadDir
+		// treats exactly that as an empty chain and fails on anything else —
+		// so a backend choosing the other spelling would otherwise fail every
+		// project that simply has no migrations. Every OTHER error surfaces.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	entries := make([]fs.DirEntry, 0, len(names))
+	for _, n := range names {
+		entries = append(entries, &memDirEntry{name: n})
+	}
+	return entries, nil
+}
+
+// readOnlyMode is the mode a config file reports through this view.
+//
+// It describes the HANDLE, not the underlying resource: an FSLoader-backed
+// migrations/001.yaml is a perfectly writable file that the operator edits in
+// an editor. fs.FS has no write surface at all, so no consumer could act on a
+// wider mode anyway — 0444 is simply the honest description of what this view
+// offers, and inventing permission bits from a backend that may not have any
+// would be fabricating detail.
+const readOnlyMode fs.FileMode = 0o444
+
+// memFile is a read-only fs.File over an in-memory byte slice.
+type memFile struct {
+	name string
+	data []byte
+	off  int
+}
+
+func (f *memFile) Stat() (fs.FileInfo, error) {
+	return &memFileInfo{name: f.name, size: int64(len(f.data))}, nil
+}
+func (f *memFile) Close() error { return nil }
+
+func (f *memFile) Read(p []byte) (int, error) {
+	if f.off >= len(f.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.data[f.off:])
+	f.off += n
+	return n, nil
+}
+
+// memFileInfo is the minimal fs.FileInfo a read-through file can honestly
+// report: a name and a size. ModTime is the zero time rather than time.Now(),
+// because a made-up timestamp is worse than an obviously absent one — a
+// consumer comparing it would silently treat every read as freshly modified.
+type memFileInfo struct {
+	name string
+	size int64
+	dir  bool
+}
+
+func (i *memFileInfo) Name() string { return i.name }
+func (i *memFileInfo) Size() int64  { return i.size }
+func (i *memFileInfo) Mode() fs.FileMode {
+	if i.dir {
+		return fs.ModeDir | readOnlyMode
+	}
+	return readOnlyMode
+}
+func (i *memFileInfo) ModTime() time.Time { return time.Time{} }
+func (i *memFileInfo) IsDir() bool        { return i.dir }
+func (i *memFileInfo) Sys() any           { return nil }
+
+// memDir is a read-only fs.ReadDirFile over an already-listed directory.
+type memDir struct {
+	name    string
+	entries []fs.DirEntry
+	off     int
+}
+
+func (d *memDir) Stat() (fs.FileInfo, error) {
+	return &memFileInfo{name: d.name, dir: true}, nil
+}
+func (d *memDir) Close() error { return nil }
+
+// Read on a directory is an error, matching os.File.
+func (d *memDir) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.name, Err: fs.ErrInvalid}
+}
+
+// ReadDir implements fs.ReadDirFile: n <= 0 returns everything remaining,
+// n > 0 returns at most n and reports io.EOF once exhausted.
+func (d *memDir) ReadDir(n int) ([]fs.DirEntry, error) {
+	remaining := d.entries[d.off:]
+	if n <= 0 {
+		d.off = len(d.entries)
+		return remaining, nil
+	}
+	if len(remaining) == 0 {
+		return nil, io.EOF
+	}
+	if n > len(remaining) {
+		n = len(remaining)
+	}
+	d.off += n
+	return remaining[:n], nil
+}
+
+// memDirEntry is a directory entry for a file the Loader listed.
+type memDirEntry struct{ name string }
+
+func (e *memDirEntry) Name() string      { return e.name }
+func (e *memDirEntry) IsDir() bool       { return false }
+func (e *memDirEntry) Type() fs.FileMode { return 0 }
+
+// Info reports the entry's name and mode. It does NOT report a size.
+//
+// [Loader.List] returns names only, so a size could not be known without
+// reading the file. Returning 0 would be a wrong number rather than an absent
+// one — the same trap the zero ModTime avoids — so this reports the size as
+// unavailable and leaves a caller that needs one to Load the file.
+func (e *memDirEntry) Info() (fs.FileInfo, error) {
+	return nil, &fs.PathError{Op: "stat", Path: e.name, Err: errSizeUnavailable}
+}
+
+// errSizeUnavailable is returned by [memDirEntry.Info]: a listing carries
+// names, not sizes.
+var errSizeUnavailable = errors.New(
+	"config: file metadata is not available from a directory listing; read the file")

--- a/internal/config/fsview_test.go
+++ b/internal/config/fsview_test.go
@@ -318,3 +318,85 @@ func TestFSView_WithContext(t *testing.T) {
 		t.Errorf("ReadFile on a ctx-bound view: %v", err)
 	}
 }
+
+// TestFSView_FileInfoAndDirEntryAccessors covers the small fs.FileInfo and
+// fs.DirEntry surface. They are one-liners, but they are the part of the
+// adapter a consumer reads metadata through, and two of them (Mode, IsDir)
+// carry decisions worth pinning rather than trusting.
+func TestFSView_FileInfoAndDirEntryAccessors(t *testing.T) {
+	t.Parallel()
+	v := newFSView(t, mapLoader{"migrations/001.yaml": []byte("a: 1\n")})
+
+	f, err := v.Open("migrations/001.yaml")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+
+	if got := info.Name(); got != "001.yaml" {
+		t.Errorf("Name = %q, want %q (base name, not the full path)", got, "001.yaml")
+	}
+	// The mode describes the HANDLE — fs.FS has no write surface — not the
+	// underlying file, which an operator edits freely.
+	if got := info.Mode(); got != 0o444 {
+		t.Errorf("Mode = %v, want 0444", got)
+	}
+	if info.IsDir() {
+		t.Error("a file reported IsDir")
+	}
+	if info.Sys() != nil {
+		t.Error("Sys should be nil: there is no underlying platform object")
+	}
+
+	// The root is the one directory, and reports itself as one.
+	root, err := v.Open(".")
+	if err != nil {
+		t.Fatalf(`Open("."): %v`, err)
+	}
+	defer func() { _ = root.Close() }()
+	rootInfo, err := root.Stat()
+	if err != nil {
+		t.Fatalf("Stat root: %v", err)
+	}
+	if !rootInfo.IsDir() || !rootInfo.Mode().IsDir() {
+		t.Errorf("root reported IsDir=%v Mode=%v; want a directory", rootInfo.IsDir(), rootInfo.Mode())
+	}
+	// Reading a directory as bytes is an error, matching os.File.
+	if _, readErr := root.Read(make([]byte, 1)); readErr == nil {
+		t.Error("Read on a directory handle should fail")
+	}
+	// And it enumerates as an fs.ReadDirFile, empty.
+	rd, ok := root.(fs.ReadDirFile)
+	if !ok {
+		t.Fatal("a directory handle must implement fs.ReadDirFile")
+	}
+	entries, err := rd.ReadDir(-1)
+	if err != nil {
+		t.Fatalf("ReadDir(-1): %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("root ReadDir = %v, want empty", entries)
+	}
+
+	// Directory entries report a name and a regular-file type.
+	listed, err := fs.ReadDir(v, "migrations")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("ReadDir = %v, want one entry", listed)
+	}
+	if got := listed[0].Name(); got != "001.yaml" {
+		t.Errorf("entry Name = %q, want %q", got, "001.yaml")
+	}
+	if listed[0].IsDir() {
+		t.Error("entry reported IsDir; the Loader lists files only")
+	}
+	if got := listed[0].Type(); got != 0 {
+		t.Errorf("entry Type = %v, want 0 (regular file)", got)
+	}
+}

--- a/internal/config/fsview_test.go
+++ b/internal/config/fsview_test.go
@@ -1,0 +1,320 @@
+package config_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/config"
+	"github.com/Sourcehaven-BV/rela/internal/storage"
+)
+
+func newFSView(t *testing.T, loader config.Loader) fs.FS {
+	t.Helper()
+	v, err := config.NewFSView(loader)
+	if err != nil {
+		t.Fatalf("NewFSView: %v", err)
+	}
+	return v
+}
+
+func TestFSView_ReadFile(t *testing.T) {
+	t.Parallel()
+	want := []byte("steps:\n  - kind: rename\n")
+	v := newFSView(t, mapLoader{"migrations/001.yaml": want})
+
+	got, err := fs.ReadFile(v, "migrations/001.yaml")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("ReadFile = %q, want %q", got, want)
+	}
+}
+
+func TestFSView_ReadFile_MissingIsNotExist(t *testing.T) {
+	t.Parallel()
+	v := newFSView(t, mapLoader{})
+
+	// datamigration.LoadDir distinguishes a missing directory from an
+	// unreadable one with errors.Is(err, fs.ErrNotExist), so the adapter must
+	// preserve that rather than flattening every failure into one error.
+	_, err := fs.ReadFile(v, "migrations/nope.yaml")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("error %v is not fs.ErrNotExist-compatible", err)
+	}
+}
+
+func TestFSView_ReadDir(t *testing.T) {
+	t.Parallel()
+	v := newFSView(t, mapLoader{
+		"migrations/002.yaml": nil,
+		"migrations/001.yaml": nil,
+		"scripts/other.lua":   nil,
+	})
+
+	entries, err := fs.ReadDir(v, "migrations")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("entry %q reported as a directory; the Loader lists files only", e.Name())
+		}
+		names = append(names, e.Name())
+	}
+	want := []string{"001.yaml", "002.yaml"}
+	if !slices.Equal(names, want) {
+		t.Errorf("ReadDir = %v, want %v (sorted, scoped to the named directory)", names, want)
+	}
+}
+
+func TestFSView_Open(t *testing.T) {
+	t.Parallel()
+	want := []byte("kind: lua\n")
+	v := newFSView(t, mapLoader{"migrations/003.yaml": want})
+
+	f, err := v.Open("migrations/003.yaml")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Open+ReadAll = %q, want %q", got, want)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() != int64(len(want)) {
+		t.Errorf("Size = %d, want %d", info.Size(), len(want))
+	}
+	if info.IsDir() {
+		t.Error("a file reported IsDir")
+	}
+	// Deliberately the zero time rather than time.Now(): a fabricated mtime
+	// would make a consumer comparing it treat every read as freshly modified.
+	if !info.ModTime().IsZero() {
+		t.Errorf("ModTime = %v, want the zero time", info.ModTime())
+	}
+}
+
+func TestFSView_RejectsInvalidPaths(t *testing.T) {
+	t.Parallel()
+	v := newFSView(t, mapLoader{})
+	for _, name := range []string{"", "../escape.yaml", "/absolute.yaml", "./dot.yaml"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := fs.ReadFile(v, name); err == nil {
+				t.Errorf("ReadFile(%q) should be rejected", name)
+			}
+			if _, err := fs.ReadDir(v, name); err == nil {
+				t.Errorf("ReadDir(%q) should be rejected", name)
+			}
+		})
+	}
+}
+
+func TestNewFSView_RejectsNil(t *testing.T) {
+	t.Parallel()
+	v, err := config.NewFSView(nil)
+	if err == nil {
+		t.Fatal("NewFSView(nil) should be rejected")
+	}
+	if v != nil {
+		t.Errorf("NewFSView returned %v alongside an error, want nil", v)
+	}
+}
+
+// TestFSView_OverFSLoader is the end-to-end shape the migration commands use:
+// a real directory, read through the Loader, seen as an fs.FS.
+func TestFSView_OverFSLoader(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(root+"/migrations", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(root+"/migrations/001.yaml", []byte("a: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	v := newFSView(t, config.NewFSLoader(storage.NewOsFS(), root))
+
+	entries, err := fs.ReadDir(v, "migrations")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "001.yaml" {
+		t.Fatalf("ReadDir = %v, want [001.yaml]", entries)
+	}
+	got, err := fs.ReadFile(v, "migrations/001.yaml")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "a: 1\n" {
+		t.Errorf("ReadFile = %q", got)
+	}
+
+	// A project with no migrations/ at all lists empty rather than erroring —
+	// the contract datamigration.LoadDir relies on.
+	empty, err := fs.ReadDir(newFSView(t, config.NewFSLoader(storage.NewOsFS(), t.TempDir())), "migrations")
+	if err != nil {
+		t.Fatalf("ReadDir of a project with no migrations/: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("ReadDir = %v, want empty", empty)
+	}
+}
+
+func TestFSView_RootOpensAndListsEmpty(t *testing.T) {
+	t.Parallel()
+	v := newFSView(t, mapLoader{"migrations/001.yaml": nil})
+
+	// The root must OPEN: fs.WalkDir and fs.Glob open "." before anything
+	// else, and an fs.FS whose root cannot be opened is malformed.
+	f, err := v.Open(".")
+	if err != nil {
+		t.Fatalf(`Open("."): %v`, err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("the root did not report IsDir")
+	}
+
+	// It lists EMPTY: Loader has no enumerate-everything capability, so a root
+	// listing could only be invented. The documented consequence is that a
+	// walk from the root finds nothing — asserted so it stays a decision
+	// rather than becoming a surprise.
+	var walked []string
+	if err := fs.WalkDir(v, ".", func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p != "." {
+			walked = append(walked, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+	if len(walked) != 0 {
+		t.Errorf("WalkDir found %v; an FSView is not walkable from the root", walked)
+	}
+}
+
+func TestFSView_MissingFileIsNotExist(t *testing.T) {
+	t.Parallel()
+	v := newFSView(t, config.NewFSLoader(storage.NewOsFS(), t.TempDir()))
+
+	// Open of a nonexistent path must report ErrNotExist, not succeed.
+	//
+	// It used to fall back to a directory listing when Load said "not found",
+	// which returned a successful EMPTY DIRECTORY for a missing file — because
+	// List reports an absent directory as an empty list and so cannot tell
+	// "empty" from "does not exist". An fs.FS that opens a missing path
+	// surfaces as a bizarre failure in whatever wraps it, rather than as the
+	// plain "file not found" the caller asked for.
+	f, err := v.Open("migrations/typo.yaml")
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("Open of a missing file succeeded; want an error")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("error %v is not fs.ErrNotExist-compatible", err)
+	}
+
+	// fs.ReadFile falls back to Open for an FS that is not a ReadFileFS, so
+	// the same must hold there.
+	if _, err := fs.ReadFile(v, "migrations/typo.yaml"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ReadFile error %v is not fs.ErrNotExist-compatible", err)
+	}
+}
+
+func TestFSView_ReadDir_SurfacesLoaderErrors(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("permission denied")
+	v := newFSView(t, errLoader{err: boom})
+
+	// datamigration.LoadDir treats ONLY ErrNotExist as "no migrations" and
+	// surfaces everything else, deliberately: an unreadable migrations/
+	// reported as "nothing to migrate" would let a chain silently go unrun.
+	// The adapter must not flatten a real error into that.
+	if _, err := fs.ReadDir(v, "migrations"); !errors.Is(err, boom) {
+		t.Errorf("ReadDir error = %v, want the loader's error surfaced", err)
+	}
+	if _, err := fs.ReadFile(v, "migrations/001.yaml"); !errors.Is(err, boom) {
+		t.Errorf("ReadFile error = %v, want the loader's error surfaced", err)
+	}
+}
+
+func TestFSView_ReadDir_NotExistFromListListsEmpty(t *testing.T) {
+	t.Parallel()
+	// FSLoader reports an absent directory as an empty list, but a Loader that
+	// reports it as ErrNotExist — the obvious alternative, and what Load is
+	// documented to do — must work too. Otherwise a database-backed Loader
+	// would fail the whole chain on a project that simply has no migrations.
+	v := newFSView(t, errLoader{err: fs.ErrNotExist})
+
+	entries, err := fs.ReadDir(v, "migrations")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("ReadDir = %v, want empty", entries)
+	}
+}
+
+func TestFSView_DirEntryInfoReportsNoSize(t *testing.T) {
+	t.Parallel()
+	v := newFSView(t, mapLoader{"migrations/001.yaml": []byte("a long migration file")})
+
+	entries, err := fs.ReadDir(v, "migrations")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	// A listing carries names, not sizes. Reporting 0 would be a WRONG number
+	// rather than an absent one — the trap the zero ModTime avoids — so Info
+	// reports the metadata as unavailable instead.
+	if _, err := entries[0].Info(); err == nil {
+		t.Error("Info() returned metadata; a listing cannot know a size")
+	}
+}
+
+func TestFSView_WithContext(t *testing.T) {
+	t.Parallel()
+	base, err := config.NewFSView(mapLoader{"a.yaml": []byte("x")})
+	if err != nil {
+		t.Fatalf("NewFSView: %v", err)
+	}
+
+	// Nil is rejected rather than silently replaced, so a caller who meant to
+	// pass a context finds out here.
+	//nolint:staticcheck // passing nil is the case under test
+	if _, nilErr := base.WithContext(nil); nilErr == nil {
+		t.Error("WithContext(nil) should be rejected")
+	}
+
+	bound, err := base.WithContext(context.Background())
+	if err != nil {
+		t.Fatalf("WithContext: %v", err)
+	}
+	if _, err := fs.ReadFile(bound, "a.yaml"); err != nil {
+		t.Errorf("ReadFile on a ctx-bound view: %v", err)
+	}
+}

--- a/tickets/entities/review-responses/RR-FSVCTX.md
+++ b/tickets/entities/review-responses/RR-FSVCTX.md
@@ -1,0 +1,9 @@
+---
+id: RR-FSVCTX
+type: review-response
+title: FSView hardcoded context.Background, severing the cancellation seam
+severity: significant
+status: addressed
+finding: 'Loader.Load and Loader.List take a context; FSView discarded it and passed context.Background() at every call site. Harmless for FSLoader, but the SQLite loader this feature exists to enable can genuinely block — waiting on a locked database file — and would then be uncancellable. The irony is pointed: internal/datamigration binds a `lua:` step''s VM to the run context precisely so a runaway migration is interruptible by Ctrl-C, and then read that step''s script through an FS that ignored ctx entirely.'
+resolution: 'Added FSView.WithContext, since fs.FS has no context in any of its method signatures and a ctx therefore has to live on the value. The `lua:` call site in migrate_data.go binds the runner''s ctx, which is the case that motivated it. loadDataMigrations and newConfigFS now take a ctx as their first parameter so the linter''s contextcheck is satisfied rather than suppressed; only the stored field carries a containedctx suppression, with the reason at the field. Nil ctx is rejected rather than silently replaced.'
+---

--- a/tickets/entities/review-responses/RR-FSVDOC.md
+++ b/tickets/entities/review-responses/RR-FSVDOC.md
@@ -1,0 +1,9 @@
+---
+id: RR-FSVDOC
+type: review-response
+title: Doclinks to unimported packages, a redundant errors.Is pair, and a one-sentinel errors.go
+severity: minor
+status: addressed
+finding: 'Three small things. (1) The doc referenced [datamigration.LoadDir] and [io/fs.ReadFileFS]; Go cannot resolve a link to an unimported package, and io/fs is imported as fs, so both rendered as literal brackets — and doclink is a blocking commentlint gate. (2) Open checked both errors.Is(err, fs.ErrNotExist) and errors.Is(err, os.ErrNotExist), which are the same variable (os.ErrNotExist = fs.ErrNotExist), suggesting the author was unsure and leaving the next reader unsure too. (3) internal/config/errors.go held a single unexported sentinel used once, forty lines away, while every other error in the package is constructed inline.'
+resolution: '(1) Unresolvable links unbracketed, io/fs ones written as [fs.X]; just comment-lint clean. (2) The redundant pair is gone with the Open rewrite (RR-FSVOPEN). (3) errors.go deleted, the sentinel inlined at NewFSView. Also fixed a govet shadow in the new test.'
+---

--- a/tickets/entities/review-responses/RR-FSVLIST.md
+++ b/tickets/entities/review-responses/RR-FSVLIST.md
@@ -1,0 +1,9 @@
+---
+id: RR-FSVLIST
+type: review-response
+title: ReadDir had no coverage of its error path, and no contract for a Loader that reports absence as ErrNotExist
+severity: critical
+status: addressed
+finding: 'FSView.ReadDir forwarded Loader.List errors verbatim. datamigration.LoadDir treats ONLY errors.Is(err, fs.ErrNotExist) as "empty chain" and surfaces everything else, deliberately — an unreadable migrations/ reported as "nothing to migrate" would let a chain silently go unrun. With FSLoader the outcomes happened to be preserved, but by two mechanisms agreeing rather than by design: FSLoader.List returns (nil, nil) for an absent directory, so LoadDir''s ErrNotExist branch became dead code. A second Loader — the SQLite one this feature exists for — would have to independently rediscover that convention, and returning ErrNotExist instead (the obvious choice, and what Load is documented to do) would have failed the whole migration chain on any project with no migrations. There was also zero test coverage of ReadDir''s error path: every mapLoader.List in the suite returned a nil error unconditionally.'
+resolution: 'ReadDir now normalizes: an os.ErrNotExist-compatible error from List means "no such directory" and lists empty, matching FSLoader''s empty-list spelling; every other error surfaces. The contract is stated on the method. Two tests added — TestFSView_ReadDir_SurfacesLoaderErrors (a real error must not be flattened) and TestFSView_ReadDir_NotExistFromListListsEmpty (the alternative spelling is accepted).'
+---

--- a/tickets/entities/review-responses/RR-FSVOPEN.md
+++ b/tickets/entities/review-responses/RR-FSVOPEN.md
@@ -1,0 +1,9 @@
+---
+id: RR-FSVOPEN
+type: review-response
+title: FSView.Open returned a successful empty directory for a missing file
+severity: critical
+status: addressed
+finding: 'Open fell back to a directory listing when Load reported not-found. Because Loader.List reports an ABSENT directory as an empty list, that fallback could not distinguish "empty directory" from "no such path" — so Open("migrations/typo.yaml") returned a successful empty directory handle instead of an ErrNotExist. That violates the fs.FS contract ("Open should return an error satisfying fs.ErrNotExist" for a nonexistent path). It was masked only because FSView implements ReadFileFS, so fs.ReadFile never fell back to Open; anything wrapping FSView in a way that loses that assertion would have turned every missing-file read into a bogus empty directory.'
+resolution: 'Directory handling is now restricted to the root ("."), which is the only case that was ever justified — fs.WalkDir and fs.Glob open the root before anything else, and an fs.FS whose root cannot be opened is malformed. Every other name must resolve to a file, so a missing path returns the Loader''s ErrNotExist unchanged. Verified before and after: Open of a missing file previously returned a non-nil handle with a nil error, and now returns isNotExist=true. Pinned by TestFSView_MissingFileIsNotExist, which also covers the fs.ReadFile fallback path.'
+---

--- a/tickets/entities/review-responses/RR-FSVSIZE.md
+++ b/tickets/entities/review-responses/RR-FSVSIZE.md
@@ -1,0 +1,9 @@
+---
+id: RR-FSVSIZE
+type: review-response
+title: DirEntry.Info reported Size 0 for every file, fabricating the detail the ModTime comment refused to
+severity: significant
+status: addressed
+finding: 'memDirEntry.Info returned a FileInfo with no size set, so every file listed through ReadDir reported Size() == 0 — a wrong number, not an absent one. The adapter had already got this principle right one type up: ModTime deliberately returns the zero time with a comment explaining that a fabricated timestamp is worse than an obviously absent one, because a consumer comparing it would silently treat every read as freshly modified. Size 0 is the same trap, and the comment on the neighbouring line claimed the code was avoiding it.'
+resolution: 'Info now returns an error stating the metadata is unavailable from a listing. Loader.List returns names only, so a size genuinely cannot be known without reading the file, and an error is the honest way to say so. Pinned by TestFSView_DirEntryInfoReportsNoSize.'
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVCTX.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVCTX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+type: has-review-response
+to: RR-FSVCTX
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVDOC.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVDOC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+type: has-review-response
+to: RR-FSVDOC
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVLIST.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVLIST.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+type: has-review-response
+to: RR-FSVLIST
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVOPEN.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVOPEN.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+type: has-review-response
+to: RR-FSVOPEN
+---

--- a/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVSIZE.md
+++ b/tickets/relations/TKT-RAT7U3--has-review-response--RR-FSVSIZE.md
@@ -1,0 +1,5 @@
+---
+from: TKT-RAT7U3
+type: has-review-response
+to: RR-FSVSIZE
+---


### PR DESCRIPTION
**Stacked on #1530** — targets its branch, so the diff here is only the adapter plus two call sites.

`internal/datamigration` already takes an `fs.FS` for both the `migrations/` directory and a `lua:` step's script. Only the two CLI call sites hardcoded `os.DirFS(projectRoot)`. Routing them through `config.Loader` is what lets a project whose config lives somewhere other than the filesystem — a self-contained SQLite file — still have a migration chain (FEAT-UP14BT).

`config.FSView` is the adapter. Three of its properties are load-bearing, and each was wrong in the first draft, so each is pinned by a test.

## Only the root opens as a directory

The tempting fallback — try `Load`, and if that says "not found" try `List` — cannot work. `List` reports an absent directory as an **empty list**, so it cannot distinguish a directory that is empty from one that does not exist. With the fallback in place, `Open("typo.yaml")` returned a **successful empty directory** instead of an error: an `fs.FS` contract violation that surfaces as a bizarre failure in whatever wraps it rather than as the plain "file not found" the caller asked for.

The root still opens, because `fs.WalkDir` and `fs.Glob` open it before anything else and an `fs.FS` whose root cannot be opened is malformed. It lists empty — `Loader` has no enumerate-everything capability — and the consequence (not walkable from the root) is documented and asserted rather than left to be discovered.

## ReadDir accepts either spelling of "no such directory"

`FSLoader` returns an empty list; returning `os.ErrNotExist` is the obvious alternative and is what `Load` is documented to do. Both must mean the same thing here, because `datamigration.LoadDir` treats exactly that as an empty chain and **fails the whole run on anything else** — so a database-backed `Loader` choosing the other spelling would fail every project that simply has no migrations. Every other error still surfaces, which is the property `LoadDir`'s comment cares about.

## A directory entry reports no size

A listing carries names, so a size would have to be invented — and `0` is a *wrong* number rather than an absent one, the same trap the zero `ModTime` already avoids. `Info` returns an error saying the metadata is unavailable.

## Context

The view carries one, because `fs.FS` has no context in any of its signatures and the runner deliberately binds a `lua:` step's VM to the run context so a runaway migration stays interruptible. Reading that step's script through an uncancellable FS would have defeated half of that. `containedctx` is suppressed with that reasoning at the field.

## Verification

`just lint` · `just comment-lint` · `just arch-lint` — clean. `go test -race` over config, cli, datamigration. End-to-end: a real project with `migrations/` has its file read and validated through the new path, and one without still no-ops cleanly.

Refs TKT-RAT7U3