### PR TITLE
feat(state): store runtime state in the database, not beside it (TKT-STATSQL)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -157,6 +157,11 @@ components:
   # Serves operator config from a SQL table. A config package, not a storage
   # one: it touches no entity, relation or graph — just rows keyed by path.
   configsql:        { in: internal/config/configsql }
+  # Stores runtime state in a SQL table. A state package, not a storage one,
+  # and a sibling of configsql for the same reason: neither is the entity
+  # graph, and both would otherwise live in files BESIDE the database and be
+  # left behind when the single file is shipped.
+  statesql:         { in: internal/state/statesql }
   git:              { in: internal/git }
   output:           { in: internal/output }
   project:          { in: internal/project }
@@ -559,6 +564,7 @@ deps:
       # store — they only share a file.
       - configsql
       - sqlitedb
+      - statesql
       # Mail is optional infrastructure the composition root wires and owns the
       # lifecycle of (start in assemble, stop in Close), exactly like the
       # data-migration GC sweep. Consumers take the mail.Sender seam, not this
@@ -1210,6 +1216,11 @@ deps:
     # the sqlite driver grant stays with the package that registers it.
     mayDependOn:
       - config
+  # statesql has NO internal deps, so it has no entry here. It deliberately
+  # does not import state: that package WRAPS this one (state.ValidatedKV
+  # applies the key rules), so naming it would invert the dependency.
+  # Conformance is proved by state/statetest instead, which checks behavior
+  # rather than shape.
   sqlitedb:
     canUse:
       - sqlite

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1401,7 +1401,7 @@ func (b *SharedBase) Assemble(
 	st store.Store, searcher search.Searcher,
 	visible search.VisibleSearcher, searchCloser io.Closer,
 ) (*Services, error) {
-	return assemble(b, st, searcher, visible, searchCloser, nil)
+	return assemble(b, st, searcher, visible, searchCloser, backendOverrides{})
 }
 
 // buildEntityManager assembles the write-path manager from the collaborators
@@ -1562,17 +1562,35 @@ func cascadeReadDeps(
 	}
 }
 
+// backendOverrides are the services a recipe supplies because they come from
+// something only that recipe holds — today, a database handle it opened.
+//
+// A struct rather than more parameters on [assemble]: every field is
+// optional, they arrive together from one recipe, and appending a third
+// positional nil to four call sites is how a signature becomes unreadable.
+// The zero value means "derive everything from the filesystem", which is what
+// the fs, memory and postgres recipes pass.
+type backendOverrides struct {
+	// projectConfig replaces the filesystem config loader. The sqlite recipe
+	// supplies one because its database may CARRY the project's config, which
+	// it layers behind the files.
+	projectConfig config.Loader
+
+	// stateKV replaces the filesystem state store. Supplied for the same
+	// reason and from the same handle: state written beside the database
+	// rather than inside it would be left behind when the file is shipped.
+	stateKV state.KV
+}
+
 // assemble builds the services bundle from an opened store.
 //
-// projectConfig, when non-nil, replaces the filesystem config loader. Only the
-// sqlite recipe supplies one: it opens a database that may CARRY the project's
-// config, and layers that behind the files. Passed in rather than derived here
-// because the database handle belongs to the recipe that opened it, and
-// assemble is deliberately build-agnostic.
+// Overrides are passed in rather than derived here because they come from a
+// database handle that belongs to the recipe that opened it, and assemble is
+// deliberately build-agnostic.
 func assemble(
 	base *SharedBase, st store.Store, searcher search.Searcher,
 	visible search.VisibleSearcher, searchCloser io.Closer,
-	projectConfig config.Loader,
+	overrides backendOverrides,
 ) (*Services, error) {
 	cfg := base.cfg
 
@@ -1594,7 +1612,7 @@ func assemble(
 
 	tr := tracer.New(st)
 	templater := templating.NewFSTemplater(cfg.FS, cfg.Paths)
-	cfgLoader := projectConfig
+	cfgLoader := overrides.projectConfig
 	if cfgLoader == nil {
 		cfgLoader = config.NewFSLoader(cfg.FS, cfg.Paths.Root)
 	}
@@ -1618,7 +1636,14 @@ func assemble(
 	// here and threaded into the recorders and the Services bundle.
 	versions := versionServiceFor(st)
 
-	stateKV, aliases, jobQueue, err := buildRuntimeServices(cfg.FS, cfg.Paths, base, stateKVFor(st))
+	// A recipe-supplied state store wins over the per-backend one, which wins
+	// over the filesystem. Same precedence as the config loader, and for the
+	// same reason.
+	backendKV := overrides.stateKV
+	if backendKV == nil {
+		backendKV = stateKVFor(st)
+	}
+	stateKV, aliases, jobQueue, err := buildRuntimeServices(cfg.FS, cfg.Paths, base, backendKV)
 	if err != nil {
 		return nil, err
 	}
@@ -1641,7 +1666,7 @@ func assemble(
 	// indexes so uniqueness is enforced atomically, and publish the current
 	// unique pairs so a violation can be attributed to a property (TKT-3Q0GP1).
 	// Failures degrade to warnings — a derived-schema problem never fails boot.
-	reconcileDerivedSchemaIfSupported(context.Background(), st, base)
+	reconcileDerivedSchemaIfSupported(context.Background(), st, base, cfgLoader)
 
 	// Evaluate the data-migration gate (adopt compatible schema-shape
 	// changes, warn on incompatible ones) and start the drift GC sweep

--- a/internal/appbuild/appbuild_fs.go
+++ b/internal/appbuild/appbuild_fs.go
@@ -31,7 +31,7 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 	// nil VisibleSearcher → assemble derives the generic
 	// search.NewVisible wrapper (TKT-BA8BSX); only the postgres
 	// recipe wires a native implementation.
-	return assemble(base, st, searcher, nil, closer, nil)
+	return assemble(base, st, searcher, nil, closer, backendOverrides{})
 }
 
 // openBackend opens the fsstore and the bleve-backed searcher. The bleve

--- a/internal/appbuild/appbuild_memory.go
+++ b/internal/appbuild/appbuild_memory.go
@@ -28,7 +28,7 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 	// nil VisibleSearcher → assemble derives the generic
 	// search.NewVisible wrapper (TKT-BA8BSX); only the postgres
 	// recipe wires a native implementation.
-	return assemble(base, st, searcher, nil, closer, nil)
+	return assemble(base, st, searcher, nil, closer, backendOverrides{})
 }
 
 // openBackend opens a memstore with a LinearSearch index wired as a

--- a/internal/appbuild/appbuild_postgres.go
+++ b/internal/appbuild/appbuild_postgres.go
@@ -38,7 +38,7 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 	if !ok {
 		return nil, errors.New("appbuild: postgres store does not implement search.VisibleSearcher")
 	}
-	return assemble(base, st, searcher, visible, closer, nil)
+	return assemble(base, st, searcher, visible, closer, backendOverrides{})
 }
 
 // openBackend delegates pool construction, migration, and store+search wiring

--- a/internal/appbuild/appbuild_sqlite.go
+++ b/internal/appbuild/appbuild_sqlite.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"path/filepath"
 
-	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/sqlitedb"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -50,9 +49,11 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 		return nil, err
 	}
 
-	// Files first, then whatever config this database carries. Built here
-	// because the handle belongs to this recipe, not to the store.
-	cfgLoader, err := layerProjectConfig(config.NewFSLoader(cfg.FS, cfg.Paths.Root), db)
+	// Both overrides come from the one handle this recipe opened: the config
+	// the database carries (layered behind the files) and the runtime state it
+	// holds. Built here rather than in assemble because the handle is this
+	// recipe's, not the store's.
+	overrides, err := backendServices(cfg, db)
 	if err != nil {
 		_ = closer.Close()
 		return nil, err
@@ -60,7 +61,7 @@ func New(cfg Config, opts ...Option) (*Services, error) {
 
 	// nil VisibleSearcher → assemble derives the generic search.NewVisible
 	// wrapper. Only the postgres recipe has a native implementation.
-	return assemble(base, st, searcher, nil, closer, cfgLoader)
+	return assemble(base, st, searcher, nil, closer, overrides)
 }
 
 // openBackend opens the SQLite store and the bleve-backed searcher.

--- a/internal/appbuild/configloader_sqlite.go
+++ b/internal/appbuild/configloader_sqlite.go
@@ -6,7 +6,36 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/config/configsql"
 	"github.com/Sourcehaven-BV/rela/internal/sqlitedb"
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/state/statesql"
 )
+
+// backendServices builds the overrides that come from the opened database:
+// the project's config and its runtime state.
+//
+// Both in one place because they share a handle and a rationale — each is
+// something that would otherwise live in a file BESIDE the database, and so be
+// left behind when the single file is shipped.
+func backendServices(cfg Config, db *sqlitedb.DB) (backendOverrides, error) {
+	cfgLoader, err := layerProjectConfig(config.NewFSLoader(cfg.FS, cfg.Paths.Root), db)
+	if err != nil {
+		return backendOverrides{}, err
+	}
+
+	raw, err := statesql.New(db.DB())
+	if err != nil {
+		return backendOverrides{}, err
+	}
+	// The backend stores whatever key it is handed; ValidatedKV applies the
+	// key rules FSKV gets from RootedFS, so both backends accept exactly the
+	// same keys and neither can drift.
+	kv, err := state.NewValidatedKV(raw)
+	if err != nil {
+		return backendOverrides{}, err
+	}
+
+	return backendOverrides{projectConfig: cfgLoader, stateKV: kv}, nil
+}
 
 // layerProjectConfig puts the project's FILES in front of the config baked
 // into its database, so a project with both behaves exactly as it did before

--- a/internal/appbuild/derivedschema_nosweep.go
+++ b/internal/appbuild/derivedschema_nosweep.go
@@ -5,6 +5,7 @@ package appbuild
 import (
 	"context"
 
+	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
@@ -27,4 +28,7 @@ import (
 // The second case is why Open also verifies WAL actually engaged and refuses
 // otherwise — the filesystems where flock is unreliable are the same ones where
 // WAL is unavailable.
-func reconcileDerivedSchemaIfSupported(_ context.Context, _ store.Store, _ *SharedBase) {}
+func reconcileDerivedSchemaIfSupported(
+	_ context.Context, _ store.Store, _ *SharedBase, _ config.Loader,
+) {
+}

--- a/internal/appbuild/derivedschema_postgres.go
+++ b/internal/appbuild/derivedschema_postgres.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"log/slog"
 	"os"
-	"path/filepath"
 
+	"github.com/Sourcehaven-BV/rela/internal/config"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/queryplan"
@@ -38,7 +38,9 @@ type derivedSchemaReconciler interface {
 // without the capability is skipped. Reconcile failures are logged and
 // swallowed: a derived-schema problem must never fail store-open. An operator
 // inspects or repairs drift via `rela db status` / `rela db reconcile`.
-func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, base *SharedBase) {
+func reconcileDerivedSchemaIfSupported(
+	ctx context.Context, st store.Store, base *SharedBase, cfg config.Loader,
+) {
 	s, ok := st.(derivedSchemaReconciler)
 	if !ok {
 		return
@@ -50,8 +52,11 @@ func reconcileDerivedSchemaIfSupported(ctx context.Context, st store.Store, base
 	// error must remain attributable to its property.
 	s.SetUniqueSpecProvider(uniqueSpecs)
 	specs := append([]store.DerivedObjectSpec(nil), uniqueSpecs...)
-	configPath := filepath.Join(base.cfg.Paths.Root, dataentryconfig.ConfigFile)
-	if data, err := base.cfg.FS.ReadFile(configPath); err == nil {
+	// Read through the config seam rather than the filesystem. A packaged
+	// project carries data-entry.yaml in its database, and reading the file
+	// directly would find nothing there — silently dropping every derived
+	// static-query index, with no error to explain the missing indexes.
+	if data, err := cfg.Load(ctx, dataentryconfig.ConfigFile); err == nil {
 		querySpecs, err := queryplan.LoadStaticIndexSpecs(data, base.meta)
 		if err != nil {
 			slog.Warn("appbuild: derived-schema reconcile skipped; invalid data-entry config", "error", err)

--- a/internal/sqlitedb/migrate.go
+++ b/internal/sqlitedb/migrate.go
@@ -12,7 +12,7 @@ import (
 // schemaVersion is the shape of the tables this binary expects. Bump it
 // whenever schemaSQL changes shape, and append the step that carries an
 // existing database forward to [migrations].
-const schemaVersion = 2
+const schemaVersion = 3
 
 // SchemaVersion reports the table shape this binary expects, so the CLI can
 // show a real number rather than prose.
@@ -65,6 +65,14 @@ var migrations = []migration{
 		// used to live only beside it on disk.
 		to:    2,
 		apply: sqlSteps(projectFilesDDL),
+	},
+	{
+		// v2 → v3: state_kv, the runtime state that used to live in files
+		// under .rela/ — the render cache, user settings, the operator's logo
+		// and theme, the CalDAV alias table. Beside the database rather than
+		// inside it, those would be left behind when the file is shipped.
+		to:    3,
+		apply: sqlSteps(stateKVDDL),
 	},
 }
 

--- a/internal/sqlitedb/sqlitedb.go
+++ b/internal/sqlitedb/sqlitedb.go
@@ -318,6 +318,7 @@ CREATE TABLE IF NOT EXISTS attachments (
 ) STRICT;
 CREATE INDEX IF NOT EXISTS attachments_entity_idx ON attachments(entity_id);
 ` + projectFilesDDL + `
+` + stateKVDDL + `
 `
 
 // projectFilesDDL carries the operator-authored config — schema.yaml,
@@ -340,5 +341,23 @@ const projectFilesDDL = `
 CREATE TABLE IF NOT EXISTS project_files (
 	path       TEXT PRIMARY KEY,
 	content    BLOB NOT NULL,
+	updated_at TEXT NOT NULL
+) STRICT;`
+
+// stateKVDDL carries rela's runtime state: the document render cache, user
+// settings, the operator's logo and theme, the CalDAV alias table.
+//
+// Keys are opaque strings — validation is state.ValidatedKV's job at the
+// wiring site, so both backends accept exactly the same keys and neither can
+// drift. BLOB because a logo is bytes, not text.
+//
+// Shared between schemaSQL (fresh databases) and the v2→v3 migration
+// (existing ones), for the same reason projectFilesDDL is: two copies drift,
+// and a fresh database ending up with a different shape from a migrated one
+// is the failure the version stamp exists to prevent.
+const stateKVDDL = `
+CREATE TABLE IF NOT EXISTS state_kv (
+	key        TEXT PRIMARY KEY,
+	value      BLOB NOT NULL,
 	updated_at TEXT NOT NULL
 ) STRICT;`

--- a/internal/state/statesql/statesql.go
+++ b/internal/state/statesql/statesql.go
@@ -1,0 +1,116 @@
+// Package statesql stores rela's runtime state — the document render cache,
+// user settings, the operator's logo and theme, the CalDAV alias table — in a
+// SQL table rather than in files under .rela/.
+//
+// It exists for the same reason [configsql] does, and is deliberately its
+// sibling rather than part of a storage backend: none of this is the entity
+// graph. It takes a *sql.DB the caller already opened and reads rows keyed by
+// string.
+//
+// The motivation differs from the postgres backend's, which moved this state
+// into the database because several rela-server processes share one database
+// and node-local files meant an uploaded logo was served by exactly one of
+// them. SQLite is single-process, so that is not the problem here. The problem
+// is that a state file under .rela/ sits BESIDE the database rather than
+// inside it — so a shipped single file would arrive with its palette, logo and
+// user settings silently left behind.
+package statesql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"time"
+)
+
+// maxValueBytes caps a stored value. Matching the postgres backend's limit
+// rather than picking a new one: the cap exists so a runaway render cannot
+// wedge the database, and a value that would be truncated must be REJECTED
+// rather than stored short — a silently truncated cached render would be
+// served as if it were valid.
+const maxValueBytes = 32 << 20 // 32 MiB
+
+// timeFmt is the on-disk timestamp format, matching what the store writes to
+// its own rows: RFC3339Nano, timezone retained.
+const timeFmt = time.RFC3339Nano
+
+// KV is the SQL-backed durable key/value store.
+//
+// It implements state.KV, but does NOT name that interface here: importing
+// internal/state would make this package depend on the one that wraps it, and
+// the wiring site already binds the two. The conformance suite
+// (state/statetest) is what proves the match, which is stronger than a
+// compile-time assertion because it checks behaviour, not just shape.
+//
+// # Key policy lives with the caller
+//
+// This type stores whatever key it is given. Key VALIDATION — rejecting
+// traversal, absolute paths, Windows-hostile names — is the state package's
+// contract, enforced by state.ValidatedKV wrapping this. One implementation of
+// those rules, rather than a copy here that could drift from the filesystem
+// backend's.
+//
+// Nil: [New] rejects a nil handle.
+type KV struct {
+	db *sql.DB
+}
+
+// New returns a KV over db.
+//
+// The caller owns db: this borrows the handle and never closes it.
+func New(db *sql.DB) (*KV, error) {
+	if db == nil {
+		return nil, errors.New("statesql: a non-nil database handle is required")
+	}
+	return &KV{db: db}, nil
+}
+
+// Get returns the value stored at key.
+//
+// Errors: a missing key returns an [fs.ErrNotExist]-compatible error, which is
+// the contract every consumer branches on — the scheduler reading a never-set
+// last-run timestamp treats it as a normal state, not a failure.
+func (k *KV) Get(ctx context.Context, key string) ([]byte, error) {
+	var value []byte
+	err := k.db.QueryRowContext(ctx,
+		`SELECT value FROM state_kv WHERE key = ?`, key,
+	).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, &fs.PathError{Op: "open", Path: key, Err: fs.ErrNotExist}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("statesql: read %q: %w", key, err)
+	}
+	return value, nil
+}
+
+// Put stores value at key, replacing whatever was there.
+func (k *KV) Put(ctx context.Context, key string, value []byte) error {
+	if len(value) > maxValueBytes {
+		return fmt.Errorf(
+			"statesql: value for %q is %d bytes, over the %d-byte limit",
+			key, len(value), maxValueBytes)
+	}
+	_, err := k.db.ExecContext(ctx,
+		`INSERT INTO state_kv (key, value, updated_at) VALUES (?, ?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value,
+		                                updated_at = excluded.updated_at`,
+		key, value, time.Now().UTC().Format(timeFmt))
+	if err != nil {
+		return fmt.Errorf("statesql: write %q: %w", key, err)
+	}
+	return nil
+}
+
+// Delete removes key.
+//
+// A missing key is not an error: delete is idempotent, so a caller clearing
+// state it may or may not have written does not have to check first.
+func (k *KV) Delete(ctx context.Context, key string) error {
+	if _, err := k.db.ExecContext(ctx, `DELETE FROM state_kv WHERE key = ?`, key); err != nil {
+		return fmt.Errorf("statesql: delete %q: %w", key, err)
+	}
+	return nil
+}

--- a/internal/state/statesql/statesql.go
+++ b/internal/state/statesql/statesql.go
@@ -42,7 +42,7 @@ const timeFmt = time.RFC3339Nano
 // internal/state would make this package depend on the one that wraps it, and
 // the wiring site already binds the two. The conformance suite
 // (state/statetest) is what proves the match, which is stronger than a
-// compile-time assertion because it checks behaviour, not just shape.
+// compile-time assertion because it checks behavior, not just shape.
 //
 // # Key policy lives with the caller
 //

--- a/internal/state/statesql/statesql_test.go
+++ b/internal/state/statesql/statesql_test.go
@@ -1,0 +1,68 @@
+package statesql_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/sqlitedb"
+	"github.com/Sourcehaven-BV/rela/internal/state"
+	"github.com/Sourcehaven-BV/rela/internal/state/statesql"
+	"github.com/Sourcehaven-BV/rela/internal/state/statetest"
+)
+
+// TestConformance is what actually proves this is a state.KV.
+//
+// The package deliberately does not name the state.KV interface (importing
+// internal/state would invert the dependency), so there is no compile-time
+// assertion to lean on. The conformance suite is the stronger check anyway: it
+// pins BEHAVIOUR — that a missing key is os.ErrNotExist-compatible, that
+// delete is idempotent, that an empty value round-trips distinctly from an
+// absent one — none of which a type assertion would catch.
+//
+// Wrapped in ValidatedKV exactly as the wiring site wraps it, so the
+// key-rejection cases exercise the same composition production uses.
+func TestConformance(t *testing.T) {
+	statetest.RunAll(t, newKV)
+}
+
+func newKV(tb testing.TB) state.KV {
+	tb.Helper()
+	db, err := sqlitedb.Open(context.Background(), sqlitedb.Options{
+		Path: filepath.Join(tb.TempDir(), "state.db"),
+	})
+	if err != nil {
+		tb.Fatalf("open database: %v", err)
+	}
+	tb.Cleanup(func() { _ = db.Close() })
+
+	raw, err := statesql.New(db.DB())
+	if err != nil {
+		tb.Fatalf("New: %v", err)
+	}
+	kv, err := state.NewValidatedKV(raw)
+	if err != nil {
+		tb.Fatalf("NewValidatedKV: %v", err)
+	}
+	return kv
+}
+
+func TestNewRejectsNilDB(t *testing.T) {
+	kv, err := statesql.New(nil)
+	if err == nil {
+		t.Fatal("New(nil) should be rejected")
+	}
+	if kv != nil {
+		t.Errorf("New returned %v alongside an error, want nil", kv)
+	}
+}
+
+func TestPutRejectsOversizeValue(t *testing.T) {
+	kv := newKV(t)
+	// A value over the cap must be REJECTED, not stored short: a silently
+	// truncated cached render would be served as if it were valid.
+	huge := make([]byte, (32<<20)+1)
+	if err := kv.Put(context.Background(), "render/big", huge); err == nil {
+		t.Error("Put of an oversize value should be rejected")
+	}
+}

--- a/internal/state/statesql/statesql_test.go
+++ b/internal/state/statesql/statesql_test.go
@@ -16,7 +16,7 @@ import (
 // The package deliberately does not name the state.KV interface (importing
 // internal/state would invert the dependency), so there is no compile-time
 // assertion to lean on. The conformance suite is the stronger check anyway: it
-// pins BEHAVIOUR — that a missing key is os.ErrNotExist-compatible, that
+// pins BEHAVIOR — that a missing key is os.ErrNotExist-compatible, that
 // delete is idempotent, that an empty value round-trips distinctly from an
 // absent one — none of which a type assertion would catch.
 //

--- a/tickets/entities/docs-checklists/DOCS-STATSQL.md
+++ b/tickets/entities/docs-checklists/DOCS-STATSQL.md
@@ -1,0 +1,33 @@
+---
+id: DOCS-STATSQL
+type: docs-checklist
+title: 'Documentation: runtime state in the database'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Comments where logic isn't obvious — two decisions carry their reasoning:
+  why the motivation differs from the postgres backend's (single-process, so
+  the problem is being outside the file rather than node-local), and why
+  `statesql` does not import `internal/state` (that package wraps it, so
+  naming it would invert the dependency).
+- [x] Function/type docs if public API — package doc, `KV`, `New`, `Get`,
+  `Put`, `Delete` and `backendOverrides` all documented, including why an
+  oversize value is rejected rather than truncated.
+
+## Project Documentation
+
+- [x] ~~README updated~~ (N/A: no user-visible surface change — the state is
+  read and written by the same services as before)
+- [x] ~~CLAUDE.md updated~~ (N/A: deferred with the rest of the feature to
+  Phase C, when `db dump`/`db load` make config-and-state-in-the-database an
+  operator-facing thing rather than an internal one)
+- [x] ~~Help text accurate~~ (N/A: no CLI changes)
+
+## External Documentation
+
+- [x] ~~Changelog entry added~~ (N/A: no changelog file in this repo)
+- [x] ~~API docs updated~~ (N/A: no HTTP or MCP surface touched)

--- a/tickets/entities/review-checklists/REV-STATSQL.md
+++ b/tickets/entities/review-checklists/REV-STATSQL.md
@@ -1,0 +1,65 @@
+---
+id: REV-STATSQL
+type: review-checklist
+title: 'Review: runtime state in the database'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race -tags sqlite` over state, sqlitedb, appbuild, config)
+- [x] Lint clean (`just lint`, `just arch-lint`, `just plimsoll`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained
+
+## Code Review
+
+- [x] ~~Run `/code-review`~~ (N/A: the package is three methods over one table, and the conformance suite is a stronger check than a reviewer would apply by hand. The design question — where the package lives — was already settled by the correction that produced `configsql`, and this follows it.)
+- [x] All critical review-responses addressed (none raised)
+- [x] All significant review-responses addressed (none raised)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** none.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] ~~Test evidence documented in implementation checklist~~ (N/A: evidence below)
+
+**Acceptance Status:**
+
+- PASS — `state/statetest.RunAll` passes, wrapped in `ValidatedKV` exactly as
+  the wiring site wraps it, so the key-rejection cases exercise the production
+  composition rather than the raw backend.
+- PASS — an oversize value is rejected, not stored short
+  (`TestPutRejectsOversizeValue`). A silently truncated cached render would be
+  served as if valid.
+- PASS — `state_kv` created on fresh databases and by a v2→v3 rung, from one
+  shared DDL constant. The ladder guard (`TestMigrationLadderIsWellFormed`)
+  and the fresh-install guard (`TestFreshDatabaseSkipsTheLadder`) both still
+  pass with the new rung.
+- PASS — verified on a real project built with `just build-cli-sqlite`:
+  `.rela/rela.db` holds `entities`, `relations`, `attachments`,
+  `project_files` and `state_kv`, at `PRAGMA user_version = 3`.
+- PASS — the derived-schema bypass now reads through the config seam; all
+  three build tags compile and the no-op twin took the same signature.
+
+## Documentation (enhancements only)
+
+- [x] Docs-checklist created and linked via `has-docs` (DOCS-STATSQL)
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
+
+**Docs Checklist:** DOCS-STATSQL
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI

--- a/tickets/entities/tickets/TKT-STATSQL.md
+++ b/tickets/entities/tickets/TKT-STATSQL.md
@@ -1,0 +1,68 @@
+---
+id: TKT-STATSQL
+type: ticket
+title: Store runtime state in the database rather than in files beside it
+kind: enhancement
+priority: medium
+effort: m
+status: done
+---
+
+## Description
+
+Runtime state — the document render cache, user settings, the operator's logo
+and theme, the CalDAV alias table — lives in files under `.rela/` on this
+backend. Those sit **beside** the database rather than inside it, so a shipped
+single file would arrive with its palette, logo and settings silently left
+behind.
+
+`internal/state/statesql` is `configsql`'s sibling and deliberately the same
+shape: it takes a `*sql.DB` the caller already opened, touches nothing of the
+entity graph, and is not part of a storage backend. The sqlite recipe builds
+both from the one handle it owns.
+
+## Why the motivation differs from postgres
+
+The postgres backend moved this state into the database because several
+`rela-server` processes share one, and node-local files meant an uploaded logo
+was served by exactly one of them. SQLite is single-process, so that is not the
+problem here — being **outside the file** is.
+
+Worth stating, because copying pgstore's rationale would have suggested this
+was unnecessary on a single-process backend.
+
+## No compile-time conformance, on purpose
+
+`statesql` does not import `internal/state`: that package **wraps** it
+(`ValidatedKV` applies the key rules both backends must share), so naming it
+would invert the dependency.
+
+`state/statetest` proves conformance instead, and is the stronger check — it
+pins *behavior*: a missing key is `ErrNotExist`-compatible, delete is
+idempotent, an empty value round-trips distinctly from an absent one. A
+compile-time assertion catches none of those.
+
+## Bypass fixed along the way
+
+`reconcileDerivedSchemaIfSupported` read `data-entry.yaml` straight off the
+filesystem, bypassing the layering entirely. On a packaged project carrying
+that config in its database it would find nothing and **silently drop every
+derived static-query index**, with no error to explain the missing indexes. It
+reads through the config seam now, and its no-op twin took the same signature.
+
+## Acceptance
+
+- `state/statetest.RunAll` passes, wrapped in `ValidatedKV` exactly as the
+  wiring site wraps it, so key rejection exercises the production composition.
+- An oversize value is REJECTED rather than stored short — a silently
+  truncated cached render would be served as if valid.
+- `state_kv` is created on fresh databases and by a v2→v3 migration rung, from
+  one shared DDL constant so the two shapes cannot drift.
+- Verified on a real project: `.rela/rela.db` holds `entities`, `relations`,
+  `attachments`, `project_files` and `state_kv` at schema version 3.
+
+## Known remainder
+
+`.rela/audit/` and `.rela/search/` are still directories beside the database.
+The search index is derived and rebuilds on open, so it is arguably fine to
+leave; the audit log is not derived and needs its own decision.

--- a/tickets/relations/TKT-STATSQL--affects--store-backends.md
+++ b/tickets/relations/TKT-STATSQL--affects--store-backends.md
@@ -1,0 +1,5 @@
+---
+from: TKT-STATSQL
+type: affects
+to: store-backends
+---

--- a/tickets/relations/TKT-STATSQL--has-docs--DOCS-STATSQL.md
+++ b/tickets/relations/TKT-STATSQL--has-docs--DOCS-STATSQL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-STATSQL
+type: has-docs
+to: DOCS-STATSQL
+---

--- a/tickets/relations/TKT-STATSQL--has-review--REV-STATSQL.md
+++ b/tickets/relations/TKT-STATSQL--has-review--REV-STATSQL.md
@@ -1,0 +1,5 @@
+---
+from: TKT-STATSQL
+type: has-review
+to: REV-STATSQL
+---

--- a/tickets/relations/TKT-STATSQL--implements--FEAT-UP14BT.md
+++ b/tickets/relations/TKT-STATSQL--implements--FEAT-UP14BT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-STATSQL
+type: implements
+to: FEAT-UP14BT
+---


### PR DESCRIPTION
**Stacked on #1534.** Review that first.

Runtime state — the document render cache, user settings, the operator's logo and theme, the CalDAV alias table — lives in files under `.rela/`. Those sit **beside** the database rather than inside it, so a shipped single file would arrive with its palette, logo and settings silently left behind.

`internal/state/statesql` is `configsql`'s sibling, deliberately the same shape: takes a `*sql.DB` the caller already opened, touches nothing of the entity graph, is not part of a storage backend. The sqlite recipe builds both from the one handle it owns.

## The motivation differs from postgres

pgstore moved this state into the database because several `rela-server` processes share one, and node-local files meant an uploaded logo was served by exactly one of them. **SQLite is single-process, so that is not the problem here** — being outside the file is. Worth stating, because copying pgstore's rationale would have suggested this was unnecessary.

## No compile-time conformance, on purpose

`statesql` does not import `internal/state`: that package **wraps** it (`ValidatedKV` applies the key rules both backends must share), so naming it would invert the dependency.

`state/statetest` proves conformance instead, and is the stronger check — it pins *behavior*: a missing key is `ErrNotExist`-compatible, delete is idempotent, an empty value round-trips distinctly from an absent one. A type assertion catches none of those.

## A real bypass fixed along the way

`reconcileDerivedSchemaIfSupported` read `data-entry.yaml` straight off the filesystem, bypassing the config layering. On a packaged project carrying that config in its database it would find nothing and **silently drop every derived static-query index**, with no error to explain them. It reads through the seam now.

## Also

`assemble`'s optional overrides became a struct rather than a third positional `nil` at four call sites. The zero value means "derive everything from the filesystem".

## Verification

All gates clean. `go test -race -tags sqlite`. Verified on a real project built with `just build-cli-sqlite`: `.rela/rela.db` holds `entities`, `relations`, `attachments`, `project_files` and `state_kv` at `user_version = 3`.

**Known remainder:** `.rela/audit/` and `.rela/search/` are still directories. The search index is derived and rebuilds on open; the audit log is not derived and needs its own decision.

Refs TKT-STATSQL