### PR TITLE
fix(entitymanager): require the copy read gates under a compiled policy (BUG-R9GOCK)

### DIFF
--- a/internal/acl/implguard_test.go
+++ b/internal/acl/implguard_test.go
@@ -1,0 +1,117 @@
+package acl
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// knownACLImplementations is the closed set of production [ACL]
+// implementations. Adding one is a deliberate act with consequences beyond
+// this package, so the set is pinned here and this test fails until the new
+// implementation is added to the list — at which point the reader is pointed
+// at what else must change.
+//
+// It is an ALLOWLIST rather than a scan-for-problems, so a new implementation
+// fails closed: it cannot be introduced without someone reading this comment.
+var knownACLImplementations = map[string]string{
+	"NopACL":      "allow-all; the no-policy default when acl.yaml is absent",
+	"ReadOnlyACL": "deny-all writes; rela-server --read-only",
+	"Declarative": "the only implementation compiled from an operator's acl.yaml",
+	// Request satisfies the interface but is NOT a deployment-wide policy: it
+	// is a per-principal scope obtained from Declarative.ForPrincipal and
+	// threaded on the context, never assigned to entitymanager.Deps.ACL. It is
+	// listed so the scan stays honest about what it found; the is-policy-active
+	// sites are unaffected by it.
+	"Request": "per-principal request scope, never wired as a deployment ACL",
+}
+
+// aclImplementation matches a method declaration satisfying the ACL interface.
+// The receiver may be a pointer or a value, and — as the stand-ins here do —
+// may be unnamed, so the name is optional in the pattern.
+var aclImplementation = regexp.MustCompile(
+	`func \((?:\w+ )?\*?(\w+)\) AuthorizeWrite\(`)
+
+// TestACLImplementations_AreAClosedSet guards a cross-package invariant that
+// no compiler check can express.
+//
+// # Why this matters outside this package
+//
+// Several call sites answer "is a real policy active?" by TYPE, because that is
+// the only thing distinguishing a compiled acl.yaml from the allow-all and
+// deny-all stand-ins:
+//
+//   - internal/entitymanager New (requireCopyGates) — refuses a nil copy read
+//     gate when the ACL is *Declarative (#1437)
+//   - internal/appbuild CompileTransitions — sets the fail-closed posture of
+//     the transition guard and both copy gates
+//   - internal/dataentry views_handler.go, commands.go,
+//     standalone_document_handler.go — switch on NopACL/ReadOnlyACL
+//
+// Those two groups fail in OPPOSITE directions on a type they do not
+// recognize: the dataentry switches default to fail-closed, while an
+// is-Declarative assertion falls through to "no policy", i.e. open. A
+// decorating implementation — auditedACL{inner: declarative}, a multi-tenant
+// wrapper, a metrics shim — would therefore make dataentry hide a UI element
+// while entitymanager waves an ungated copy read through. That is the exact
+// forgotten-wiring-becomes-a-bypass shape (RR-X9NVHI) #1437 closed, one
+// wrapper later.
+//
+// The set is closed today, which is what makes every one of those sites
+// correct. This test is what makes "closed" a property rather than an
+// observation.
+//
+// If you are here because you added an implementation: decide, per site above,
+// whether it represents an active policy, and update each one. Prefer wrapping
+// Declarative's behavior to introducing a fourth peer.
+func TestACLImplementations_AreAClosedSet(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	found := map[string]string{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, rerr := os.ReadFile(filepath.Clean(name))
+		if rerr != nil {
+			t.Fatalf("read %s: %v", name, rerr)
+		}
+		for _, m := range aclImplementation.FindAllStringSubmatch(string(src), -1) {
+			found[m[1]] = name
+		}
+	}
+
+	if len(found) == 0 {
+		t.Fatal("the scan found no ACL implementations at all — the regexp has " +
+			"drifted from the code and this guard is now vacuous")
+	}
+
+	for impl, file := range found {
+		if _, known := knownACLImplementations[impl]; !known {
+			t.Errorf("new ACL implementation %q in %s.\n\n"+
+				"Several packages answer \"is a real policy active?\" by asserting on "+
+				"*acl.Declarative, and they fail OPEN on a type they do not recognize "+
+				"while internal/dataentry's switches fail closed. Read this test's doc "+
+				"comment, update the sites it lists, then add %q to "+
+				"knownACLImplementations with a one-line reason.",
+				impl, file, impl)
+		}
+	}
+
+	// The reverse direction: a removed implementation should not leave a stale
+	// entry claiming the set is wider than it is.
+	for impl := range knownACLImplementations {
+		if _, ok := found[impl]; !ok {
+			t.Errorf("knownACLImplementations lists %q but no such implementation "+
+				"exists — remove the stale entry", impl)
+		}
+	}
+}

--- a/internal/appbuild/appbuild.go
+++ b/internal/appbuild/appbuild.go
@@ -1414,19 +1414,6 @@ func buildEntityManager(
 	readDeps lua.ReadDeps, versions store.VersionService, tw TransitionWiring,
 	computedSet *computed.Set,
 ) (*entitymanager.Manager, error) {
-	// A policy is "active" when the resolved ACL is the declarative one — the
-	// same test CompileTransitions applies, spelled here rather than widened
-	// onto TransitionWiring so the copy deps do not depend on the transition
-	// wiring's shape.
-	declarative, policyActive := resolvedACL.(*acl.Declarative)
-	// The cross-entity copy reads the source through the caller's FIELD
-	// redaction too — the same redactor the API read path uses, so a
-	// `visible:`-hidden property cannot travel into a new entity.
-	copyRedactor, err := buildFieldRedactor(base.meta, st, declarative)
-	if err != nil {
-		return nil, fmt.Errorf("build entitymanager: copy redactor: %w", err)
-	}
-
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		AliasRewriter:           aliases,
 		Store:                   st,
@@ -1456,8 +1443,8 @@ func buildEntityManager(
 		// identical implementation and cannot drift into asking different
 		// ones.
 		CopyGuard:      tw.Guard,
-		CopyReadGate:   copyReadGate{policyActive: policyActive},
-		CopyVisibility: copyVisibility{st: st, redact: copyRedactor, policyActive: policyActive},
+		CopyReadGate:   tw.ReadGate,
+		CopyVisibility: tw.Visibility,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build entitymanager: %w", err)

--- a/internal/appbuild/appbuildtest/fixture.go
+++ b/internal/appbuild/appbuildtest/fixture.go
@@ -189,6 +189,11 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 		// be unwired in BOTH places at once (TKT-WRLDAPI item 5). If you add a
 		// dep to buildEntityManager, add it here too.
 		//
+		// The authorization deps are the ones where drift is dangerous rather
+		// than merely confusing, so they no longer rely on this note: each is
+		// either required by entitymanager.New or taken from the shared
+		// appbuild.TransitionWiring below.
+		//
 		// Mirrors the production wiring in appbuild.assemble: elevated reads
 		// are granted here so an integration test exercises the same
 		// capability set a real deployment has (TKT-ACSBSA). Still inert
@@ -203,15 +208,22 @@ func New(meta *metamodel.Metamodel, opts ...Option) *appbuild.Services {
 		FieldGate:       entitymanager.AllowAllFieldGate{},
 		TransitionGuard: tw.Guard,
 		TransitionGraph: tw.Graph,
-		// The copy deps (TKT-WRLDAPI item 5). CopyGuard reuses tw.Guard for
-		// the same reason production does: entitymanager.CopyGuard and
+		// The copy deps (TKT-WRLDAPI item 5), all three taken from the same
+		// TransitionWiring production uses. CopyGuard reuses tw.Guard for the
+		// reason production does: entitymanager.CopyGuard and
 		// statemachine.Guard are deliberately the same shape, so the two
 		// cannot drift into asking different questions.
 		//
-		// CopyReadGate / CopyVisibility are left nil here, which is the
-		// no-policy posture — this fixture's default ACL is NopACL and every
-		// other read it performs is raw too.
-		CopyGuard: tw.Guard,
+		// These were previously left nil here on the reasoning that this
+		// fixture's default ACL is NopACL and its other reads are raw too.
+		// That held for the default and broke for WithACL(declarative): a
+		// test could get a policy-backed manager whose copy path still read
+		// its source ungated — the forgotten-wiring state entitymanager.New
+		// now refuses (#1437). Taking all three from tw makes the posture
+		// follow the ACL, exactly as in production.
+		CopyGuard:      tw.Guard,
+		CopyReadGate:   tw.ReadGate,
+		CopyVisibility: tw.Visibility,
 	})
 	if err != nil {
 		panic(fmt.Sprintf("appbuildtest.New: build entitymanager: %v", err))

--- a/internal/appbuild/appbuildtest/fixture_test.go
+++ b/internal/appbuild/appbuildtest/fixture_test.go
@@ -83,6 +83,23 @@ func TestNew_WithDeclarative_WiresBothACLAndDeclarative(t *testing.T) {
 		t.Fatalf("acl.NewDeclarative: %v", err)
 	}
 
+	// Constructing at all is the assertion for #1437: this is the only
+	// fixture path that reaches entitymanager.New with a POLICY-backed ACL, so
+	// a fixture that left CopyReadGate / CopyVisibility nil panics here rather
+	// than quietly handing back a manager whose copy path reads its source
+	// ungated. appbuild's TestCompileTransitions_AlwaysSuppliesCopyGates proves
+	// the bundle offers the gates; this proves the fixture CONSUMES them —
+	// which is the half that actually broke, since the gates were available
+	// and simply not passed.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("building the fixture with a compiled policy must succeed. A "+
+				"panic here means a wiring site stopped taking the copy gates from "+
+				"appbuild.TransitionWiring — restore them rather than relaxing the "+
+				"guard in entitymanager.New (#1437).\ngot: %v", r)
+		}
+	}()
+
 	svc := appbuildtest.New(meta, appbuildtest.WithDeclarative(d))
 	if svc.ACL() != acl.ACL(d) {
 		t.Errorf("svc.ACL() = %T, want the supplied *acl.Declarative", svc.ACL())

--- a/internal/appbuild/copygatewiring_test.go
+++ b/internal/appbuild/copygatewiring_test.go
@@ -1,0 +1,84 @@
+package appbuild_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// TestCompileTransitions_AlwaysSuppliesCopyGates pins the invariant that makes
+// the #1437 guard hold at the WIRING layer rather than only at the constructor.
+//
+// entitymanager.New refuses a policy-backed Deps whose copy read gates are
+// nil. That is the backstop. This is the reason the backstop should never
+// fire in production: every wiring site — assemble and the appbuildtest
+// fixture alike — takes both gates from the TransitionWiring bundle, and the
+// bundle always populates them.
+//
+// Before this, the gates were built inline in buildEntityManager and
+// hand-copied into the fixture, which left the fixture passing a policy-backed
+// ACL with both gates nil. Asserting non-nil here is the cheap check that the
+// single source stayed single; if someone reintroduces an inline build at one
+// site, the other site's gates go nil and this fails.
+//
+// The posture the gates take (inert without a policy, fail-closed with one) is
+// tested where it is observable — through actual copy behavior in
+// copywiring_test.go and entitymanager's own suite. This test asserts only
+// that a gate EXISTS, because a nil is the one failure that is invisible at
+// the call site.
+func TestCompileTransitions_AlwaysSuppliesCopyGates(t *testing.T) {
+	t.Parallel()
+
+	meta, err := metamodel.Parse([]byte(copyWiringMeta))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+
+	declarative := func(t *testing.T) acl.ACL {
+		t.Helper()
+		policy := &acl.Policy{
+			Roles:       map[string]acl.RoleDef{"author": {Read: []string{"page"}}},
+			Assignments: map[string]string{"alice": "author"},
+		}
+		if verr := policy.Validate(); verr != nil {
+			t.Fatalf("policy must load: %v", verr)
+		}
+		d, derr := acl.NewDeclarative(policy, acl.NullGraph{}, acl.NullGraphQueryer{})
+		if derr != nil {
+			t.Fatalf("NewDeclarative: %v", derr)
+		}
+		return d
+	}
+
+	// Both tiers, because the no-policy one is where a nil would be easiest to
+	// justify — and it is exactly the tier the fixture used to sit in while
+	// callers could hand it a real policy.
+	for _, tc := range []struct {
+		name    string
+		aclFunc func(*testing.T) acl.ACL
+	}{
+		{"no policy", func(*testing.T) acl.ACL { return acl.NopACL{} }},
+		{"compiled policy", declarative},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tw, cerr := appbuild.CompileTransitions(meta, memstore.New(), tc.aclFunc(t))
+			if cerr != nil {
+				t.Fatalf("CompileTransitions: %v", cerr)
+			}
+			if tw.ReadGate == nil {
+				t.Error("ReadGate must never be nil: a nil copy read gate makes the " +
+					"copy path read its source ungated, and every wiring site now " +
+					"takes this field verbatim")
+			}
+			if tw.Visibility == nil {
+				t.Error("Visibility must never be nil: a nil field gate lets a " +
+					"cross-entity copy launder `visible:`-hidden properties into an " +
+					"entity with a different audience")
+			}
+		})
+	}
+}

--- a/internal/appbuild/transitions.go
+++ b/internal/appbuild/transitions.go
@@ -2,9 +2,11 @@ package appbuild
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 	"github.com/Sourcehaven-BV/rela/internal/store"
@@ -67,6 +69,23 @@ type TransitionWiring struct {
 	Enforcer *statemachine.Set
 	Guard    statemachine.Guard
 	Graph    statemachine.GraphLookup
+
+	// ReadGate and Visibility are the COPY path's two read gates. They live
+	// here rather than beside the copy code because they share this bundle's
+	// single job: give every wiring site one way to build the collaborators,
+	// so a site cannot silently omit one.
+	//
+	// They were previously assembled inline in buildEntityManager and
+	// hand-copied into the test fixture, which is how the fixture came to
+	// pass a policy-backed ACL with both gates nil — the exact
+	// forgotten-wiring state entitymanager.New now refuses (#1437).
+	//
+	// Nil: never — CompileTransitions always populates both. Their POSTURE
+	// follows resolvedACL (inert without a policy, fail-closed with one),
+	// which is what keeps the no-policy CLI case working without leaving a
+	// nil for a wiring site to inherit by accident.
+	ReadGate   entitymanager.CopyReadGate
+	Visibility entitymanager.CopyReader
 }
 
 // CompileTransitions builds the executable state machines from the metamodel
@@ -84,11 +103,20 @@ func CompileTransitions(meta *metamodel.Metamodel, st store.Store, resolvedACL a
 	if err != nil {
 		return TransitionWiring{}, err
 	}
-	_, policyActive := resolvedACL.(*acl.Declarative)
+	declarative, policyActive := resolvedACL.(*acl.Declarative)
+	// The cross-entity copy reads its source through the caller's FIELD
+	// redaction too — the same redactor the API read path uses, so a
+	// `visible:`-hidden property cannot travel into a new entity.
+	copyRedactor, err := buildFieldRedactor(meta, st, declarative)
+	if err != nil {
+		return TransitionWiring{}, fmt.Errorf("copy redactor: %w", err)
+	}
 	return TransitionWiring{
-		Enforcer: set,
-		Guard:    transitionGuard{policyActive: policyActive},
-		Graph:    transitionGraph{st: st},
+		Enforcer:   set,
+		Guard:      transitionGuard{policyActive: policyActive},
+		Graph:      transitionGraph{st: st},
+		ReadGate:   copyReadGate{policyActive: policyActive},
+		Visibility: copyVisibility{st: st, redact: copyRedactor, policyActive: policyActive},
 	}, nil
 }
 

--- a/internal/entitymanager/acl_empty_fromtype_test.go
+++ b/internal/entitymanager/acl_empty_fromtype_test.go
@@ -207,7 +207,7 @@ func createRelationAllowed(t *testing.T, createGrants []string, seedSource bool)
 		// Not a copy test: opt out of the copy read gates explicitly, which is
 		// what New requires of a policy-backed Deps (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/acl_empty_fromtype_test.go
+++ b/internal/entitymanager/acl_empty_fromtype_test.go
@@ -204,6 +204,10 @@ func createRelationAllowed(t *testing.T, createGrants []string, seedSource bool)
 		ACL:         d,
 		Transitions: statemachine.EmptySet(),
 		FieldGate:   entitymanager.AllowAllFieldGate{},
+		// Not a copy test: opt out of the copy read gates explicitly, which is
+		// what New requires of a policy-backed Deps (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/acl_test.go
+++ b/internal/entitymanager/acl_test.go
@@ -429,7 +429,7 @@ role_relations:
 		// Not a copy test: opt out of the copy read gates explicitly, which is
 		// what New requires of a policy-backed Deps (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: store},
+		CopyVisibility: allowAllCopyVisibility(t, store),
 		Store:          store, Meta: meta, Templater: nopTemplater{},
 		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
@@ -585,7 +585,7 @@ assignments:
 		// Not a copy test: opt out of the copy read gates explicitly, which is
 		// what New requires of a policy-backed Deps (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: store},
+		CopyVisibility: allowAllCopyVisibility(t, store),
 		Store:          store, Meta: meta, Templater: nopTemplater{},
 		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})

--- a/internal/entitymanager/acl_test.go
+++ b/internal/entitymanager/acl_test.go
@@ -426,7 +426,11 @@ role_relations:
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		FieldGate: entitymanager.AllowAllFieldGate{},
-		Store:     store, Meta: meta, Templater: nopTemplater{},
+		// Not a copy test: opt out of the copy read gates explicitly, which is
+		// what New requires of a policy-backed Deps (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: store},
+		Store:          store, Meta: meta, Templater: nopTemplater{},
 		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
@@ -578,7 +582,11 @@ assignments:
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		FieldGate: entitymanager.AllowAllFieldGate{},
-		Store:     store, Meta: meta, Templater: nopTemplater{},
+		// Not a copy test: opt out of the copy read gates explicitly, which is
+		// what New requires of a policy-backed Deps (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: store},
+		Store:          store, Meta: meta, Templater: nopTemplater{},
 		Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {

--- a/internal/entitymanager/apply_type_confusion_test.go
+++ b/internal/entitymanager/apply_type_confusion_test.go
@@ -95,7 +95,11 @@ assignments:
 	sink := audit.NewMemory()
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		FieldGate: entitymanager.AllowAllFieldGate{},
-		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
+		// Not a copy test: opt out of the copy read gates explicitly, which is
+		// what New requires of a policy-backed Deps (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		Store:          st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -179,7 +183,11 @@ assignments:
 	}
 	mgr, err := entitymanager.New(entitymanager.Deps{
 		FieldGate: entitymanager.AllowAllFieldGate{},
-		Store:     st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative, Transitions: statemachine.EmptySet(),
+		// Not a copy test: opt out of the copy read gates explicitly, which is
+		// what New requires of a policy-backed Deps (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		Store:          st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/entitymanager/apply_type_confusion_test.go
+++ b/internal/entitymanager/apply_type_confusion_test.go
@@ -98,7 +98,7 @@ assignments:
 		// Not a copy test: opt out of the copy read gates explicitly, which is
 		// what New requires of a policy-backed Deps (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 		Store:          st, Meta: meta, Templater: nopTemplater{}, Audit: sink, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {
@@ -186,7 +186,7 @@ assignments:
 		// Not a copy test: opt out of the copy read gates explicitly, which is
 		// what New requires of a policy-backed Deps (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 		Store:          st, Meta: meta, Templater: nopTemplater{}, Audit: audit.Nop{}, ACL: declarative, Transitions: statemachine.EmptySet(),
 	})
 	if err != nil {

--- a/internal/entitymanager/cascade_authz_test.go
+++ b/internal/entitymanager/cascade_authz_test.go
@@ -58,6 +58,10 @@ func cascadeManager(t *testing.T, st store.Store) *entitymanager.Manager {
 		ACL:         d,
 		Transitions: statemachine.EmptySet(),
 		FieldGate:   entitymanager.AllowAllFieldGate{},
+		// Not a copy test: opt out of the copy read gates explicitly, which is
+		// what New requires of a policy-backed Deps (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/cascade_authz_test.go
+++ b/internal/entitymanager/cascade_authz_test.go
@@ -61,7 +61,7 @@ func cascadeManager(t *testing.T, st store.Store) *entitymanager.Manager {
 		// Not a copy test: opt out of the copy read gates explicitly, which is
 		// what New requires of a policy-backed Deps (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/ceiling_test.go
+++ b/internal/entitymanager/ceiling_test.go
@@ -69,6 +69,10 @@ func ceilingManager(t *testing.T) (mgr *entitymanager.Manager, seededID string) 
 		ACL:         decl,
 		Transitions: statemachine.EmptySet(),
 		FieldGate:   entitymanager.AllowAllFieldGate{},
+		// Not a copy test: opt out of the copy read gates explicitly, which is
+		// what New requires of a policy-backed Deps (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/ceiling_test.go
+++ b/internal/entitymanager/ceiling_test.go
@@ -72,7 +72,7 @@ func ceilingManager(t *testing.T) (mgr *entitymanager.Manager, seededID string) 
 		// Not a copy test: opt out of the copy read gates explicitly, which is
 		// what New requires of a policy-backed Deps (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 	})
 	if err != nil {
 		t.Fatalf("entitymanager.New: %v", err)

--- a/internal/entitymanager/copy_gate_required_test.go
+++ b/internal/entitymanager/copy_gate_required_test.go
@@ -1,0 +1,178 @@
+package entitymanager_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/acl"
+	"github.com/Sourcehaven-BV/rela/internal/audit"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/entitymanager"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/statemachine"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
+)
+
+// declarativeForGateTest builds the production-shaped ACL: a compiled policy,
+// which is the state that makes the copy read gates mandatory.
+func declarativeForGateTest(t *testing.T) *acl.Declarative {
+	t.Helper()
+	policy := &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"author": {Read: []string{"page"}, Update: []string{"page@draft"}}},
+		Assignments: map[string]string{"alice": "author"},
+	}
+	if err := policy.Validate(); err != nil {
+		t.Fatalf("policy must load: %v", err)
+	}
+	d, err := acl.NewDeclarative(policy, acl.NullGraph{}, acl.NullGraphQueryer{})
+	if err != nil {
+		t.Fatalf("NewDeclarative: %v", err)
+	}
+	return d
+}
+
+// depsForGateTest is the minimal valid Deps, with the copy read gates left to
+// the caller.
+func depsForGateTest(t *testing.T, st store.Store, aclImpl acl.ACL) entitymanager.Deps {
+	t.Helper()
+	meta, err := metamodel.Parse([]byte(copyMetaYAML))
+	if err != nil {
+		t.Fatalf("metamodel.Parse: %v", err)
+	}
+	return entitymanager.Deps{
+		Store: st, Meta: meta, Templater: nopTemplater{},
+		Audit: audit.Nop{}, ACL: aclImpl,
+		Transitions: statemachine.EmptySet(),
+		FieldGate:   entitymanager.AllowAllFieldGate{},
+	}
+}
+
+// TestNew_CopyGatesRequiredUnderPolicy is the regression test for
+// sourcehaven-bv/rela#1437.
+//
+// # What was wrong
+//
+// Deps.CopyReadGate and Deps.CopyVisibility were silently nil-tolerant, while
+// every other authorization dep in the same struct — Store, Meta, Templater,
+// Audit, ACL, Transitions, Computed, FieldGate — hard-failed in New. The
+// tolerance is correct for a deployment with no acl.yaml, where every read is
+// raw anyway. It is NOT correct once a policy is present: authorizeCopy then
+// skips its read check entirely and readCopySource takes the raw-store branch
+// for cross-entity copies, so a principal reads a source entity, and the
+// `visible:`-hidden fields on it, that every other read path would refuse.
+//
+// There was no error and no log line. The only marker was a code comment
+// asserting the assumption ("nil gate means no ACL is wired"), with nothing
+// enforcing it — and the sibling CopyGuard on the same struct already failed
+// CLOSED, which is what made these two the odd ones out.
+//
+// # Why the subtest matrix is shaped this way
+//
+// The distinction the guard has to draw is between the legitimate state (no
+// policy, gates absent) and the risky one (policy present, gates absent), so
+// both directions are pinned. Nop and ReadOnly ACLs must still build without
+// the gates — a check that just demanded them everywhere would be a different,
+// noisier change, and would break the CLI's no-policy posture.
+func TestNew_CopyGatesRequiredUnderPolicy(t *testing.T) {
+	t.Parallel()
+
+	st := memstore.New()
+
+	t.Run("policy present and both gates nil is refused", func(t *testing.T) {
+		t.Parallel()
+		_, err := entitymanager.New(depsForGateTest(t, st, declarativeForGateTest(t)))
+		if err == nil {
+			t.Fatal("a compiled policy with no copy read gates must be REFUSED at " +
+				"construction: the copy path would read its source ungated and " +
+				"unredacted, silently. This is the forgotten-wiring ACL bypass " +
+				"(RR-X9NVHI) that FieldGate next door already fails fast on")
+		}
+		// The message must name both, so an operator fixes the wiring in one
+		// pass rather than rebuilding to discover the second.
+		for _, want := range []string{"CopyReadGate", "CopyVisibility"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error must name the missing dep %q; got %v", want, err)
+			}
+		}
+	})
+
+	t.Run("policy present and only CopyVisibility nil is refused", func(t *testing.T) {
+		t.Parallel()
+		d := depsForGateTest(t, st, declarativeForGateTest(t))
+		d.CopyReadGate = entitymanager.AllowAllCopyReadGate{}
+		_, err := entitymanager.New(d)
+		if err == nil {
+			t.Fatal("a half-wired copy path must be refused too — the row gate and " +
+				"the field redactor answer different questions, and a cross-entity " +
+				"copy with no CopyVisibility launders `visible:`-hidden fields")
+		}
+		if strings.Contains(err.Error(), "CopyReadGate") {
+			t.Errorf("the error must name only what is MISSING, or it sends the "+
+				"operator to re-wire something already correct; got %v", err)
+		}
+	})
+
+	t.Run("policy present and both gates supplied builds", func(t *testing.T) {
+		t.Parallel()
+		d := depsForGateTest(t, st, declarativeForGateTest(t))
+		d.CopyReadGate = entitymanager.AllowAllCopyReadGate{}
+		d.CopyVisibility = entitymanager.AllowAllCopyVisibility{Store: st}
+		if _, err := entitymanager.New(d); err != nil {
+			t.Fatalf("explicitly opting out must be ACCEPTED — the guard is about "+
+				"forgotten wiring, not about forbidding allow-all; got %v", err)
+		}
+	})
+
+	// The no-policy tier. Leaving the gates nil here is the documented CLI
+	// posture, so the guard must not disturb it.
+	for _, tc := range []struct {
+		name    string
+		aclImpl acl.ACL
+	}{
+		{"NopACL", acl.NopACL{}},
+		{"ReadOnlyACL", acl.ReadOnlyACL{}},
+	} {
+		t.Run("no policy with "+tc.name+" still builds without the gates", func(t *testing.T) {
+			t.Parallel()
+			if _, err := entitymanager.New(depsForGateTest(t, st, tc.aclImpl)); err != nil {
+				t.Fatalf("%s is the NO-POLICY case: every other read on such a "+
+					"deployment is raw too, so requiring the copy gates here would "+
+					"be theater that breaks the CLI; got %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestAllowAllCopyVisibility_ReportsAbsentAsMiss pins the opt-out's failure
+// shape rather than only its happy path: a read gate must report a missing
+// entity as a MISS, never as an error, because absent and denied are
+// deliberately indistinguishable everywhere else on the read path. Getting
+// this wrong would turn the opt-out into an existence oracle.
+func TestAllowAllCopyVisibility_ReportsAbsentAsMiss(t *testing.T) {
+	t.Parallel()
+
+	st := memstore.New()
+	v := entitymanager.AllowAllCopyVisibility{Store: st}
+	ctx := context.Background()
+
+	if err := st.CreateEntity(ctx, &entity.Entity{
+		ID: "PAGE-1", Type: "page", Properties: map[string]any{"title": "Draft"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, ok, err := v.Get(ctx, "page", "PAGE-1", "")
+	if err != nil || !ok {
+		t.Fatalf("an existing entity must be a hit: ok=%v err=%v", ok, err)
+	}
+	if got.ID != "PAGE-1" {
+		t.Errorf("Get returned %q, want PAGE-1", got.ID)
+	}
+
+	if _, ok, err := v.Get(ctx, "page", "PAGE-404", ""); err != nil || ok {
+		t.Errorf("an absent entity must be a MISS with a nil error, matching every "+
+			"other read gate; got ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/entitymanager/copy_gate_required_test.go
+++ b/internal/entitymanager/copy_gate_required_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/store/memstore"
 )
 
+// allowAllCopyVisibility is the opt-out every non-copy test wants: ungated
+// reads, built through the real constructor so the tests exercise the same
+// validation production would. Failing the construction is a test bug, not an
+// assertion, hence t.Fatalf rather than a returned error.
+func allowAllCopyVisibility(t *testing.T, st store.Store) entitymanager.AllowAllCopyVisibility {
+	t.Helper()
+	v, err := entitymanager.NewAllowAllCopyVisibility(st)
+	if err != nil {
+		t.Fatalf("NewAllowAllCopyVisibility: %v", err)
+	}
+	return v
+}
+
 // declarativeForGateTest builds the production-shaped ACL: a compiled policy,
 // which is the state that makes the copy read gates mandatory.
 func declarativeForGateTest(t *testing.T) *acl.Declarative {
@@ -118,7 +131,7 @@ func TestNew_CopyGatesRequiredUnderPolicy(t *testing.T) {
 		t.Parallel()
 		d := depsForGateTest(t, st, declarativeForGateTest(t))
 		d.CopyReadGate = entitymanager.AllowAllCopyReadGate{}
-		d.CopyVisibility = entitymanager.AllowAllCopyVisibility{Store: st}
+		d.CopyVisibility = allowAllCopyVisibility(t, st)
 		if _, err := entitymanager.New(d); err != nil {
 			t.Fatalf("explicitly opting out must be ACCEPTED — the guard is about "+
 				"forgotten wiring, not about forbidding allow-all; got %v", err)
@@ -145,6 +158,30 @@ func TestNew_CopyGatesRequiredUnderPolicy(t *testing.T) {
 	}
 }
 
+// TestNewAllowAllCopyVisibility_RejectsNilStore keeps the opt-out from
+// reintroducing the very failure the guard exists to prevent.
+//
+// A bare AllowAllCopyVisibility{} satisfies CopyReader, so it passes
+// requireCopyGates and then nil-panics on the first cross-entity copy — a code
+// path that may not run until long after deploy. That is the
+// deferred-downstream-symptom shape CLAUDE.md's "constructors reject nil
+// required fields" rule is about, which would be an awkward thing for THIS
+// change to ship.
+//
+// The store field is unexported, so the constructor is the only way in and
+// this is the only place the check can be bypassed. Note it is validated here
+// rather than in requireCopyGates because a nil store is broken under ANY
+// ACL, not only a policy-backed one.
+func TestNewAllowAllCopyVisibility_RejectsNilStore(t *testing.T) {
+	t.Parallel()
+
+	if _, err := entitymanager.NewAllowAllCopyVisibility(nil); err == nil {
+		t.Fatal("a nil store must be rejected at construction: the zero value " +
+			"would satisfy CopyReader, pass New, and nil-panic on the first " +
+			"cross-entity copy")
+	}
+}
+
 // TestAllowAllCopyVisibility_ReportsAbsentAsMiss pins the opt-out's failure
 // shape rather than only its happy path: a read gate must report a missing
 // entity as a MISS, never as an error, because absent and denied are
@@ -154,7 +191,7 @@ func TestAllowAllCopyVisibility_ReportsAbsentAsMiss(t *testing.T) {
 	t.Parallel()
 
 	st := memstore.New()
-	v := entitymanager.AllowAllCopyVisibility{Store: st}
+	v := allowAllCopyVisibility(t, st)
 	ctx := context.Background()
 
 	if err := st.CreateEntity(ctx, &entity.Entity{

--- a/internal/entitymanager/copy_security_test.go
+++ b/internal/entitymanager/copy_security_test.go
@@ -362,7 +362,7 @@ func TestCopy_GuardedFaceIsWritableOnlyViaDefinition(t *testing.T) {
 		// gates, so both are opted out explicitly — permissive, so a refusal
 		// below can only come from the mechanism under test (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 	})
 	if merr != nil {
 		t.Fatalf("entitymanager.New: %v", merr)
@@ -413,7 +413,7 @@ func TestCopy_GuardedFaceIsWritableOnlyViaDefinition(t *testing.T) {
 		// Permissive read gates, so the refusal below can only be the
 		// denying guard — the point of case (c) (#1437).
 		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 	})
 	if derr2 != nil {
 		t.Fatalf("entitymanager.New: %v", derr2)
@@ -469,7 +469,7 @@ func TestCopy_StrangerCannotPromote(t *testing.T) {
 		// (it reads raw and elevated by design). Opted out explicitly rather
 		// than left nil so the refusal under test can only come from
 		// CopyReadGate above (#1437).
-		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
+		CopyVisibility: allowAllCopyVisibility(t, st),
 	})
 	if merr != nil {
 		t.Fatalf("entitymanager.New: %v", merr)

--- a/internal/entitymanager/copy_security_test.go
+++ b/internal/entitymanager/copy_security_test.go
@@ -358,6 +358,11 @@ func TestCopy_GuardedFaceIsWritableOnlyViaDefinition(t *testing.T) {
 		Transitions: statemachine.EmptySet(),
 		FieldGate:   entitymanager.AllowAllFieldGate{},
 		CopyGuard:   allowGuard{allow: true},
+		// The subject here is the GUARD and the write verdict, not the read
+		// gates, so both are opted out explicitly — permissive, so a refusal
+		// below can only come from the mechanism under test (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
 	})
 	if merr != nil {
 		t.Fatalf("entitymanager.New: %v", merr)
@@ -405,6 +410,10 @@ func TestCopy_GuardedFaceIsWritableOnlyViaDefinition(t *testing.T) {
 		Transitions: statemachine.EmptySet(),
 		FieldGate:   entitymanager.AllowAllFieldGate{},
 		CopyGuard:   allowGuard{allow: false},
+		// Permissive read gates, so the refusal below can only be the
+		// denying guard — the point of case (c) (#1437).
+		CopyReadGate:   entitymanager.AllowAllCopyReadGate{},
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
 	})
 	if derr2 != nil {
 		t.Fatalf("entitymanager.New: %v", derr2)
@@ -456,6 +465,11 @@ func TestCopy_StrangerCannotPromote(t *testing.T) {
 		FieldGate:    entitymanager.AllowAllFieldGate{},
 		CopyGuard:    allowGuard{allow: true}, // even a PERMISSIVE guard
 		CopyReadGate: req,
+		// This is a SAME-ENTITY copy, which never consults CopyVisibility
+		// (it reads raw and elevated by design). Opted out explicitly rather
+		// than left nil so the refusal under test can only come from
+		// CopyReadGate above (#1437).
+		CopyVisibility: entitymanager.AllowAllCopyVisibility{Store: st},
 	})
 	if merr != nil {
 		t.Fatalf("entitymanager.New: %v", merr)

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -343,6 +343,42 @@ type CopyReadGate interface {
 	PermitsReadFace(ctx context.Context, entityType, entityID string, face entity.Face) (bool, error)
 }
 
+// AllowAllCopyReadGate permits reading every copy source. It is the explicit
+// opt-out from [requireCopyGates] for a surface that sits on the operator
+// trust boundary, and for tests that build a policy-backed [Deps] without
+// caring about the copy path.
+//
+// Named and passed deliberately, exactly like [AllowAllFieldGate] and
+// [acl.NopACL] — never the result of leaving [Deps.CopyReadGate] nil, because
+// that is the shape a forgotten wiring takes.
+type AllowAllCopyReadGate struct{}
+
+// PermitsReadFace implements [CopyReadGate] by permitting everything.
+func (AllowAllCopyReadGate) PermitsReadFace(
+	context.Context, string, string, entity.Face,
+) (bool, error) {
+	return true, nil
+}
+
+// AllowAllCopyVisibility reads a copy source raw — no row gate, no field
+// redaction. The explicit opt-out counterpart to [AllowAllCopyReadGate];
+// the same "named, never nil" rule applies.
+//
+// It needs a store to read through, so unlike the other opt-outs it is
+// constructed rather than a bare struct literal.
+type AllowAllCopyVisibility struct{ Store store.Store }
+
+// Get implements [CopyReader] by reading the stored face ungated.
+func (v AllowAllCopyVisibility) Get(
+	ctx context.Context, _, id string, face entity.Face,
+) (*entity.Entity, bool, error) {
+	e, err := v.Store.GetEntityState(ctx, id, face)
+	if err != nil {
+		return nil, false, nil //nolint:nilerr // absent and denied are indistinguishable, as in every read gate
+	}
+	return e, true, nil
+}
+
 type CopyGuard interface {
 	HoldsPermission(ctx context.Context, entityID, permission string) bool
 }
@@ -392,7 +428,69 @@ func New(d Deps) (*Manager, error) {
 			"entitymanager: New: Automations and Cascade must be supplied together (both non-nil or both nil)",
 		)
 	}
+	if err := requireCopyGates(d); err != nil {
+		return nil, err
+	}
 	return &Manager{deps: d}, nil
+}
+
+// requireCopyGates refuses a policy-backed deployment that forgot to wire the
+// copy read gates.
+//
+// [Deps.CopyReadGate] and [Deps.CopyVisibility] are nil-tolerant on purpose:
+// a deployment with no acl.yaml has no gate to consult, and every other read
+// on it is raw too. But that tolerance is only safe while nil actually MEANS
+// "no policy". When a real policy is present and these two are nil, the copy
+// path degrades silently: [copyEngine.authorizeCopy] skips its read check
+// entirely and [copyEngine.readCopySource] takes the raw-store branch for
+// cross-entity copies, so a principal can read a source entity — and the
+// `visible:`-hidden fields on it — that every other read path would refuse.
+// There is no error and no log line; the only marker was a code comment.
+//
+// So the nil-tolerance is conditioned rather than removed. The test for "a
+// real policy" is that the ACL is an [*acl.Declarative]: that is the only
+// implementation compiled from an operator's acl.yaml, and it is the identical
+// test appbuild's buildEntityManager already applies to decide whether the
+// gates it wires behave actively. [acl.NopACL] and [acl.ReadOnlyACL] are
+// deliberately excluded — the former IS the no-policy case, and the latter
+// denies every write without expressing any per-principal read policy for a
+// gate to enforce.
+//
+// Checking d.ACL == nil instead would be vacuous: ACL is already required
+// above, so it is never nil by the time this runs.
+//
+// This is the same fail-fast posture as [Deps.FieldGate] (RR-X9NVHI:
+// forgotten wiring must not become an ACL bypass) and the sibling
+// [Deps.CopyGuard], which already fails closed on a guarded copy. Those two
+// made the copy READ gates the odd ones out; this closes that asymmetry at
+// the load-time moment the rest of New already uses.
+//
+// Nil: rejected when ACL is *acl.Declarative — pass AllowAllCopyReadGate and
+// AllowAllCopyVisibility to opt out explicitly.
+func requireCopyGates(d Deps) error {
+	if _, policyActive := d.ACL.(*acl.Declarative); !policyActive {
+		return nil
+	}
+	var missing, optOuts []string
+	if d.CopyReadGate == nil {
+		missing = append(missing, "CopyReadGate")
+		optOuts = append(optOuts, "AllowAllCopyReadGate{}")
+	}
+	if d.CopyVisibility == nil {
+		missing = append(missing, "CopyVisibility")
+		optOuts = append(optOuts, "AllowAllCopyVisibility{Store: ...}")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	// Name only what is actually missing, in both halves of the message: a
+	// half-wired Deps that is told to re-wire the gate it already supplied
+	// sends the operator looking at correct code.
+	return fmt.Errorf(
+		"entitymanager: New: %s required when ACL is a compiled policy "+
+			"(*acl.Declarative): a nil copy read gate makes the copy path read its source "+
+			"ungated and unredacted. Wire the real gate, or pass %s to opt out explicitly",
+		strings.Join(missing, " and "), strings.Join(optOuts, " / "))
 }
 
 // authorizeAndAudit consults the ACL and, on deny, records a

--- a/internal/entitymanager/manager.go
+++ b/internal/entitymanager/manager.go
@@ -237,15 +237,19 @@ type Deps struct {
 	FieldGate FieldWriteGate
 
 	// CopyVisibility is the CALLER'S read gate, used only by CROSS-ENTITY
-	// copies (TKT-C1XUA8, design doc §9.2). Nil disables the gating, which is
-	// correct for a deployment with no ACL — every other read there is raw
-	// too — and is what the CLI passes.
+	// copies (TKT-C1XUA8, design doc §9.2).
 	//
 	// Deliberately NOT used by same-entity copies: those run elevated,
 	// because hidden fields travel with the entity and the same policy
 	// governs them on the target face. Routing them through this gate would
 	// be the redacted-read-feeds-a-write bug, which destroys the fields the
 	// principal could not see.
+	//
+	// Nil: accepted without a policy — the read is then raw, which is what
+	// every other read on such a deployment does, and is what the CLI passes.
+	// REJECTED when ACL is an [*acl.Declarative]; pass
+	// [AllowAllCopyVisibility] to opt out explicitly. See [requireCopyGates]
+	// for why the tolerance is conditioned rather than unconditional.
 	CopyVisibility CopyReader
 
 	// CopyGuard evaluates a copy definition's `guard:` permission against the
@@ -256,12 +260,14 @@ type Deps struct {
 
 	// CopyReadGate answers "may this principal READ the copy's source at
 	// all", before either half of the elevation split runs (TKT-C1XUA8).
+	// Elevation decides which FIELDS travel, not whether the principal may
+	// touch the entity.
 	//
-	// Required in spirit and nil-tolerant in practice for the same reason
-	// every other gate here is: a deployment with no acl.yaml has no gate to
-	// consult, and every other read on it is ungated too. What it must never
-	// be is absent on a deployment that HAS a policy — elevation decides
-	// which fields travel, not whether the principal may touch the entity.
+	// Nil: accepted without a policy — a deployment with no acl.yaml has no
+	// gate to consult, and every other read on it is ungated too. REJECTED
+	// when ACL is an [*acl.Declarative]; pass [AllowAllCopyReadGate] to opt
+	// out explicitly. This used to say "required in spirit and nil-tolerant
+	// in practice", which is exactly the gap [requireCopyGates] closes.
 	CopyReadGate CopyReadGate
 }
 
@@ -364,17 +370,42 @@ func (AllowAllCopyReadGate) PermitsReadFace(
 // redaction. The explicit opt-out counterpart to [AllowAllCopyReadGate];
 // the same "named, never nil" rule applies.
 //
-// It needs a store to read through, so unlike the other opt-outs it is
-// constructed rather than a bare struct literal.
-type AllowAllCopyVisibility struct{ Store store.Store }
+// Unlike the other opt-outs it needs a store to read through, so the field is
+// unexported and [NewAllowAllCopyVisibility] is the only way to build one. A
+// bare `AllowAllCopyVisibility{}` would pass [requireCopyGates] and then nil-
+// panic on the first cross-entity copy — the deferred-downstream-symptom
+// failure this whole guard exists to prevent, reintroduced by its own opt-out.
+type AllowAllCopyVisibility struct{ store store.Store }
 
-// Get implements [CopyReader] by reading the stored face ungated.
+// NewAllowAllCopyVisibility builds the ungated copy reader.
+//
+// Nil: st is rejected — a nil store here is broken under ANY ACL, not only a
+// policy-backed one, which is why this is validated at construction rather
+// than inside [requireCopyGates].
+func NewAllowAllCopyVisibility(st store.Store) (AllowAllCopyVisibility, error) {
+	if st == nil {
+		return AllowAllCopyVisibility{}, errors.New(
+			"entitymanager: NewAllowAllCopyVisibility: Store is required")
+	}
+	return AllowAllCopyVisibility{store: st}, nil
+}
+
+// Get implements [CopyReader] by reading the stored face ungated. entityType
+// is ignored: allow-all draws no per-type distinction.
+//
+// A store error is reported as a MISS rather than propagated, matching
+// appbuild's real copyVisibility so a caller's `!ok` handling is uniform
+// across the two. Note the usual "absent and denied are indistinguishable"
+// rationale does NOT apply here — this gate denies nothing, so there is no
+// confidentiality property to preserve; the reason is shape-consistency
+// alone. Both share the same wart: a transient store failure surfaces to the
+// operator as ErrCopySourceMissing for an entity that plainly exists.
 func (v AllowAllCopyVisibility) Get(
 	ctx context.Context, _, id string, face entity.Face,
 ) (*entity.Entity, bool, error) {
-	e, err := v.Store.GetEntityState(ctx, id, face)
+	e, err := v.store.GetEntityState(ctx, id, face)
 	if err != nil {
-		return nil, false, nil //nolint:nilerr // absent and denied are indistinguishable, as in every read gate
+		return nil, false, nil //nolint:nilerr // a miss, to match copyVisibility's shape; see the doc comment
 	}
 	return e, true, nil
 }
@@ -459,6 +490,13 @@ func New(d Deps) (*Manager, error) {
 // Checking d.ACL == nil instead would be vacuous: ACL is already required
 // above, so it is never nil by the time this runs.
 //
+// The assertion is safe only because the implementation set is CLOSED — an
+// unrecognized type falls through to "no policy", i.e. open, whereas
+// internal/dataentry spells the same question as a switch that fails closed.
+// A decorating implementation would split those two apart. That is guarded in
+// the acl package itself by TestACLImplementations_AreAClosedSet, which fails
+// on a new implementation and names the sites to update.
+//
 // This is the same fail-fast posture as [Deps.FieldGate] (RR-X9NVHI:
 // forgotten wiring must not become an ACL bypass) and the sibling
 // [Deps.CopyGuard], which already fails closed on a guarded copy. Those two
@@ -478,7 +516,7 @@ func requireCopyGates(d Deps) error {
 	}
 	if d.CopyVisibility == nil {
 		missing = append(missing, "CopyVisibility")
-		optOuts = append(optOuts, "AllowAllCopyVisibility{Store: ...}")
+		optOuts = append(optOuts, "NewAllowAllCopyVisibility(store)")
 	}
 	if len(missing) == 0 {
 		return nil

--- a/tickets/entities/automated-measures/copy-read-gates-required-under-policy.md
+++ b/tickets/entities/automated-measures/copy-read-gates-required-under-policy.md
@@ -1,0 +1,29 @@
+---
+id: copy-read-gates-required-under-policy
+type: automated-measure
+title: Copy read gates are mandatory under a compiled ACL policy
+description: entitymanager.New refuses a Deps whose ACL is *acl.Declarative while CopyReadGate or CopyVisibility is nil, so forgotten copy-gate wiring is a construction failure rather than a silent ungated read. TestNew_CopyGatesRequiredUnderPolicy pins both tiers (refused under a compiled policy, still permitted under NopACL/ReadOnlyACL so the CLI case cannot regress); TestCompileTransitions_AlwaysSuppliesCopyGates pins the wiring layer, asserting the shared TransitionWiring bundle always populates both so the constructor check stays a backstop rather than the only line.
+kind: test
+location: internal/entitymanager/copy_gate_required_test.go + internal/appbuild/copygatewiring_test.go
+status: active
+---
+
+Two layers, because the defect had two halves.
+
+**The constructor check** (`internal/entitymanager/manager.go`,
+`requireCopyGates`) makes forgotten wiring fail fast.
+`TestNew_CopyGatesRequiredUnderPolicy` exercises both-nil, half-nil, and
+explicit opt-out under a compiled policy, and — importantly — asserts that
+`NopACL` / `ReadOnlyACL` still build *without* the gates. That second half is
+what stops the guard from being tightened into something that breaks the
+no-policy CLI posture.
+
+**The wiring invariant** (`internal/appbuild/copygatewiring_test.go`) asserts
+`CompileTransitions` always populates `ReadGate` and `Visibility`, in both the
+policy and no-policy tiers. This is what keeps the constructor check a backstop
+that never fires in practice: every wiring site takes both gates from the one
+bundle, so a site cannot omit one by hand-copying an incomplete literal — which
+is precisely how the `appbuildtest` fixture came to sit in the unsafe state.
+
+Verified non-vacuous: reverting only the fixture's two gate lines fails the
+`appbuild` suite with the new error; restoring them goes green.

--- a/tickets/entities/bugs/BUG-R9GOCK.md
+++ b/tickets/entities/bugs/BUG-R9GOCK.md
@@ -1,0 +1,74 @@
+---
+id: BUG-R9GOCK
+type: bug
+title: Copy read gates are silently nil-tolerant under a compiled ACL policy
+description: 'Deps.CopyReadGate and Deps.CopyVisibility had no non-nil check in entitymanager.New, unlike the eight other collaborators in the same struct. With a compiled acl.yaml wired but the two gates forgotten, authorizeCopy skips its source READ verdict and readCopySource reads cross-entity sources raw — bypassing visible: field redaction, with no error and no log line. The appbuildtest fixture sat in exactly that state for any caller passing WithACL(declarative). Reported as GitHub issue #1437 from an IB-review of PR #1431.'
+priority: high
+effort: s
+why1: CopyReadGate and CopyVisibility were declared in Deps with no non-nil check in New, so a wiring site that omitted them produced a Manager whose copy path read its source ungated and unredacted, with no error and no log line.
+why2: Their nil-tolerance was justified by the no-policy case (a CLI deployment with no acl.yaml, where every read is raw anyway), but nothing enforced the condition the justification rested on — that nil actually MEANS no policy. The assumption lived only in a code comment.
+why3: 'The obvious guard, gating on d.ACL != nil, is vacuous here: ACL is itself required a few lines above, so it is never nil. Expressing the real condition needs a different predicate (the ACL being a compiled *acl.Declarative), which is more thought than a nil check, so the check was skipped rather than adapted.'
+why4: The sibling deps hid it. FieldGate right above carries a godoc explaining that a silently-nil authz gate is the forgotten-wiring ACL bypass (RR-X9NVHI), and CopyGuard beside it already fails closed. Two of the three copy deps were safe, so the pair that was not looked consistent with its neighbours at a glance.
+why5: There is no invariant that an authorization dependency must fail fast, so each is given whatever strictness its author considered. The rule was recorded as prose on individual fields (FieldGate's godoc, CLAUDE.md's constructors reject nil required fields) rather than as an enumeration over the struct, so a later-added pair of gates inherited the prose without inheriting the check.
+prevention: 'entitymanager.New now refuses a policy-backed Deps (ACL is *acl.Declarative) whose CopyReadGate or CopyVisibility is nil, naming only the missing one, with AllowAllCopyReadGate / AllowAllCopyVisibility as the explicit opt-outs. Both gates moved into the shared appbuild.TransitionWiring bundle so production and the test fixture build them from one source rather than by hand-copy — which is what let the fixture drift into the unsafe state. Pinned by TestNew_CopyGatesRequiredUnderPolicy (both tiers, so the no-policy CLI case cannot regress either) and TestCompileTransitions_AlwaysSuppliesCopyGates at the wiring layer. The broader lesson, not yet mechanised: an authorization dependency added to an existing Deps struct should be checked against the struct''s other authz fields rather than against prose, since the prose does not enumerate the fields it governs.'
+status: done
+---
+
+## Symptom
+
+`entitymanager.Deps` requires eight collaborators — `Store`, `Meta`,
+`Templater`, `Audit`, `ACL`, `Transitions`, `Computed`, `FieldGate` — each with
+a non-nil check that makes `New` fail fast. Two more in the same struct had no
+such check:
+
+```go
+CopyVisibility CopyReader
+CopyReadGate   CopyReadGate
+```
+
+With a policy wired and these two left nil, the copy path degrades silently:
+
+- `authorizeCopy` skips check (1), the READ verdict on the copy's source
+(`internal/entitymanager/copy.go:421`), and
+- `readCopySource` takes the raw-store branch for cross-entity copies
+(`internal/entitymanager/copy.go:362`), bypassing `visible:` field redaction.
+
+No error, no warning, no log line. The only marker was a comment asserting an
+assumption that nothing enforced: *"A nil gate means no ACL is wired, which is
+the CLI/no-policy case."*
+
+## The risky state existed; it was not hypothetical
+
+`appbuild.buildEntityManager` wires all three copy deps correctly. The
+`appbuildtest` fixture hand-copies that `Deps` literal and left both read gates
+nil, reasoning that its default ACL is `NopACL`. But the fixture accepts
+`WithACL(...)`, so a caller passing a real declarative policy got a
+policy-backed manager whose copy path read its source ungated and unredacted.
+
+Adding the guard failed those tests immediately — which is the evidence the
+condition was reachable rather than theoretical. The fixture's own comment had
+already predicted the mechanism:
+
+> NOTE: this Deps literal is a HAND-COPY of buildEntityManager's, not a call to
+> it, so the two drift silently […] That is how the Copy* deps came to be
+> unwired in BOTH places at once.
+
+## Fix
+
+`New` refuses a policy-backed `Deps` with either gate nil, where "policy-backed"
+means the ACL is `*acl.Declarative` — the same test the wiring already applied.
+The no-policy tier (`NopACL` / `ReadOnlyACL`: CLI, demos) is untouched. Opting
+out remains possible but must be stated: `AllowAllCopyReadGate{}` /
+`AllowAllCopyVisibility{Store: …}`.
+
+Both gates moved into the existing `TransitionWiring` bundle, whose stated job
+is that "every wiring site (production assemble + test fixtures) builds the
+enforcer the same way", so the two sites can no longer drift.
+
+## Provenance
+
+GitHub issue #1437, from an IB-review of PR #1431. That PR was closed unmerged
+and the issue was triaged twice as "the code this describes is not in the tree."
+That was accurate when written — the copy kernel has since landed on `develop`
+by another route, so all four symbols and both fail-open branches now exist
+exactly as the reporter described.

--- a/tickets/entities/implementation-checklists/IMPL-O78SCH.md
+++ b/tickets/entities/implementation-checklists/IMPL-O78SCH.md
@@ -1,0 +1,67 @@
+---
+id: IMPL-O78SCH
+type: implementation-checklist
+title: Implementation
+status: done
+---
+
+## Development
+
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+The guard is one function, `requireCopyGates`, called from `New`. Edge cases
+covered: both gates nil, exactly one nil (the error must name only what is
+missing, or it sends the operator to re-wire correct code), explicit opt-out,
+and both no-policy ACL implementations.
+
+## Test Quality
+
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] ~~Interpolated values constructed from objects~~ (N/A: assertions are on
+error text and nil-ness, no interpolated object values)
+- [x] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario
+- [x] Edge cases manually verified
+
+**Verification Evidence:**
+
+The guard was verified **non-vacuous** by reverting the fix at the site that
+motivated it: removing the two `CopyReadGate` / `CopyVisibility` lines from
+`appbuildtest/fixture.go` fails `./internal/appbuild/...` with
+
+```
+panic: appbuildtest.New: build entitymanager: entitymanager: New:
+CopyReadGate and CopyVisibility required when ACL is a compiled policy
+```
+
+on `TestScheduledLuaWriteDeps_ReadsAreACLBound` and
+`TestNew_WithDeclarative_WiresBothACLAndDeclarative`. Restoring the two lines
+returns the suite to green. That is the evidence the unsafe state was reachable
+rather than theoretical: those two tests pass a real declarative policy into a
+fixture that left both gates nil.
+
+Half-nil messaging was caught by its own test during development — the first cut
+named both opt-outs in the hint even when only one gate was missing.
+
+## Quality
+
+- [x] Code follows project patterns (`AllowAllFieldGate`, the
+`Automations`/`Cascade` coupling check, the `TransitionWiring` bundle)
+- [x] Checked for DRY opportunities — the gates now have ONE construction
+site (`CompileTransitions`) instead of an inline build plus a hand-copy
+- [x] `just lint` clean (0 issues)
+- [x] `just arch-lint` clean
+- [x] `just comment-lint` gate clean
+- [x] `just plimsoll` clean
+- [x] `just coverage-check` passes (78.9% total)
+- [x] `go test -race ./...` passes (enforced by the pre-commit hook)

--- a/tickets/entities/review-checklists/REV-OVNBN2.md
+++ b/tickets/entities/review-checklists/REV-OVNBN2.md
@@ -1,0 +1,82 @@
+---
+id: REV-OVNBN2
+type: review-checklist
+title: Review
+status: done
+---
+
+## Automated Checks
+
+- [x] All tests pass (`go test -race ./...`, enforced by the pre-commit hook)
+- [x] Lint clean (`just lint` — 0 issues)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check` — 78.9% total, all floors pass)
+
+Also clean: `just arch-lint` (the new `appbuild → entitymanager` import is
+already permitted — appbuild is the composition root) and `just plimsoll`.
+
+## Code Review
+
+- [x] Run `/code-review` (cranky-code-reviewer + rela-security-reviewer)
+- [x] All critical review-responses addressed — none were raised
+- [x] All significant review-responses addressed (RR-SAXKLP, RR-Q7836T)
+- [x] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** RR-SAXKLP, RR-Q7836T, RR-ZVM78B, RR-DPYJ3V, RR-UEP3A0,
+RR-37NMKG
+
+The security review returned **no findings**; it independently enumerated the
+four `acl.ACL` implementations, confirmed the guard cannot be bypassed by a
+policy expressed as a different type, confirmed no production path reaches the
+new allow-all opt-outs, and confirmed the gate construction move is semantically
+identical at both call sites.
+
+The general review raised no critical issues and two blocking ones, both fixed:
+
+- **RR-SAXKLP** was the one worth the whole review: the opt-out I added to
+satisfy the guard could itself be constructed broken (`AllowAllCopyVisibility{}`
+with a nil store passed `New` and nil-panicked at copy time) — the same
+deferred-downstream-symptom failure the guard exists to prevent. Fixed by
+unexporting the field behind a validating constructor, so the broken value is
+now unconstructible rather than merely detected.
+- **RR-Q7836T**: the two field godocs still stated the old unconditional
+nil-tolerance. Rewritten to the repo's `Nil:` convention.
+
+RR-37NMKG is **deferred with a documented reason** (a composition-root refactor,
+out of scope for a bug fix; the reviewer scoped it the same way). No open
+critical or significant responses remain.
+
+## Acceptance Verification
+
+- [x] Each acceptance criterion tested
+- [x] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+
+- *A policy-backed `Deps` with either copy gate nil is refused* — **PASS**
+(`TestNew_CopyGatesRequiredUnderPolicy`, both-nil and half-nil subtests).
+- *The no-policy tier is undisturbed* — **PASS** (same test, `NopACL` and
+`ReadOnlyACL` subtests both build without the gates).
+- *Explicit opt-out is accepted* — **PASS** (same test).
+- *The unsafe state was real* — **PASS**: reverting the fixture's two gate
+lines fails `./internal/appbuild/...`; restoring goes green.
+- *The guard is not vacuous* — **PASS**: the reviewer independently mutated the
+guard away and both new tests failed.
+
+## Documentation (enhancements only)
+
+- [x] ~~Docs-checklist created and linked via `has-docs`~~ (N/A: bug fix, no
+user-facing surface changes)
+- [x] ~~User-facing documentation updated~~ (N/A: constructor contract and
+wiring only; no CLI, API or config change)
+- [x] ~~Docs-checklist marked as done~~ (N/A: see above)
+
+## Final Checks
+
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
+
+## Pull Request
+
+- [x] Run `/pr` command to create PR and monitor CI

--- a/tickets/entities/review-responses/RR-37NMKG.md
+++ b/tickets/entities/review-responses/RR-37NMKG.md
@@ -1,0 +1,9 @@
+---
+id: RR-37NMKG
+type: review-response
+title: The appbuildtest Deps hand-copy stays a comment where it should be structure
+finding: The fixture's Deps literal remains a hand-copy of buildEntityManager's rather than a call to it, and the note added by this change ('the authorization deps are the ones where drift is dangerous — each is either required by entitymanager.New or taken from TransitionWiring') is accurate today only because it was checked by hand. That is precisely the class of claim that was previously false for CopyReadGate and became this security bug. Deps will grow another optional authz field and the note will be wrong again, with nothing failing. The structural remedy is for the fixture to CALL the production Deps construction rather than mirror it — TKT-WRLDAPI item 5 already named this hand-copy as the root cause.
+severity: minor
+reason: 'Agreed, and deliberately not done here. The remedy is a refactor of the composition root''s Deps construction affecting both wiring sites and every test using the fixture, which is a different change from the one-line-guard bug fix under review — mixing them would make the security fix harder to review and to revert. The immediate risk is already removed by other means: the three authorization deps this bug was about are no longer hand-copied (they come from the shared TransitionWiring), and any FUTURE authz dep that is forgotten under a policy is caught by requireCopyGates rather than by the comment. Filed as follow-up work on the ticket; the reviewer explicitly scoped it as ''worth a ticket, not a scope expansion''.'
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-DPYJ3V.md
+++ b/tickets/entities/review-responses/RR-DPYJ3V.md
@@ -1,0 +1,9 @@
+---
+id: RR-DPYJ3V
+type: review-response
+title: The nolint reason on AllowAllCopyVisibility.Get cited a rationale that does not hold for it
+finding: 'Get maps a store error to a miss with a //nolint:nilerr reading ''absent and denied are indistinguishable, as in every read gate''. That rationale is wrong for this type specifically: AllowAllCopyVisibility denies nothing, so there is no confidentiality property to preserve. The real reason is shape-consistency with appbuild''s copyVisibility so the caller''s !ok handling is uniform. Propagating a rationale that does not apply teaches the next reader something false. Separately, both this and the production gate turn a transient store failure into ErrCopySourceMissing, so an operator debugging a failed copy is told the source is missing for an entity that plainly exists — a pre-existing wart, flagged not fixed.'
+severity: nit
+resolution: Rewrote the nolint reason and the method doc to state the actual justification (match copyVisibility's error shape) and to say explicitly that the absent-and-denied-are-indistinguishable rationale does NOT apply here because this gate denies nothing. The shared wart is named in the same comment so it is discoverable from either site. Also documented that entityType is ignored because allow-all draws no per-type distinction (the reviewer's separate nit).
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Q7836T.md
+++ b/tickets/entities/review-responses/RR-Q7836T.md
@@ -1,0 +1,9 @@
+---
+id: RR-Q7836T
+type: review-response
+title: Deps.CopyVisibility and Deps.CopyReadGate godoc contradicted the new constructor check
+finding: The field docs still described the old contract after the constructor changed it. CopyVisibility said 'Nil disables the gating' unconditionally, which is no longer true; CopyReadGate said 'required in spirit and nil-tolerant in practice' with 'what it must never be is absent on a deployment that HAS a policy' as aspiration, when that is now enforced. The field doc is what a developer sees on hover, so the accurate prose was added where it is least likely to be read while the stale claim stayed where it is most likely to be. The repo runs commentlint's duplication rule precisely because a fact stored twice goes stale in one place.
+severity: significant
+resolution: 'Rewrote both field docs to the repo''s nil-contract convention: each now states the tier explicitly (accepted without a policy, REJECTED when ACL is *acl.Declarative) and names its opt-out. The unconditional claims are gone, and CopyReadGate''s doc cites the old ''required in spirit'' wording as the gap the guard closes, so the history stays legible. Detail lives once, in requireCopyGates; the fields link to it rather than restating it.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-SAXKLP.md
+++ b/tickets/entities/review-responses/RR-SAXKLP.md
@@ -1,0 +1,9 @@
+---
+id: RR-SAXKLP
+type: review-response
+title: AllowAllCopyVisibility with a nil Store passes New and nil-panics at copy time
+finding: The opt-out shipped alongside the guard reproduces the failure mode the guard exists to prevent. AllowAllCopyVisibility had an exported Store field, so a bare AllowAllCopyVisibility{} — a plausible copy-paste from the AllowAllCopyReadGate{} literal beside it — satisfies CopyReader, passes requireCopyGates, and nil-panics on the first cross-entity copy, a path that may not run until long after deploy. This is the exact 'never substitute a no-op or sentinel implementation silently, that defers the failure to a downstream symptom' rule from CLAUDE.md that the change itself invokes.
+severity: significant
+resolution: Made the field unexported and added NewAllowAllCopyVisibility(st) (AllowAllCopyVisibility, error), which rejects a nil store. The broken zero value is now unconstructible outside the package rather than merely checked for. Validated at construction rather than inside requireCopyGates because a nil store is broken under ANY ACL, not only a policy-backed one, as the reviewer noted. The error hint in requireCopyGates now names the constructor. Pinned by TestNewAllowAllCopyVisibility_RejectsNilStore; the 12 test call sites go through a t.Helper wrapper so they exercise the real constructor.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-UEP3A0.md
+++ b/tickets/entities/review-responses/RR-UEP3A0.md
@@ -1,0 +1,9 @@
+---
+id: RR-UEP3A0
+type: review-response
+title: The wiring test proved the bundle OFFERS the gates, not that the fixture CONSUMES them
+finding: 'TestCompileTransitions_AlwaysSuppliesCopyGates asserts CompileTransitions returns non-nil gates. But the reported bug was not that the gates were unavailable — they were available and simply not passed. Someone reverting the fixture to CopyReadGate: nil leaves that test green, so the new test does not cover the half that actually broke.'
+severity: minor
+resolution: 'Strengthened TestNew_WithDeclarative_WiresBothACLAndDeclarative in appbuildtest, which is the only fixture path reaching entitymanager.New with a policy-backed ACL. It now recovers explicitly and fails with a message naming the regression, rather than dying on an unexplained panic. The two tests are now complementary and the doc comments on each say so: appbuild''s proves the bundle offers the gates, the fixture''s proves the wiring site consumes them. Verified by reverting the fixture''s two lines — both TestNew_WithDeclarative_WiresBothACLAndDeclarative and TestScheduledLuaWriteDeps_ReadsAreACLBound fail; restoring goes green.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-ZVM78B.md
+++ b/tickets/entities/review-responses/RR-ZVM78B.md
@@ -1,0 +1,9 @@
+---
+id: RR-ZVM78B
+type: review-response
+title: The *acl.Declarative assertion fails OPEN on an unrecognized type, unlike dataentry's switches
+finding: 'The predicate is correct today (both reviewers independently enumerated all four ACL implementations and confirmed nothing slips through), but it is a third divergent spelling of ''is a policy active''. internal/dataentry asks the same question as a switch on NopACL/ReadOnlyACL whose default arm fails CLOSED; the is-Declarative assertion falls through to ''no policy'', i.e. OPEN. A future decorating implementation — an audited or multi-tenant wrapper — would make dataentry hide a UI element while entitymanager waves an ungated copy read through: the forgotten-wiring-becomes-a-bypass shape (RR-X9NVHI) this change closes, reintroduced one wrapper later.'
+severity: minor
+resolution: 'Took the reviewer''s third option, the one matching how this repo already handles clamp-point drift (ceilingguard_test.go): added TestACLImplementations_AreAClosedSet in internal/acl. It scans the package for AuthorizeWrite implementations against an allowlist, so a new implementation fails the build with a message naming every is-policy-active site to update; it also flags a stale entry if one is removed. Request is listed explicitly as satisfying the interface while never being wireable as a deployment ACL. Verified non-vacuous by adding a decorating auditedACL, which the guard caught. requireCopyGates now carries a comment stating that the assertion is safe only because the set is closed, and pointing at the guard.'
+status: addressed
+---

--- a/tickets/relations/BUG-R9GOCK--adds-measure--copy-read-gates-required-under-policy.md
+++ b/tickets/relations/BUG-R9GOCK--adds-measure--copy-read-gates-required-under-policy.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: adds-measure
+to: copy-read-gates-required-under-policy
+---

--- a/tickets/relations/BUG-R9GOCK--affects--authorization.md
+++ b/tickets/relations/BUG-R9GOCK--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: affects
+to: authorization
+---

--- a/tickets/relations/BUG-R9GOCK--fixes--FEAT-9CD2MX.md
+++ b/tickets/relations/BUG-R9GOCK--fixes--FEAT-9CD2MX.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: fixes
+to: FEAT-9CD2MX
+---

--- a/tickets/relations/BUG-R9GOCK--has-implementation--IMPL-O78SCH.md
+++ b/tickets/relations/BUG-R9GOCK--has-implementation--IMPL-O78SCH.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-implementation
+to: IMPL-O78SCH
+---

--- a/tickets/relations/BUG-R9GOCK--has-review--REV-OVNBN2.md
+++ b/tickets/relations/BUG-R9GOCK--has-review--REV-OVNBN2.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-review
+to: REV-OVNBN2
+---

--- a/tickets/relations/BUG-R9GOCK--has-review-response--RR-37NMKG.md
+++ b/tickets/relations/BUG-R9GOCK--has-review-response--RR-37NMKG.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-review-response
+to: RR-37NMKG
+---

--- a/tickets/relations/BUG-R9GOCK--has-review-response--RR-DPYJ3V.md
+++ b/tickets/relations/BUG-R9GOCK--has-review-response--RR-DPYJ3V.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-review-response
+to: RR-DPYJ3V
+---

--- a/tickets/relations/BUG-R9GOCK--has-review-response--RR-Q7836T.md
+++ b/tickets/relations/BUG-R9GOCK--has-review-response--RR-Q7836T.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-review-response
+to: RR-Q7836T
+---

--- a/tickets/relations/BUG-R9GOCK--has-review-response--RR-SAXKLP.md
+++ b/tickets/relations/BUG-R9GOCK--has-review-response--RR-SAXKLP.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-review-response
+to: RR-SAXKLP
+---

--- a/tickets/relations/BUG-R9GOCK--has-review-response--RR-UEP3A0.md
+++ b/tickets/relations/BUG-R9GOCK--has-review-response--RR-UEP3A0.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-review-response
+to: RR-UEP3A0
+---

--- a/tickets/relations/BUG-R9GOCK--has-review-response--RR-ZVM78B.md
+++ b/tickets/relations/BUG-R9GOCK--has-review-response--RR-ZVM78B.md
@@ -1,0 +1,5 @@
+---
+from: BUG-R9GOCK
+relation: has-review-response
+to: RR-ZVM78B
+---


### PR DESCRIPTION
Closes #1437. Source: IB-review of #1431. Violated requirement: CONTROL-5-15.

## The finding was filed against a closed PR, and then the code landed anyway

Worth stating up front, because the issue's two triage comments say the
opposite. Both concluded "the code this describes is not in the tree" — #1431
was closed unmerged, so `CopyReadGate`, `CopyVisibility`, `authorizeCopy` and
`readCopySource` did not exist, and a standalone fix "would not compile."

That was true when written. It is no longer: the copy kernel has since landed
on `develop` by another route. All four symbols exist, and the two fail-open
branches are present exactly as the reporter described them.

## The defect

`Deps.CopyReadGate` and `Deps.CopyVisibility` are silently nil-tolerant, while
the eight other collaborators in the same struct — `Store`, `Meta`,
`Templater`, `Audit`, `ACL`, `Transitions`, `Computed`, `FieldGate` — each
hard-fail in `New`. With a policy wired but these two forgotten:

- `authorizeCopy` skips check (1), the READ verdict on the copy's source
  (`copy.go:421`), and
- `readCopySource` takes the raw-store branch for cross-entity copies
  (`copy.go:362`), bypassing `visible:` field redaction.

No error, no warning, no log line. The only marker was a code comment
asserting the assumption it could not enforce:

```go
// Cross-entity: through the caller's gate. A nil gate means no ACL is
// wired, which is the CLI/no-policy case
```

`FieldGate`'s own godoc, three fields up, spells out why that shape is a
problem — "a silently-nil authz gate is the *forgotten wiring must not become
an ACL bypass* failure (RR-X9NVHI)" — and the sibling `CopyGuard` already
fails **closed**. That made the two copy READ gates the odd ones out.

## Not the patch the issue proposed

The issue suggested gating on `d.ACL != nil`. That is vacuous here: `ACL` is
required a few lines above, so it is never nil by the time the check runs, and
every test passes `acl.NopACL{}` — the guard would have fired on all 66 of
them while catching nothing.

The predicate that actually separates the two states is **"is there a real
policy"**, i.e. the ACL is an `*acl.Declarative`. That is the only
implementation compiled from an operator's `acl.yaml`, and it is the *same*
test `buildEntityManager` already applied to decide whether the gates it wires
behave actively. So `New` refuses a policy-backed `Deps` with either gate nil,
and the no-policy tier (`NopACL` / `ReadOnlyACL` — the CLI, demos) is
untouched.

Opting out stays possible, but must be **said**: `AllowAllCopyReadGate{}` /
`AllowAllCopyVisibility{Store: …}`, named and passed exactly like
`AllowAllFieldGate` and `acl.NopACL`.

## The risky state was real, not hypothetical

Adding the check immediately failed `appbuildtest`, which is the part worth
reviewing.

`appbuild.buildEntityManager` wires all three copy deps correctly. The test
fixture next to it hand-copies that `Deps` literal and left `CopyReadGate` /
`CopyVisibility` nil, reasoning that its default ACL is `NopACL`. But the
fixture accepts `WithACL(...)` — so a caller passing a real declarative policy
got a policy-backed manager whose copy path read its source ungated and
unredacted. Precisely the state the issue describes. The fixture's own comment
had already predicted the mechanism:

> NOTE: this Deps literal is a HAND-COPY of buildEntityManager's, not a call to
> it, so the two drift silently […] That is how the Copy* deps came to be
> unwired in BOTH places at once.

So rather than patch the fixture, both gates move into the existing
`TransitionWiring` bundle — whose stated job is already that "every wiring site
(production assemble + test fixtures) builds the enforcer the same way."
Production and fixture now take all three copy deps from one source, and
`CompileTransitions` always populates them.

## Tests

- `TestNew_CopyGatesRequiredUnderPolicy` — refuses both-nil and half-nil under
  a compiled policy; accepts explicit opt-outs; **still builds without the
  gates under `NopACL`/`ReadOnlyACL`**, pinning the tier that must not regress.
- `TestAllowAllCopyVisibility_ReportsAbsentAsMiss` — the opt-out reports an
  absent entity as a miss with a nil error, so it cannot become an existence
  oracle.
- `TestCompileTransitions_AlwaysSuppliesCopyGates` — the wiring-layer
  invariant, so the constructor guard is a backstop rather than the only line.

Verified the guard catches the original defect: reverting just the fixture's
two lines fails `appbuild` with the new error, and restoring them goes green.

Existing entitymanager tests that build a policy-backed `Deps` by hand now
opt out explicitly (16 sites, 6 files). In `copy_security_test.go` the opt-outs
are permissive on purpose, so a refusal under test can only come from the
mechanism being tested.

`go test ./...`, `just lint`, `just arch-lint`, `just comment-lint`,
`just plimsoll` and `just coverage-check` all pass.

## Scope

Only the constructor contract and the wiring seam. No change to how the gates
behave when they *are* wired, and no change to the copy authorization model.

## Review

Both reviewers ran against this diff. The **security review returned no
findings** — it independently enumerated the four `acl.ACL` implementations,
confirmed the guard cannot be bypassed by a policy expressed as a different
type, confirmed no production path reaches the new opt-outs, and confirmed the
gate-construction move is semantically identical at both call sites.

The general review raised no critical issues and two blocking ones, both fixed
in the second commit:

- **The opt-out could itself be built broken.** A bare
  `AllowAllCopyVisibility{}` — a plausible copy-paste from the
  `AllowAllCopyReadGate{}` literal beside it — satisfied `CopyReader`, passed
  the new guard, and nil-panicked on the first cross-entity copy. That is the
  same deferred-downstream-symptom failure the guard exists to prevent, which
  would have been an awkward thing for *this* change to ship. `Store` is now
  unexported behind `NewAllowAllCopyVisibility`, so the broken value is
  unconstructible rather than merely detected, and it is validated there rather
  than in `requireCopyGates` because a nil store is broken under any ACL.
- **The two field godocs still stated the old unconditional nil-tolerance**,
  which is what a developer sees on hover. Rewritten to the repo's `Nil:`
  convention.

One minor finding is worth calling out because it outlives this PR: the
`*acl.Declarative` assertion **fails open** on a type it does not recognize,
while `internal/dataentry` spells the same question as a switch that fails
closed. Correct today — the set is closed — but a decorating implementation
would split the two apart. Added `TestACLImplementations_AreAClosedSet` in
`internal/acl`, following the existing `ceilingguard_test.go` idiom: it fails on
a new `AuthorizeWrite` implementation and names the sites to update. Verified
non-vacuous against a decorating `auditedACL`.

`RR-37NMKG` (the fixture's `Deps` hand-copy should be structure, not a comment)
is **deferred with a reason**: it is a composition-root refactor, out of scope
for a bug fix, and the reviewer scoped it the same way. The risk it describes is
already reduced — the three copy deps are no longer hand-copied, and a future
forgotten authz dep is caught by the constructor rather than by the comment.

Tracked as **BUG-R9GOCK** with review responses RR-SAXKLP, RR-Q7836T, RR-ZVM78B,
RR-DPYJ3V, RR-UEP3A0, RR-37NMKG.
