### PR TITLE
Predicate language: current_user with pushdown into next-action queries (TKT-OIRBFH)

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -557,7 +557,13 @@ deps:
       - datamigration
       # Bridges conditionlint's next-action condition compiler to the seam
       # dataentry declares, so the app never imports the predicate engine.
+      # predicatefns + principal: the same bridge derives the query identity
+      # (`current_user`) from the request principal and stamps it for the
+      # matcher, so dataentry never learns the predicate engine's identity
+      # type either.
       - conditionlint
+      - predicatefns
+      - principal
       - computed
       - dataentryconfig
       - nextaction

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -1123,6 +1123,9 @@ deps:
       - filter
   queryplan:
     mayDependOn:
+      # Static index derivation must refuse exactly the configs the server
+      # refuses, so it runs the same next-action condition compiler.
+      - conditionlint
       - dataentryconfig
       - filter
       - metamodel

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -1120,6 +1120,8 @@ deps:
       - dataentryconfig
       - filter
       - metamodel
+      - predicate
+      - predicatefns
       - searchparser
       - store
   store:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -671,7 +671,14 @@ Rules when touching this:
   failure: an absent desired object means DROP, so partial input is destructive.
   Runtime/ad-hoc queries never issue DDL. Pushdown and index inference must use
   the same `internal/queryplan` eligibility decision, and an EXPLAIN test must
-  prove each newly supported SQL shape actually uses its generated index.
+  prove each newly supported SQL shape actually uses its generated index. A
+  next-action `condition:` participates on both sides: its store-safe scalar
+  equalities (`entity.x == 'lit'`, `entity.x == current_user.id`,
+  `is_current_user(entity.x)`) are pushed with the query and derive columns of
+  the SAME composite index; `has_current_user(list)` is pushed as a non-scalar
+  `PropEqual` (jsonb containment) and deliberately derives no index, since the
+  btree over `->>` does not serve it — a GIN shape would need its own EXPLAIN
+  test first.
 - **Migrations** are embedded SQL (`pgstore/migrations/*.sql`), applied by
   `pgstore.Migrate` in one transaction under a `pg_advisory_xact_lock`
   (concurrent-start safe; forward-only). Auto-applied on first store open;

--- a/docs-project/entities/guides/GUIDE-data-entry.md
+++ b/docs-project/entities/guides/GUIDE-data-entry.md
@@ -1828,10 +1828,67 @@ Rules worth knowing:
   "dew" on record`. A condition that silently matched nothing would be
   indistinguishable from a source with nothing to say.
 - **Not available on a `count` source** — there is no entity to test.
+- **Not available with free text in `query`** (`type:task urgent`). Free-text
+  results are capped by relevance before the condition runs, so a condition
+  matching only a hit past the cut would silently never fire. Select with
+  `prop:` filters instead.
 
 The available functions are the ones automations use: `days_between`,
 `date_add`, `rrule_next`, `today`, plus `match`, `regex`, `contains` and
 `len`. See [metamodel.md](metamodel.md) for their signatures.
+
+##### Per-user sources: `current_user`
+
+A next action resolves for one signed-in person, so a condition may refer to
+them. Three spellings, all meaning the same identity:
+
+```yaml
+next_actions:
+  my-stale-tickets:
+    band: attention
+    query: "type:ticket prop:status=open"
+    condition: "is_current_user(entity.assignee) and days_between(entity.updated, today()) > 14"
+    suggest: "{title} has been yours for two weeks without movement."
+  watching:
+    band: ambient
+    query: "type:ticket prop:status=blocked"
+    condition: "has_current_user(entity.watchers)"
+    suggest: "{title} — something you watch is blocked."
+```
+
+- `entity.assignee == current_user.id` — plain equality against the current
+  user's id.
+- `is_current_user(entity.assignee)` — the same, for a string property. Reads
+  better, and is what to write when the property may be unset (an unset
+  property is simply "not me", never an error).
+- `has_current_user(entity.watchers)` — membership, for a **list** property:
+  true when the current user is one of the values. (Lists cannot be compared
+  with `==`; this is the way to ask.)
+
+`current_user.id` is the user **entity id** when your ACL policy declares a
+`user_entity_type` and the signed-in principal resolves to one of its
+entities, so it compares directly against a property that holds an entity id.
+Without that, it is the raw principal (the header or JWT subject), and the
+property must hold that string instead. `current_user.tool` (`data-entry`,
+`mcp`, …) is available for diagnostics and is never a permission input.
+
+**Fail-closed.** A per-user condition on a request that carries no identity —
+a deployment without an identity source, for example — makes that source
+contribute nothing for the request, with a warning in the server log naming
+the source. It is never evaluated against a placeholder identity, so it can
+never match "everyone's unset rows" or another user's. Other sources are
+unaffected, and a condition that does not mention the current user keeps
+working unauthenticated.
+
+**Pushed to the store.** The current-user forms (and plain string equalities)
+in a top-level `and` chain are lowered into the candidate query as a
+pre-filter, so "tickets assigned to me" is an indexed lookup rather than a scan
+of every ticket. On PostgreSQL the scalar ones (`==`, `is_current_user`) also
+join the derived static-query index for that source; membership
+(`has_current_user`) is pushed but not indexed. Anything under `or`/`not`, or
+a typed comparison, stays Go-side — still correct, just not pre-filtered. The
+full condition is always evaluated per candidate; pushdown only narrows what
+is fetched.
 
 #### `key_props` and re-triggering
 

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1827,6 +1827,57 @@ The available functions are the ones automations use: `days_between`,
 `date_add`, `rrule_next`, `today`, plus `match`, `regex`, `contains` and
 `len`. See [metamodel.md](metamodel.md) for their signatures.
 
+##### Per-user sources: `current_user`
+
+A next action resolves for one signed-in person, so a condition may refer to
+them. Three spellings, all meaning the same identity:
+
+```yaml
+next_actions:
+  my-stale-tickets:
+    band: attention
+    query: "type:ticket prop:status=open"
+    condition: "is_current_user(entity.assignee) and days_between(entity.updated, today()) > 14"
+    suggest: "{title} has been yours for two weeks without movement."
+  watching:
+    band: ambient
+    query: "type:ticket prop:status=blocked"
+    condition: "has_current_user(entity.watchers)"
+    suggest: "{title} — something you watch is blocked."
+```
+
+- `entity.assignee == current_user.id` — plain equality against the current
+  user's id.
+- `is_current_user(entity.assignee)` — the same, for a string property. Reads
+  better, and is what to write when the property may be unset (an unset
+  property is simply "not me", never an error).
+- `has_current_user(entity.watchers)` — membership, for a **list** property:
+  true when the current user is one of the values. (Lists cannot be compared
+  with `==`; this is the way to ask.)
+
+`current_user.id` is the user **entity id** when your ACL policy declares a
+`user_entity_type` and the signed-in principal resolves to one of its
+entities, so it compares directly against a property that holds an entity id.
+Without that, it is the raw principal (the header or JWT subject), and the
+property must hold that string instead. `current_user.tool` (`data-entry`,
+`mcp`, …) is available for diagnostics and is never a permission input.
+
+**Fail-closed.** A per-user condition on a request that carries no identity —
+a deployment without an identity source, for example — is refused with
+`next_action_identity_required`, never evaluated as "matches nothing" or
+"matches everyone". A condition that does not mention the current user is
+unaffected and keeps working unauthenticated.
+
+**Pushed to the store.** The current-user forms (and plain string equalities)
+in a top-level `and` chain are lowered into the candidate query as a
+pre-filter, so "tickets assigned to me" is an indexed lookup rather than a scan
+of every ticket. On PostgreSQL the scalar ones (`==`, `is_current_user`) also
+join the derived static-query index for that source; membership
+(`has_current_user`) is pushed but not indexed. Anything under `or`/`not`, or
+a typed comparison, stays Go-side — still correct, just not pre-filtered. The
+full condition is always evaluated per candidate; pushdown only narrows what
+is fetched.
+
 #### `key_props` and re-triggering
 
 A suggestion is identified by `(source, entity, key_props values)`. Without

--- a/docs/data-entry.md
+++ b/docs/data-entry.md
@@ -1822,6 +1822,10 @@ Rules worth knowing:
   "dew" on record`. A condition that silently matched nothing would be
   indistinguishable from a source with nothing to say.
 - **Not available on a `count` source** — there is no entity to test.
+- **Not available with free text in `query`** (`type:task urgent`). Free-text
+  results are capped by relevance before the condition runs, so a condition
+  matching only a hit past the cut would silently never fire. Select with
+  `prop:` filters instead.
 
 The available functions are the ones automations use: `days_between`,
 `date_add`, `rrule_next`, `today`, plus `match`, `regex`, `contains` and
@@ -1863,10 +1867,12 @@ property must hold that string instead. `current_user.tool` (`data-entry`,
 `mcp`, …) is available for diagnostics and is never a permission input.
 
 **Fail-closed.** A per-user condition on a request that carries no identity —
-a deployment without an identity source, for example — is refused with
-`next_action_identity_required`, never evaluated as "matches nothing" or
-"matches everyone". A condition that does not mention the current user is
-unaffected and keeps working unauthenticated.
+a deployment without an identity source, for example — makes that source
+contribute nothing for the request, with a warning in the server log naming
+the source. It is never evaluated against a placeholder identity, so it can
+never match "everyone's unset rows" or another user's. Other sources are
+unaffected, and a condition that does not mention the current user keeps
+working unauthenticated.
 
 **Pushed to the store.** The current-user forms (and plain string equalities)
 in a top-level `and` chain are lowered into the candidate query as a

--- a/internal/affordances/bindings.go
+++ b/internal/affordances/bindings.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/predicate"
-	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
@@ -58,6 +57,11 @@ type bindingContext struct {
 	// userID is the principal's identity as it appears on role-relation
 	// edges and current_user.id.
 	userID string
+	// userFuncs are the is_current_user / has_current_user implementations
+	// closed over identity(), built ONCE per binding context: newBindings
+	// runs per grant per role per entity on the list-render path, and the
+	// identity does not change across those calls.
+	userFuncs map[string]predicate.FuncFunc
 
 	// outgoing caches the entity's outgoing-edge counts, loaded once
 	// on first host-func use (has_relation / count_relations) so a
@@ -128,7 +132,7 @@ func (bc *bindingContext) newBindings(meta *metamodel.Metamodel) (*predicate.Bin
 	// package's own resolved principal, not the query-identity context —
 	// so the sugar and the explicit comparison agree whichever way
 	// identity arrived, including the no-identity case.
-	for name, fn := range predicatefns.CurrentUserBindings(identity) {
+	for name, fn := range bc.userFuncs {
 		if err := b.SetFunc(name, fn); err != nil {
 			return nil, err
 		}

--- a/internal/affordances/bindings.go
+++ b/internal/affordances/bindings.go
@@ -95,8 +95,15 @@ func (bc *bindingContext) newBindings(meta *metamodel.Metamodel) (*predicate.Bin
 	if err := b.SetVar("entity", bc.entityRecord(meta)); err != nil {
 		return nil, err
 	}
+	// See bindingContext.identity: an unidentified caller binds an EMPTY
+	// id, and PolicyResolver.passes has already refused any grant whose
+	// clause reads it. The sugar below closes over the same value and never
+	// matches on empty (predicatefns.CurrentUserBindings), so even a clause
+	// that slipped past that refusal could not match an entity whose
+	// property holds the placeholder.
+	identity := bc.identity()
 	if err := b.SetVar("current_user", predicate.NewRecord(map[string]predicate.Value{
-		"id":   predicate.NewString(bc.userID),
+		"id":   predicate.NewString(identity),
 		"tool": predicate.NewString(bc.principal.Tool),
 	})); err != nil {
 		return nil, err
@@ -117,15 +124,34 @@ func (bc *bindingContext) newBindings(meta *metamodel.Metamodel) (*predicate.Bin
 			return nil, err
 		}
 	}
-	// Bound from bc.userID — this package's own resolved principal —
-	// rather than the query-identity context, so the sugar agrees with
-	// current_user.id above whichever way identity arrived.
-	for name, fn := range predicatefns.CurrentUserBindings(bc.userID) {
+	// Bound from the same identity as current_user.id above — this
+	// package's own resolved principal, not the query-identity context —
+	// so the sugar and the explicit comparison agree whichever way
+	// identity arrived, including the no-identity case.
+	for name, fn := range predicatefns.CurrentUserBindings(identity) {
 		if err := b.SetFunc(name, fn); err != nil {
 			return nil, err
 		}
 	}
 	return b, nil
+}
+
+// identity is the value current_user.id binds to: the principal's user, or
+// "" when the caller is not identified.
+//
+// The attribution placeholder is not a user. A data-entry server without an
+// identity source stamps principal.Unknown on every request, and an unstamped
+// ctx reads as the same placeholder; binding either literally would let
+// `entity.owner == current_user.id` — an AUTHORIZATION input here, gating
+// visible: and actions — match an entity whose owner property happens to hold
+// "unknown". Both read as no identity, and a `when:` that needs one is refused
+// in passes, which is the same fail-closed reading the query path gets from
+// predicatefns.ErrNoCurrentUser.
+func (bc *bindingContext) identity() string {
+	if bc.userID == principal.Unknown {
+		return ""
+	}
+	return bc.userID
 }
 
 // entityRecord coerces the entity's properties into a predicate.Record

--- a/internal/affordances/bindings.go
+++ b/internal/affordances/bindings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 )
 
@@ -113,6 +114,14 @@ func (bc *bindingContext) newBindings(meta *metamodel.Metamodel) (*predicate.Bin
 	}
 	for _, s := range setters {
 		if err := b.SetFunc(s.name, s.fn); err != nil {
+			return nil, err
+		}
+	}
+	// Bound from bc.userID — this package's own resolved principal —
+	// rather than the query-identity context, so the sugar agrees with
+	// current_user.id above whichever way identity arrived.
+	for name, fn := range predicatefns.CurrentUserBindings(bc.userID) {
+		if err := b.SetFunc(name, fn); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/affordances/currentuser_sugar_test.go
+++ b/internal/affordances/currentuser_sugar_test.go
@@ -1,6 +1,7 @@
 package affordances_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Sourcehaven-BV/rela/internal/affordances"
@@ -107,4 +108,60 @@ assignments:
 // expressions use.
 func quoteYAML(s string) string {
 	return `"` + s + `"`
+}
+
+// TestAffordances_CurrentUserSugar_UnknownPlaceholderNeverMatches pins the
+// fail-closed reading on the one path where an UNIDENTIFIED caller reaches a
+// `when:` clause: the `everyone` role, which the resolver applies to an
+// unstamped principal and to the "unknown" attribution placeholder alike.
+// An entity whose property literally holds "unknown" is not owned by an
+// anonymous caller, in any of the three spellings. The control case proves
+// the same grant DOES evaluate for a real principal, so the refusal is not
+// an artifact of the role never applying.
+func TestAffordances_CurrentUserSugar_UnknownPlaceholderNeverMatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		when        string
+		props       map[string]any
+		ctx         context.Context //nolint:containedctx // table fixture
+		wantVisible bool
+	}{
+		{"control: a real principal matches via everyone",
+			"is_current_user(entity.assignee)", map[string]any{"assignee": "alice"}, ctxAs("alice"), true},
+		{"unknown placeholder, sugar",
+			"is_current_user(entity.assignee)", map[string]any{"assignee": "unknown"}, ctxAs("unknown"), false},
+		{"unknown placeholder, explicit comparison",
+			"entity.assignee == current_user.id", map[string]any{"assignee": "unknown"}, ctxAs("unknown"), false},
+		{"unknown placeholder, list membership",
+			"has_current_user(entity.tags)", map[string]any{"tags": []any{"unknown"}}, ctxAs("unknown"), false},
+		{"unstamped context, sugar",
+			"is_current_user(entity.assignee)", map[string]any{"assignee": "unknown"}, context.Background(), false},
+		{"unstamped context, explicit comparison against an empty owner",
+			"entity.assignee == current_user.id", map[string]any{"assignee": ""}, context.Background(), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := policyFromYAML(t, `
+roles:
+  everyone:
+    visible:
+      ticket:
+        - field: assignee
+          when: `+quoteYAML(tc.when)+`
+`)
+			r, err := affordances.New(testMeta(t), newStubLookup(), declFor(t, p))
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			fv := r.FieldVerdicts(tc.ctx, ticket("T-1", tc.props))
+			v, ok := fv.Visible["assignee"]
+			hidden := ok && !v
+			if hidden == tc.wantVisible {
+				t.Fatalf("when %q: visible=%v, want visible=%v", tc.when, !hidden, tc.wantVisible)
+			}
+		})
+	}
 }

--- a/internal/affordances/currentuser_sugar_test.go
+++ b/internal/affordances/currentuser_sugar_test.go
@@ -1,0 +1,110 @@
+package affordances_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/affordances"
+)
+
+// TestAffordances_CurrentUserSugar proves the shared sugar
+// (is_current_user / has_current_user) is usable in an affordance
+// `when:` and agrees with the explicit current_user.id comparison it
+// replaces. Same package, same semantics, one implementation.
+func TestAffordances_CurrentUserSugar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		when        string
+		props       map[string]any
+		user        string
+		wantVisible bool
+	}{
+		{
+			name:        "is_current_user matches the owner",
+			when:        "is_current_user(entity.assignee)",
+			props:       map[string]any{"assignee": "alice"},
+			user:        "alice",
+			wantVisible: true,
+		},
+		{
+			name:        "is_current_user rejects another user",
+			when:        "is_current_user(entity.assignee)",
+			props:       map[string]any{"assignee": "alice"},
+			user:        "bob",
+			wantVisible: false,
+		},
+		{
+			name:        "is_current_user on an unset property is a non-match",
+			when:        "is_current_user(entity.assignee)",
+			props:       nil,
+			user:        "alice",
+			wantVisible: false,
+		},
+		{
+			name:        "has_current_user finds the user in a list property",
+			when:        "has_current_user(entity.tags)",
+			props:       map[string]any{"tags": []any{"bob", "alice"}},
+			user:        "alice",
+			wantVisible: true,
+		},
+		{
+			name:        "has_current_user rejects a list without the user",
+			when:        "has_current_user(entity.tags)",
+			props:       map[string]any{"tags": []any{"bob"}},
+			user:        "alice",
+			wantVisible: false,
+		},
+		{
+			name:        "the sugar agrees with the explicit comparison",
+			when:        "entity.assignee == current_user.id",
+			props:       map[string]any{"assignee": "alice"},
+			user:        "alice",
+			wantVisible: true,
+		},
+		{
+			name:        "the sugar composes with the existing host funcs",
+			when:        "is_current_user(entity.assignee) or has_global_role(current_user, 'viewer')",
+			props:       map[string]any{"assignee": "nobody"},
+			user:        "alice",
+			wantVisible: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := policyFromYAML(t, `
+roles:
+  viewer:
+    visible:
+      ticket:
+        - field: assignee
+          when: `+quoteYAML(tc.when)+`
+assignments:
+  alice: viewer
+  bob: viewer
+`)
+			r, err := affordances.New(testMeta(t), newStubLookup(), declFor(t, p))
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			fv := r.FieldVerdicts(ctxAs(tc.user), ticket("T-1", tc.props))
+			// A field is hidden only when the map says so explicitly;
+			// absence means no grant narrowed it.
+			v, ok := fv.Visible["assignee"]
+			hidden := ok && !v
+			if hidden == tc.wantVisible {
+				t.Fatalf("when %q as %q: visible=%v, want visible=%v",
+					tc.when, tc.user, !hidden, tc.wantVisible)
+			}
+		})
+	}
+}
+
+// quoteYAML wraps an expression in double quotes for embedding in the
+// test policy, escaping the single-quoted string literals predicate
+// expressions use.
+func quoteYAML(s string) string {
+	return `"` + s + `"`
+}

--- a/internal/affordances/env.go
+++ b/internal/affordances/env.go
@@ -14,10 +14,15 @@ import (
 //     through ("data-entry", "mcp", "cli", ...). It is NOT a user
 //     classification; gate by role via has_role / has_global_role,
 //     not by inspecting current_user.tool (M1).
-var userRecordType = predicate.RecordType{
-	"id":   predicate.StringType,
-	"tool": predicate.StringType,
-}
+//
+// Aliased to [predicatefns.CurrentUserType] rather than redeclared:
+// affordance `when:` and a query condition are one language to the
+// operator writing them, so a field added to one and not the other
+// would be a silent divergence between two surfaces that look
+// identical. This package still binds the VALUE itself (bindings.go),
+// because its identity comes from its own resolver rather than the
+// query-identity context.
+var userRecordType = predicatefns.CurrentUserType
 
 // buildEnv constructs the predicate environment for one entity type:
 // the `entity` record (materialized from the metamodel), `current_user`,
@@ -59,6 +64,14 @@ func buildEnv(meta *metamodel.Metamodel, entityType string) (*predicate.Env, err
 		if err := env.DeclareFunc(f.name, f.sig); err != nil {
 			return nil, err
 		}
+	}
+	// The current-user sugar comes from the shared package so an
+	// affordance `when:` and a query condition mean the same thing by
+	// the same code. Note this env deliberately does NOT take the whole
+	// predicatefns stdlib (no match/regex/today) — the ACL surface is
+	// intentionally narrower.
+	if err := predicatefns.DeclareCurrentUserFuncs(env); err != nil {
+		return nil, err
 	}
 	return env, nil
 }

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -662,6 +662,7 @@ func (r *PolicyResolver) bindingFor(ctx context.Context, e *entity.Entity) (bc *
 		userID:      p.User,
 		resolver:    r,
 	}
+	bc.userFuncs = predicatefns.CurrentUserBindings(bc.identity())
 	return bc, roles
 }
 

--- a/internal/affordances/resolver.go
+++ b/internal/affordances/resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
 	"github.com/Sourcehaven-BV/rela/internal/principal"
 	"github.com/Sourcehaven-BV/rela/internal/statemachine"
 )
@@ -810,6 +811,17 @@ func (r *PolicyResolver) passes(
 ) bool {
 	if prog == nil {
 		return true
+	}
+	// A clause that reads the current user cannot be honored for a caller
+	// who has none: an unidentified caller is not "the user with the empty
+	// id", and `entity.owner == current_user.id` against an owner that is
+	// itself empty would otherwise GRANT. Refuse the grant — the direction
+	// every other identity gap in this codebase takes — rather than
+	// evaluate it against a placeholder. Only the `everyone` role can bring
+	// an unidentified caller here at all (resolveViaDeclarative), so this
+	// costs an anonymous-readable workspace exactly its per-user clauses.
+	if bc.identity() == "" && predicatefns.RequiresCurrentUser(prog) {
+		return false
 	}
 	b, err := bc.newBindings(r.meta)
 	if err != nil {

--- a/internal/appbuild/nextaction_matchers.go
+++ b/internal/appbuild/nextaction_matchers.go
@@ -1,11 +1,103 @@
 package appbuild
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	"github.com/Sourcehaven-BV/rela/internal/conditionlint"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/queryplan"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
+
+// nextActionMatcher adapts one compiled condition to the two seams dataentry
+// declares: [nextaction.Matcher] (the authoritative per-candidate pass) and
+// dataentry.ConditionPrefilterer (the store-side pre-filter). appbuild cannot
+// name the latter — dataentry's tests import appbuild, so the edge would
+// cycle — which is why dataentry's own test suite asserts the adapter
+// satisfies it (TestNextAction_CurrentUserConditionEndToEnd).
+//
+// It is also where "who is the current user?" is answered for next actions.
+// Both methods derive the identity from the principal on ctx through ONE
+// function, queryIdentityFor, so the pre-filter and the Go pass cannot
+// disagree about whose rows they are selecting.
+type nextActionMatcher struct {
+	m *conditionlint.NextActionMatcher
+}
+
+// Match evaluates the whole condition, with the identity stamped on ctx if
+// the request boundary has not already done so.
+func (w nextActionMatcher) Match(ctx context.Context, e *entity.Entity) (bool, error) {
+	if _, stamped := predicatefns.QueryIdentityFrom(ctx); !stamped {
+		if q, ok := queryIdentityFor(ctx); ok {
+			ctx = predicatefns.WithQueryIdentity(ctx, q)
+		}
+	}
+	ok, err := w.m.Match(ctx, e)
+	if errors.Is(err, predicatefns.ErrNoCurrentUser) {
+		// Translate to the engine's sentinel so the HTTP layer can name the
+		// misconfiguration without importing the predicate engine.
+		return false, fmt.Errorf("%w: %w", nextaction.ErrIdentityRequired, err)
+	}
+	return ok, err
+}
+
+// Prefilters lowers the condition's store-evaluable conjuncts for the types
+// the source's query names (queryplan.ConditionPrefilters). With no
+// resolvable identity the current-user conjuncts push nothing; Match then
+// fails the same condition closed, so the request is refused rather than
+// answered with the wrong rows.
+func (w nextActionMatcher) Prefilters(
+	ctx context.Context, meta *metamodel.Metamodel, types []string,
+) []store.PropPredicate {
+	if len(types) == 0 {
+		return nil
+	}
+	prog, ok := w.m.Program(types[0])
+	if !ok {
+		return nil
+	}
+	var identity string
+	if q, stamped := predicatefns.QueryIdentityFrom(ctx); stamped {
+		identity = q.ID()
+	} else if q, ok := queryIdentityFor(ctx); ok {
+		identity = q.ID()
+	}
+	return queryplan.ConditionPrefilters(prog, meta, types, identity)
+}
+
+// queryIdentityFor derives the query identity from the principal on ctx.
+//
+// It does NOT call the ACL resolver: on the data-entry API the router has
+// already run resolvePrincipalEntity, so principal.User IS the resolved user
+// entity id when the policy has a user_entity_type and the principal matched
+// one, with RawUser holding the original identifier. When no resolution
+// happened, User is the raw identifier and that is what graph data can be
+// compared against (predicatefns.QueryIdentity documents the fallback).
+//
+// Two states yield no identity, and both must: an unstamped ctx, and the
+// "unknown" attribution placeholder the data-entry server stamps when it has
+// no identity source. Neither is a user, and comparing either against
+// `entity.assignee` would be a match against nobody at best and against an
+// entity literally assigned to "unknown" at worst.
+func queryIdentityFor(ctx context.Context) (predicatefns.QueryIdentity, bool) {
+	p, ok := principal.Stamped(ctx)
+	if !ok || p.User == "" || p.User == principal.Unknown {
+		return predicatefns.QueryIdentity{}, false
+	}
+	q := predicatefns.QueryIdentity{Raw: p.User, Tool: p.Tool}
+	if p.RawUser != "" && p.RawUser != p.User {
+		q.EntityID = p.User
+		q.Raw = p.RawUser
+	}
+	return q, true
+}
 
 // NextActionMatchers compiles the `condition:` of every next-action source,
 // adapting conditionlint's compiler to the seam internal/dataentry declares.
@@ -31,6 +123,6 @@ func NextActionMatchers(
 			// wrapping a nil *NextActionMatcher — the classic typed-nil trap.
 			return nil, false
 		}
-		return m, true
+		return nextActionMatcher{m: m}, true
 	}, nil
 }

--- a/internal/appbuild/nextaction_matchers.go
+++ b/internal/appbuild/nextaction_matchers.go
@@ -72,17 +72,18 @@ func (w nextActionMatcher) Prefilters(ctx context.Context, meta *metamodel.Metam
 // different user than the principal means two layers disagree about who is
 // calling, and silently preferring either would evaluate every condition for
 // the wrong person with no signal — the hazard dataentry's attachACLRequest
-// refuses for an ACL request whose principal disagrees with ctx. Nothing
-// stamps upstream in production today (that boundary stamp is TKT-ZQV9O5), so
-// this is the guard that keeps that future change from widening quietly.
+// refuses for an ACL request whose principal disagrees with ctx. That is
+// [nextaction.ErrIdentityConflict], a refusal of the whole request, distinct
+// from the per-source [nextaction.ErrIdentityRequired] an unauthenticated
+// caller gets. Nothing stamps upstream in production today (that boundary
+// stamp is TKT-ZQV9O5), so this is the guard that keeps that future change
+// from widening quietly.
 func nextActionRequestScope(ctx context.Context) (context.Context, error) {
 	stamped, hasStamp := predicatefns.QueryIdentityFrom(ctx)
 	derived, hasPrincipal := queryIdentityFor(ctx)
 	switch {
 	case hasStamp && hasPrincipal && stamped.ID() != derived.ID():
-		return ctx, fmt.Errorf(
-			"%w: query identity on the context disagrees with the request principal",
-			nextaction.ErrIdentityRequired)
+		return ctx, nextaction.ErrIdentityConflict
 	case hasStamp:
 		return ctx, nil
 	case hasPrincipal:

--- a/internal/appbuild/nextaction_matchers.go
+++ b/internal/appbuild/nextaction_matchers.go
@@ -23,22 +23,16 @@ import (
 // cycle — which is why dataentry's own test suite asserts the adapter
 // satisfies it (TestNextAction_CurrentUserConditionEndToEnd).
 //
-// It is also where "who is the current user?" is answered for next actions.
-// Both methods derive the identity from the principal on ctx through ONE
-// function, queryIdentityFor, so the pre-filter and the Go pass cannot
-// disagree about whose rows they are selecting.
+// Neither method derives an identity. Both read the [predicatefns.QueryIdentity]
+// that [nextActionRequestScope] stamped ONCE per request, so the pre-filter
+// and the Go pass cannot disagree about whose rows they select, and a
+// resolve over N candidates costs one derivation, not N.
 type nextActionMatcher struct {
 	m *conditionlint.NextActionMatcher
 }
 
-// Match evaluates the whole condition, with the identity stamped on ctx if
-// the request boundary has not already done so.
+// Match evaluates the whole condition against the identity on ctx.
 func (w nextActionMatcher) Match(ctx context.Context, e *entity.Entity) (bool, error) {
-	if _, stamped := predicatefns.QueryIdentityFrom(ctx); !stamped {
-		if q, ok := queryIdentityFor(ctx); ok {
-			ctx = predicatefns.WithQueryIdentity(ctx, q)
-		}
-	}
 	ok, err := w.m.Match(ctx, e)
 	if errors.Is(err, predicatefns.ErrNoCurrentUser) {
 		// Translate to the engine's sentinel so the HTTP layer can name the
@@ -49,13 +43,12 @@ func (w nextActionMatcher) Match(ctx context.Context, e *entity.Entity) (bool, e
 }
 
 // Prefilters lowers the condition's store-evaluable conjuncts for the types
-// the source's query names (queryplan.ConditionPrefilters). With no
-// resolvable identity the current-user conjuncts push nothing; Match then
+// the condition was compiled against (queryplan.ConditionPrefilters). With
+// no identity on ctx the current-user conjuncts push nothing; Match then
 // fails the same condition closed, so the request is refused rather than
 // answered with the wrong rows.
-func (w nextActionMatcher) Prefilters(
-	ctx context.Context, meta *metamodel.Metamodel, types []string,
-) []store.PropPredicate {
+func (w nextActionMatcher) Prefilters(ctx context.Context, meta *metamodel.Metamodel) []store.PropPredicate {
+	types := w.m.Types()
 	if len(types) == 0 {
 		return nil
 	}
@@ -66,10 +59,36 @@ func (w nextActionMatcher) Prefilters(
 	var identity string
 	if q, stamped := predicatefns.QueryIdentityFrom(ctx); stamped {
 		identity = q.ID()
-	} else if q, ok := queryIdentityFor(ctx); ok {
-		identity = q.ID()
 	}
 	return queryplan.ConditionPrefilters(prog, meta, types, identity)
+}
+
+// nextActionRequestScope stamps the query identity on ctx once per
+// next-action resolve. It is the ONE place the identity is derived for this
+// surface (dataentry.NextActionRequestScope).
+//
+// A boundary-stamped identity already on ctx is honored — but when the
+// request also carries a principal, the two must AGREE. A stamp naming a
+// different user than the principal means two layers disagree about who is
+// calling, and silently preferring either would evaluate every condition for
+// the wrong person with no signal — the hazard dataentry's attachACLRequest
+// refuses for an ACL request whose principal disagrees with ctx. Nothing
+// stamps upstream in production today (that boundary stamp is TKT-ZQV9O5), so
+// this is the guard that keeps that future change from widening quietly.
+func nextActionRequestScope(ctx context.Context) (context.Context, error) {
+	stamped, hasStamp := predicatefns.QueryIdentityFrom(ctx)
+	derived, hasPrincipal := queryIdentityFor(ctx)
+	switch {
+	case hasStamp && hasPrincipal && stamped.ID() != derived.ID():
+		return ctx, fmt.Errorf(
+			"%w: query identity on the context disagrees with the request principal",
+			nextaction.ErrIdentityRequired)
+	case hasStamp:
+		return ctx, nil
+	case hasPrincipal:
+		return predicatefns.WithQueryIdentity(ctx, derived), nil
+	}
+	return ctx, nil
 }
 
 // queryIdentityFor derives the query identity from the principal on ctx.
@@ -86,6 +105,14 @@ func (w nextActionMatcher) Prefilters(
 // no identity source. Neither is a user, and comparing either against
 // `entity.assignee` would be a match against nobody at best and against an
 // entity literally assigned to "unknown" at worst.
+//
+// One degradation is inherited from the router and worth knowing: when the
+// principal_property lookup fails with a BACKEND error, resolvePrincipalEntity
+// keeps the raw principal, so this derives the raw identifier while the
+// operator's condition compares against user-entity ids. The source then
+// matches NOTHING for that request (narrowing, never widening) rather than
+// erroring; predicatefns.ResolveQueryIdentity is the stricter shape the
+// boundary stamp (TKT-ZQV9O5) should adopt.
 func queryIdentityFor(ctx context.Context) (predicatefns.QueryIdentity, bool) {
 	p, ok := principal.Stamped(ctx)
 	if !ok || p.User == "" || p.User == principal.Unknown {
@@ -109,12 +136,20 @@ func queryIdentityFor(ctx context.Context) (predicatefns.QueryIdentity, bool) {
 // Takes config + metamodel rather than returning a prebuilt lookup because
 // both reload at runtime — a lookup captured at boot would keep evaluating a
 // condition the operator has since edited.
+//
+// The second result is the per-request scope binder (dataentry.NextActionRequestScope):
+// the handler applies it to the request ctx once, before resolving, and every
+// matcher then reads the identity it stamped. Returned alongside the lookup
+// because the two are one contract — matchers compiled here evaluate only
+// against an identity stamped here.
 func NextActionMatchers(
 	cfg *dataentryconfig.Config, meta *metamodel.Metamodel,
-) (lookup func(string) (nextaction.Matcher, bool), problems []string) {
+) (lookup func(string) (nextaction.Matcher, bool), scope func(context.Context) (context.Context, error),
+	problems []string,
+) {
 	compiled, issues := conditionlint.NextActionMatchers(cfg, meta)
 	if len(issues) > 0 || compiled == nil {
-		return nil, issues
+		return nil, nil, issues
 	}
 	return func(id string) (nextaction.Matcher, bool) {
 		m, ok := compiled(id)
@@ -124,5 +159,5 @@ func NextActionMatchers(
 			return nil, false
 		}
 		return nextActionMatcher{m: m}, true
-	}, nil
+	}, nextActionRequestScope, nil
 }

--- a/internal/appbuild/nextaction_matchers_test.go
+++ b/internal/appbuild/nextaction_matchers_test.go
@@ -164,7 +164,9 @@ func TestNextActionRequestScope(t *testing.T) {
 	require.Equal(t, "alice", q.ID())
 
 	_, err = nextActionRequestScope(predicatefns.WithQueryIdentity(stampedCtx(bobP), aliceQ))
-	require.ErrorIs(t, err, nextaction.ErrIdentityRequired)
+	require.ErrorIs(t, err, nextaction.ErrIdentityConflict)
+	require.NotErrorIs(t, err, nextaction.ErrIdentityRequired,
+		"a conflict is not an unauthenticated caller and must not be skipped as one")
 
 	ctx, err = nextActionRequestScope(context.Background())
 	require.NoError(t, err)

--- a/internal/appbuild/nextaction_matchers_test.go
+++ b/internal/appbuild/nextaction_matchers_test.go
@@ -1,0 +1,138 @@
+package appbuild
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+func matcherMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{Entities: map[string]metamodel.EntityDef{
+		"task": {Properties: map[string]metamodel.PropertyDef{
+			"status":   {Type: metamodel.PropertyTypeString},
+			"assignee": {Type: metamodel.PropertyTypeString},
+			"watchers": {Type: metamodel.PropertyTypeString, List: true},
+		}},
+	}}
+}
+
+func matcherCfg(condition string) *dataentryconfig.Config {
+	return &dataentryconfig.Config{
+		NextActionBands: []dataentryconfig.NextActionBand{{ID: "b"}},
+		NextActions: map[string]dataentryconfig.NextActionSource{
+			"s": {Band: "b", Query: "type:task", Condition: condition, Suggest: "x"},
+		},
+	}
+}
+
+func stampedCtx(p principal.Principal) context.Context {
+	return principal.With(context.Background(), p)
+}
+
+// TestQueryIdentityFor pins how the request principal becomes the query
+// identity: nothing for an unstamped ctx or the "unknown" placeholder, the
+// raw user otherwise, and the resolved entity id when the router resolved
+// one (RawUser then holds the original).
+func TestQueryIdentityFor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		ctx    context.Context //nolint:containedctx // table fixture
+		want   string
+		wantOK bool
+	}{
+		{"unstamped", context.Background(), "", false},
+		{"unknown placeholder", stampedCtx(principal.Principal{User: principal.Unknown, Tool: "data-entry"}), "", false},
+		{"empty user", stampedCtx(principal.Principal{Tool: "data-entry"}), "", false},
+		{"raw user", stampedCtx(principal.Principal{User: "alice@example.com", Tool: "data-entry"}), "alice@example.com", true},
+		{"resolved user entity",
+			stampedCtx(principal.Principal{User: "PERS-A", RawUser: "alice@example.com", Tool: "data-entry"}),
+			"PERS-A", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q, ok := queryIdentityFor(tc.ctx)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.want, q.ID())
+		})
+	}
+}
+
+// TestNextActionMatchers_PrefiltersAndMatchShareTheIdentity is the contract
+// dataentry builds on: whatever identity the pre-filter pushes to the store
+// is the one the authoritative pass compares against.
+func TestNextActionMatchers_PrefiltersAndMatchShareTheIdentity(t *testing.T) {
+	t.Parallel()
+	meta := matcherMeta()
+	lookup, problems := NextActionMatchers(
+		matcherCfg("entity.status == 'open' and is_current_user(entity.assignee) and has_current_user(entity.watchers)"),
+		meta)
+	require.Empty(t, problems)
+	m, ok := lookup("s")
+	require.True(t, ok)
+	pf, ok := m.(interface {
+		Prefilters(context.Context, *metamodel.Metamodel, []string) []store.PropPredicate
+	})
+	require.True(t, ok, "the matcher must offer the pre-filter capability dataentry looks for")
+
+	alice := stampedCtx(principal.Principal{User: "alice", Tool: "data-entry"})
+	require.Equal(t, []store.PropPredicate{
+		{Property: "assignee", Op: store.PropEqual, Value: "alice", Scalar: true},
+		{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true},
+		{Property: "watchers", Op: store.PropEqual, Value: "alice", Scalar: false},
+	}, pf.Prefilters(alice, meta, []string{"task"}))
+
+	mine := entity.New("T-1", "task")
+	mine.Properties["status"] = "open"
+	mine.Properties["assignee"] = "alice"
+	mine.Properties["watchers"] = []any{"bob", "alice"}
+	got, err := m.Match(alice, mine)
+	require.NoError(t, err)
+	require.True(t, got)
+
+	bob := stampedCtx(principal.Principal{User: "bob", Tool: "data-entry"})
+	got, err = m.Match(bob, mine)
+	require.NoError(t, err)
+	require.False(t, got)
+
+	// No identity: the current-user conjuncts are not pushed (the literal
+	// still is), and the Go pass refuses with the engine's sentinel.
+	require.Equal(t, []store.PropPredicate{
+		{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true},
+	}, pf.Prefilters(context.Background(), meta, []string{"task"}))
+	_, err = m.Match(context.Background(), mine)
+	require.ErrorIs(t, err, nextaction.ErrIdentityRequired)
+	require.ErrorIs(t, err, predicatefns.ErrNoCurrentUser)
+
+	// An identity already stamped by a boundary wins over the principal.
+	pre := predicatefns.WithQueryIdentity(bob, predicatefns.QueryIdentity{EntityID: "alice"})
+	got, err = m.Match(pre, mine)
+	require.NoError(t, err)
+	require.True(t, got)
+	require.Equal(t, "alice", pf.Prefilters(pre, meta, []string{"task"})[0].Value)
+
+	// No types: nothing to gate against, nothing pushed.
+	require.Nil(t, pf.Prefilters(alice, meta, nil))
+}
+
+func TestNextActionMatchers_IdentityFreeConditionWorksUnidentified(t *testing.T) {
+	t.Parallel()
+	lookup, problems := NextActionMatchers(matcherCfg("entity.status == 'open'"), matcherMeta())
+	require.Empty(t, problems)
+	m, _ := lookup("s")
+	e := entity.New("T-1", "task")
+	e.Properties["status"] = "open"
+	got, err := m.Match(context.Background(), e)
+	require.NoError(t, err)
+	require.True(t, got)
+}

--- a/internal/appbuild/nextaction_matchers_test.go
+++ b/internal/appbuild/nextaction_matchers_test.go
@@ -68,29 +68,39 @@ func TestQueryIdentityFor(t *testing.T) {
 	}
 }
 
+// scoped applies the per-request scope binder the way the handler does.
+func scoped(ctx context.Context, t *testing.T, scope func(context.Context) (context.Context, error)) context.Context {
+	t.Helper()
+	out, err := scope(ctx)
+	require.NoError(t, err)
+	return out
+}
+
 // TestNextActionMatchers_PrefiltersAndMatchShareTheIdentity is the contract
-// dataentry builds on: whatever identity the pre-filter pushes to the store
-// is the one the authoritative pass compares against.
+// dataentry builds on: the identity is stamped ONCE per request by the scope
+// binder, and whatever the pre-filter pushes to the store is what the
+// authoritative pass compares against.
 func TestNextActionMatchers_PrefiltersAndMatchShareTheIdentity(t *testing.T) {
 	t.Parallel()
 	meta := matcherMeta()
-	lookup, problems := NextActionMatchers(
+	lookup, scope, problems := NextActionMatchers(
 		matcherCfg("entity.status == 'open' and is_current_user(entity.assignee) and has_current_user(entity.watchers)"),
 		meta)
 	require.Empty(t, problems)
+	require.NotNil(t, scope)
 	m, ok := lookup("s")
 	require.True(t, ok)
 	pf, ok := m.(interface {
-		Prefilters(context.Context, *metamodel.Metamodel, []string) []store.PropPredicate
+		Prefilters(context.Context, *metamodel.Metamodel) []store.PropPredicate
 	})
 	require.True(t, ok, "the matcher must offer the pre-filter capability dataentry looks for")
 
-	alice := stampedCtx(principal.Principal{User: "alice", Tool: "data-entry"})
+	alice := scoped(stampedCtx(principal.Principal{User: "alice", Tool: "data-entry"}), t, scope)
 	require.Equal(t, []store.PropPredicate{
 		{Property: "assignee", Op: store.PropEqual, Value: "alice", Scalar: true},
 		{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true},
 		{Property: "watchers", Op: store.PropEqual, Value: "alice", Scalar: false},
-	}, pf.Prefilters(alice, meta, []string{"task"}))
+	}, pf.Prefilters(alice, meta))
 
 	mine := entity.New("T-1", "task")
 	mine.Properties["status"] = "open"
@@ -100,39 +110,76 @@ func TestNextActionMatchers_PrefiltersAndMatchShareTheIdentity(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, got)
 
-	bob := stampedCtx(principal.Principal{User: "bob", Tool: "data-entry"})
+	bob := scoped(stampedCtx(principal.Principal{User: "bob", Tool: "data-entry"}), t, scope)
 	got, err = m.Match(bob, mine)
 	require.NoError(t, err)
 	require.False(t, got)
 
-	// No identity: the current-user conjuncts are not pushed (the literal
-	// still is), and the Go pass refuses with the engine's sentinel.
-	require.Equal(t, []store.PropPredicate{
-		{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true},
-	}, pf.Prefilters(context.Background(), meta, []string{"task"}))
-	_, err = m.Match(context.Background(), mine)
+	// No identity (unstamped, or the placeholder): the current-user
+	// conjuncts are not pushed (the literal still is), and the Go pass
+	// refuses with the engine's sentinel.
+	for _, ctx := range []context.Context{
+		scoped(context.Background(), t, scope),
+		scoped(stampedCtx(principal.Principal{User: principal.Unknown, Tool: "data-entry"}), t, scope),
+	} {
+		require.Equal(t, []store.PropPredicate{
+			{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true},
+		}, pf.Prefilters(ctx, meta))
+		_, err = m.Match(ctx, mine)
+		require.ErrorIs(t, err, nextaction.ErrIdentityRequired)
+		require.ErrorIs(t, err, predicatefns.ErrNoCurrentUser)
+	}
+
+	// The matcher never derives on its own: an unscoped ctx with a principal
+	// still has no identity. This is what makes "once per request" true.
+	_, err = m.Match(stampedCtx(principal.Principal{User: "alice", Tool: "data-entry"}), mine)
 	require.ErrorIs(t, err, nextaction.ErrIdentityRequired)
-	require.ErrorIs(t, err, predicatefns.ErrNoCurrentUser)
+}
 
-	// An identity already stamped by a boundary wins over the principal.
-	pre := predicatefns.WithQueryIdentity(bob, predicatefns.QueryIdentity{EntityID: "alice"})
-	got, err = m.Match(pre, mine)
+// TestNextActionRequestScope pins the scope binder: a boundary stamp is
+// honored when it agrees with the principal (or there is none), derived
+// from the principal otherwise, and REFUSED when the two disagree — two
+// layers disagreeing about who is calling must never select either one's
+// rows quietly.
+func TestNextActionRequestScope(t *testing.T) {
+	t.Parallel()
+	aliceP := principal.Principal{User: "alice", Tool: "data-entry"}
+	bobP := principal.Principal{User: "bob", Tool: "data-entry"}
+	aliceQ := predicatefns.QueryIdentity{EntityID: "alice"}
+
+	ctx, err := nextActionRequestScope(stampedCtx(aliceP))
 	require.NoError(t, err)
-	require.True(t, got)
-	require.Equal(t, "alice", pf.Prefilters(pre, meta, []string{"task"})[0].Value)
+	q, ok := predicatefns.QueryIdentityFrom(ctx)
+	require.True(t, ok)
+	require.Equal(t, "alice", q.ID())
 
-	// No types: nothing to gate against, nothing pushed.
-	require.Nil(t, pf.Prefilters(alice, meta, nil))
+	ctx, err = nextActionRequestScope(predicatefns.WithQueryIdentity(context.Background(), aliceQ))
+	require.NoError(t, err)
+	q, _ = predicatefns.QueryIdentityFrom(ctx)
+	require.Equal(t, "alice", q.ID())
+
+	ctx, err = nextActionRequestScope(predicatefns.WithQueryIdentity(stampedCtx(aliceP), aliceQ))
+	require.NoError(t, err)
+	q, _ = predicatefns.QueryIdentityFrom(ctx)
+	require.Equal(t, "alice", q.ID())
+
+	_, err = nextActionRequestScope(predicatefns.WithQueryIdentity(stampedCtx(bobP), aliceQ))
+	require.ErrorIs(t, err, nextaction.ErrIdentityRequired)
+
+	ctx, err = nextActionRequestScope(context.Background())
+	require.NoError(t, err)
+	_, ok = predicatefns.QueryIdentityFrom(ctx)
+	require.False(t, ok)
 }
 
 func TestNextActionMatchers_IdentityFreeConditionWorksUnidentified(t *testing.T) {
 	t.Parallel()
-	lookup, problems := NextActionMatchers(matcherCfg("entity.status == 'open'"), matcherMeta())
+	lookup, scope, problems := NextActionMatchers(matcherCfg("entity.status == 'open'"), matcherMeta())
 	require.Empty(t, problems)
 	m, _ := lookup("s")
 	e := entity.New("T-1", "task")
 	e.Properties["status"] = "open"
-	got, err := m.Match(context.Background(), e)
+	got, err := m.Match(scoped(context.Background(), t, scope), e)
 	require.NoError(t, err)
 	require.True(t, got)
 }

--- a/internal/conditionlint/nextaction.go
+++ b/internal/conditionlint/nextaction.go
@@ -116,6 +116,17 @@ func conditionEntityTypes(src dataentryconfig.NextActionSource) ([]string, error
 			return nil, errors.New(
 				"condition requires the query to name at least one entity type (e.g. \"type:task ...\")")
 		}
+		if sq.HasFreeText() {
+			// A free-text query runs through the search index, which caps
+			// hits by relevance BEFORE the engine applies the condition. A
+			// selection predicate after a cap is lossy (a match ranked past
+			// the cut silently never fires) — the very failure the
+			// condition-before-cap rule in internal/nextaction exists to
+			// prevent, so refuse the combination rather than under-report.
+			return nil, errors.New(
+				"condition is not supported with free text in the query " +
+					"(search results are capped before the condition runs); use prop: filters")
+		}
 		return sq.EntityTypes, nil
 	}
 	return nil, errors.New("condition requires a query or context source")

--- a/internal/conditionlint/nextaction.go
+++ b/internal/conditionlint/nextaction.go
@@ -26,6 +26,12 @@ type NextActionPrograms map[string]*predicate.Program
 // fail at startup instead of silently suppressing a suggestion forever — the
 // failure mode this whole feature exists to remove.
 //
+// The Env is the REQUEST-SCOPED profile (predicatefns.Evaluator.CompileWithCurrentUser):
+// a next-action resolves for one principal, so a condition may name
+// `current_user` and the `is_current_user` / `has_current_user` sugar. A
+// condition that does so is evaluated only against a request carrying an
+// identity — see [NextActionMatcher.Match].
+//
 // Returns the programs keyed by source id, plus one message per problem. A
 // source with no `condition:` is absent from the result, which the engine
 // reads as "keep every candidate".
@@ -72,7 +78,7 @@ func compileNextActionSource(
 		// only type-checks against one of them would silently drop the
 		// other's candidates. Same rule as the pushdown's
 		// stringComparableOnEveryType: valid everywhere, or refused.
-		prog, err := ev.Compile(t, src.Condition)
+		prog, err := ev.CompileWithCurrentUser(t, src.Condition)
 		if err != nil {
 			problems = append(problems, fmt.Sprintf(
 				"%s: condition does not compile against entity type %q: %v", where, t, err))

--- a/internal/conditionlint/nextaction_matcher.go
+++ b/internal/conditionlint/nextaction_matcher.go
@@ -3,6 +3,7 @@ package conditionlint
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -63,6 +64,19 @@ func (m *NextActionMatcher) Match(ctx context.Context, e *entity.Entity) (bool, 
 func (m *NextActionMatcher) Program(entityType string) (*predicate.Program, bool) {
 	prog, ok := m.progs[entityType]
 	return prog, ok
+}
+
+// Types returns, sorted, the entity types the condition was compiled against
+// — the types the source's query names. A pushdown caller takes them from
+// here rather than re-parsing the query, so the two cannot disagree about
+// which types the compiled programs cover.
+func (m *NextActionMatcher) Types() []string {
+	out := make([]string, 0, len(m.progs))
+	for t := range m.progs {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // NextActionMatchers compiles every source's condition and returns a lookup

--- a/internal/conditionlint/nextaction_matcher.go
+++ b/internal/conditionlint/nextaction_matcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
 	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
 )
 
@@ -19,6 +20,14 @@ type NextActionMatcher struct {
 }
 
 // Match reports whether e satisfies the condition.
+//
+// The identity for `current_user` is read from ctx (predicatefns.QueryIdentityFrom),
+// stamped by the wiring site that resolved the principal. A condition that
+// names the current user on a ctx carrying no identity returns
+// predicatefns.ErrNoCurrentUser rather than false: evaluating it against a
+// guessed identity would surface someone else's rows, and treating it as a
+// non-match would make a mis-wired deployment look like a quiet source. A
+// condition that never names the current user is unaffected.
 //
 // An entity whose type has no compiled program does NOT match. That is
 // unreachable through the normal path — [CompileNextActions] compiles against
@@ -34,7 +43,7 @@ func (m *NextActionMatcher) Match(ctx context.Context, e *entity.Entity) (bool, 
 	if !ok {
 		return false, nil
 	}
-	ok, err := m.ev.Matches(ctx, prog, e.Type, e.ID, e.Properties)
+	ok, err := m.ev.MatchesAs(ctx, prog, e.Type, e.ID, e.Properties)
 	if err != nil {
 		// Surfaced, not swallowed. A missing date property is an eval error,
 		// and treating it as "does not match" would make a broken condition
@@ -43,6 +52,17 @@ func (m *NextActionMatcher) Match(ctx context.Context, e *entity.Entity) (bool, 
 		return false, fmt.Errorf("conditionlint: evaluating condition for %s: %w", e.ID, err)
 	}
 	return ok, nil
+}
+
+// Program returns the compiled condition for one entity type, for a caller
+// that lowers part of it to the store (internal/queryplan.ConditionPrefilters)
+// before Match runs the whole of it in Go. The programs for the types a
+// source's query names are compiled from one source text, so any of them
+// describes the pushable shape; the metamodel gate in queryplan is what makes
+// the result valid across all of them.
+func (m *NextActionMatcher) Program(entityType string) (*predicate.Program, bool) {
+	prog, ok := m.progs[entityType]
+	return prog, ok
 }
 
 // NextActionMatchers compiles every source's condition and returns a lookup

--- a/internal/conditionlint/nextaction_test.go
+++ b/internal/conditionlint/nextaction_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
 )
 
 // naMeta declares two types sharing `due` (so a cross-type condition is
@@ -17,8 +18,10 @@ func naMeta() *metamodel.Metamodel {
 	return &metamodel.Metamodel{
 		Entities: map[string]metamodel.EntityDef{
 			"task": {Properties: map[string]metamodel.PropertyDef{
-				"due":    {Type: metamodel.PropertyTypeDate},
-				"status": {Type: metamodel.PropertyTypeString},
+				"due":      {Type: metamodel.PropertyTypeDate},
+				"status":   {Type: metamodel.PropertyTypeString},
+				"assignee": {Type: metamodel.PropertyTypeString},
+				"watchers": {Type: metamodel.PropertyTypeString, List: true},
 			}},
 			"bug": {Properties: map[string]metamodel.PropertyDef{
 				"due": {Type: metamodel.PropertyTypeDate},
@@ -162,4 +165,59 @@ func taskWith(id, status string) *entity.Entity {
 	e := entity.New(id, "task")
 	e.Properties["status"] = status
 	return e
+}
+
+// A next-action condition may name the current user. Compiling proves the
+// request-scoped profile is in use; the three Match cases pin the identity
+// contract: fail closed without one, honor a stamped one, and leave a
+// condition that never mentions the user untouched.
+func TestNextActionMatchers_CurrentUser(t *testing.T) {
+	t.Parallel()
+	lookup, errs := NextActionMatchers(naCfg(dataentryconfig.NextActionSource{
+		Query:     "type:task",
+		Condition: "is_current_user(entity.assignee) or has_current_user(entity.watchers)",
+	}), naMeta())
+	require.Empty(t, errs)
+	m, ok := lookup("s")
+	require.True(t, ok)
+
+	mine := entity.New("T-1", "task")
+	mine.Properties["assignee"] = "PERS-JV"
+	watched := entity.New("T-2", "task")
+	watched.Properties["watchers"] = []any{"PERS-AB", "PERS-JV"}
+	theirs := entity.New("T-3", "task")
+	theirs.Properties["assignee"] = "PERS-AB"
+
+	// No identity: refused, not a quiet non-match.
+	_, err := m.Match(context.Background(), mine)
+	require.ErrorIs(t, err, predicatefns.ErrNoCurrentUser)
+
+	ctx := predicatefns.WithQueryIdentity(context.Background(), predicatefns.QueryIdentity{EntityID: "PERS-JV"})
+	for _, tc := range []struct {
+		e    *entity.Entity
+		want bool
+	}{{mine, true}, {watched, true}, {theirs, false}} {
+		got, err := m.Match(ctx, tc.e)
+		require.NoError(t, err, tc.e.ID)
+		require.Equal(t, tc.want, got, tc.e.ID)
+	}
+
+	// The compiled program is exposed for the pushdown, per type.
+	prog, ok := m.Program("task")
+	require.True(t, ok)
+	require.NotNil(t, prog)
+	_, ok = m.Program("quip")
+	require.False(t, ok)
+}
+
+func TestNextActionMatchers_IdentityFreeConditionNeedsNoIdentity(t *testing.T) {
+	t.Parallel()
+	lookup, errs := NextActionMatchers(naCfg(dataentryconfig.NextActionSource{
+		Query: "type:task", Condition: "entity.status == 'todo'",
+	}), naMeta())
+	require.Empty(t, errs)
+	m, _ := lookup("s")
+	got, err := m.Match(context.Background(), taskWith("T-1", "todo"))
+	require.NoError(t, err)
+	require.True(t, got)
 }

--- a/internal/conditionlint/nextaction_test.go
+++ b/internal/conditionlint/nextaction_test.go
@@ -221,3 +221,24 @@ func TestNextActionMatchers_IdentityFreeConditionNeedsNoIdentity(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, got)
 }
+
+// A free-text query is relevance-capped before the condition runs, so a
+// condition on it would silently under-report; it is refused at load.
+func TestCompileNextActions_RefusesFreeTextQuery(t *testing.T) {
+	t.Parallel()
+	_, errs := CompileNextActions(naCfg(dataentryconfig.NextActionSource{
+		Query: "type:task urgent", Condition: "entity.status == 'todo'",
+	}), naMeta())
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0], "free text")
+}
+
+func TestNextActionMatcher_TypesAreTheCompiledTypes(t *testing.T) {
+	t.Parallel()
+	lookup, errs := NextActionMatchers(naCfg(dataentryconfig.NextActionSource{
+		Query: "type:task,bug", Condition: "days_between(entity.due, today()) > 1",
+	}), naMeta())
+	require.Empty(t, errs)
+	m, _ := lookup("s")
+	require.Equal(t, []string{"bug", "task"}, m.Types())
+}

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -10,6 +10,7 @@ import (
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/userstate"
 )
@@ -38,8 +39,25 @@ import (
 //     Uses the ungated count deliberately: see countCandidates.
 //   - Context -> not reachable from the dashboard; a context-aware source is
 //     resolved against the entity being viewed, which is a later surface.
-func (a *App) nextActionCandidates() nextaction.CandidateFunc {
-	return func(ctx context.Context, src dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+//
+// # The condition rides along with the query
+//
+// A source's `condition:` is evaluated per candidate by the engine (the
+// authoritative pass), but its store-evaluable conjuncts — `entity.assignee ==
+// current_user.id`, the is_current_user / has_current_user sugar, string
+// literals — are ALSO pushed into the candidate query here, through the
+// [ConditionPrefilterer] capability of that source's matcher. That is what
+// turns "tickets assigned to me" from a scan of every ticket into an indexed
+// lookup, and it is sound for the same reason the query's own pushdown is: the
+// store can only ever remove rows the engine's condition pass would also have
+// removed. `meta` and `lookup` are the request's snapshot and matcher lookup,
+// captured once by the caller.
+func (a *App) nextActionCandidates(
+	meta *metamodel.Metamodel, lookup nextaction.MatcherFunc,
+) nextaction.CandidateFunc {
+	return func(
+		ctx context.Context, id string, src dataentryconfig.NextActionSource,
+	) ([]nextaction.Candidate, error) {
 		// The SOURCE world is resolved per source, before any read, and
 		// REPLACES whatever world the request carried. See
 		// nextActionSourceWorld for why the caller's `?world=` must not reach
@@ -57,7 +75,7 @@ func (a *App) nextActionCandidates() nextaction.CandidateFunc {
 		case src.Count != "":
 			return a.countCandidates(ctx, src.Count, src.CountUngated)
 		case src.Query != "":
-			return a.queryCandidates(ctx, src.Query)
+			return a.queryCandidates(ctx, src.Query, nextActionPrefilters(ctx, meta, lookup, id, src))
 		default:
 			// A context-aware source has no dashboard candidates. Not an
 			// error: the same config serves both surfaces, and each ignores
@@ -65,6 +83,56 @@ func (a *App) nextActionCandidates() nextaction.CandidateFunc {
 			return nil, nil
 		}
 	}
+}
+
+// ConditionPrefilterer is the OPTIONAL capability of a next-action
+// [nextaction.Matcher] whose compiled `condition:` can be partly lowered to
+// store predicates.
+//
+// Consumer-side (see docs/architecture/consumer-side-interfaces.md): dataentry
+// declares the one method it needs and the composition root's matcher
+// (appbuild.NextActionMatchers) supplies it. The predicate engine that knows
+// how to do the lowering sits above this package, which is why the method
+// takes the request ctx — the identity `current_user` resolves to is derived
+// from the principal on it by the implementation, and the SAME derivation
+// serves the matcher's Match, so the pre-filter and the authoritative pass
+// can never compare against two different identities.
+//
+// Returned predicates are ANDed into the candidate query. The contract is the
+// one every pushdown in this package carries: they may only remove rows the
+// matcher's Match would also reject. A matcher without this capability simply
+// gets an unpushed query, with the same result.
+type ConditionPrefilterer interface {
+	Prefilters(ctx context.Context, meta *metamodel.Metamodel, types []string) []store.PropPredicate
+}
+
+// nextActionPrefilters lowers a source's condition for the types its query
+// names, or returns nil when there is nothing to push: no condition, no
+// matcher wired, a matcher without the capability, or a query naming no type
+// (there is then no metamodel gate to check the lowering against — the same
+// reason conditionlint refuses such a condition at load).
+//
+// A free function rather than an App method: App is at its plimsoll cap.
+func nextActionPrefilters(
+	ctx context.Context, meta *metamodel.Metamodel, lookup nextaction.MatcherFunc,
+	id string, src dataentryconfig.NextActionSource,
+) []store.PropPredicate {
+	if src.Condition == "" || lookup == nil || meta == nil {
+		return nil
+	}
+	m, ok := lookup(id)
+	if !ok || m == nil {
+		return nil
+	}
+	p, ok := m.(ConditionPrefilterer)
+	if !ok {
+		return nil
+	}
+	types := searchparser.ParseQuery(src.Query).EntityTypes
+	if len(types) == 0 {
+		return nil
+	}
+	return p.Prefilters(ctx, meta, types)
 }
 
 // nextActionSourceWorld rebinds ctx to the world a source's QUERY runs in,
@@ -213,8 +281,13 @@ func (a *App) nextActionOptions() nextaction.OptionFunc {
 // text. Without this an operator writing `suggest: "{title} needs a look"` on
 // a type whose title is hidden by `visible:` would put the hidden value on
 // the wire — the BUG-R9EHKV leak class, through a new door.
-func (a *App) queryCandidates(ctx context.Context, query string) ([]nextaction.Candidate, error) {
-	entities, err := a.queries.executeQuery(ctx, query)
+//
+// `prefilters` are the condition's store-evaluable conjuncts (see
+// nextActionPrefilters); nil pushes only the query's own filters.
+func (a *App) queryCandidates(
+	ctx context.Context, query string, prefilters []store.PropPredicate,
+) ([]nextaction.Candidate, error) {
+	entities, err := a.queries.executeQueryPrefiltered(ctx, query, prefilters)
 	if err != nil {
 		return nil, fmt.Errorf("next-action query %q: %w", query, err)
 	}

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -10,7 +10,6 @@ import (
 	entityPkg "github.com/Sourcehaven-BV/rela/internal/entity"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/nextaction"
-	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 	"github.com/Sourcehaven-BV/rela/internal/userstate"
 )
@@ -101,16 +100,24 @@ func (a *App) nextActionCandidates(
 // Returned predicates are ANDed into the candidate query. The contract is the
 // one every pushdown in this package carries: they may only remove rows the
 // matcher's Match would also reject. A matcher without this capability simply
-// gets an unpushed query, with the same result.
+// gets an unpushed query, with the same result. The matcher knows which entity
+// types its condition was compiled against, so it needs no query here.
+//
+// One asymmetry is load-bearing for that contract: the pre-filter compares RAW
+// store values, while Match sees the candidate AFTER field redaction
+// (redactedForSuggestion). That is sound only because redaction REMOVES a
+// hidden property — it binds Nil, and every current-user form is false on Nil —
+// so the Go pass is strictly narrower than the pre-filter, never wider. A
+// change that made a hidden property bind to something truthy, or that ran the
+// condition before redaction, would break this; pinned by
+// TestNextAction_HiddenPropertyMakesCurrentUserConditionFalse.
 type ConditionPrefilterer interface {
-	Prefilters(ctx context.Context, meta *metamodel.Metamodel, types []string) []store.PropPredicate
+	Prefilters(ctx context.Context, meta *metamodel.Metamodel) []store.PropPredicate
 }
 
-// nextActionPrefilters lowers a source's condition for the types its query
-// names, or returns nil when there is nothing to push: no condition, no
-// matcher wired, a matcher without the capability, or a query naming no type
-// (there is then no metamodel gate to check the lowering against — the same
-// reason conditionlint refuses such a condition at load).
+// nextActionPrefilters lowers a source's condition, or returns nil when there
+// is nothing to push: no condition, no matcher wired, or a matcher without the
+// capability.
 //
 // A free function rather than an App method: App is at its plimsoll cap.
 func nextActionPrefilters(
@@ -128,11 +135,7 @@ func nextActionPrefilters(
 	if !ok {
 		return nil
 	}
-	types := searchparser.ParseQuery(src.Query).EntityTypes
-	if len(types) == 0 {
-		return nil
-	}
-	return p.Prefilters(ctx, meta, types)
+	return p.Prefilters(ctx, meta)
 }
 
 // nextActionSourceWorld rebinds ctx to the world a source's QUERY runs in,
@@ -416,12 +419,29 @@ func (a *App) SetNextActionMatchers(fn NextActionMatcherFunc) error {
 }
 
 // NextActionMatcherFunc compiles the `condition:` of every configured source
-// against the current metamodel, returning a per-source lookup plus one
-// message per problem.
+// against the current metamodel, returning a per-source lookup, the
+// per-request scope binder the matchers evaluate under, and one message per
+// problem.
 //
 // The consumer-side seam for the predicate compiler: this package must not
 // import it (arch-lint keeps the condition/policy engine above the data-entry
 // app), so the composition root supplies an implementation.
+//
+// The scope result is spelled as the bare func type (not [NextActionRequestScope])
+// so a composition root that cannot import this package still satisfies the
+// seam; the named type is the same signature under a name for the handler.
 type NextActionMatcherFunc func(
 	cfg *dataentryconfig.Config, meta *metamodel.Metamodel,
-) (func(sourceID string) (nextaction.Matcher, bool), []string)
+) (func(sourceID string) (nextaction.Matcher, bool), func(context.Context) (context.Context, error), []string)
+
+// NextActionRequestScope binds request-scoped evaluation state — today the
+// identity `current_user` resolves to — onto ctx ONCE per resolve, before the
+// engine runs. Every matcher and pre-filter then reads what it stamped, so a
+// resolve over N candidates derives the identity once, not N times, and the
+// pre-filter and the authoritative pass cannot see two different identities.
+//
+// Nil: accepted — a compiler with no request-scoped state returns nil and the
+// handler resolves on the request ctx as is. An error is a refusal of the
+// whole request (the binder found the request's identity inconsistent), and
+// the handler reports it rather than resolving without a scope.
+type NextActionRequestScope func(ctx context.Context) (context.Context, error)

--- a/internal/dataentry/nextaction.go
+++ b/internal/dataentry/nextaction.go
@@ -51,6 +51,15 @@ import (
 // store can only ever remove rows the engine's condition pass would also have
 // removed. `meta` and `lookup` are the request's snapshot and matcher lookup,
 // captured once by the caller.
+//
+// `meta` is the SAME snapshot the matchers were compiled against, which is
+// the coherence that matters: the condition's pre-filter and its Go pass must
+// agree on property types. executeQuery gates the QUERY's own pushdown against
+// the read bundle's metamodel, resolved separately; a reload landing between
+// the two can make one request mix snapshots for the two pushdowns, but each
+// pushdown is coherent with its own authoritative pass, and a gate can only
+// decline to push, never widen — so the divergence is tolerated rather than
+// threaded through queryService.
 func (a *App) nextActionCandidates(
 	meta *metamodel.Metamodel, lookup nextaction.MatcherFunc,
 ) nextaction.CandidateFunc {

--- a/internal/dataentry/nextaction_condition_test.go
+++ b/internal/dataentry/nextaction_condition_test.go
@@ -97,6 +97,8 @@ func matcherFuncFor(m nextaction.Matcher) NextActionMatcherFunc {
 // before the engine sees candidates, and the engine's own pass stays
 // authoritative over whatever the pre-filter let through.
 func TestNextAction_ConditionPrefiltersReachTheStore(t *testing.T) {
+	// The subtests share one app and swap its matcher func between them, so
+	// they must stay sequential — do not add t.Parallel() to them.
 	app := newTestAppV1(t)
 	withTicketAssignment(t, app)
 	seedAssignedTicket(app, "TKT-mine", "alice")
@@ -133,10 +135,15 @@ func TestNextAction_ConditionPrefiltersReachTheStore(t *testing.T) {
 	})
 
 	t.Run("no pre-filter falls back to the unpushed query", func(t *testing.T) {
+		// Nothing pushed and Match accepts everything: BOTH tickets are
+		// candidates, so whichever the stable-random pick lands on, it must
+		// be one of them — proving the empty pre-filter did not narrow.
 		m := &recordingMatcher{match: true}
 		require.NoError(t, app.SetNextActionMatchers(matcherFuncFor(m)))
-		_, status := getNextAction(aliceCtx(), t, app)
+		resp, status := getNextAction(aliceCtx(), t, app)
 		require.Equal(t, http.StatusOK, status)
+		require.NotNil(t, resp.Suggestion)
+		require.Contains(t, []string{"TKT-mine", "TKT-theirs"}, resp.Suggestion.EntityID)
 		require.Equal(t, 1, m.calls)
 	})
 }
@@ -198,34 +205,66 @@ func TestNextAction_CurrentUserConditionEndToEnd(t *testing.T) {
 	}
 }
 
-// TestNextAction_CurrentUserConditionWithoutIdentityIsNamed pins the
-// fail-closed direction at the HTTP layer: a per-user condition on a request
-// with no identity (the "unknown" placeholder the server stamps without an
-// identity source) is refused with an error that names the misconfiguration
-// — never answered with nobody's rows, and never dressed as "search failed".
-func TestNextAction_CurrentUserConditionWithoutIdentityIsNamed(t *testing.T) {
+// TestNextAction_CurrentUserConditionWithoutIdentitySkipsTheSource pins the
+// fail-closed direction at the HTTP layer for an UNIDENTIFIED caller (no
+// principal, or the "unknown" placeholder the server stamps without an
+// identity source): a per-user source contributes nothing — never nobody's
+// rows, never everyone's — while every identity-free source keeps answering,
+// and the result does not depend on band order.
+func TestNextAction_CurrentUserConditionWithoutIdentitySkipsTheSource(t *testing.T) {
 	app := newTestAppV1(t)
 	withTicketAssignment(t, app)
 	seedAssignedTicket(app, "TKT-alice", "alice")
 	require.NoError(t, app.SetNextActionMatchers(appbuild.NextActionMatchers))
-	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
-		"s": {Band: "b", Query: "type:ticket", Condition: "is_current_user(entity.assignee)", Suggest: "{id}"},
+	twoBands := []dataentryconfig.NextActionBand{{ID: "b"}, {ID: "c"}}
+	withNextActions(t, app, twoBands, map[string]dataentryconfig.NextActionSource{
+		"mine": {Band: "b", Query: "type:ticket", Condition: "is_current_user(entity.assignee)", Suggest: "mine {id}"},
+		"any":  {Band: "c", Query: "type:ticket", Suggest: "any {id}"},
 	})
 
 	for _, ctx := range []context.Context{context.Background(), principalCtx(principal.Unknown)} {
-		rec := doNextActionGet(ctx, t, app)
-		require.Equal(t, http.StatusInternalServerError, rec.Code)
-		require.Contains(t, rec.Body.String(), "next_action_identity_required")
+		resp, status := getNextAction(ctx, t, app)
+		require.Equal(t, http.StatusOK, status)
+		require.NotNil(t, resp.Suggestion)
+		require.Equal(t, "any", resp.Suggestion.Source, "the identity-free source still resolves")
 	}
 
-	// A condition that never mentions the user is unaffected on the same
-	// unidentified request.
-	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
-		"s": {Band: "b", Query: "type:ticket", Condition: "entity.status == 'open'", Suggest: "{id}"},
-	})
-	resp, status := getNextAction(context.Background(), t, app)
+	// An identified caller gets the higher band.
+	resp, status := getNextAction(principalCtx("alice"), t, app)
 	require.Equal(t, http.StatusOK, status)
-	require.NotNil(t, resp.Suggestion)
+	require.Equal(t, "mine", resp.Suggestion.Source)
+
+	// With only per-user sources, an unidentified caller gets silence, not an
+	// error and not a stranger's ticket.
+	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
+		"mine": {Band: "b", Query: "type:ticket", Condition: "is_current_user(entity.assignee)", Suggest: "{id}"},
+	})
+	resp, status = getNextAction(context.Background(), t, app)
+	require.Equal(t, http.StatusOK, status)
+	require.Nil(t, resp.Suggestion)
+}
+
+// TestNextAction_IdentityConflictIsNamed pins the one error this surface owns:
+// a request-scope binder that finds two disagreeing identities refuses the
+// whole request with its own code, distinct from an unidentified caller.
+func TestNextAction_IdentityConflictIsNamed(t *testing.T) {
+	app := newTestAppV1(t)
+	seedNextActionTickets(t, app, "TKT-1")
+	conflicting := func(
+		*dataentryconfig.Config, *metamodel.Metamodel,
+	) (func(string) (nextaction.Matcher, bool), func(context.Context) (context.Context, error), []string) {
+		return func(string) (nextaction.Matcher, bool) { return &recordingMatcher{match: true}, true },
+			func(ctx context.Context) (context.Context, error) { return ctx, nextaction.ErrIdentityConflict },
+			nil
+	}
+	require.NoError(t, app.SetNextActionMatchers(conflicting))
+	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
+		"s": {Band: "b", Query: "type:ticket", Condition: "x", Suggest: "{id}"},
+	})
+	rec := doNextActionGet(aliceCtx(), t, app)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), "next_action_identity_conflict")
+	require.NotContains(t, rec.Body.String(), "alice", "neither identity is echoed")
 }
 
 // TestNextAction_HiddenPropertyMakesCurrentUserConditionFalse pins the

--- a/internal/dataentry/nextaction_condition_test.go
+++ b/internal/dataentry/nextaction_condition_test.go
@@ -1,0 +1,227 @@
+package dataentry
+
+import (
+	"context"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sourcehaven-BV/rela/internal/appbuild"
+	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
+	"github.com/Sourcehaven-BV/rela/internal/entity"
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/nextaction"
+	"github.com/Sourcehaven-BV/rela/internal/principal"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+// withTicketAssignment republishes the app's metamodel with the two
+// properties a per-user condition needs on `ticket`: a scalar `assignee`
+// and a list `watchers`. Copies the snapshot rather than mutating the
+// shared fixture, exactly as withNextActions does for the config.
+func withTicketAssignment(t *testing.T, app *App) {
+	t.Helper()
+	s := app.State()
+	meta := *s.Meta
+	meta.Entities = maps.Clone(meta.Entities)
+	def := meta.Entities["ticket"]
+	def.Properties = maps.Clone(def.Properties)
+	def.Properties["assignee"] = metamodel.PropertyDef{Type: metamodel.PropertyTypeString}
+	def.Properties["watchers"] = metamodel.PropertyDef{Type: metamodel.PropertyTypeString, List: true}
+	meta.Entities["ticket"] = def
+	app.schema.Publish(&Schema{
+		Cfg: s.Cfg, Meta: &meta, StyleMap: s.StyleMap,
+		StyledTypes: s.StyledTypes, OpenAPIGen: s.OpenAPIGen,
+	})
+}
+
+func seedAssignedTicket(app *App, id, assignee string, watchers ...string) {
+	props := map[string]any{"title": "Ticket " + id, "status": "open"}
+	if assignee != "" {
+		props["assignee"] = assignee
+	}
+	if len(watchers) > 0 {
+		w := make([]any, 0, len(watchers))
+		for _, x := range watchers {
+			w = append(w, x)
+		}
+		props["watchers"] = w
+	}
+	seedEntity(app, &entity.Entity{ID: id, Type: "ticket", Properties: props})
+}
+
+var oneBand = []dataentryconfig.NextActionBand{{ID: "b"}}
+
+// recordingMatcher is a fake condition matcher: it pushes whatever
+// predicates the test hands it and answers Match with a fixed verdict,
+// recording the types it was asked to pre-filter for.
+type recordingMatcher struct {
+	push  []store.PropPredicate
+	match bool
+	types [][]string
+}
+
+func (m *recordingMatcher) Match(context.Context, *entity.Entity) (bool, error) {
+	return m.match, nil
+}
+
+func (m *recordingMatcher) Prefilters(
+	_ context.Context, _ *metamodel.Metamodel, types []string,
+) []store.PropPredicate {
+	m.types = append(m.types, types)
+	return m.push
+}
+
+// doNextActionGet is getNextAction without the JSON decode, for asserting
+// on an error body.
+func doNextActionGet(ctx context.Context, t *testing.T, app *App) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/_next_action", http.NoBody).WithContext(ctx)
+	app.handleV1NextAction(rec, req)
+	return rec
+}
+
+func matcherFuncFor(m nextaction.Matcher) NextActionMatcherFunc {
+	return func(*dataentryconfig.Config, *metamodel.Metamodel) (func(string) (nextaction.Matcher, bool), []string) {
+		return func(string) (nextaction.Matcher, bool) { return m, true }, nil
+	}
+}
+
+// TestNextAction_ConditionPrefiltersReachTheStore proves the plumbing, not
+// the predicate semantics: a matcher's pre-filter is applied by the STORE
+// before the engine sees candidates, and the engine's own pass stays
+// authoritative over whatever the pre-filter let through.
+func TestNextAction_ConditionPrefiltersReachTheStore(t *testing.T) {
+	app := newTestAppV1(t)
+	withTicketAssignment(t, app)
+	seedAssignedTicket(app, "TKT-mine", "alice")
+	seedAssignedTicket(app, "TKT-theirs", "bob")
+	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
+		"s": {Band: "b", Query: "type:ticket", Condition: "irrelevant-to-the-fake", Suggest: "{id}"},
+	})
+
+	t.Run("the pre-filter narrows the fetch", func(t *testing.T) {
+		// Match accepts EVERYTHING, so the only way TKT-theirs can be
+		// absent is the predicate having reached the store.
+		m := &recordingMatcher{
+			push:  []store.PropPredicate{{Property: "assignee", Op: store.PropEqual, Value: "alice", Scalar: true}},
+			match: true,
+		}
+		require.NoError(t, app.SetNextActionMatchers(matcherFuncFor(m)))
+		resp, status := getNextAction(aliceCtx(), t, app)
+		require.Equal(t, http.StatusOK, status)
+		require.NotNil(t, resp.Suggestion)
+		require.Equal(t, "TKT-mine", resp.Suggestion.EntityID)
+		require.Equal(t, [][]string{{"ticket"}}, m.types, "pre-filtered for the query's types")
+	})
+
+	t.Run("the Go pass stays authoritative", func(t *testing.T) {
+		// The pre-filter keeps TKT-mine; Match rejects it anyway.
+		m := &recordingMatcher{
+			push:  []store.PropPredicate{{Property: "assignee", Op: store.PropEqual, Value: "alice", Scalar: true}},
+			match: false,
+		}
+		require.NoError(t, app.SetNextActionMatchers(matcherFuncFor(m)))
+		resp, status := getNextAction(aliceCtx(), t, app)
+		require.Equal(t, http.StatusOK, status)
+		require.Nil(t, resp.Suggestion)
+	})
+
+	t.Run("no pre-filter falls back to the unpushed query", func(t *testing.T) {
+		m := &recordingMatcher{match: true}
+		require.NoError(t, app.SetNextActionMatchers(matcherFuncFor(m)))
+		_, status := getNextAction(aliceCtx(), t, app)
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, [][]string{{"ticket"}}, m.types)
+	})
+}
+
+// TestNextAction_CurrentUserConditionEndToEnd runs the real composition-root
+// matcher (appbuild.NextActionMatchers) behind the handler: the condition
+// compiles with current_user, the identity comes from the request
+// principal, and each principal is offered only their own ticket.
+func TestNextAction_CurrentUserConditionEndToEnd(t *testing.T) {
+	app := newTestAppV1(t)
+	withTicketAssignment(t, app)
+	seedAssignedTicket(app, "TKT-alice", "alice")
+	seedAssignedTicket(app, "TKT-bob", "bob")
+	seedAssignedTicket(app, "TKT-watched", "carol", "dave", "alice")
+	require.NoError(t, app.SetNextActionMatchers(appbuild.NextActionMatchers))
+
+	t.Run("the composition-root matcher offers the pre-filter capability", func(t *testing.T) {
+		lookup, problems := appbuild.NextActionMatchers(&dataentryconfig.Config{
+			NextActions: map[string]dataentryconfig.NextActionSource{
+				"s": {Query: "type:ticket", Condition: "is_current_user(entity.assignee)"},
+			},
+		}, app.State().Meta)
+		require.Empty(t, problems)
+		m, ok := lookup("s")
+		require.True(t, ok)
+		_, ok = m.(ConditionPrefilterer)
+		require.True(t, ok, "appbuild's matcher must satisfy dataentry.ConditionPrefilterer")
+	})
+
+	cases := []struct {
+		name      string
+		condition string
+		user      string
+		want      string
+	}{
+		{"equality against current_user.id", "entity.assignee == current_user.id", "alice", "TKT-alice"},
+		{"is_current_user picks alice's", "is_current_user(entity.assignee)", "alice", "TKT-alice"},
+		{"is_current_user picks bob's", "is_current_user(entity.assignee)", "bob", "TKT-bob"},
+		{"has_current_user finds the watcher", "has_current_user(entity.watchers)", "alice", "TKT-watched"},
+		{"has_current_user for a non-watcher finds nothing", "has_current_user(entity.watchers)", "bob", ""},
+		{"an OR still evaluates correctly, just unpushed",
+			"is_current_user(entity.assignee) or has_current_user(entity.watchers)", "dave", "TKT-watched"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
+				"s": {Band: "b", Query: "type:ticket", Condition: tc.condition, Suggest: "{id}"},
+			})
+			resp, status := getNextAction(principalCtx(tc.user), t, app)
+			require.Equal(t, http.StatusOK, status)
+			if tc.want == "" {
+				require.Nil(t, resp.Suggestion)
+				return
+			}
+			require.NotNil(t, resp.Suggestion)
+			require.Equal(t, tc.want, resp.Suggestion.EntityID)
+		})
+	}
+}
+
+// TestNextAction_CurrentUserConditionWithoutIdentityIsNamed pins the
+// fail-closed direction at the HTTP layer: a per-user condition on a request
+// with no identity (the "unknown" placeholder the server stamps without an
+// identity source) is refused with an error that names the misconfiguration
+// — never answered with nobody's rows, and never dressed as "search failed".
+func TestNextAction_CurrentUserConditionWithoutIdentityIsNamed(t *testing.T) {
+	app := newTestAppV1(t)
+	withTicketAssignment(t, app)
+	seedAssignedTicket(app, "TKT-alice", "alice")
+	require.NoError(t, app.SetNextActionMatchers(appbuild.NextActionMatchers))
+	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
+		"s": {Band: "b", Query: "type:ticket", Condition: "is_current_user(entity.assignee)", Suggest: "{id}"},
+	})
+
+	for _, ctx := range []context.Context{context.Background(), principalCtx(principal.Unknown)} {
+		rec := doNextActionGet(ctx, t, app)
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		require.Contains(t, rec.Body.String(), "next_action_identity_required")
+	}
+
+	// A condition that never mentions the user is unaffected on the same
+	// unidentified request.
+	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
+		"s": {Band: "b", Query: "type:ticket", Condition: "entity.status == 'open'", Suggest: "{id}"},
+	})
+	resp, status := getNextAction(context.Background(), t, app)
+	require.Equal(t, http.StatusOK, status)
+	require.NotNil(t, resp.Suggestion)
+}

--- a/internal/dataentry/nextaction_condition_test.go
+++ b/internal/dataentry/nextaction_condition_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/Sourcehaven-BV/rela/internal/acl"
 	"github.com/Sourcehaven-BV/rela/internal/appbuild"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/entity"
@@ -57,21 +58,19 @@ var oneBand = []dataentryconfig.NextActionBand{{ID: "b"}}
 
 // recordingMatcher is a fake condition matcher: it pushes whatever
 // predicates the test hands it and answers Match with a fixed verdict,
-// recording the types it was asked to pre-filter for.
+// counting how often it was asked to pre-filter.
 type recordingMatcher struct {
 	push  []store.PropPredicate
 	match bool
-	types [][]string
+	calls int
 }
 
 func (m *recordingMatcher) Match(context.Context, *entity.Entity) (bool, error) {
 	return m.match, nil
 }
 
-func (m *recordingMatcher) Prefilters(
-	_ context.Context, _ *metamodel.Metamodel, types []string,
-) []store.PropPredicate {
-	m.types = append(m.types, types)
+func (m *recordingMatcher) Prefilters(context.Context, *metamodel.Metamodel) []store.PropPredicate {
+	m.calls++
 	return m.push
 }
 
@@ -86,8 +85,10 @@ func doNextActionGet(ctx context.Context, t *testing.T, app *App) *httptest.Resp
 }
 
 func matcherFuncFor(m nextaction.Matcher) NextActionMatcherFunc {
-	return func(*dataentryconfig.Config, *metamodel.Metamodel) (func(string) (nextaction.Matcher, bool), []string) {
-		return func(string) (nextaction.Matcher, bool) { return m, true }, nil
+	return func(
+		*dataentryconfig.Config, *metamodel.Metamodel,
+	) (func(string) (nextaction.Matcher, bool), func(context.Context) (context.Context, error), []string) {
+		return func(string) (nextaction.Matcher, bool) { return m, true }, nil, nil
 	}
 }
 
@@ -116,7 +117,7 @@ func TestNextAction_ConditionPrefiltersReachTheStore(t *testing.T) {
 		require.Equal(t, http.StatusOK, status)
 		require.NotNil(t, resp.Suggestion)
 		require.Equal(t, "TKT-mine", resp.Suggestion.EntityID)
-		require.Equal(t, [][]string{{"ticket"}}, m.types, "pre-filtered for the query's types")
+		require.Equal(t, 1, m.calls, "pre-filtered exactly once for the source")
 	})
 
 	t.Run("the Go pass stays authoritative", func(t *testing.T) {
@@ -136,7 +137,7 @@ func TestNextAction_ConditionPrefiltersReachTheStore(t *testing.T) {
 		require.NoError(t, app.SetNextActionMatchers(matcherFuncFor(m)))
 		_, status := getNextAction(aliceCtx(), t, app)
 		require.Equal(t, http.StatusOK, status)
-		require.Equal(t, [][]string{{"ticket"}}, m.types)
+		require.Equal(t, 1, m.calls)
 	})
 }
 
@@ -153,12 +154,13 @@ func TestNextAction_CurrentUserConditionEndToEnd(t *testing.T) {
 	require.NoError(t, app.SetNextActionMatchers(appbuild.NextActionMatchers))
 
 	t.Run("the composition-root matcher offers the pre-filter capability", func(t *testing.T) {
-		lookup, problems := appbuild.NextActionMatchers(&dataentryconfig.Config{
+		lookup, scope, problems := appbuild.NextActionMatchers(&dataentryconfig.Config{
 			NextActions: map[string]dataentryconfig.NextActionSource{
 				"s": {Query: "type:ticket", Condition: "is_current_user(entity.assignee)"},
 			},
 		}, app.State().Meta)
 		require.Empty(t, problems)
+		require.NotNil(t, scope, "appbuild supplies the per-request scope binder")
 		m, ok := lookup("s")
 		require.True(t, ok)
 		_, ok = m.(ConditionPrefilterer)
@@ -224,4 +226,40 @@ func TestNextAction_CurrentUserConditionWithoutIdentityIsNamed(t *testing.T) {
 	resp, status := getNextAction(context.Background(), t, app)
 	require.Equal(t, http.StatusOK, status)
 	require.NotNil(t, resp.Suggestion)
+}
+
+// TestNextAction_HiddenPropertyMakesCurrentUserConditionFalse pins the
+// raw-vs-redacted asymmetry documented on ConditionPrefilterer: the store
+// pre-filter keeps alice's ticket (it compares the raw assignee), but the
+// authoritative Go pass evaluates the REDACTED candidate, where a
+// visible:-hidden assignee binds Nil and is_current_user is false. The Go
+// pass is therefore strictly narrower, and a hidden value can never drive a
+// suggestion.
+func TestNextAction_HiddenPropertyMakesCurrentUserConditionFalse(t *testing.T) {
+	app := newTestAppV1(t)
+	withTicketAssignment(t, app)
+	seedAssignedTicket(app, "TKT-alice", "alice")
+	require.NoError(t, app.SetNextActionMatchers(appbuild.NextActionMatchers))
+	d := mustNewACL(t, &acl.Policy{
+		Roles:       map[string]acl.RoleDef{"viewer": {Read: []string{"ticket"}}},
+		Assignments: map[string]string{"alice": "viewer"},
+	}, app.store)
+	app.acl = d
+	withNextActions(t, app, oneBand, map[string]dataentryconfig.NextActionSource{
+		"s": {Band: "b", Query: "type:ticket", Condition: "is_current_user(entity.assignee)", Suggest: "{id}"},
+	})
+	ctx := gateCtxFor(principalCtx("alice"), t, d)
+
+	// Baseline: with the assignee visible the suggestion fires.
+	resp, status := getNextAction(ctx, t, app)
+	require.Equal(t, http.StatusOK, status)
+	require.NotNil(t, resp.Suggestion)
+	require.Equal(t, "TKT-alice", resp.Suggestion.EntityID)
+
+	// Hide the assignee: the pre-filter still selects the row, the Go pass
+	// does not.
+	app.fieldResolver = fakeResolver{fv: FieldVerdicts{Visible: map[string]bool{"assignee": false}}}
+	resp, status = getNextAction(ctx, t, app)
+	require.Equal(t, http.StatusOK, status)
+	require.Nil(t, resp.Suggestion, "a hidden property must not satisfy a per-user condition")
 }

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -115,33 +115,19 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	var err error
 	if scope != nil {
 		// Once per request, before any source runs: every matcher and
 		// pre-filter below reads what this stamps.
-		ctx, err = scope(ctx)
+		scoped, err := scope(ctx)
+		if err != nil {
+			writeNextActionError(w, r, err)
+			return
+		}
+		ctx = scoped
 	}
-	var (
-		sug   nextaction.Suggestion
-		found bool
-	)
-	if err == nil {
-		sug, found, err = eng.Resolve(ctx, nextActionUser(ctx), time.Now())
-	}
-	if errors.Is(err, nextaction.ErrIdentityRequired) {
-		// A source's condition names current_user but this request has no
-		// identity (no identity source configured, or the placeholder
-		// principal). Operator misconfiguration, not a client fault: name it
-		// so the log says what to fix, rather than "search failed".
-		slog.Warn("dataentry: next-action condition needs an identified principal",
-			"err", err, "path", r.URL.Path)
-		writeV1Error(w, r, http.StatusInternalServerError, "next_action_identity_required",
-			"A next-action condition references current_user but the request has no identity",
-			"configure an identity source (see docs/data-entry.md, next actions)")
-		return
-	}
+	sug, found, err := eng.Resolve(ctx, nextActionUser(ctx), time.Now())
 	if err != nil {
-		writeListPipelineError(w, r, err)
+		writeNextActionError(w, r, err)
 		return
 	}
 	if !found {
@@ -158,6 +144,26 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 		Actions:     sug.Actions,
 		PickOptions: pickOptionsWire(sug.PickOptions),
 	}})
+}
+
+// writeNextActionError maps a resolve failure to a response. The one error
+// this surface owns is an identity CONFLICT — the request carries a
+// boundary-stamped identity and a principal that name different users — which
+// is named so the operator can find the layer that disagrees rather than
+// reading "search failed". (An unidentified caller on a per-user source is not
+// an error at all: the engine skips that source, see
+// nextaction.ErrIdentityRequired.) Everything else is the shared list-pipeline
+// mapping. A free function: App is at its plimsoll method cap.
+func writeNextActionError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, nextaction.ErrIdentityConflict) {
+		slog.Warn("dataentry: next-action request carries disagreeing identities",
+			"err", err, "path", r.URL.Path)
+		writeV1Error(w, r, http.StatusInternalServerError, "next_action_identity_conflict",
+			"The request's query identity disagrees with its principal",
+			"an upstream layer stamped an identity for a different user than the request principal")
+		return
+	}
+	writeListPipelineError(w, r, err)
 }
 
 // pickOptionsWire converts the engine's index-keyed options to the wire

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -3,7 +3,9 @@ package dataentry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -114,6 +116,18 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	sug, found, err := eng.Resolve(ctx, nextActionUser(ctx), time.Now())
+	if errors.Is(err, nextaction.ErrIdentityRequired) {
+		// A source's condition names current_user but this request has no
+		// identity (no identity source configured, or the placeholder
+		// principal). Operator misconfiguration, not a client fault: name it
+		// so the log says what to fix, rather than "search failed".
+		slog.Warn("dataentry: next-action condition needs an identified principal",
+			"err", err, "path", r.URL.Path)
+		writeV1Error(w, r, http.StatusInternalServerError, "next_action_identity_required",
+			"A next-action condition references current_user but the request has no identity",
+			"configure an identity source (see docs/data-entry.md, next actions)")
+		return
+	}
 	if err != nil {
 		writeListPipelineError(w, r, err)
 		return
@@ -298,17 +312,22 @@ func (a *App) nextActionEngine(displayWorld string) (*nextaction.Engine, bool) {
 		nextaction.WithOptions(a.nextActionOptions()),
 		nextaction.WithDisplayWorld(displayWorld),
 	}
+	var lookup nextaction.MatcherFunc
 	if a.nextActionMatchers != nil {
 		// Compile errors are already reported at load by projectsetup; a
 		// config that reached here should compile. If it somehow does not,
 		// leave matchers unwired so New fails loudly for a source that
 		// declares a condition, rather than silently keeping every candidate.
-		if lookup, issues := a.nextActionMatchers(cfg, st.Meta); len(issues) == 0 && lookup != nil {
+		if l, issues := a.nextActionMatchers(cfg, st.Meta); len(issues) == 0 && l != nil {
+			lookup = l
 			opts = append(opts, nextaction.WithMatchers(lookup))
 		}
 	}
 
-	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates(), opts...)
+	// The SAME lookup feeds both the engine (which runs each condition in
+	// full) and the candidate func (which pushes the condition's
+	// store-evaluable part into the query) — see nextActionCandidates.
+	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates(st.Meta, lookup), opts...)
 	if err != nil {
 		return nil, false
 	}

--- a/internal/dataentry/nextaction_handler.go
+++ b/internal/dataentry/nextaction_handler.go
@@ -106,7 +106,7 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 	// The request's world is the DISPLAY world: it decides which sources may
 	// surface here (visible_worlds), never which world a source queries. See
 	// nextActionSourceWorld.
-	eng, ok := a.nextActionEngine(nextActionDisplayWorld(r.Context()))
+	eng, scope, ok := a.nextActionEngine(nextActionDisplayWorld(r.Context()))
 	if !ok {
 		// No sources configured: a valid, common state (the feature is
 		// opt-in). An empty answer, not a 404 — the SPA renders nothing.
@@ -115,7 +115,19 @@ func (a *App) handleV1NextActionGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	sug, found, err := eng.Resolve(ctx, nextActionUser(ctx), time.Now())
+	var err error
+	if scope != nil {
+		// Once per request, before any source runs: every matcher and
+		// pre-filter below reads what this stamps.
+		ctx, err = scope(ctx)
+	}
+	var (
+		sug   nextaction.Suggestion
+		found bool
+	)
+	if err == nil {
+		sug, found, err = eng.Resolve(ctx, nextActionUser(ctx), time.Now())
+	}
 	if errors.Is(err, nextaction.ErrIdentityRequired) {
 		// A source's condition names current_user but this request has no
 		// identity (no identity source configured, or the placeholder
@@ -299,27 +311,30 @@ func nextActionDisplayWorld(ctx context.Context) string {
 	return defaultWorldName
 }
 
-func (a *App) nextActionEngine(displayWorld string) (*nextaction.Engine, bool) {
+func (a *App) nextActionEngine(displayWorld string) (*nextaction.Engine, NextActionRequestScope, bool) {
 	// Snapshot the config once: State() reads an atomic face, and two
 	// reads could observe different snapshots if a reload lands between them.
 	st := a.State()
 	cfg := st.Cfg
 	if cfg == nil || len(cfg.NextActions) == 0 || a.userState == nil {
-		return nil, false
+		return nil, nil, false
 	}
 
 	opts := []nextaction.Option{
 		nextaction.WithOptions(a.nextActionOptions()),
 		nextaction.WithDisplayWorld(displayWorld),
 	}
-	var lookup nextaction.MatcherFunc
+	var (
+		lookup nextaction.MatcherFunc
+		scope  NextActionRequestScope
+	)
 	if a.nextActionMatchers != nil {
 		// Compile errors are already reported at load by projectsetup; a
 		// config that reached here should compile. If it somehow does not,
 		// leave matchers unwired so New fails loudly for a source that
 		// declares a condition, rather than silently keeping every candidate.
-		if l, issues := a.nextActionMatchers(cfg, st.Meta); len(issues) == 0 && l != nil {
-			lookup = l
+		if l, s, issues := a.nextActionMatchers(cfg, st.Meta); len(issues) == 0 && l != nil {
+			lookup, scope = l, s
 			opts = append(opts, nextaction.WithMatchers(lookup))
 		}
 	}
@@ -329,7 +344,7 @@ func (a *App) nextActionEngine(displayWorld string) (*nextaction.Engine, bool) {
 	// store-evaluable part into the query) — see nextActionCandidates.
 	eng, err := nextaction.New(cfg, a.userState, a.nextActionCandidates(st.Meta, lookup), opts...)
 	if err != nil {
-		return nil, false
+		return nil, nil, false
 	}
-	return eng, true
+	return eng, scope, true
 }

--- a/internal/dataentry/queryservice.go
+++ b/internal/dataentry/queryservice.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
 	"github.com/Sourcehaven-BV/rela/internal/search"
 	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
+	"github.com/Sourcehaven-BV/rela/internal/store"
 )
 
 // queryService owns the search-query pipeline: the `/_search` and
@@ -100,6 +101,27 @@ func newQueryService(app *App) *queryService {
 // pre-TKT-BA8BSX version swallowed both error classes into silently
 // truncated results.
 func (q *queryService) executeQuery(ctx context.Context, query string) ([]*entity.Entity, error) {
+	return q.executeQueryPrefiltered(ctx, query, nil)
+}
+
+// executeQueryPrefiltered is executeQuery with extra store predicates ANDed
+// into the no-free-text branch's pushdown.
+//
+// `extra` is for a caller that will apply a FURTHER authoritative filter of
+// its own over the result — the next-action engine's `condition:` — and has
+// lowered the store-safe part of it (queryplan.ConditionPrefilters). The
+// contract is the same belt-and-braces one as the query's own pushdown: the
+// predicates may only ever remove rows the caller's Go pass would also
+// remove, so the outcome is identical to fetching everything, minus the I/O.
+// Nothing here evaluates them; a caller that passes a predicate it does not
+// also enforce has widened nothing but has narrowed on its own authority.
+//
+// They are ignored on the free-text branch, which runs through the search
+// index rather than a type-scoped store list; the caller's Go pass still
+// applies, so the result is the same, only unpushed.
+func (q *queryService) executeQueryPrefiltered(
+	ctx context.Context, query string, extra []store.PropPredicate,
+) ([]*entity.Entity, error) {
 	sq := searchparser.ParseQuery(query)
 	if sq.IsEmpty() {
 		return nil, nil
@@ -141,6 +163,7 @@ func (q *queryService) executeQuery(ctx context.Context, query string) ([]*entit
 		// pre-pushdown behavior — the store can only ever remove rows the Go
 		// pass would also have removed — while still winning the I/O.
 		pushed := pushdownPrefilters(sq.PropertyFilters, svc.Meta, sq.EntityTypes)
+		pushed = append(pushed, extra...)
 		candidates, err = visibleListByTypes(ctx, svc, sq.EntityTypes, scope, pushed)
 	}
 	if err != nil {

--- a/internal/dataentry/queryservice.go
+++ b/internal/dataentry/queryservice.go
@@ -117,8 +117,12 @@ func (q *queryService) executeQuery(ctx context.Context, query string) ([]*entit
 // also enforce has widened nothing but has narrowed on its own authority.
 //
 // They are ignored on the free-text branch, which runs through the search
-// index rather than a type-scoped store list; the caller's Go pass still
-// applies, so the result is the same, only unpushed.
+// index rather than a type-scoped store list. That branch is also
+// relevance-CAPPED (maxFreeTextSearchResults) before any caller's pass runs,
+// so a selection predicate over it would be lossy; the only caller with a
+// condition — the next-action engine — is refused a free-text query at load
+// (conditionlint) for exactly that reason, and this comment is the reminder
+// for the next one.
 func (q *queryService) executeQueryPrefiltered(
 	ctx context.Context, query string, extra []store.PropPredicate,
 ) ([]*entity.Entity, error) {

--- a/internal/dataentry/router.go
+++ b/internal/dataentry/router.go
@@ -520,7 +520,7 @@ type PrincipalResolver func(*http.Request) principal.Principal
 // be actively misleading.
 func defaultPrincipalResolver(_ *http.Request) principal.Principal {
 	return principal.Principal{
-		User: "unknown",
+		User: principal.Unknown,
 		Tool: principal.ToolDataEntry,
 	}
 }

--- a/internal/dataentry/webhook_conflict_postgres_test.go
+++ b/internal/dataentry/webhook_conflict_postgres_test.go
@@ -278,7 +278,7 @@ func TestWebhookConflict_LoserRefindsAndProceeds(t *testing.T) {
 	//
 	// Driving the real router is the point. The previous version of this test
 	// called st.CreateEntity directly and asserted the store's behaviour, so it
-	// could not observe that the pipeline never recognises the conflict — which
+	// could not observe that the pipeline never recognizes the conflict — which
 	// is exactly the defect it was supposed to guard (RR-HI9QIU / RR-SG8P1N).
 	const deliveries = 8
 	var wg sync.WaitGroup

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -151,6 +151,19 @@ type NextActionSource struct {
 	// refines (predicate syntax, evaluated per candidate). Date arithmetic
 	// lives here because ordered comparison needs the property's declared
 	// type from the metamodel, which the store layer does not consult.
+	//
+	// The split is about LANGUAGE, not about where work happens: the
+	// condition's store-safe conjuncts — string equalities, and the
+	// current-user forms `entity.assignee == current_user.id`,
+	// `is_current_user(entity.assignee)`, `has_current_user(entity.watchers)`
+	// — are ALSO pushed into the candidate query as a pre-filter
+	// (internal/queryplan.ConditionPrefilters), and derive the same static
+	// index the query does. The per-candidate pass still evaluates the whole
+	// condition and remains authoritative.
+	//
+	// A condition naming the current user requires an identified request:
+	// on a deployment with no identity source the source is refused at
+	// render (never answered with nobody's rows).
 	Condition string `yaml:"condition,omitempty" json:"condition,omitempty"`
 
 	// Count makes this an entity-LESS source: it fires on a whole-graph

--- a/internal/dataentryconfig/nextaction.go
+++ b/internal/dataentryconfig/nextaction.go
@@ -162,8 +162,9 @@ type NextActionSource struct {
 	// condition and remains authoritative.
 	//
 	// A condition naming the current user requires an identified request:
-	// on a deployment with no identity source the source is refused at
-	// render (never answered with nobody's rows).
+	// for an unidentified caller (no identity source configured) the source
+	// contributes nothing and a warning is logged — never nobody's rows, and
+	// never another caller's. Other sources are unaffected.
 	Condition string `yaml:"condition,omitempty" json:"condition,omitempty"`
 
 	// Count makes this an entity-LESS source: it fires on a whole-graph

--- a/internal/nextaction/condition_test.go
+++ b/internal/nextaction/condition_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -172,4 +173,47 @@ func TestCondition_MissingMatcherFailsClosed(t *testing.T) {
 
 func idFor(i int) string {
 	return "T-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+}
+
+// A per-user condition evaluated for a caller with no identity skips THAT
+// source and nothing else: the identity-free source in the lower band still
+// resolves, and the outcome does not depend on which band the short-circuit
+// reaches first.
+func TestCondition_IdentityRequiredSkipsOnlyThatSource(t *testing.T) {
+	cfg := &dataentryconfig.Config{
+		NextActionBands: []dataentryconfig.NextActionBand{{ID: "mine"}, {ID: "ambient"}},
+		NextActions: map[string]dataentryconfig.NextActionSource{
+			"assigned": {Band: "mine", Query: "type:task", Condition: "is_current_user(entity.assignee)", Suggest: "mine"},
+			"anything": {Band: "ambient", Query: "type:task", Suggest: "anything"},
+		},
+	}
+	fn := func(_ context.Context, _ string, _ dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+		return []nextaction.Candidate{{Entity: entity.New("T-1", "task")}}, nil
+	}
+	st := memuserstate.New()
+	t.Cleanup(func() { _ = st.Close() })
+	needsIdentity := &matchIDs{err: nextaction.ErrIdentityRequired}
+	eng, err := nextaction.New(cfg, st, fn, nextaction.WithMatchers(func(id string) (nextaction.Matcher, bool) {
+		if id == "assigned" {
+			return needsIdentity, true
+		}
+		return nil, false
+	}))
+	require.NoError(t, err)
+
+	sug, ok, err := eng.Resolve(context.Background(), "anon", time.Now())
+	require.NoError(t, err, "an unidentified caller must not fail the resolve")
+	require.True(t, ok)
+	require.Equal(t, "anything", sug.Source, "the identity-free source still resolves")
+	require.Equal(t, 1, needsIdentity.seen, "the per-user source was consulted once and then skipped")
+
+	// Any OTHER matcher error still propagates: a broken condition must not
+	// be mistaken for an unidentified caller.
+	broken := &matchIDs{err: errors.New("boom")}
+	eng, err = nextaction.New(cfg, st, fn, nextaction.WithMatchers(func(string) (nextaction.Matcher, bool) {
+		return broken, true
+	}))
+	require.NoError(t, err)
+	_, _, err = eng.Resolve(context.Background(), "anon", time.Now())
+	require.ErrorContains(t, err, "boom")
 }

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -54,11 +54,26 @@ const DefaultCooldown = 24 * time.Hour
 const DefaultCandidateCap = 20
 
 // ErrIdentityRequired is wrapped by a [Matcher] whose condition names the
-// current user when the request carries no usable identity. It lets the
-// HTTP layer report a misconfiguration — a per-user source on a deployment
-// with no identity source — rather than a generic failure, without this
-// package or that layer learning the predicate engine's own error type.
+// current user when the request carries no usable identity — a per-user
+// source resolved for an unauthenticated caller.
+//
+// The engine treats it as a per-source SKIP, not a failure: the source
+// contributes no candidates for that request and a warning is logged (see
+// the engine's condition pass). Propagating it would fail the whole resolve —
+// every band, every other source — and only when the short-circuit happened
+// to reach that source, so the same config would 500 for one caller and
+// answer for another. Contributing nothing is deterministic, fails closed
+// (no rows, never somebody else's), and matches how a source whose world
+// the caller may not read is handled.
 var ErrIdentityRequired = errors.New("nextaction: condition requires an identified principal")
+
+// ErrIdentityConflict is returned by a wiring site's request-scope binder
+// when the request carries TWO identities that disagree — one stamped by a
+// boundary and one derived from the principal. Unlike [ErrIdentityRequired]
+// this is not an unauthenticated caller but two layers disagreeing about who
+// is calling, so it is a refusal of the whole request: evaluating for either
+// would be evaluating for the wrong one.
+var ErrIdentityConflict = errors.New("nextaction: query identity on the context disagrees with the request principal")
 
 // Candidate is one entity a source proposes, already ACL-filtered by the
 // caller's reader.
@@ -367,6 +382,14 @@ func (e *Engine) applyCondition(
 	out := make([]Candidate, 0, len(cands))
 	for _, c := range cands {
 		match, err := m.Match(ctx, c.Entity)
+		if errors.Is(err, ErrIdentityRequired) {
+			// A per-user condition for a caller with no identity: this
+			// source has nothing to say to them. Skip it — see the
+			// sentinel's doc for why this is not propagated.
+			slog.Warn("nextaction: source skipped, its condition needs an identified principal",
+				"source", id)
+			return nil, nil
+		}
 		if err != nil {
 			return nil, fmt.Errorf("nextaction: condition for %q: %w", id, err)
 		}

--- a/internal/nextaction/nextaction.go
+++ b/internal/nextaction/nextaction.go
@@ -53,6 +53,13 @@ const DefaultCooldown = 24 * time.Hour
 // the pick. Engine-owned, not configurable — see the package doc.
 const DefaultCandidateCap = 20
 
+// ErrIdentityRequired is wrapped by a [Matcher] whose condition names the
+// current user when the request carries no usable identity. It lets the
+// HTTP layer report a misconfiguration — a per-user source on a deployment
+// with no identity source — rather than a generic failure, without this
+// package or that layer learning the predicate engine's own error type.
+var ErrIdentityRequired = errors.New("nextaction: condition requires an identified principal")
+
 // Candidate is one entity a source proposes, already ACL-filtered by the
 // caller's reader.
 type Candidate struct {
@@ -106,10 +113,17 @@ type Matcher interface {
 // site so this package depends on no store, searcher or ACL type: it is the
 // consumer-side interface that keeps the engine testable without a graph.
 //
+// It receives the source's config id as well as the source, because the
+// wiring site pairs the candidate query with that source's compiled
+// `condition:` (looked up by id — see [MatcherFunc]) to push the condition's
+// store-evaluable conjuncts into the same query. The engine still runs the
+// whole condition over what comes back; the id only lets the fetch be
+// narrower.
+//
 // Implementations MUST apply the caller's read gate. The engine never sees
 // an entity the principal may not read, which is also why there is no cache
 // here — see [Engine.Resolve].
-type CandidateFunc func(ctx context.Context, src dataentryconfig.NextActionSource) ([]Candidate, error)
+type CandidateFunc func(ctx context.Context, id string, src dataentryconfig.NextActionSource) ([]Candidate, error)
 
 // Suggestion is the resolved hint.
 type Suggestion struct {
@@ -368,7 +382,7 @@ func (e *Engine) applyCondition(
 func (e *Engine) eligibleFromSource(
 	ctx context.Context, user, id string, src dataentryconfig.NextActionSource, bandID string, now time.Time,
 ) ([]Suggestion, error) {
-	cands, err := e.candidates(ctx, src)
+	cands, err := e.candidates(ctx, id, src)
 	if err != nil {
 		return nil, fmt.Errorf("nextaction: candidates for %q: %w", id, err)
 	}

--- a/internal/nextaction/nextaction_test.go
+++ b/internal/nextaction/nextaction_test.go
@@ -34,7 +34,7 @@ func staticCandidates(
 	bySource map[string][]*entity.Entity,
 ) (fn nextaction.CandidateFunc, queriedSuggests *[]string) {
 	var queried []string
-	fn = func(_ context.Context, src dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+	fn = func(_ context.Context, _ string, src dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
 		// Identify the source by its Suggest, which the fixtures make unique.
 		queried = append(queried, src.Suggest)
 		var out []nextaction.Candidate
@@ -323,7 +323,7 @@ func TestInterpolation(t *testing.T) {
 			src.Suggest = tc.suggest
 			cfg.NextActions["urgent"] = src
 
-			fn := func(_ context.Context, s dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+			fn := func(_ context.Context, _ string, s dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
 				if s.Suggest != tc.suggest {
 					return nil, nil
 				}
@@ -399,7 +399,7 @@ func TestResolve_EntitylessSource(t *testing.T) {
 			"first-run": {Band: "blocking", Count: "client == 0", Suggest: "Start with a client?"},
 		},
 	}
-	fn := func(_ context.Context, _ dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
+	fn := func(_ context.Context, _ string, _ dataentryconfig.NextActionSource) ([]nextaction.Candidate, error) {
 		return []nextaction.Candidate{{Entity: nil}}, nil
 	}
 	eng, st := newEngine(t, cfg, fn)

--- a/internal/predicate/prefilter.go
+++ b/internal/predicate/prefilter.go
@@ -1,0 +1,166 @@
+package predicate
+
+import "sort"
+
+// ConstEqualities returns the attributes of recordVar that the program
+// constrains, at the TOP LEVEL of an AND-chain, to be equal to a value
+// that is constant for one evaluation — either a string literal or a
+// field of constVar.
+//
+// # What it is for
+//
+// A store can pre-filter rows by an indexed equality far more cheaply
+// than the Go pass can reject them, but only if the comparison holds for
+// EVERY row the authoritative pass would keep. This reports exactly the
+// comparisons for which that is true, so a caller can lower them to a
+// backend predicate (see internal/queryplan) while still running the
+// full program in Go.
+//
+// # Why the shape is so restricted
+//
+// A pre-filter is sound only if it can never remove a row the
+// authoritative pass would keep, which forces three restrictions:
+//
+//   - Top-level AND only. Under an `or`, either side may be false while
+//     the program is still true, so pushing one branch would drop rows
+//     the program accepts. `not` inverts the sense entirely.
+//   - Equality only. Ordered and inequality comparisons have
+//     backend-vs-Go semantics that differ on typed and missing values;
+//     the store compares by string form, the Go pass by declared type.
+//   - Constant right-hand side. A comparison against another entity
+//     field varies per row and is not a filter the store can bind.
+//
+// Values are returned only for comparisons whose other side is a plain
+// string: a literal, or a string-typed field of constVar (the request's
+// current_user record, whose value the caller supplies at bind time and
+// is therefore the same for every row). For a constVar field the
+// returned Value is empty and FromVar names the field, because the
+// program does not know the identity — the caller does.
+//
+// Pass "" for constVar to consider literals only.
+//
+// The result is sorted by attribute name for deterministic output. A
+// program that constrains the same attribute twice reports it once, with
+// the FIRST binding encountered — a caller must treat the result as a
+// subset of the program's constraints, never as the whole of them.
+func (p *Program) ConstEqualities(recordVar, constVar string) []ConstEquality {
+	if p == nil || recordVar == "" {
+		return nil
+	}
+	seen := map[string]ConstEquality{}
+	collectConstEqualities(p.root, recordVar, constVar, seen)
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]ConstEquality, 0, len(seen))
+	for _, eq := range seen {
+		out = append(out, eq)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Attribute < out[j].Attribute })
+	return out
+}
+
+// ConstEquality is one pushable equality reported by
+// [Program.ConstEqualities].
+//
+// Exactly one of Value and FromVar is meaningful: a literal comparison
+// sets Value, and a comparison against the constant record's field sets
+// FromVar (leaving Value empty for the caller to fill in).
+type ConstEquality struct {
+	// Attribute is the field of recordVar being constrained.
+	Attribute string
+
+	// Value is the string literal the attribute must equal. Meaningful
+	// only when FromVar is empty.
+	Value string
+
+	// FromVar names the field of constVar supplying the value. Empty for
+	// a literal comparison.
+	FromVar string
+}
+
+// collectConstEqualities walks the top-level AND spine only. It
+// deliberately does not descend into `or`, `not`, or any other node:
+// see the soundness argument on [Program.ConstEqualities].
+func collectConstEqualities(n node, recordVar, constVar string, out map[string]ConstEquality) {
+	switch x := n.(type) {
+	case *logicalNode:
+		if x.op != "and" {
+			return
+		}
+		collectConstEqualities(x.lhs, recordVar, constVar, out)
+		collectConstEqualities(x.rhs, recordVar, constVar, out)
+	case *relationalNode:
+		if x.op != "==" {
+			return
+		}
+		attr, eq, ok := constEqualityFrom(x.lhs, x.rhs, recordVar, constVar)
+		if !ok {
+			attr, eq, ok = constEqualityFrom(x.rhs, x.lhs, recordVar, constVar)
+		}
+		if !ok {
+			return
+		}
+		if _, dup := out[attr]; !dup {
+			out[attr] = eq
+		}
+	}
+}
+
+// constEqualityFrom matches `recordVar.attr == <const>` in one operand
+// order, returning the attribute and the constant side.
+func constEqualityFrom(
+	lhs, rhs node, recordVar, constVar string,
+) (string, ConstEquality, bool) {
+	attr, ok := recordAttr(lhs, recordVar)
+	if !ok {
+		return "", ConstEquality{}, false
+	}
+	// Only string-valued equalities are reported. A store pre-filter
+	// compares by string form, so a typed comparison (int, date, bool)
+	// could disagree with the Go pass about the same row — exactly the
+	// widening the belt-and-braces design exists to prevent.
+	if attr := attrTypeOf(lhs); attr != nil && !attr.equalsType(StringType) {
+		return "", ConstEquality{}, false
+	}
+	switch c := rhs.(type) {
+	case *constNode:
+		s, isStr := c.v.(String)
+		if !isStr {
+			return "", ConstEquality{}, false
+		}
+		return attr, ConstEquality{Attribute: attr, Value: s.String()}, true
+	case *attrNode:
+		if constVar == "" {
+			return "", ConstEquality{}, false
+		}
+		field, isVar := recordAttr(c, constVar)
+		if !isVar || !c.typ.equalsType(StringType) {
+			return "", ConstEquality{}, false
+		}
+		return attr, ConstEquality{Attribute: attr, FromVar: field}, true
+	}
+	return "", ConstEquality{}, false
+}
+
+// recordAttr reports the field name when n is a direct attribute access
+// on the named record variable.
+func recordAttr(n node, recordVar string) (string, bool) {
+	a, ok := n.(*attrNode)
+	if !ok {
+		return "", false
+	}
+	v, ok := a.obj.(*varNode)
+	if !ok || v.name != recordVar {
+		return "", false
+	}
+	return a.name, true
+}
+
+// attrTypeOf returns the static type of an attribute node, or nil.
+func attrTypeOf(n node) Type {
+	if a, ok := n.(*attrNode); ok {
+		return a.typ
+	}
+	return nil
+}

--- a/internal/predicate/prefilter.go
+++ b/internal/predicate/prefilter.go
@@ -2,10 +2,39 @@ package predicate
 
 import "sort"
 
-// ConstEqualities returns the attributes of recordVar that the program
-// constrains, at the TOP LEVEL of an AND-chain, to be equal to a value
-// that is constant for one evaluation — either a string literal or a
-// field of constVar.
+// PrefilterSpec names the variables and host functions
+// [Program.ConstEqualities] recognizes as request-constant comparisons.
+//
+// The predicate engine knows nothing about entities or users; the caller
+// tells it which record is the row under test, which record is constant
+// for the request, and which of its own host functions are equality
+// sugar over that constant.
+type PrefilterSpec struct {
+	// RecordVar is the record whose attributes are being constrained (the
+	// entity under test). Required.
+	RecordVar string
+
+	// ConstVar is the record whose fields are constant for one evaluation
+	// (the request's current_user). Optional: empty considers string
+	// literals only.
+	ConstVar string
+
+	// ConstFuncs maps a host-function name to the field of ConstVar its
+	// single argument is compared against. Listing a function here is the
+	// caller's ASSERTION about its semantics, which the engine cannot
+	// verify: `f(RecordVar.attr)` must mean exactly `RecordVar.attr ==
+	// ConstVar.<field>` when attr is a string, and "some element of
+	// RecordVar.attr equals ConstVar.<field>" when attr is a list of
+	// strings. The argument's static type decides which reading applies;
+	// a call whose argument is anything but a direct attribute of
+	// RecordVar is ignored.
+	ConstFuncs map[string]string
+}
+
+// ConstEqualities returns the attributes of the spec's RecordVar that the
+// program constrains, at the TOP LEVEL of an AND-chain, to be equal to a
+// value that is constant for one evaluation — a string literal, a field of
+// ConstVar, or a ConstFuncs call over the attribute.
 //
 // # What it is for
 //
@@ -31,24 +60,26 @@ import "sort"
 //     field varies per row and is not a filter the store can bind.
 //
 // Values are returned only for comparisons whose other side is a plain
-// string: a literal, or a string-typed field of constVar (the request's
-// current_user record, whose value the caller supplies at bind time and
-// is therefore the same for every row). For a constVar field the
-// returned Value is empty and FromVar names the field, because the
-// program does not know the identity — the caller does.
+// string: a literal, or a string-typed field of ConstVar (whose value the
+// caller supplies at bind time and is therefore the same for every row).
+// For a ConstVar field the returned Value is empty and FromVar names the
+// field, because the program does not know the identity — the caller
+// does.
 //
-// Pass "" for constVar to consider literals only.
+// A ConstFuncs call over a LIST attribute is reported with List set: the
+// constraint is membership, not scalar equality, and a caller lowering it
+// must pick a store operation with that meaning.
 //
 // The result is sorted by attribute name for deterministic output. A
 // program that constrains the same attribute twice reports it once, with
 // the FIRST binding encountered — a caller must treat the result as a
 // subset of the program's constraints, never as the whole of them.
-func (p *Program) ConstEqualities(recordVar, constVar string) []ConstEquality {
-	if p == nil || recordVar == "" {
+func (p *Program) ConstEqualities(spec PrefilterSpec) []ConstEquality {
+	if p == nil || spec.RecordVar == "" {
 		return nil
 	}
 	seen := map[string]ConstEquality{}
-	collectConstEqualities(p.root, recordVar, constVar, seen)
+	collectConstEqualities(p.root, spec, seen)
 	if len(seen) == 0 {
 		return nil
 	}
@@ -67,52 +98,64 @@ func (p *Program) ConstEqualities(recordVar, constVar string) []ConstEquality {
 // sets Value, and a comparison against the constant record's field sets
 // FromVar (leaving Value empty for the caller to fill in).
 type ConstEquality struct {
-	// Attribute is the field of recordVar being constrained.
+	// Attribute is the field of RecordVar being constrained.
 	Attribute string
 
 	// Value is the string literal the attribute must equal. Meaningful
 	// only when FromVar is empty.
 	Value string
 
-	// FromVar names the field of constVar supplying the value. Empty for
+	// FromVar names the field of ConstVar supplying the value. Empty for
 	// a literal comparison.
 	FromVar string
+
+	// List reports that Attribute is a list of strings and the constraint
+	// is MEMBERSHIP — some element equals the value — rather than scalar
+	// equality. Only a ConstFuncs call produces it: the language has no
+	// list equality operator.
+	List bool
 }
 
 // collectConstEqualities walks the top-level AND spine only. It
 // deliberately does not descend into `or`, `not`, or any other node:
 // see the soundness argument on [Program.ConstEqualities].
-func collectConstEqualities(n node, recordVar, constVar string, out map[string]ConstEquality) {
+func collectConstEqualities(n node, spec PrefilterSpec, out map[string]ConstEquality) {
+	var (
+		attr string
+		eq   ConstEquality
+		ok   bool
+	)
 	switch x := n.(type) {
 	case *logicalNode:
 		if x.op != "and" {
 			return
 		}
-		collectConstEqualities(x.lhs, recordVar, constVar, out)
-		collectConstEqualities(x.rhs, recordVar, constVar, out)
+		collectConstEqualities(x.lhs, spec, out)
+		collectConstEqualities(x.rhs, spec, out)
+		return
 	case *relationalNode:
 		if x.op != "==" {
 			return
 		}
-		attr, eq, ok := constEqualityFrom(x.lhs, x.rhs, recordVar, constVar)
+		attr, eq, ok = constEqualityFrom(x.lhs, x.rhs, spec)
 		if !ok {
-			attr, eq, ok = constEqualityFrom(x.rhs, x.lhs, recordVar, constVar)
+			attr, eq, ok = constEqualityFrom(x.rhs, x.lhs, spec)
 		}
-		if !ok {
-			return
-		}
-		if _, dup := out[attr]; !dup {
-			out[attr] = eq
-		}
+	case *callNode:
+		attr, eq, ok = constFuncEquality(x, spec)
+	}
+	if !ok {
+		return
+	}
+	if _, dup := out[attr]; !dup {
+		out[attr] = eq
 	}
 }
 
-// constEqualityFrom matches `recordVar.attr == <const>` in one operand
+// constEqualityFrom matches `RecordVar.attr == <const>` in one operand
 // order, returning the attribute and the constant side.
-func constEqualityFrom(
-	lhs, rhs node, recordVar, constVar string,
-) (string, ConstEquality, bool) {
-	attr, ok := recordAttr(lhs, recordVar)
+func constEqualityFrom(lhs, rhs node, spec PrefilterSpec) (string, ConstEquality, bool) {
+	attr, ok := recordAttr(lhs, spec.RecordVar)
 	if !ok {
 		return "", ConstEquality{}, false
 	}
@@ -120,7 +163,7 @@ func constEqualityFrom(
 	// compares by string form, so a typed comparison (int, date, bool)
 	// could disagree with the Go pass about the same row — exactly the
 	// widening the belt-and-braces design exists to prevent.
-	if attr := attrTypeOf(lhs); attr != nil && !attr.equalsType(StringType) {
+	if t := attrTypeOf(lhs); t != nil && !t.equalsType(StringType) {
 		return "", ConstEquality{}, false
 	}
 	switch c := rhs.(type) {
@@ -131,14 +174,37 @@ func constEqualityFrom(
 		}
 		return attr, ConstEquality{Attribute: attr, Value: s.String()}, true
 	case *attrNode:
-		if constVar == "" {
+		if spec.ConstVar == "" {
 			return "", ConstEquality{}, false
 		}
-		field, isVar := recordAttr(c, constVar)
+		field, isVar := recordAttr(c, spec.ConstVar)
 		if !isVar || !c.typ.equalsType(StringType) {
 			return "", ConstEquality{}, false
 		}
 		return attr, ConstEquality{Attribute: attr, FromVar: field}, true
+	}
+	return "", ConstEquality{}, false
+}
+
+// constFuncEquality matches `f(RecordVar.attr)` for an f the spec lists,
+// reading it as equality (string attr) or membership (list-of-string
+// attr) against the ConstVar field the spec maps f to.
+func constFuncEquality(call *callNode, spec PrefilterSpec) (string, ConstEquality, bool) {
+	field, listed := spec.ConstFuncs[call.name]
+	if !listed || spec.ConstVar == "" || len(call.args) != 1 {
+		return "", ConstEquality{}, false
+	}
+	attr, ok := recordAttr(call.args[0], spec.RecordVar)
+	if !ok {
+		return "", ConstEquality{}, false
+	}
+	switch t := attrTypeOf(call.args[0]); {
+	case t == nil:
+		return "", ConstEquality{}, false
+	case t.equalsType(StringType):
+		return attr, ConstEquality{Attribute: attr, FromVar: field}, true
+	case t.equalsType(ListType{Elem: StringType}):
+		return attr, ConstEquality{Attribute: attr, FromVar: field, List: true}, true
 	}
 	return "", ConstEquality{}, false
 }

--- a/internal/predicate/prefilter.go
+++ b/internal/predicate/prefilter.go
@@ -169,7 +169,13 @@ func constEqualityFrom(lhs, rhs node, spec PrefilterSpec) (string, ConstEquality
 	switch c := rhs.(type) {
 	case *constNode:
 		s, isStr := c.v.(String)
-		if !isStr {
+		// An empty literal is refused. Every store backend reads an
+		// empty-valued equality as "is empty" (absent key, null, empty
+		// list), while `x == ''` in this language is false for an unset
+		// attribute (Nil is not String). The direction would still be safe
+		// — the store keeps a superset — but the two operators would mean
+		// different things by the same expression, so it is not reported.
+		if !isStr || s.String() == "" {
 			return "", ConstEquality{}, false
 		}
 		return attr, ConstEquality{Attribute: attr, Value: s.String()}, true

--- a/internal/predicate/prefilter_test.go
+++ b/internal/predicate/prefilter_test.go
@@ -23,10 +23,10 @@ func prefilterEnv(t *testing.T) *Env {
 	}); err != nil {
 		t.Fatalf("declare current_user: %v", err)
 	}
-	if err := env.DeclareFunc("is_me", FuncSig{
+	if err := env.DeclareFunc("is_current_user", FuncSig{
 		Params: []Type{StringType}, Return: BoolType, SQLPortable: true,
 	}); err != nil {
-		t.Fatalf("declare is_me: %v", err)
+		t.Fatalf("declare is_current_user: %v", err)
 	}
 	return env
 }
@@ -98,7 +98,7 @@ func TestConstEqualities(t *testing.T) {
 		},
 		{
 			name: "a host-func call is not an equality",
-			src:  "is_me(entity.assignee)",
+			src:  "is_current_user(entity.assignee)",
 			want: nil,
 		},
 		{

--- a/internal/predicate/prefilter_test.go
+++ b/internal/predicate/prefilter_test.go
@@ -175,6 +175,11 @@ func TestConstEqualities(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "an empty string literal is not pushed: the store reads it as 'is empty'",
+			src:  "entity.status == ''",
+			want: nil,
+		},
+		{
 			name: "a typed (int) equality is not pushed: string-form comparison could disagree",
 			src:  "entity.count == 3",
 			want: nil,

--- a/internal/predicate/prefilter_test.go
+++ b/internal/predicate/prefilter_test.go
@@ -3,7 +3,8 @@ package predicate
 import "testing"
 
 // prefilterEnv is the request-scoped shape: an entity record with mixed
-// property types plus a constant current_user record.
+// property types plus a constant current_user record and the two sugar
+// functions a caller would list in PrefilterSpec.ConstFuncs.
 func prefilterEnv(t *testing.T) *Env {
 	t.Helper()
 	env := NewEnv()
@@ -14,6 +15,8 @@ func prefilterEnv(t *testing.T) *Env {
 		"count":    IntType,
 		"done":     BoolType,
 		"tags":     ListType{Elem: StringType},
+		"watchers": ListType{Elem: StringType},
+		"scores":   ListType{Elem: IntType},
 	}); err != nil {
 		t.Fatalf("declare entity: %v", err)
 	}
@@ -23,12 +26,31 @@ func prefilterEnv(t *testing.T) *Env {
 	}); err != nil {
 		t.Fatalf("declare current_user: %v", err)
 	}
-	if err := env.DeclareFunc("is_current_user", FuncSig{
-		Params: []Type{StringType}, Return: BoolType, SQLPortable: true,
-	}); err != nil {
-		t.Fatalf("declare is_current_user: %v", err)
+	funcs := map[string]FuncSig{
+		"is_current_user":  {Params: []Type{StringType}, Return: BoolType, SQLPortable: true},
+		"has_current_user": {Params: []Type{ListType{Elem: StringType}}, Return: BoolType, SQLPortable: true},
+		// A look-alike the spec does NOT list: proves recognition is
+		// opt-in per function, not by shape.
+		"is_reporter": {Params: []Type{StringType}, Return: BoolType},
+		"any_int":     {Params: []Type{ListType{Elem: IntType}}, Return: BoolType},
+	}
+	for name, sig := range funcs {
+		if err := env.DeclareFunc(name, sig); err != nil {
+			t.Fatalf("declare %s: %v", name, err)
+		}
 	}
 	return env
+}
+
+// fullSpec is what internal/predicatefns hands over: both records and
+// both sugar functions.
+var fullSpec = PrefilterSpec{
+	RecordVar: "entity",
+	ConstVar:  "current_user",
+	ConstFuncs: map[string]string{
+		"is_current_user":  "id",
+		"has_current_user": "id",
+	},
 }
 
 func TestConstEqualities(t *testing.T) {
@@ -70,6 +92,57 @@ func TestConstEqualities(t *testing.T) {
 			},
 		},
 
+		// --- the sugar functions ---
+		{
+			name: "is_current_user over a string attribute is the same equality",
+			src:  "is_current_user(entity.assignee)",
+			want: []ConstEquality{{Attribute: "assignee", FromVar: "id"}},
+		},
+		{
+			name: "has_current_user over a string list is membership",
+			src:  "has_current_user(entity.watchers)",
+			want: []ConstEquality{{Attribute: "watchers", FromVar: "id", List: true}},
+		},
+		{
+			name: "sugar composes with the other conjuncts",
+			src:  "entity.status == 'open' and is_current_user(entity.assignee) and has_current_user(entity.watchers)",
+			want: []ConstEquality{
+				{Attribute: "assignee", FromVar: "id"},
+				{Attribute: "status", Value: "open"},
+				{Attribute: "watchers", FromVar: "id", List: true},
+			},
+		},
+		{
+			name: "a sugar call under an OR pushes nothing",
+			src:  "is_current_user(entity.assignee) or has_current_user(entity.watchers)",
+			want: nil,
+		},
+		{
+			name: "a negated sugar call pushes nothing",
+			src:  "not has_current_user(entity.watchers)",
+			want: nil,
+		},
+		{
+			name: "a sugar call compared as a boolean is not the bare call shape",
+			src:  "is_current_user(entity.assignee) == true",
+			want: nil,
+		},
+		{
+			name: "a sugar call over the constant record's own field is not an entity attribute",
+			src:  "is_current_user(current_user.tool)",
+			want: nil,
+		},
+		{
+			name: "a sugar call over a literal pushes nothing",
+			src:  "is_current_user('PERS-JV')",
+			want: nil,
+		},
+		{
+			name: "a function the spec does not list is not recognized, whatever its shape",
+			src:  "is_reporter(entity.assignee)",
+			want: nil,
+		},
+
 		// --- soundness restrictions: each of these MUST push nothing ---
 		{
 			name: "OR pushes nothing: either branch may be false in a matching row",
@@ -94,11 +167,6 @@ func TestConstEqualities(t *testing.T) {
 		{
 			name: "ordered comparison pushes nothing",
 			src:  "entity.status > 'open'",
-			want: nil,
-		},
-		{
-			name: "a host-func call is not an equality",
-			src:  "is_current_user(entity.assignee)",
 			want: nil,
 		},
 		{
@@ -139,7 +207,7 @@ func TestConstEqualities(t *testing.T) {
 			if err != nil {
 				t.Fatalf("compile %q: %v", tc.src, err)
 			}
-			got := prog.ConstEqualities("entity", "current_user")
+			got := prog.ConstEqualities(fullSpec)
 			if len(got) != len(tc.want) {
 				t.Fatalf("got %d equalities %+v, want %d %+v", len(got), got, len(tc.want), tc.want)
 			}
@@ -153,18 +221,52 @@ func TestConstEqualities(t *testing.T) {
 }
 
 // TestConstEqualities_WithoutConstVar proves the constant record is
-// opt-in: a caller that names no constVar gets literals only, never a
-// field whose value it has no way to supply.
+// opt-in: a caller that names no ConstVar gets literals only, never a
+// field whose value it has no way to supply — and the sugar functions
+// go with it, since they are equalities against that same record.
 func TestConstEqualities_WithoutConstVar(t *testing.T) {
 	prog, err := Compile(prefilterEnv(t),
-		"entity.status == 'open' and entity.assignee == current_user.id")
+		"entity.status == 'open' and entity.assignee == current_user.id and is_current_user(entity.reporter)")
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	got := prog.ConstEqualities("entity", "")
+	got := prog.ConstEqualities(PrefilterSpec{RecordVar: "entity", ConstFuncs: fullSpec.ConstFuncs})
 	want := []ConstEquality{{Attribute: "status", Value: "open"}}
 	if len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestConstEqualities_WithoutConstFuncs proves the sugar functions are
+// opt-in independently of the record: a caller that names the record but
+// lists no functions gets the `==` shapes only.
+func TestConstEqualities_WithoutConstFuncs(t *testing.T) {
+	prog, err := Compile(prefilterEnv(t),
+		"entity.assignee == current_user.id and is_current_user(entity.reporter)")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got := prog.ConstEqualities(PrefilterSpec{RecordVar: "entity", ConstVar: "current_user"})
+	want := []ConstEquality{{Attribute: "assignee", FromVar: "id"}}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestConstEqualities_ListedFuncWithUnsupportedArgType pins that a listed
+// function is still only recognized over the two attribute types whose
+// store lowering is known — a list of ints is neither.
+func TestConstEqualities_ListedFuncWithUnsupportedArgType(t *testing.T) {
+	prog, err := Compile(prefilterEnv(t), "any_int(entity.scores)")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	spec := PrefilterSpec{
+		RecordVar: "entity", ConstVar: "current_user",
+		ConstFuncs: map[string]string{"any_int": "id"},
+	}
+	if got := prog.ConstEqualities(spec); got != nil {
+		t.Fatalf("got %+v, want nil for a list-of-int argument", got)
 	}
 }
 
@@ -172,18 +274,18 @@ func TestConstEqualities_WithoutConstVar(t *testing.T) {
 // than leaving them to a panic at a call site.
 func TestConstEqualities_NilAndEmpty(t *testing.T) {
 	var nilProg *Program
-	if got := nilProg.ConstEqualities("entity", "current_user"); got != nil {
+	if got := nilProg.ConstEqualities(fullSpec); got != nil {
 		t.Fatalf("nil program: got %+v, want nil", got)
 	}
 	prog, err := Compile(prefilterEnv(t), "entity.status == 'open'")
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	if got := prog.ConstEqualities("", "current_user"); got != nil {
-		t.Fatalf("empty recordVar: got %+v, want nil", got)
+	if got := prog.ConstEqualities(PrefilterSpec{ConstVar: "current_user"}); got != nil {
+		t.Fatalf("empty RecordVar: got %+v, want nil", got)
 	}
-	if got := prog.ConstEqualities("nosuchvar", "current_user"); got != nil {
-		t.Fatalf("unknown recordVar: got %+v, want nil", got)
+	if got := prog.ConstEqualities(PrefilterSpec{RecordVar: "nosuchvar", ConstVar: "current_user"}); got != nil {
+		t.Fatalf("unknown RecordVar: got %+v, want nil", got)
 	}
 }
 
@@ -196,8 +298,50 @@ func TestConstEqualities_DuplicateAttributeReportedOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	got := prog.ConstEqualities("entity", "current_user")
+	got := prog.ConstEqualities(fullSpec)
 	if len(got) != 1 || got[0].Attribute != "status" {
 		t.Fatalf("got %+v, want a single status equality", got)
+	}
+}
+
+// TestProgram_ReferencesAndFunctions pins the two dependency accessors a
+// caller uses to decide whether a binding is required at all.
+func TestProgram_ReferencesAndFunctions(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		refsUser  bool
+		functions []string
+	}{
+		{"attribute access references the record", "entity.assignee == current_user.id", true, nil},
+		{"a literal comparison references nothing else", "entity.status == 'open'", false, nil},
+		{"a sugar call is a function, not a variable reference",
+			"is_current_user(entity.assignee)", false, []string{"is_current_user"}},
+		{"functions are sorted and deduplicated",
+			"has_current_user(entity.watchers) and is_current_user(entity.assignee) and is_current_user(entity.reporter)",
+			false, []string{"has_current_user", "is_current_user"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := Compile(prefilterEnv(t), tc.src)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if got := prog.References("current_user"); got != tc.refsUser {
+				t.Fatalf("References(current_user) = %v, want %v", got, tc.refsUser)
+			}
+			if !prog.References("entity") {
+				t.Fatalf("every fixture references entity")
+			}
+			got := prog.Functions()
+			if len(got) != len(tc.functions) {
+				t.Fatalf("Functions() = %v, want %v", got, tc.functions)
+			}
+			for i := range got {
+				if got[i] != tc.functions[i] {
+					t.Fatalf("Functions() = %v, want %v", got, tc.functions)
+				}
+			}
+		})
 	}
 }

--- a/internal/predicate/prefilter_test.go
+++ b/internal/predicate/prefilter_test.go
@@ -350,3 +350,51 @@ func TestProgram_ReferencesAndFunctions(t *testing.T) {
 		})
 	}
 }
+
+// TestProgram_InspectCoversEveryNodeType compiles one expression per sealed
+// node type and reads the dependency accessors, so the default arm in
+// inspect (which panics on an unhandled node) is exercised by construction:
+// a node type added without extending the walk fails here, not at runtime.
+func TestProgram_InspectCoversEveryNodeType(t *testing.T) {
+	env := prefilterEnv(t)
+	if err := env.DeclareFunc("with_table", FuncSig{
+		Params: []Type{StringType, tableArgType{}}, Return: BoolType,
+	}); err != nil {
+		t.Fatalf("declare with_table: %v", err)
+	}
+	value := ValueProfile(StringType)
+	number := ValueProfile(IntType)
+	tests := []struct {
+		name    string
+		src     string
+		profile *Profile // nil → boolean condition profile
+	}{
+		{"const + var + attr + relational", "entity.status == 'x'", nil},
+		{"logical + not", "not (entity.done and entity.count == 1)", nil},
+		{"call", "is_current_user(entity.assignee)", nil},
+		{"table argument", "with_table(entity.status, {mode='x'})", nil},
+		{"arithmetic", "entity.count + 1", &number},
+		{"unary minus", "-entity.count", &number},
+		{"concatenation", "entity.status .. 'x'", &value},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				prog *Program
+				err  error
+			)
+			if tc.profile == nil {
+				prog, err = Compile(env, tc.src)
+			} else {
+				prog, err = CompileValue(env, tc.src, *tc.profile)
+			}
+			if err != nil {
+				t.Fatalf("compile %q: %v", tc.src, err)
+			}
+			if !prog.References("entity") {
+				t.Fatalf("%q: entity not reported as referenced", tc.src)
+			}
+			_ = prog.Functions()
+		})
+	}
+}

--- a/internal/predicate/prefilter_test.go
+++ b/internal/predicate/prefilter_test.go
@@ -1,0 +1,203 @@
+package predicate
+
+import "testing"
+
+// prefilterEnv is the request-scoped shape: an entity record with mixed
+// property types plus a constant current_user record.
+func prefilterEnv(t *testing.T) *Env {
+	t.Helper()
+	env := NewEnv()
+	if err := env.DeclareVar("entity", RecordType{
+		"assignee": StringType,
+		"reporter": StringType,
+		"status":   StringType,
+		"count":    IntType,
+		"done":     BoolType,
+		"tags":     ListType{Elem: StringType},
+	}); err != nil {
+		t.Fatalf("declare entity: %v", err)
+	}
+	if err := env.DeclareVar("current_user", RecordType{
+		"id":   StringType,
+		"tool": StringType,
+	}); err != nil {
+		t.Fatalf("declare current_user: %v", err)
+	}
+	if err := env.DeclareFunc("is_me", FuncSig{
+		Params: []Type{StringType}, Return: BoolType, SQLPortable: true,
+	}); err != nil {
+		t.Fatalf("declare is_me: %v", err)
+	}
+	return env
+}
+
+func TestConstEqualities(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []ConstEquality
+	}{
+		{
+			name: "equality against the constant record is pushable",
+			src:  "entity.assignee == current_user.id",
+			want: []ConstEquality{{Attribute: "assignee", FromVar: "id"}},
+		},
+		{
+			name: "reversed operand order is the same constraint",
+			src:  "current_user.id == entity.assignee",
+			want: []ConstEquality{{Attribute: "assignee", FromVar: "id"}},
+		},
+		{
+			name: "string literal equality is pushable",
+			src:  "entity.status == 'open'",
+			want: []ConstEquality{{Attribute: "status", Value: "open"}},
+		},
+		{
+			name: "an AND chain yields every conjunct",
+			src:  "entity.status == 'open' and entity.assignee == current_user.id",
+			want: []ConstEquality{
+				{Attribute: "assignee", FromVar: "id"},
+				{Attribute: "status", Value: "open"},
+			},
+		},
+		{
+			name: "nested AND is still a top-level chain",
+			src:  "(entity.status == 'open' and entity.reporter == 'x') and entity.assignee == current_user.id",
+			want: []ConstEquality{
+				{Attribute: "assignee", FromVar: "id"},
+				{Attribute: "reporter", Value: "x"},
+				{Attribute: "status", Value: "open"},
+			},
+		},
+
+		// --- soundness restrictions: each of these MUST push nothing ---
+		{
+			name: "OR pushes nothing: either branch may be false in a matching row",
+			src:  "entity.assignee == current_user.id or entity.reporter == current_user.id",
+			want: nil,
+		},
+		{
+			name: "an AND under an OR pushes nothing",
+			src:  "entity.status == 'open' or (entity.assignee == current_user.id and entity.reporter == 'x')",
+			want: nil,
+		},
+		{
+			name: "NOT inverts the sense, so pushes nothing",
+			src:  "not (entity.assignee == current_user.id)",
+			want: nil,
+		},
+		{
+			name: "inequality pushes nothing",
+			src:  "entity.assignee ~= current_user.id",
+			want: nil,
+		},
+		{
+			name: "ordered comparison pushes nothing",
+			src:  "entity.status > 'open'",
+			want: nil,
+		},
+		{
+			name: "a host-func call is not an equality",
+			src:  "is_me(entity.assignee)",
+			want: nil,
+		},
+		{
+			name: "field-to-field equality varies per row",
+			src:  "entity.assignee == entity.reporter",
+			want: nil,
+		},
+		{
+			name: "a typed (int) equality is not pushed: string-form comparison could disagree",
+			src:  "entity.count == 3",
+			want: nil,
+		},
+		{
+			name: "a bool equality is not pushed either",
+			src:  "entity.done == true",
+			want: nil,
+		},
+		{
+			name: "the constant record's own fields are not entity attributes",
+			src:  "current_user.id == 'PERS-JV'",
+			want: nil,
+		},
+		{
+			name: "a mixed AND still pushes the sound conjunct only",
+			src:  "entity.assignee == current_user.id and entity.count == 3",
+			want: []ConstEquality{{Attribute: "assignee", FromVar: "id"}},
+		},
+		{
+			name: "an OR beside a pushable AND conjunct keeps the conjunct",
+			src:  "entity.status == 'open' and (entity.assignee == current_user.id or entity.reporter == 'x')",
+			want: []ConstEquality{{Attribute: "status", Value: "open"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := Compile(prefilterEnv(t), tc.src)
+			if err != nil {
+				t.Fatalf("compile %q: %v", tc.src, err)
+			}
+			got := prog.ConstEqualities("entity", "current_user")
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d equalities %+v, want %d %+v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("equality %d: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestConstEqualities_WithoutConstVar proves the constant record is
+// opt-in: a caller that names no constVar gets literals only, never a
+// field whose value it has no way to supply.
+func TestConstEqualities_WithoutConstVar(t *testing.T) {
+	prog, err := Compile(prefilterEnv(t),
+		"entity.status == 'open' and entity.assignee == current_user.id")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got := prog.ConstEqualities("entity", "")
+	want := []ConstEquality{{Attribute: "status", Value: "open"}}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestConstEqualities_NilAndEmpty covers the degenerate inputs rather
+// than leaving them to a panic at a call site.
+func TestConstEqualities_NilAndEmpty(t *testing.T) {
+	var nilProg *Program
+	if got := nilProg.ConstEqualities("entity", "current_user"); got != nil {
+		t.Fatalf("nil program: got %+v, want nil", got)
+	}
+	prog, err := Compile(prefilterEnv(t), "entity.status == 'open'")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got := prog.ConstEqualities("", "current_user"); got != nil {
+		t.Fatalf("empty recordVar: got %+v, want nil", got)
+	}
+	if got := prog.ConstEqualities("nosuchvar", "current_user"); got != nil {
+		t.Fatalf("unknown recordVar: got %+v, want nil", got)
+	}
+}
+
+// TestConstEqualities_DuplicateAttributeReportedOnce pins the documented
+// contract that the result is a SUBSET of the program's constraints: the
+// Go pass remains authoritative for the one that is dropped.
+func TestConstEqualities_DuplicateAttributeReportedOnce(t *testing.T) {
+	prog, err := Compile(prefilterEnv(t),
+		"entity.status == 'open' and entity.status == 'closed'")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got := prog.ConstEqualities("entity", "current_user")
+	if len(got) != 1 || got[0].Attribute != "status" {
+		t.Fatalf("got %+v, want a single status equality", got)
+	}
+}

--- a/internal/predicate/program.go
+++ b/internal/predicate/program.go
@@ -1,6 +1,9 @@
 package predicate
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // Program is a compiled predicate, ready for repeated evaluation.
 //
@@ -107,6 +110,14 @@ func (p *Program) inspect() {
 		case *concatNode:
 			visit(x.lhs)
 			visit(x.rhs)
+		default:
+			// The node set is sealed (sealedNode), so this is reachable only
+			// from a new node type added without extending this walk. Failing
+			// loudly is the point: References/Functions/Attributes are exact
+			// dependency sets that callers use to decide whether a binding is
+			// REQUIRED, and a node silently skipped here would make a program
+			// look independent of a variable it reads.
+			panic(fmt.Sprintf("predicate: inspect: unhandled node type %T", n))
 		}
 	}
 	visit(p.root)

--- a/internal/predicate/program.go
+++ b/internal/predicate/program.go
@@ -13,6 +13,8 @@ type Program struct {
 	resultTyp   Type
 	env         *Env
 	attributes  map[string]map[string]struct{}
+	vars        map[string]struct{}
+	funcs       map[string]struct{}
 	sqlPortable bool
 }
 
@@ -33,17 +35,44 @@ func (p *Program) Attributes(recordVar string) []string {
 	return out
 }
 
+// References reports whether the program reads the variable at all —
+// bare (passed whole to a host function) or through an attribute. It is
+// the question a caller asks before deciding whether a binding for it is
+// REQUIRED: a program that never names a variable evaluates identically
+// with or without one.
+func (p *Program) References(varName string) bool {
+	_, ok := p.vars[varName]
+	return ok
+}
+
+// Functions returns the host functions the program calls, sorted. Like
+// [Program.Attributes] it is exact: calls are resolved statically, so a
+// caller can decide from this alone whether the program depends on a
+// binding one of them closes over.
+func (p *Program) Functions() []string {
+	out := make([]string, 0, len(p.funcs))
+	for name := range p.funcs {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // SQLPortable reports whether every node and host function in the program has
 // declared target-neutral semantics suitable for a future SQL lowering.
 func (p *Program) SQLPortable() bool { return p.sqlPortable }
 
 func (p *Program) inspect() {
 	p.attributes = map[string]map[string]struct{}{}
+	p.vars = map[string]struct{}{}
+	p.funcs = map[string]struct{}{}
 	p.sqlPortable = true
 	var visit func(node)
 	visit = func(n node) {
 		switch x := n.(type) {
-		case *constNode, *varNode:
+		case *constNode:
+		case *varNode:
+			p.vars[x.name] = struct{}{}
 		case *attrNode:
 			if v, ok := x.obj.(*varNode); ok {
 				if p.attributes[v.name] == nil {
@@ -53,6 +82,7 @@ func (p *Program) inspect() {
 			}
 			visit(x.obj)
 		case *callNode:
+			p.funcs[x.name] = struct{}{}
 			if sig, ok := p.env.lookupFunc(x.name); !ok || !sig.SQLPortable {
 				p.sqlPortable = false
 			}

--- a/internal/predicatefns/currentuser.go
+++ b/internal/predicatefns/currentuser.go
@@ -187,6 +187,13 @@ func CurrentUserFuncs() map[string]predicate.FuncSig {
 // the SAME semantics rather than reimplement them. Two implementations
 // of "is this the current user" that disagree on, say, an unset property
 // is exactly the drift this avoids.
+//
+// An EMPTY identity binds functions that never match. [BindCurrentUser]
+// refuses to reach this point at all (ErrNoCurrentUser), but a caller that
+// must still evaluate the rest of an expression without an identity — an
+// affordance `when:` on an unauthenticated deployment — gets the
+// fail-closed reading here rather than "matches every entity whose
+// property is the empty string".
 func CurrentUserBindings(identity string) map[string]predicate.FuncFunc {
 	return map[string]predicate.FuncFunc{
 		FuncIsCurrentUser:  isCurrentUser(identity),
@@ -321,10 +328,8 @@ func isCurrentUser(identity string) predicate.FuncFunc {
 		case predicate.Nil:
 			return predicate.NewBool(false), nil
 		case predicate.String:
-			// identity is non-empty (QueryIdentity.Valid gates the
-			// binding), so this cannot degenerate into matching every
-			// entity whose property is unset.
-			return predicate.NewBool(v.String() == identity), nil
+			// An empty identity matches nothing — see CurrentUserBindings.
+			return predicate.NewBool(identity != "" && v.String() == identity), nil
 		default:
 			return nil, errArg
 		}
@@ -345,6 +350,9 @@ func hasCurrentUser(identity string) predicate.FuncFunc {
 		case predicate.Nil:
 			return predicate.NewBool(false), nil
 		case predicate.List:
+			if identity == "" {
+				return predicate.NewBool(false), nil
+			}
 			for _, e := range v.Elems() {
 				if s, ok := e.(predicate.String); ok && s.String() == identity {
 					return predicate.NewBool(true), nil
@@ -391,6 +399,12 @@ type PrincipalResolver interface {
 // An unstamped context yields an invalid identity (not an error): "no
 // identity" is a legitimate state for the CLI and the scheduler, and it
 // is [BindCurrentUser] that refuses to evaluate against it.
+//
+// No request boundary calls this yet. The next-action adapter
+// (internal/appbuild) reads the principal the data-entry router has
+// ALREADY resolved instead, which is equivalent on that transport; the
+// boundary stamp that makes every surface share one derivation is the
+// first step of the `where:`-surfaces follow-up (TKT-ZQV9O5).
 func ResolveQueryIdentity(
 	ctx context.Context, r PrincipalResolver, rawUser, tool string,
 ) (QueryIdentity, error) {

--- a/internal/predicatefns/currentuser.go
+++ b/internal/predicatefns/currentuser.go
@@ -1,0 +1,281 @@
+package predicatefns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+)
+
+// Names of the current-user surface. Exported so generated predicate
+// source (FromFilter, and any future sugar) references them without
+// stringly-typed drift, exactly as the stdlib names above do.
+const (
+	// VarCurrentUser is the record variable naming the request's identity.
+	VarCurrentUser = "current_user"
+
+	// VarEntity is the record variable naming the entity under test. It
+	// is declared by the Evaluator rather than here, but the name is
+	// exported alongside VarCurrentUser so a pushdown caller naming both
+	// records reads them from one place.
+	VarEntity = "entity"
+
+	// FieldCurrentUserID is the identity field of [VarCurrentUser] — the
+	// only field a pushdown may resolve to a value.
+	FieldCurrentUserID = "id"
+
+	// FuncIsMe reports whether a string equals the current user's query
+	// identity: is_me(entity.assignee).
+	FuncIsMe = "is_me"
+
+	// FuncMeIn reports whether the current user's query identity appears
+	// in a list of strings: me_in(entity.watchers).
+	FuncMeIn = "me_in"
+)
+
+// CurrentUserType is the declared shape of [VarCurrentUser].
+//
+// It is a RECORD, not a bare string, and that is a compatibility
+// constraint rather than a preference: operator-authored acl.yaml
+// already passes the variable whole to affordance host functions
+// (`has_role(current_user, entity, "editor")`), and internal/affordances
+// declares it as predicate.RecordType. Redeclaring it as a string here
+// would make the same identifier mean two different types in two
+// dialects an operator experiences as one language.
+//
+// The fields mirror internal/affordances/env.go so a `when:` clause and
+// a query condition read identically:
+//
+//   - id   — the query identity (see [QueryIdentity]).
+//   - tool — the entry-point tool ("data-entry", "mcp", "cli", ...).
+//
+// As in affordances, `tool` is NOT a user classification. It exists for
+// diagnostics and transport-shaped conditions; authorization gates by
+// role, never by inspecting it.
+var CurrentUserType = predicate.RecordType{
+	"id":   predicate.StringType,
+	"tool": predicate.StringType,
+}
+
+// ErrNoCurrentUser is returned by [BindCurrentUser] when the context
+// carries no usable query identity.
+//
+// It is an ERROR rather than a nil/empty binding by deliberate design.
+// An empty identity would make `entity.assignee == current_user.id`
+// match every entity whose assignee is unset — turning "who am I?"
+// being unanswerable into a filter that silently WIDENS. Every other
+// direction in this codebase fails closed (acl.ResolvePrincipal returns
+// no id on ambiguity; an unparseable where: clause is a load error), and
+// a personal inbox that shows a stranger's rows is the worst version of
+// getting this wrong.
+var ErrNoCurrentUser = errors.New("predicatefns: no current user on this context")
+
+// QueryIdentity is the value `current_user.id` binds to.
+//
+// # Why a distinct type
+//
+// The string a principal carries is NOT stable across transports.
+// internal/dataentry rewrites principal.User to the resolved user-entity
+// id on /api/ (resolvePrincipalEntity), while CLI, MCP, scheduler and
+// desktop keep the raw identifier — acl.Declarative.ResolvePrincipal
+// documents that split and its fail-closed rationale. A query condition
+// compares against entity DATA (`entity.assignee`, which holds an entity
+// id), so binding whichever string happened to be on the context would
+// make the same view correct in the browser and silently empty from the
+// CLI.
+//
+// So the identity is resolved ONCE, by the wiring site that knows the
+// ACL policy, and carried on the context as this type. Consumers bind it
+// verbatim; they never re-derive it from principal.User.
+type QueryIdentity struct {
+	// EntityID is the user entity this principal resolves to. Empty when
+	// the deployment configures no user_entity_type, in which case there
+	// is no entity id to compare against and Raw is used instead.
+	EntityID string
+
+	// Raw is the underlying principal identifier (an email, a UPN, a
+	// service account name).
+	Raw string
+
+	// Tool is the entry-point tool, bound to current_user.tool.
+	Tool string
+}
+
+// ID returns the value bound to current_user.id: the resolved user
+// entity id when the deployment has one, else the raw principal.
+//
+// Preferring the entity id is what makes `entity.assignee ==
+// current_user.id` mean what an operator reads it to mean, since an
+// assignee property holds an entity id. Falling back to the raw
+// identifier keeps the feature usable in deployments with no user
+// entity type at all (the data-entry prototype is one), where the raw
+// string IS the only identity the graph could reference.
+func (q QueryIdentity) ID() string {
+	if q.EntityID != "" {
+		return q.EntityID
+	}
+	return q.Raw
+}
+
+// Valid reports whether this identity can be compared against graph
+// data. A zero QueryIdentity is invalid, which is what makes the
+// unstamped-context case fail closed.
+func (q QueryIdentity) Valid() bool { return q.ID() != "" }
+
+type queryIdentityKey struct{}
+
+// WithQueryIdentity stamps the resolved identity on ctx.
+//
+// Call it at a REQUEST boundary that has already resolved the principal
+// against the ACL policy. It is deliberately not derived lazily inside
+// the evaluator: resolution is a store lookup, and doing it per matched
+// entity would turn one list render into one query per row.
+func WithQueryIdentity(ctx context.Context, q QueryIdentity) context.Context {
+	return context.WithValue(ctx, queryIdentityKey{}, q)
+}
+
+// QueryIdentityFrom returns the identity stamped on ctx, if any.
+//
+// Absence is reported rather than defaulted. principal.From supplies an
+// "unknown/unknown" default for attribution, which is right for an audit
+// record and wrong here: "unknown" is not a user id, and binding it
+// would let a condition match an entity whose assignee is literally
+// "unknown".
+func QueryIdentityFrom(ctx context.Context) (QueryIdentity, bool) {
+	q, ok := ctx.Value(queryIdentityKey{}).(QueryIdentity)
+	if !ok || !q.Valid() {
+		return QueryIdentity{}, false
+	}
+	return q, true
+}
+
+// DeclareCurrentUser registers the current-user variable and its sugar
+// functions on env.
+//
+// Kept SEPARATE from [Declare] rather than folded into it, because the
+// stdlib is safe everywhere and this is not. Validation compiles with
+// context.Background() (internal/validation), the scheduler and mail
+// templates compile at load with no request in sight, and index
+// derivation compiles a query shape with no user at all. Those profiles
+// must NOT declare current_user: referencing it there is an operator
+// mistake, and an undeclared variable is a COMPILE error naming the line
+// — which is the failure an operator can act on, and the direction
+// CLAUDE.md mandates for a condition that cannot be honored.
+//
+// Call it after DeclareVar("entity", ...) and before Compile, alongside
+// [Declare].
+func DeclareCurrentUser(env *predicate.Env) error {
+	if err := env.DeclareVar(VarCurrentUser, CurrentUserType); err != nil {
+		return fmt.Errorf("predicatefns: declare %s: %w", VarCurrentUser, err)
+	}
+	str := predicate.StringType
+	decls := []struct {
+		name string
+		sig  predicate.FuncSig
+	}{
+		// Both are SQL-portable: each compares stored data against a
+		// scalar that is CONSTANT for the request, which is exactly the
+		// shape a pushdown binds as a query parameter. Classifying them
+		// portable is what lets a future predicate->SQL compiler push
+		// `is_me(entity.assignee)` down as `assignee = $1`; it does not
+		// by itself perform any pushdown.
+		{FuncIsMe, predicate.FuncSig{Params: []predicate.Type{str}, Return: predicate.BoolType, SQLPortable: true}},
+		{FuncMeIn, predicate.FuncSig{
+			Params: []predicate.Type{predicate.ListType{Elem: predicate.StringType}},
+			Return: predicate.BoolType, SQLPortable: true,
+		}},
+	}
+	for _, d := range decls {
+		if err := env.DeclareFunc(d.name, d.sig); err != nil {
+			return fmt.Errorf("predicatefns: declare %s: %w", d.name, err)
+		}
+	}
+	return nil
+}
+
+// BindCurrentUser binds the variable and sugar functions declared by
+// [DeclareCurrentUser], reading the identity from ctx.
+//
+// Returns [ErrNoCurrentUser] when ctx carries none. A caller that
+// compiled a program referencing current_user and then cannot bind it
+// has a wiring bug, and surfacing it beats evaluating a condition whose
+// identity is a guess.
+func BindCurrentUser(ctx context.Context, b *predicate.Bindings) error {
+	q, ok := QueryIdentityFrom(ctx)
+	if !ok {
+		return ErrNoCurrentUser
+	}
+	me := q.ID()
+	if err := b.SetVar(VarCurrentUser, predicate.NewRecord(map[string]predicate.Value{
+		"id":   predicate.NewString(me),
+		"tool": predicate.NewString(q.Tool),
+	})); err != nil {
+		return err
+	}
+	binds := []struct {
+		name string
+		fn   predicate.FuncFunc
+	}{
+		{FuncIsMe, isMe(me)},
+		{FuncMeIn, meIn(me)},
+	}
+	for _, bd := range binds {
+		if err := b.SetFunc(bd.name, bd.fn); err != nil {
+			return fmt.Errorf("predicatefns: bind %s: %w", bd.name, err)
+		}
+	}
+	return nil
+}
+
+// isMe implements is_me(s).
+//
+// A Nil argument (an unset property binds Nil, per coerceScalar) is a
+// non-match rather than an error: `is_me(entity.assignee)` on an
+// unassigned entity is a legitimate question with the answer "no". Only
+// a genuinely off-type argument fails, which the type checker should
+// already have rejected.
+func isMe(me string) predicate.FuncFunc {
+	return func(_ context.Context, args []predicate.Value) (predicate.Value, error) {
+		if len(args) != 1 {
+			return nil, errArg
+		}
+		switch v := args[0].(type) {
+		case predicate.Nil:
+			return predicate.NewBool(false), nil
+		case predicate.String:
+			// me is non-empty (QueryIdentity.Valid gates the binding), so
+			// this cannot degenerate into matching every empty property.
+			return predicate.NewBool(v.String() == me), nil
+		default:
+			return nil, errArg
+		}
+	}
+}
+
+// meIn implements me_in(list).
+//
+// Argument order follows contains(list, elem) — the stdlib member of
+// this package — rather than affordances' string_in_list(value, list).
+// The two disagree already; a third convention would be worse than
+// picking the one a caller of this package meets first.
+func meIn(me string) predicate.FuncFunc {
+	return func(_ context.Context, args []predicate.Value) (predicate.Value, error) {
+		if len(args) != 1 {
+			return nil, errArg
+		}
+		switch v := args[0].(type) {
+		case predicate.Nil:
+			return predicate.NewBool(false), nil
+		case predicate.List:
+			for _, e := range v.Elems() {
+				if s, ok := e.(predicate.String); ok && s.String() == me {
+					return predicate.NewBool(true), nil
+				}
+			}
+			return predicate.NewBool(false), nil
+		default:
+			return nil, errArg
+		}
+	}
+}

--- a/internal/predicatefns/currentuser.go
+++ b/internal/predicatefns/currentuser.go
@@ -194,6 +194,57 @@ func CurrentUserBindings(identity string) map[string]predicate.FuncFunc {
 	}
 }
 
+// CurrentUserPrefilterSpec is the [predicate.PrefilterSpec] a pushdown
+// hands to [predicate.Program.ConstEqualities] to lower current-user
+// comparisons: the entity record under test, the constant current_user
+// record, and the two sugar functions read as equalities against its id.
+//
+// Defined HERE, beside the implementations it describes, because the
+// spec is an assertion about what the functions mean — is_current_user(s)
+// is `s == current_user.id`, has_current_user(xs) is "current_user.id is
+// an element of xs" — and the engine cannot check it. Keeping the
+// assertion in the file that defines the functions is what stops the two
+// from drifting.
+func CurrentUserPrefilterSpec() predicate.PrefilterSpec {
+	return predicate.PrefilterSpec{
+		RecordVar: VarEntity,
+		ConstVar:  VarCurrentUser,
+		ConstFuncs: map[string]string{
+			FuncIsCurrentUser:  FieldCurrentUserID,
+			FuncHasCurrentUser: FieldCurrentUserID,
+		},
+	}
+}
+
+// RequiresCurrentUser reports whether evaluating prog needs an identity:
+// it references the current_user record, or calls one of the sugar
+// functions that close over it.
+//
+// This is what lets one request-scoped profile serve conditions with and
+// without an identity clause. A program compiled with current_user
+// DECLARED but never USED evaluates identically with or without the
+// binding, so refusing it for want of an identity would fail a plain
+// `entity.status == 'todo'` on every unauthenticated deployment for no
+// gain. Only a program that would actually read the identity is held to
+// [ErrNoCurrentUser].
+//
+// Nil: accepted — a nil program requires nothing.
+func RequiresCurrentUser(prog *predicate.Program) bool {
+	if prog == nil {
+		return false
+	}
+	if prog.References(VarCurrentUser) {
+		return true
+	}
+	funcs := CurrentUserFuncs()
+	for _, name := range prog.Functions() {
+		if _, ok := funcs[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // DeclareCurrentUser registers the current-user variable and its sugar
 // functions on env.
 //

--- a/internal/predicatefns/currentuser.go
+++ b/internal/predicatefns/currentuser.go
@@ -25,13 +25,14 @@ const (
 	// only field a pushdown may resolve to a value.
 	FieldCurrentUserID = "id"
 
-	// FuncIsMe reports whether a string equals the current user's query
-	// identity: is_me(entity.assignee).
-	FuncIsMe = "is_me"
+	// FuncIsCurrentUser reports whether a string equals the current
+	// user's query identity: is_current_user(entity.assignee).
+	FuncIsCurrentUser = "is_current_user"
 
-	// FuncMeIn reports whether the current user's query identity appears
-	// in a list of strings: me_in(entity.watchers).
-	FuncMeIn = "me_in"
+	// FuncHasCurrentUser reports whether the current user's query
+	// identity appears in a list of strings:
+	// has_current_user(entity.watchers).
+	FuncHasCurrentUser = "has_current_user"
 )
 
 // CurrentUserType is the declared shape of [VarCurrentUser].
@@ -178,10 +179,12 @@ func DeclareCurrentUser(env *predicate.Env) error {
 		// scalar that is CONSTANT for the request, which is exactly the
 		// shape a pushdown binds as a query parameter. Classifying them
 		// portable is what lets a future predicate->SQL compiler push
-		// `is_me(entity.assignee)` down as `assignee = $1`; it does not
+		// `is_current_user(entity.assignee)` down as `assignee = $1`; it does not
 		// by itself perform any pushdown.
-		{FuncIsMe, predicate.FuncSig{Params: []predicate.Type{str}, Return: predicate.BoolType, SQLPortable: true}},
-		{FuncMeIn, predicate.FuncSig{
+		{FuncIsCurrentUser, predicate.FuncSig{
+			Params: []predicate.Type{str}, Return: predicate.BoolType, SQLPortable: true,
+		}},
+		{FuncHasCurrentUser, predicate.FuncSig{
 			Params: []predicate.Type{predicate.ListType{Elem: predicate.StringType}},
 			Return: predicate.BoolType, SQLPortable: true,
 		}},
@@ -206,9 +209,9 @@ func BindCurrentUser(ctx context.Context, b *predicate.Bindings) error {
 	if !ok {
 		return ErrNoCurrentUser
 	}
-	me := q.ID()
+	identity := q.ID()
 	if err := b.SetVar(VarCurrentUser, predicate.NewRecord(map[string]predicate.Value{
-		"id":   predicate.NewString(me),
+		"id":   predicate.NewString(identity),
 		"tool": predicate.NewString(q.Tool),
 	})); err != nil {
 		return err
@@ -217,8 +220,8 @@ func BindCurrentUser(ctx context.Context, b *predicate.Bindings) error {
 		name string
 		fn   predicate.FuncFunc
 	}{
-		{FuncIsMe, isMe(me)},
-		{FuncMeIn, meIn(me)},
+		{FuncIsCurrentUser, isCurrentUser(identity)},
+		{FuncHasCurrentUser, hasCurrentUser(identity)},
 	}
 	for _, bd := range binds {
 		if err := b.SetFunc(bd.name, bd.fn); err != nil {
@@ -228,14 +231,14 @@ func BindCurrentUser(ctx context.Context, b *predicate.Bindings) error {
 	return nil
 }
 
-// isMe implements is_me(s).
+// isCurrentUser implements is_current_user(s).
 //
 // A Nil argument (an unset property binds Nil, per coerceScalar) is a
-// non-match rather than an error: `is_me(entity.assignee)` on an
+// non-match rather than an error: is_current_user(entity.assignee) on an
 // unassigned entity is a legitimate question with the answer "no". Only
 // a genuinely off-type argument fails, which the type checker should
 // already have rejected.
-func isMe(me string) predicate.FuncFunc {
+func isCurrentUser(identity string) predicate.FuncFunc {
 	return func(_ context.Context, args []predicate.Value) (predicate.Value, error) {
 		if len(args) != 1 {
 			return nil, errArg
@@ -244,22 +247,22 @@ func isMe(me string) predicate.FuncFunc {
 		case predicate.Nil:
 			return predicate.NewBool(false), nil
 		case predicate.String:
-			// me is non-empty (QueryIdentity.Valid gates the binding), so
-			// this cannot degenerate into matching every empty property.
-			return predicate.NewBool(v.String() == me), nil
+			// identity is non-empty (QueryIdentity.Valid gates the
+			// binding), so this cannot degenerate into matching every
+			// entity whose property is unset.
+			return predicate.NewBool(v.String() == identity), nil
 		default:
 			return nil, errArg
 		}
 	}
 }
 
-// meIn implements me_in(list).
+// hasCurrentUser implements has_current_user(list).
 //
-// Argument order follows contains(list, elem) — the stdlib member of
-// this package — rather than affordances' string_in_list(value, list).
-// The two disagree already; a third convention would be worse than
-// picking the one a caller of this package meets first.
-func meIn(me string) predicate.FuncFunc {
+// Named for the LIST, not the user: it reads as a question about the
+// property being tested ("do the watchers include the current user?"),
+// which is the direction an operator is thinking in when they write it.
+func hasCurrentUser(identity string) predicate.FuncFunc {
 	return func(_ context.Context, args []predicate.Value) (predicate.Value, error) {
 		if len(args) != 1 {
 			return nil, errArg
@@ -269,7 +272,7 @@ func meIn(me string) predicate.FuncFunc {
 			return predicate.NewBool(false), nil
 		case predicate.List:
 			for _, e := range v.Elems() {
-				if s, ok := e.(predicate.String); ok && s.String() == me {
+				if s, ok := e.(predicate.String); ok && s.String() == identity {
 					return predicate.NewBool(true), nil
 				}
 			}

--- a/internal/predicatefns/currentuser.go
+++ b/internal/predicatefns/currentuser.go
@@ -243,13 +243,21 @@ func RequiresCurrentUser(prog *predicate.Program) bool {
 	if prog.References(VarCurrentUser) {
 		return true
 	}
-	funcs := CurrentUserFuncs()
 	for _, name := range prog.Functions() {
-		if _, ok := funcs[name]; ok {
+		if _, ok := currentUserFuncNames[name]; ok {
 			return true
 		}
 	}
 	return false
+}
+
+// currentUserFuncNames is the set of sugar-function names, precomputed so
+// RequiresCurrentUser — called per candidate on the query path — does not
+// rebuild the signature map each time. Kept in step with [CurrentUserFuncs]
+// by TestCurrentUserPrefilterSpec_MatchesTheDeclaredFuncs.
+var currentUserFuncNames = map[string]struct{}{
+	FuncIsCurrentUser:  {},
+	FuncHasCurrentUser: {},
 }
 
 // DeclareCurrentUser registers the current-user variable and its sugar

--- a/internal/predicatefns/currentuser.go
+++ b/internal/predicatefns/currentuser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/predicate"
@@ -152,6 +153,47 @@ func QueryIdentityFrom(ctx context.Context) (QueryIdentity, bool) {
 	return q, true
 }
 
+// CurrentUserFuncs returns the sugar-function signatures, so a package
+// that declares its own host-function set (internal/affordances) can add
+// them without also inheriting the stdlib.
+//
+// Pair every entry with the matching [CurrentUserBindings] entry: the
+// two are keyed by the same names and must not drift.
+func CurrentUserFuncs() map[string]predicate.FuncSig {
+	str := predicate.StringType
+	return map[string]predicate.FuncSig{
+		// Both are SQL-portable: each compares stored data against a
+		// scalar that is CONSTANT for the request, which is exactly the
+		// shape a pushdown binds as a query parameter. Classifying them
+		// portable is what lets a future predicate->SQL compiler push
+		// `is_current_user(entity.assignee)` down as `assignee = $1`; it
+		// does not by itself perform any pushdown.
+		FuncIsCurrentUser: {
+			Params: []predicate.Type{str}, Return: predicate.BoolType, SQLPortable: true,
+		},
+		FuncHasCurrentUser: {
+			Params: []predicate.Type{predicate.ListType{Elem: predicate.StringType}},
+			Return: predicate.BoolType, SQLPortable: true,
+		},
+	}
+}
+
+// CurrentUserBindings returns the sugar implementations closed over
+// identity — the value bound to current_user.id.
+//
+// Exported for the same reason as [CurrentUserFuncs]: a package with its
+// own identity source (affordances resolves the principal through its
+// own resolver, not through [QueryIdentityFrom]) must be able to bind
+// the SAME semantics rather than reimplement them. Two implementations
+// of "is this the current user" that disagree on, say, an unset property
+// is exactly the drift this avoids.
+func CurrentUserBindings(identity string) map[string]predicate.FuncFunc {
+	return map[string]predicate.FuncFunc{
+		FuncIsCurrentUser:  isCurrentUser(identity),
+		FuncHasCurrentUser: hasCurrentUser(identity),
+	}
+}
+
 // DeclareCurrentUser registers the current-user variable and its sugar
 // functions on env.
 //
@@ -171,31 +213,18 @@ func DeclareCurrentUser(env *predicate.Env) error {
 	if err := env.DeclareVar(VarCurrentUser, CurrentUserType); err != nil {
 		return fmt.Errorf("predicatefns: declare %s: %w", VarCurrentUser, err)
 	}
-	str := predicate.StringType
-	decls := []struct {
-		name string
-		sig  predicate.FuncSig
-	}{
-		// Both are SQL-portable: each compares stored data against a
-		// scalar that is CONSTANT for the request, which is exactly the
-		// shape a pushdown binds as a query parameter. Classifying them
-		// portable is what lets a future predicate->SQL compiler push
-		// `is_current_user(entity.assignee)` down as `assignee = $1`; it does not
-		// by itself perform any pushdown.
-		{FuncIsCurrentUser, predicate.FuncSig{
-			Params: []predicate.Type{str}, Return: predicate.BoolType, SQLPortable: true,
-		}},
-		{FuncHasCurrentUser, predicate.FuncSig{
-			Params: []predicate.Type{predicate.ListType{Elem: predicate.StringType}},
-			Return: predicate.BoolType, SQLPortable: true,
-		}},
+	return DeclareCurrentUserFuncs(env)
+}
+
+// sortedFuncNames orders a signature map so declaration (and any error
+// it produces) is deterministic across runs.
+func sortedFuncNames(m map[string]predicate.FuncSig) []string {
+	out := make([]string, 0, len(m))
+	for name := range m {
+		out = append(out, name)
 	}
-	for _, d := range decls {
-		if err := env.DeclareFunc(d.name, d.sig); err != nil {
-			return fmt.Errorf("predicatefns: declare %s: %w", d.name, err)
-		}
-	}
-	return nil
+	sort.Strings(out)
+	return out
 }
 
 // BindCurrentUser binds the variable and sugar functions declared by
@@ -217,16 +246,9 @@ func BindCurrentUser(ctx context.Context, b *predicate.Bindings) error {
 	})); err != nil {
 		return err
 	}
-	binds := []struct {
-		name string
-		fn   predicate.FuncFunc
-	}{
-		{FuncIsCurrentUser, isCurrentUser(identity)},
-		{FuncHasCurrentUser, hasCurrentUser(identity)},
-	}
-	for _, bd := range binds {
-		if err := b.SetFunc(bd.name, bd.fn); err != nil {
-			return fmt.Errorf("predicatefns: bind %s: %w", bd.name, err)
+	for name, fn := range CurrentUserBindings(identity) {
+		if err := b.SetFunc(name, fn); err != nil {
+			return fmt.Errorf("predicatefns: bind %s: %w", name, err)
 		}
 	}
 	return nil
@@ -336,4 +358,20 @@ func ResolveQueryIdentity(
 		q.EntityID = id
 	}
 	return q, nil
+}
+
+// DeclareCurrentUserFuncs registers ONLY the sugar functions, without
+// the current_user variable or the stdlib.
+//
+// For a package that declares current_user itself (internal/affordances
+// binds it from its own resolver) but wants the shared sugar. Use
+// [DeclareCurrentUser] when the variable is not already declared.
+func DeclareCurrentUserFuncs(env *predicate.Env) error {
+	funcs := CurrentUserFuncs()
+	for _, name := range sortedFuncNames(funcs) {
+		if err := env.DeclareFunc(name, funcs[name]); err != nil {
+			return fmt.Errorf("predicatefns: declare %s: %w", name, err)
+		}
+	}
+	return nil
 }

--- a/internal/predicatefns/currentuser.go
+++ b/internal/predicatefns/currentuser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Sourcehaven-BV/rela/internal/predicate"
 )
@@ -281,4 +282,58 @@ func hasCurrentUser(identity string) predicate.FuncFunc {
 			return nil, errArg
 		}
 	}
+}
+
+// PrincipalResolver maps a raw principal identifier to the user entity
+// that represents it, or "" when the deployment configures no user
+// entity type or the identifier matches none.
+//
+// Consumer-side interface (see docs/architecture/consumer-side-interfaces.md):
+// the one implementation is acl.Declarative.ResolvePrincipal, but
+// predicatefns must not depend on internal/acl — and the one method it
+// needs is far narrower than that type's surface. The wiring site
+// supplies it.
+//
+// Nil: accepted by [ResolveQueryIdentity], which then treats the
+// deployment as having no user entity type.
+type PrincipalResolver interface {
+	ResolvePrincipal(ctx context.Context, rawUser string) (string, error)
+}
+
+// ResolveQueryIdentity builds the [QueryIdentity] for the principal
+// carried on ctx, resolving it through r when one is supplied.
+//
+// This is the single place a transport turns "who is calling" into "what
+// string do I compare against graph data", so every surface agrees. Call
+// it once per request at the boundary and stamp the result with
+// [WithQueryIdentity]; do not call it per row.
+//
+// A resolver error is returned rather than swallowed. The caller decides
+// whether to fail the request or proceed without an identity — but an
+// identity that silently degrades to the raw principal after a backend
+// error would compare against a DIFFERENT namespace than the one the
+// operator wrote the condition for, and match the wrong rows rather than
+// none.
+//
+// An unstamped context yields an invalid identity (not an error): "no
+// identity" is a legitimate state for the CLI and the scheduler, and it
+// is [BindCurrentUser] that refuses to evaluate against it.
+func ResolveQueryIdentity(
+	ctx context.Context, r PrincipalResolver, rawUser, tool string,
+) (QueryIdentity, error) {
+	q := QueryIdentity{Raw: strings.TrimSpace(rawUser), Tool: tool}
+	if q.Raw == "" || r == nil {
+		return q, nil
+	}
+	id, err := r.ResolvePrincipal(ctx, q.Raw)
+	if err != nil {
+		return QueryIdentity{}, fmt.Errorf("predicatefns: resolve current user: %w", err)
+	}
+	// id == raw means "resolved to itself", which carries no more
+	// information than Raw already does; leaving EntityID empty keeps
+	// ID()'s fallback the single explanation of the value.
+	if id != "" && id != q.Raw {
+		q.EntityID = id
+	}
+	return q, nil
 }

--- a/internal/predicatefns/currentuser_test.go
+++ b/internal/predicatefns/currentuser_test.go
@@ -1,0 +1,338 @@
+package predicatefns_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
+)
+
+// compileWithUser builds the request-scoped profile: entity + stdlib +
+// current_user. Mirrors what a view condition would use.
+func compileWithUser(t *testing.T, src string, entityFields predicate.RecordType) *predicate.Program {
+	t.Helper()
+	env := predicate.NewEnv()
+	if err := env.DeclareVar("entity", entityFields); err != nil {
+		t.Fatalf("declare entity: %v", err)
+	}
+	if err := predicatefns.Declare(env); err != nil {
+		t.Fatalf("declare stdlib: %v", err)
+	}
+	if err := predicatefns.DeclareCurrentUser(env); err != nil {
+		t.Fatalf("declare current_user: %v", err)
+	}
+	prog, err := predicate.Compile(env, src)
+	if err != nil {
+		t.Fatalf("compile %q: %v", src, err)
+	}
+	return prog
+}
+
+func evalWithUser(
+	ctx context.Context, t *testing.T, prog *predicate.Program, entity predicate.Value,
+) (bool, error) {
+	t.Helper()
+	b := predicate.NewBindings()
+	if err := b.SetVar("entity", entity); err != nil {
+		t.Fatalf("bind entity: %v", err)
+	}
+	if err := predicatefns.Bind(b, testNow()); err != nil {
+		t.Fatalf("bind stdlib: %v", err)
+	}
+	if err := predicatefns.BindCurrentUser(ctx, b); err != nil {
+		return false, err
+	}
+	v, err := prog.Eval(ctx, b)
+	if err != nil {
+		return false, err
+	}
+	bv, ok := v.(predicate.Bool)
+	if !ok {
+		t.Fatalf("program did not return bool, got %T", v)
+	}
+	return bv.Bool(), nil
+}
+
+func meCtx(entityID, raw, tool string) context.Context {
+	return predicatefns.WithQueryIdentity(context.Background(), predicatefns.QueryIdentity{
+		EntityID: entityID, Raw: raw, Tool: tool,
+	})
+}
+
+// TestCurrentUser_EqualityAndSugar pins the three spellings an operator
+// may write for "assigned to me" and proves they agree.
+func TestCurrentUser_EqualityAndSugar(t *testing.T) {
+	fields := predicate.RecordType{
+		"assignee": predicate.StringType,
+		"watchers": predicate.ListType{Elem: predicate.StringType},
+	}
+	ctx := meCtx("PERS-JV", "jeroen@example.com", "data-entry")
+
+	tests := []struct {
+		name     string
+		src      string
+		assignee predicate.Value
+		watchers predicate.Value
+		want     bool
+	}{
+		{
+			name:     "explicit id comparison matches",
+			src:      "entity.assignee == current_user.id",
+			assignee: predicate.NewString("PERS-JV"),
+			want:     true,
+		},
+		{
+			name:     "explicit id comparison rejects another user",
+			src:      "entity.assignee == current_user.id",
+			assignee: predicate.NewString("PERS-AB"),
+			want:     false,
+		},
+		{
+			name:     "is_me sugar matches",
+			src:      "is_me(entity.assignee)",
+			assignee: predicate.NewString("PERS-JV"),
+			want:     true,
+		},
+		{
+			name:     "is_me on an unset property is a non-match, not an error",
+			src:      "is_me(entity.assignee)",
+			assignee: predicate.NewNil(),
+			want:     false,
+		},
+		{
+			name:     "me_in finds the user in a list",
+			src:      "me_in(entity.watchers)",
+			assignee: predicate.NewNil(),
+			watchers: predicate.NewList([]predicate.Value{
+				predicate.NewString("PERS-AB"), predicate.NewString("PERS-JV"),
+			}),
+			want: true,
+		},
+		{
+			name:     "me_in rejects a list without the user",
+			src:      "me_in(entity.watchers)",
+			assignee: predicate.NewNil(),
+			watchers: predicate.NewList([]predicate.Value{predicate.NewString("PERS-AB")}),
+			want:     false,
+		},
+		{
+			name:     "me_in on an unset list is a non-match",
+			src:      "me_in(entity.watchers)",
+			assignee: predicate.NewNil(),
+			watchers: predicate.NewNil(),
+			want:     false,
+		},
+		{
+			name:     "the inbox shape: mine or watched, composed with or",
+			src:      "is_me(entity.assignee) or me_in(entity.watchers)",
+			assignee: predicate.NewString("PERS-AB"),
+			watchers: predicate.NewList([]predicate.Value{predicate.NewString("PERS-JV")}),
+			want:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			watchers := tc.watchers
+			if watchers == nil {
+				watchers = predicate.NewList(nil)
+			}
+			prog := compileWithUser(t, tc.src, fields)
+			got, err := evalWithUser(ctx, t, prog, predicate.NewRecord(map[string]predicate.Value{
+				"assignee": tc.assignee,
+				"watchers": watchers,
+			}))
+			if err != nil {
+				t.Fatalf("eval: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCurrentUser_RecordComparisonIsACompileError documents WHY the
+// ergonomic `entity.assignee == current_user` is not the spelling: the
+// variable must stay a record for affordance compatibility, and the type
+// checker rejects record-vs-string. is_me() is the sugar that replaces it.
+func TestCurrentUser_RecordComparisonIsACompileError(t *testing.T) {
+	env := predicate.NewEnv()
+	if err := env.DeclareVar("entity", predicate.RecordType{"assignee": predicate.StringType}); err != nil {
+		t.Fatalf("declare entity: %v", err)
+	}
+	if err := predicatefns.Declare(env); err != nil {
+		t.Fatalf("declare stdlib: %v", err)
+	}
+	if err := predicatefns.DeclareCurrentUser(env); err != nil {
+		t.Fatalf("declare current_user: %v", err)
+	}
+	if _, err := predicate.Compile(env, "entity.assignee == current_user"); err == nil {
+		t.Fatal("expected a compile error comparing a string to a record")
+	}
+}
+
+// TestCurrentUser_UndeclaredInStdlibProfile is the load-time guard: a
+// profile that did not opt in must REJECT a current_user reference
+// rather than evaluate it against a guessed identity.
+func TestCurrentUser_UndeclaredInStdlibProfile(t *testing.T) {
+	for _, src := range []string{"entity.assignee == current_user.id", "is_me(entity.assignee)"} {
+		t.Run(src, func(t *testing.T) {
+			env := predicate.NewEnv()
+			if err := env.DeclareVar("entity", predicate.RecordType{"assignee": predicate.StringType}); err != nil {
+				t.Fatalf("declare entity: %v", err)
+			}
+			if err := predicatefns.Declare(env); err != nil {
+				t.Fatalf("declare stdlib: %v", err)
+			}
+			// Deliberately no DeclareCurrentUser.
+			if _, err := predicate.Compile(env, src); err == nil {
+				t.Fatalf("expected a compile error for %q in a profile without current_user", src)
+			}
+		})
+	}
+}
+
+// TestCurrentUser_BindFailsClosed proves an unidentified context cannot
+// silently widen a filter: binding errors instead of producing an empty
+// identity that would match unset properties.
+func TestCurrentUser_BindFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		// stamp reports whether an identity is put on the context at
+		// all, distinguishing "never stamped" from "stamped but empty".
+		stamp bool
+		tool  string
+	}{
+		{name: "no identity stamped", stamp: false},
+		{name: "zero identity", stamp: true},
+		{name: "tool without identity", stamp: true, tool: "scheduler"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.stamp {
+				ctx = meCtx("", "", tc.tool)
+			}
+			b := predicate.NewBindings()
+			err := predicatefns.BindCurrentUser(ctx, b)
+			if !errors.Is(err, predicatefns.ErrNoCurrentUser) {
+				t.Fatalf("got %v, want ErrNoCurrentUser", err)
+			}
+		})
+	}
+}
+
+// TestQueryIdentity_PrefersEntityIDFallsBackToRaw pins the resolution
+// rule: an entity id when the deployment has one (so a comparison
+// against entity.assignee works), the raw principal when it does not.
+func TestQueryIdentity_PrefersEntityIDFallsBackToRaw(t *testing.T) {
+	tests := []struct {
+		name  string
+		q     predicatefns.QueryIdentity
+		want  string
+		valid bool
+	}{
+		{
+			name:  "entity id wins when resolved",
+			q:     predicatefns.QueryIdentity{EntityID: "PERS-JV", Raw: "jeroen@example.com"},
+			want:  "PERS-JV",
+			valid: true,
+		},
+		{
+			name:  "raw principal when no user entity type",
+			q:     predicatefns.QueryIdentity{Raw: "jeroen@example.com"},
+			want:  "jeroen@example.com",
+			valid: true,
+		},
+		{
+			name:  "zero identity is invalid",
+			q:     predicatefns.QueryIdentity{},
+			want:  "",
+			valid: false,
+		},
+		{
+			name:  "a tool alone does not make an identity",
+			q:     predicatefns.QueryIdentity{Tool: "cli"},
+			want:  "",
+			valid: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.q.ID(); got != tc.want {
+				t.Fatalf("ID() = %q, want %q", got, tc.want)
+			}
+			if got := tc.q.Valid(); got != tc.valid {
+				t.Fatalf("Valid() = %v, want %v", got, tc.valid)
+			}
+		})
+	}
+}
+
+// TestCurrentUser_RawFallbackComparesAgainstRawPrincipal covers the
+// no-user_entity_type deployment (the data-entry prototype): the raw
+// identifier is what the graph can reference, so that is what binds.
+func TestCurrentUser_RawFallbackComparesAgainstRawPrincipal(t *testing.T) {
+	prog := compileWithUser(t, "is_me(entity.reporter)", predicate.RecordType{
+		"reporter": predicate.StringType,
+	})
+	ctx := meCtx("", "jeroen@example.com", "data-entry")
+	got, err := evalWithUser(ctx, t, prog, predicate.NewRecord(map[string]predicate.Value{
+		"reporter": predicate.NewString("jeroen@example.com"),
+	}))
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Fatal("expected the raw principal to match reporter")
+	}
+}
+
+// TestCurrentUser_SQLPortableClassification guards the pushdown
+// precondition: a current-user condition must classify as portable, or a
+// future predicate->SQL compiler could never push it down.
+func TestCurrentUser_SQLPortableClassification(t *testing.T) {
+	fields := predicate.RecordType{
+		"assignee": predicate.StringType,
+		"watchers": predicate.ListType{Elem: predicate.StringType},
+	}
+	tests := []struct {
+		src      string
+		portable bool
+	}{
+		{src: "entity.assignee == current_user.id", portable: true},
+		{src: "is_me(entity.assignee)", portable: true},
+		{src: "me_in(entity.watchers)", portable: true},
+		{src: "is_me(entity.assignee) or me_in(entity.watchers)", portable: true},
+		// A non-portable stdlib func still poisons the program, proving the
+		// classification is genuinely computed rather than always true.
+		{src: "is_me(sha256(entity.assignee))", portable: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.src, func(t *testing.T) {
+			prog := compileWithUser(t, tc.src, fields)
+			if got := prog.SQLPortable(); got != tc.portable {
+				t.Fatalf("SQLPortable() = %v, want %v", got, tc.portable)
+			}
+		})
+	}
+}
+
+// TestCurrentUser_TypeMatchesAffordances is the drift guard. The two
+// dialects are one language to an operator, so the record shape must not
+// diverge; if affordances gains a field, this fails until it is mirrored.
+func TestCurrentUser_TypeMatchesAffordances(t *testing.T) {
+	want := []string{"id", "tool"}
+	for _, f := range want {
+		if _, ok := predicatefns.CurrentUserType[f]; !ok {
+			t.Fatalf("current_user is missing field %q", f)
+		}
+	}
+	if len(predicatefns.CurrentUserType) != len(want) {
+		t.Fatalf("current_user has %d fields, want %d (%s) — mirror internal/affordances/env.go",
+			len(predicatefns.CurrentUserType), len(want), strings.Join(want, ", "))
+	}
+}

--- a/internal/predicatefns/currentuser_test.go
+++ b/internal/predicatefns/currentuser_test.go
@@ -336,3 +336,98 @@ func TestCurrentUser_TypeMatchesAffordances(t *testing.T) {
 			len(predicatefns.CurrentUserType), len(want), strings.Join(want, ", "))
 	}
 }
+
+// stubResolver is a PrincipalResolver for the resolution tests.
+type stubResolver struct {
+	id  string
+	err error
+}
+
+func (s stubResolver) ResolvePrincipal(context.Context, string) (string, error) {
+	return s.id, s.err
+}
+
+func TestResolveQueryIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver predicatefns.PrincipalResolver
+		raw      string
+		tool     string
+		wantID   string
+		wantErr  bool
+	}{
+		{
+			name:     "resolves to the user entity id",
+			resolver: stubResolver{id: "PERS-JV"},
+			raw:      "jeroen@example.com",
+			tool:     "data-entry",
+			wantID:   "PERS-JV",
+		},
+		{
+			name:     "no resolver means the raw principal is the identity",
+			resolver: nil,
+			raw:      "jeroen@example.com",
+			tool:     "cli",
+			wantID:   "jeroen@example.com",
+		},
+		{
+			name:     "an unmatched principal falls back to raw",
+			resolver: stubResolver{id: ""},
+			raw:      "jeroen@example.com",
+			tool:     "data-entry",
+			wantID:   "jeroen@example.com",
+		},
+		{
+			name:     "resolving to itself is not treated as an entity id",
+			resolver: stubResolver{id: "jeroen@example.com"},
+			raw:      "jeroen@example.com",
+			tool:     "data-entry",
+			wantID:   "jeroen@example.com",
+		},
+		{
+			name:     "whitespace is trimmed before resolution",
+			resolver: nil,
+			raw:      "  jeroen@example.com  ",
+			tool:     "cli",
+			wantID:   "jeroen@example.com",
+		},
+		{
+			name:     "an empty principal yields an invalid identity, not an error",
+			resolver: stubResolver{id: "PERS-JV"},
+			raw:      "",
+			tool:     "cli",
+			wantID:   "",
+		},
+		{
+			name:     "a resolver error is surfaced, never degraded to raw",
+			resolver: stubResolver{err: errors.New("backend down")},
+			raw:      "jeroen@example.com",
+			tool:     "data-entry",
+			wantErr:  true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := predicatefns.ResolveQueryIdentity(
+				context.Background(), tc.resolver, tc.raw, tc.tool)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				if q.Valid() {
+					t.Fatalf("a failed resolution must not yield a usable identity, got %+v", q)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := q.ID(); got != tc.wantID {
+				t.Fatalf("ID() = %q, want %q", got, tc.wantID)
+			}
+			if q.Tool != tc.tool {
+				t.Fatalf("Tool = %q, want %q", q.Tool, tc.tool)
+			}
+		})
+	}
+}

--- a/internal/predicatefns/currentuser_test.go
+++ b/internal/predicatefns/currentuser_test.go
@@ -56,20 +56,20 @@ func evalWithUser(
 	return bv.Bool(), nil
 }
 
-func meCtx(entityID, raw, tool string) context.Context {
+func identityCtx(entityID, raw, tool string) context.Context {
 	return predicatefns.WithQueryIdentity(context.Background(), predicatefns.QueryIdentity{
 		EntityID: entityID, Raw: raw, Tool: tool,
 	})
 }
 
 // TestCurrentUser_EqualityAndSugar pins the three spellings an operator
-// may write for "assigned to me" and proves they agree.
+// may write for "assigned to the current user", proving they agree.
 func TestCurrentUser_EqualityAndSugar(t *testing.T) {
 	fields := predicate.RecordType{
 		"assignee": predicate.StringType,
 		"watchers": predicate.ListType{Elem: predicate.StringType},
 	}
-	ctx := meCtx("PERS-JV", "jeroen@example.com", "data-entry")
+	ctx := identityCtx("PERS-JV", "jeroen@example.com", "data-entry")
 
 	tests := []struct {
 		name     string
@@ -91,20 +91,20 @@ func TestCurrentUser_EqualityAndSugar(t *testing.T) {
 			want:     false,
 		},
 		{
-			name:     "is_me sugar matches",
-			src:      "is_me(entity.assignee)",
+			name:     "is_current_user sugar matches",
+			src:      "is_current_user(entity.assignee)",
 			assignee: predicate.NewString("PERS-JV"),
 			want:     true,
 		},
 		{
-			name:     "is_me on an unset property is a non-match, not an error",
-			src:      "is_me(entity.assignee)",
+			name:     "is_current_user on an unset property is a non-match, not an error",
+			src:      "is_current_user(entity.assignee)",
 			assignee: predicate.NewNil(),
 			want:     false,
 		},
 		{
-			name:     "me_in finds the user in a list",
-			src:      "me_in(entity.watchers)",
+			name:     "has_current_user finds the user in a list",
+			src:      "has_current_user(entity.watchers)",
 			assignee: predicate.NewNil(),
 			watchers: predicate.NewList([]predicate.Value{
 				predicate.NewString("PERS-AB"), predicate.NewString("PERS-JV"),
@@ -112,22 +112,22 @@ func TestCurrentUser_EqualityAndSugar(t *testing.T) {
 			want: true,
 		},
 		{
-			name:     "me_in rejects a list without the user",
-			src:      "me_in(entity.watchers)",
+			name:     "has_current_user rejects a list without the user",
+			src:      "has_current_user(entity.watchers)",
 			assignee: predicate.NewNil(),
 			watchers: predicate.NewList([]predicate.Value{predicate.NewString("PERS-AB")}),
 			want:     false,
 		},
 		{
-			name:     "me_in on an unset list is a non-match",
-			src:      "me_in(entity.watchers)",
+			name:     "has_current_user on an unset list is a non-match",
+			src:      "has_current_user(entity.watchers)",
 			assignee: predicate.NewNil(),
 			watchers: predicate.NewNil(),
 			want:     false,
 		},
 		{
 			name:     "the inbox shape: mine or watched, composed with or",
-			src:      "is_me(entity.assignee) or me_in(entity.watchers)",
+			src:      "is_current_user(entity.assignee) or has_current_user(entity.watchers)",
 			assignee: predicate.NewString("PERS-AB"),
 			watchers: predicate.NewList([]predicate.Value{predicate.NewString("PERS-JV")}),
 			want:     true,
@@ -157,7 +157,7 @@ func TestCurrentUser_EqualityAndSugar(t *testing.T) {
 // TestCurrentUser_RecordComparisonIsACompileError documents WHY the
 // ergonomic `entity.assignee == current_user` is not the spelling: the
 // variable must stay a record for affordance compatibility, and the type
-// checker rejects record-vs-string. is_me() is the sugar that replaces it.
+// checker rejects record-vs-string. is_current_user() is the sugar that replaces it.
 func TestCurrentUser_RecordComparisonIsACompileError(t *testing.T) {
 	env := predicate.NewEnv()
 	if err := env.DeclareVar("entity", predicate.RecordType{"assignee": predicate.StringType}); err != nil {
@@ -178,7 +178,7 @@ func TestCurrentUser_RecordComparisonIsACompileError(t *testing.T) {
 // profile that did not opt in must REJECT a current_user reference
 // rather than evaluate it against a guessed identity.
 func TestCurrentUser_UndeclaredInStdlibProfile(t *testing.T) {
-	for _, src := range []string{"entity.assignee == current_user.id", "is_me(entity.assignee)"} {
+	for _, src := range []string{"entity.assignee == current_user.id", "is_current_user(entity.assignee)"} {
 		t.Run(src, func(t *testing.T) {
 			env := predicate.NewEnv()
 			if err := env.DeclareVar("entity", predicate.RecordType{"assignee": predicate.StringType}); err != nil {
@@ -214,7 +214,7 @@ func TestCurrentUser_BindFailsClosed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			if tc.stamp {
-				ctx = meCtx("", "", tc.tool)
+				ctx = identityCtx("", "", tc.tool)
 			}
 			b := predicate.NewBindings()
 			err := predicatefns.BindCurrentUser(ctx, b)
@@ -276,10 +276,10 @@ func TestQueryIdentity_PrefersEntityIDFallsBackToRaw(t *testing.T) {
 // no-user_entity_type deployment (the data-entry prototype): the raw
 // identifier is what the graph can reference, so that is what binds.
 func TestCurrentUser_RawFallbackComparesAgainstRawPrincipal(t *testing.T) {
-	prog := compileWithUser(t, "is_me(entity.reporter)", predicate.RecordType{
+	prog := compileWithUser(t, "is_current_user(entity.reporter)", predicate.RecordType{
 		"reporter": predicate.StringType,
 	})
-	ctx := meCtx("", "jeroen@example.com", "data-entry")
+	ctx := identityCtx("", "jeroen@example.com", "data-entry")
 	got, err := evalWithUser(ctx, t, prog, predicate.NewRecord(map[string]predicate.Value{
 		"reporter": predicate.NewString("jeroen@example.com"),
 	}))
@@ -304,12 +304,12 @@ func TestCurrentUser_SQLPortableClassification(t *testing.T) {
 		portable bool
 	}{
 		{src: "entity.assignee == current_user.id", portable: true},
-		{src: "is_me(entity.assignee)", portable: true},
-		{src: "me_in(entity.watchers)", portable: true},
-		{src: "is_me(entity.assignee) or me_in(entity.watchers)", portable: true},
+		{src: "is_current_user(entity.assignee)", portable: true},
+		{src: "has_current_user(entity.watchers)", portable: true},
+		{src: "is_current_user(entity.assignee) or has_current_user(entity.watchers)", portable: true},
 		// A non-portable stdlib func still poisons the program, proving the
 		// classification is genuinely computed rather than always true.
-		{src: "is_me(sha256(entity.assignee))", portable: false},
+		{src: "is_current_user(sha256(entity.assignee))", portable: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.src, func(t *testing.T) {

--- a/internal/predicatefns/evaluator.go
+++ b/internal/predicatefns/evaluator.go
@@ -57,7 +57,35 @@ func NewEvaluatorWithClock(meta *metamodel.Metamodel, now func() time.Time) *Eva
 // funcs) — no current_user / has_role (deferred). A compile error is
 // returned to the caller (surface it once, at load/flag-parse time).
 func (e *Evaluator) Compile(entityType, source string) (*predicate.Program, error) {
-	key := entityType + "\x00" + source
+	return e.compile(entityType, source, false)
+}
+
+// CompileWithCurrentUser is [Evaluator.Compile] for a REQUEST-SCOPED
+// surface: the Env additionally carries current_user and its sugar (see
+// [DeclareCurrentUser]), so `is_me(entity.assignee)` compiles.
+//
+// It is a separate entry point rather than a flag on Compile because the
+// two profiles must not be confused at a call site. A program compiled
+// here REQUIRES an identity to evaluate — [Evaluator.MatchesAs] returns
+// [ErrNoCurrentUser] without one — so only a caller that can guarantee a
+// resolved principal may use it. Everything compiled through Compile
+// stays principal-free and evaluable with context.Background(), which is
+// what internal/validation does.
+func (e *Evaluator) CompileWithCurrentUser(entityType, source string) (*predicate.Program, error) {
+	return e.compile(entityType, source, true)
+}
+
+func (e *Evaluator) compile(entityType, source string, withUser bool) (*predicate.Program, error) {
+	// The profile is part of the cache key. Without it the two Envs would
+	// collide: whichever spelling compiled first would be served to the
+	// other, so a validation rule could silently receive a Program that
+	// expects a current_user binding it will never get (or vice versa,
+	// masking the load error that is the whole point of the split).
+	profile := "base"
+	if withUser {
+		profile = "user"
+	}
+	key := profile + "\x00" + entityType + "\x00" + source
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if prog, ok := e.cache[key]; ok {
@@ -73,6 +101,11 @@ func (e *Evaluator) Compile(entityType, source string) (*predicate.Program, erro
 	}
 	if err := Declare(env); err != nil {
 		return nil, err
+	}
+	if withUser {
+		if err := DeclareCurrentUser(env); err != nil {
+			return nil, err
+		}
 	}
 	prog, err := predicate.Compile(env, source)
 	if err != nil {
@@ -105,6 +138,27 @@ func (e *Evaluator) CompileFilter(entityType string, filters []*filter.Filter) (
 func (e *Evaluator) Matches(
 	ctx context.Context, prog *predicate.Program, entityType, id string, props map[string]any,
 ) (bool, error) {
+	return e.matches(ctx, prog, entityType, id, props, false)
+}
+
+// MatchesAs evaluates a Program compiled by [Evaluator.CompileWithCurrentUser],
+// binding the query identity carried by ctx (see [WithQueryIdentity]).
+//
+// Returns [ErrNoCurrentUser] if ctx carries no identity. That is a hard
+// failure rather than a non-match: a caller that reached this point has
+// already accepted a condition referencing the current user, and the
+// honest outcomes are "the right rows" or "an error" — never "somebody
+// else's rows".
+func (e *Evaluator) MatchesAs(
+	ctx context.Context, prog *predicate.Program, entityType, id string, props map[string]any,
+) (bool, error) {
+	return e.matches(ctx, prog, entityType, id, props, true)
+}
+
+func (e *Evaluator) matches(
+	ctx context.Context, prog *predicate.Program, entityType, id string,
+	props map[string]any, withUser bool,
+) (bool, error) {
 	def, ok := e.meta.GetEntityDef(entityType)
 	if !ok {
 		return false, fmt.Errorf("predicatefns: unknown entity type %q", entityType)
@@ -115,6 +169,11 @@ func (e *Evaluator) Matches(
 	}
 	if err := Bind(b, e.now()); err != nil {
 		return false, err
+	}
+	if withUser {
+		if err := BindCurrentUser(ctx, b); err != nil {
+			return false, err
+		}
 	}
 	v, err := prog.Eval(ctx, b)
 	if err != nil {

--- a/internal/predicatefns/evaluator.go
+++ b/internal/predicatefns/evaluator.go
@@ -144,11 +144,17 @@ func (e *Evaluator) Matches(
 // MatchesAs evaluates a Program compiled by [Evaluator.CompileWithCurrentUser],
 // binding the query identity carried by ctx (see [WithQueryIdentity]).
 //
-// Returns [ErrNoCurrentUser] if ctx carries no identity. That is a hard
-// failure rather than a non-match: a caller that reached this point has
-// already accepted a condition referencing the current user, and the
-// honest outcomes are "the right rows" or "an error" — never "somebody
-// else's rows".
+// The identity is bound only when the program needs it (see
+// [RequiresCurrentUser]); a condition that never mentions the current
+// user evaluates exactly as [Evaluator.Matches] would, so one
+// request-scoped matcher serves both kinds without the caller telling
+// them apart.
+//
+// Returns [ErrNoCurrentUser] if the program needs an identity and ctx
+// carries none. That is a hard failure rather than a non-match: a caller
+// that reached this point has already accepted a condition referencing
+// the current user, and the honest outcomes are "the right rows" or "an
+// error" — never "somebody else's rows".
 func (e *Evaluator) MatchesAs(
 	ctx context.Context, prog *predicate.Program, entityType, id string, props map[string]any,
 ) (bool, error) {
@@ -170,7 +176,7 @@ func (e *Evaluator) matches(
 	if err := Bind(b, e.now()); err != nil {
 		return false, err
 	}
-	if withUser {
+	if withUser && RequiresCurrentUser(prog) {
 		if err := BindCurrentUser(ctx, b); err != nil {
 			return false, err
 		}

--- a/internal/predicatefns/evaluator.go
+++ b/internal/predicatefns/evaluator.go
@@ -62,7 +62,7 @@ func (e *Evaluator) Compile(entityType, source string) (*predicate.Program, erro
 
 // CompileWithCurrentUser is [Evaluator.Compile] for a REQUEST-SCOPED
 // surface: the Env additionally carries current_user and its sugar (see
-// [DeclareCurrentUser]), so `is_me(entity.assignee)` compiles.
+// [DeclareCurrentUser]), so `is_current_user(entity.assignee)` compiles.
 //
 // It is a separate entry point rather than a flag on Compile because the
 // two profiles must not be confused at a call site. A program compiled

--- a/internal/predicatefns/evaluator_currentuser_test.go
+++ b/internal/predicatefns/evaluator_currentuser_test.go
@@ -159,3 +159,28 @@ func TestCurrentUserPrefilterSpec_MatchesTheDeclaredFuncs(t *testing.T) {
 		}
 	}
 }
+
+// TestCurrentUserBindings_EmptyIdentityNeverMatches pins the fail-closed
+// reading a caller without an identity gets from the shared bindings: an
+// empty identity is not "the user whose id is the empty string".
+func TestCurrentUserBindings_EmptyIdentityNeverMatches(t *testing.T) {
+	fns := predicatefns.CurrentUserBindings("")
+	ctx := context.Background()
+	for _, arg := range []predicate.Value{predicate.NewString(""), predicate.NewString("unknown")} {
+		got, err := fns[predicatefns.FuncIsCurrentUser](ctx, []predicate.Value{arg})
+		if err != nil {
+			t.Fatalf("is_current_user: %v", err)
+		}
+		if got.(predicate.Bool).Bool() {
+			t.Fatalf("is_current_user(%v) matched with an empty identity", arg)
+		}
+	}
+	list := predicate.NewList([]predicate.Value{predicate.NewString(""), predicate.NewString("x")})
+	got, err := fns[predicatefns.FuncHasCurrentUser](ctx, []predicate.Value{list})
+	if err != nil {
+		t.Fatalf("has_current_user: %v", err)
+	}
+	if got.(predicate.Bool).Bool() {
+		t.Fatal("has_current_user matched with an empty identity")
+	}
+}

--- a/internal/predicatefns/evaluator_currentuser_test.go
+++ b/internal/predicatefns/evaluator_currentuser_test.go
@@ -1,0 +1,161 @@
+package predicatefns_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
+)
+
+func evaluatorMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"task": {Properties: map[string]metamodel.PropertyDef{
+				"assignee": {Type: metamodel.PropertyTypeString},
+				"status":   {Type: metamodel.PropertyTypeString},
+				"watchers": {Type: metamodel.PropertyTypeString, List: true},
+			}},
+		},
+	}
+}
+
+// TestRequiresCurrentUser pins the dependency test the request-scoped
+// matcher relies on: every spelling that reads the identity is detected,
+// and a condition that never mentions it is not.
+func TestRequiresCurrentUser(t *testing.T) {
+	ev := predicatefns.NewEvaluator(evaluatorMeta())
+	tests := []struct {
+		src  string
+		want bool
+	}{
+		{"entity.assignee == current_user.id", true},
+		{"current_user.tool == 'mcp'", true},
+		{"is_current_user(entity.assignee)", true},
+		{"has_current_user(entity.watchers)", true},
+		{"entity.status == 'todo' and is_current_user(entity.assignee)", true},
+		{"entity.status == 'todo'", false},
+		{"contains(entity.watchers, 'x')", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.src, func(t *testing.T) {
+			prog, err := ev.CompileWithCurrentUser("task", tc.src)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if got := predicatefns.RequiresCurrentUser(prog); got != tc.want {
+				t.Fatalf("RequiresCurrentUser = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if predicatefns.RequiresCurrentUser(nil) {
+		t.Fatal("a nil program must require nothing")
+	}
+}
+
+// TestMatchesAs_IdentityBoundOnlyWhenNeeded is the contract that lets one
+// request-scoped profile serve every next-action condition: a condition
+// without an identity clause evaluates on an unidentified ctx, one with
+// an identity clause fails closed on it, and both work once an identity
+// is stamped.
+func TestMatchesAs_IdentityBoundOnlyWhenNeeded(t *testing.T) {
+	ev := predicatefns.NewEvaluator(evaluatorMeta())
+	props := map[string]any{"status": "todo", "assignee": "PERS-JV", "watchers": []any{"PERS-AB", "PERS-JV"}}
+	noIdentity := context.Background()
+	withIdentity := predicatefns.WithQueryIdentity(noIdentity, predicatefns.QueryIdentity{EntityID: "PERS-JV"})
+	otherIdentity := predicatefns.WithQueryIdentity(noIdentity, predicatefns.QueryIdentity{EntityID: "PERS-ZZ"})
+
+	tests := []struct {
+		name    string
+		src     string
+		ctx     context.Context //nolint:containedctx // table fixture selects among three prebuilt contexts
+		want    bool
+		wantErr error
+	}{
+		{"identity-free condition evaluates without an identity",
+			"entity.status == 'todo'", noIdentity, true, nil},
+		{"identity-free condition evaluates with one too",
+			"entity.status == 'todo'", withIdentity, true, nil},
+		{"equality clause fails closed without an identity",
+			"entity.assignee == current_user.id", noIdentity, false, predicatefns.ErrNoCurrentUser},
+		{"is_current_user fails closed without an identity",
+			"is_current_user(entity.assignee)", noIdentity, false, predicatefns.ErrNoCurrentUser},
+		{"has_current_user fails closed without an identity",
+			"has_current_user(entity.watchers)", noIdentity, false, predicatefns.ErrNoCurrentUser},
+		{"equality clause matches the stamped identity",
+			"entity.assignee == current_user.id", withIdentity, true, nil},
+		{"is_current_user matches the stamped identity",
+			"is_current_user(entity.assignee)", withIdentity, true, nil},
+		{"has_current_user finds the stamped identity in the list",
+			"has_current_user(entity.watchers)", withIdentity, true, nil},
+		{"a different identity does not match",
+			"is_current_user(entity.assignee) or has_current_user(entity.watchers)", otherIdentity, false, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := ev.CompileWithCurrentUser("task", tc.src)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			got, err := ev.MatchesAs(tc.ctx, prog, "task", "T-1", props)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("got err %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MatchesAs: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("MatchesAs = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCurrentUserPrefilterSpec_MatchesTheDeclaredFuncs is the drift guard
+// between the sugar functions and the pushdown's reading of them: every
+// declared sugar function is listed, and it resolves to the identity
+// field.
+func TestCurrentUserPrefilterSpec_MatchesTheDeclaredFuncs(t *testing.T) {
+	spec := predicatefns.CurrentUserPrefilterSpec()
+	if spec.RecordVar != predicatefns.VarEntity || spec.ConstVar != predicatefns.VarCurrentUser {
+		t.Fatalf("spec names %q/%q, want entity/current_user", spec.RecordVar, spec.ConstVar)
+	}
+	for name := range predicatefns.CurrentUserFuncs() {
+		field, ok := spec.ConstFuncs[name]
+		if !ok {
+			t.Fatalf("sugar function %q is declared but not in the prefilter spec", name)
+		}
+		if field != predicatefns.FieldCurrentUserID {
+			t.Fatalf("%q maps to %q, want %q", name, field, predicatefns.FieldCurrentUserID)
+		}
+	}
+	if len(spec.ConstFuncs) != len(predicatefns.CurrentUserFuncs()) {
+		t.Fatalf("spec lists %d functions, %d are declared", len(spec.ConstFuncs), len(predicatefns.CurrentUserFuncs()))
+	}
+
+	// And the spec drives ConstEqualities as the pushdown expects.
+	ev := predicatefns.NewEvaluator(evaluatorMeta())
+	prog, err := ev.CompileWithCurrentUser("task",
+		"is_current_user(entity.assignee) and has_current_user(entity.watchers)")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	want := []predicate.ConstEquality{
+		{Attribute: "assignee", FromVar: "id"},
+		{Attribute: "watchers", FromVar: "id", List: true},
+	}
+	got := prog.ConstEqualities(spec)
+	if len(got) != len(want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("equality %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/predicatefns/evaluator_currentuser_test.go
+++ b/internal/predicatefns/evaluator_currentuser_test.go
@@ -137,6 +137,21 @@ func TestCurrentUserPrefilterSpec_MatchesTheDeclaredFuncs(t *testing.T) {
 	if len(spec.ConstFuncs) != len(predicatefns.CurrentUserFuncs()) {
 		t.Fatalf("spec lists %d functions, %d are declared", len(spec.ConstFuncs), len(predicatefns.CurrentUserFuncs()))
 	}
+	// And RequiresCurrentUser recognizes every declared function — its
+	// precomputed name set must not lag a new declaration.
+	for name := range predicatefns.CurrentUserFuncs() {
+		src := name + "(entity.assignee)"
+		if name == predicatefns.FuncHasCurrentUser {
+			src = name + "(entity.watchers)"
+		}
+		prog, err := predicatefns.NewEvaluator(evaluatorMeta()).CompileWithCurrentUser("task", src)
+		if err != nil {
+			t.Fatalf("compile %q: %v", src, err)
+		}
+		if !predicatefns.RequiresCurrentUser(prog) {
+			t.Fatalf("RequiresCurrentUser does not recognize declared function %q", name)
+		}
+	}
 
 	// And the spec drives ConstEqualities as the pushdown expects.
 	ev := predicatefns.NewEvaluator(evaluatorMeta())

--- a/internal/principal/principal.go
+++ b/internal/principal/principal.go
@@ -496,6 +496,13 @@ func With(ctx context.Context, p Principal) context.Context {
 	return context.WithValue(ctx, principalKey{}, p)
 }
 
+// Unknown is the placeholder user (and tool) for a ctx that carries no
+// identity, and for a transport that could not determine one — the data-entry
+// server without an identity source stamps it explicitly. It is an
+// ATTRIBUTION default, adequate for an audit record; it is not a user, and a
+// consumer comparing an identity against graph data must treat it as absent.
+const Unknown = "unknown"
+
 // From returns the Principal carried by ctx, or
 // Principal{User:"unknown", Tool:"unknown"} if none was stamped.
 // Returning a default rather than panicking keeps downstream consumers
@@ -509,7 +516,7 @@ func From(ctx context.Context) Principal {
 		// consumer mutate what another is about to authorize against.
 		return v.Clone()
 	}
-	return Principal{User: "unknown", Tool: "unknown"}
+	return Principal{User: Unknown, Tool: Unknown}
 }
 
 // Stamped returns the Principal carried by ctx and whether one was actually
@@ -546,7 +553,7 @@ func Stamped(ctx context.Context) (Principal, bool) {
 func SystemUser() string {
 	u := strings.TrimSpace(os.Getenv("USER"))
 	if u == "" {
-		return "unknown"
+		return Unknown
 	}
 	return u
 }

--- a/internal/queryplan/conditionprefilter_test.go
+++ b/internal/queryplan/conditionprefilter_test.go
@@ -91,25 +91,43 @@ func TestConditionPrefilters(t *testing.T) {
 			want:     nil,
 		},
 		{
-			name:     "the is_current_user sugar is not a pushable equality shape",
+			name:     "the is_current_user sugar lowers to the same scalar equality",
 			src:      "is_current_user(entity.assignee)",
 			types:    []string{"task"},
 			identity: identity,
+			want: []store.PropPredicate{
+				{Property: "assignee", Op: store.PropEqual, Value: identity, Scalar: true},
+			},
+		},
+		{
+			// A NON-scalar PropEqual: every backend reads that as "some
+			// element equals" for a list value, which is exactly the Go
+			// semantics of has_current_user.
+			name:     "has_current_user lowers to a non-scalar equality (list membership)",
+			src:      "has_current_user(entity.watchers)",
+			types:    []string{"task"},
+			identity: identity,
+			want: []store.PropPredicate{
+				{Property: "watchers", Op: store.PropEqual, Value: identity, Scalar: false},
+			},
+		},
+		{
+			name:     "membership is gated on the property being a string list on every type",
+			src:      "has_current_user(entity.watchers)",
+			types:    []string{"task", "bug"},
+			identity: identity,
+			want:     nil,
+		},
+		{
+			name:     "sugar without an identity pushes nothing",
+			src:      "is_current_user(entity.assignee) and has_current_user(entity.watchers)",
+			types:    []string{"task"},
+			identity: "",
 			want:     nil,
 		},
 		{
 			name:     "current_user.tool is never pushed",
 			src:      "entity.status == current_user.tool",
-			types:    []string{"task"},
-			identity: identity,
-			want:     nil,
-		},
-		{
-			// A list property cannot even be COMPARED (the type checker
-			// rejects it), so membership is spelled has_current_user — and a host
-			// call is not an equality shape, so it pushes nothing.
-			name:     "list membership is not pushed",
-			src:      "has_current_user(entity.watchers)",
 			types:    []string{"task"},
 			identity: identity,
 			want:     nil,
@@ -161,5 +179,88 @@ func TestConditionPrefilters_NilInputs(t *testing.T) {
 	}
 	if got := queryplan.ConditionPrefilters(prog, nil, []string{"task"}, "x"); got != nil {
 		t.Fatalf("nil meta: got %+v, want nil", got)
+	}
+}
+
+// TestConditionIndexProperties pins the index-inference half of the
+// eligibility decision: scalar equalities derive an index column,
+// memberships and everything ConditionPrefilters would refuse do not.
+func TestConditionIndexProperties(t *testing.T) {
+	meta := conditionMeta()
+	ev := predicatefns.NewEvaluator(meta)
+	tests := []struct {
+		name  string
+		src   string
+		types []string
+		want  []string
+	}{
+		{"identity equality", "entity.assignee == current_user.id", []string{"task"}, []string{"assignee"}},
+		{"sugar equality", "is_current_user(entity.assignee)", []string{"task"}, []string{"assignee"}},
+		{"literal equality", "entity.status == 'open'", []string{"task"}, []string{"status"}},
+		{"membership is not indexable", "has_current_user(entity.watchers)", []string{"task"}, nil},
+		{"mixed keeps the scalar ones",
+			"entity.status == 'open' and is_current_user(entity.assignee) and has_current_user(entity.watchers)",
+			[]string{"task"}, []string{"assignee", "status"}},
+		{"OR derives nothing", "entity.status == 'open' or is_current_user(entity.assignee)", []string{"task"}, nil},
+		{"typed equality derives nothing", "entity.count == 3", []string{"task"}, nil},
+		{"multi-type keeps only the shared string property",
+			"entity.count == 3 and entity.assignee == current_user.id", []string{"task", "bug"}, []string{"assignee"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := ev.CompileWithCurrentUser("task", tc.src)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			got := queryplan.ConditionIndexProperties(prog, meta, tc.types)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestConditionPrefilters_AgreesWithIndexProperties is the drift guard
+// the CLAUDE.md rule asks for: every scalar predicate the runtime pushes
+// is a column the static index derives, and vice versa.
+func TestConditionPrefilters_AgreesWithIndexProperties(t *testing.T) {
+	meta := conditionMeta()
+	ev := predicatefns.NewEvaluator(meta)
+	srcs := []string{
+		"entity.assignee == current_user.id",
+		"is_current_user(entity.assignee)",
+		"has_current_user(entity.watchers)",
+		"entity.status == 'open' and is_current_user(entity.assignee) and has_current_user(entity.watchers)",
+		"entity.status == 'open' or is_current_user(entity.assignee)",
+		"entity.count == 3 and entity.assignee == current_user.id",
+	}
+	for _, src := range srcs {
+		t.Run(src, func(t *testing.T) {
+			prog, err := ev.CompileWithCurrentUser("task", src)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			types := []string{"task"}
+			var pushedScalar []string
+			for _, p := range queryplan.ConditionPrefilters(prog, meta, types, "PERS-JV") {
+				if p.Scalar {
+					pushedScalar = append(pushedScalar, p.Property)
+				}
+			}
+			indexed := queryplan.ConditionIndexProperties(prog, meta, types)
+			if len(pushedScalar) != len(indexed) {
+				t.Fatalf("pushed %v, indexed %v", pushedScalar, indexed)
+			}
+			for i := range indexed {
+				if pushedScalar[i] != indexed[i] {
+					t.Fatalf("pushed %v, indexed %v", pushedScalar, indexed)
+				}
+			}
+		})
 	}
 }

--- a/internal/queryplan/conditionprefilter_test.go
+++ b/internal/queryplan/conditionprefilter_test.go
@@ -28,98 +28,98 @@ func conditionMeta() *metamodel.Metamodel {
 
 func TestConditionPrefilters(t *testing.T) {
 	meta := conditionMeta()
-	const me = "PERS-JV"
+	const identity = "PERS-JV"
 
 	tests := []struct {
-		name  string
-		src   string
-		types []string
-		me    string
-		want  []store.PropPredicate
+		name     string
+		src      string
+		types    []string
+		identity string
+		want     []store.PropPredicate
 	}{
 		{
-			name:  "current-user equality resolves to the identity",
-			src:   "entity.assignee == current_user.id",
-			types: []string{"task"},
-			me:    me,
+			name:     "current-user equality resolves to the identity",
+			src:      "entity.assignee == current_user.id",
+			types:    []string{"task"},
+			identity: identity,
 			want: []store.PropPredicate{
-				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+				{Property: "assignee", Op: store.PropEqual, Value: identity, Scalar: true},
 			},
 		},
 		{
-			name:  "literal and identity push together",
-			src:   "entity.status == 'open' and entity.assignee == current_user.id",
-			types: []string{"task"},
-			me:    me,
+			name:     "literal and identity push together",
+			src:      "entity.status == 'open' and entity.assignee == current_user.id",
+			types:    []string{"task"},
+			identity: identity,
 			want: []store.PropPredicate{
-				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+				{Property: "assignee", Op: store.PropEqual, Value: identity, Scalar: true},
 				{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true},
 			},
 		},
 		{
-			name:  "pushes only across types that all declare the property as a string",
-			src:   "entity.assignee == current_user.id",
-			types: []string{"task", "bug"},
-			me:    me,
+			name:     "pushes only across types that all declare the property as a string",
+			src:      "entity.assignee == current_user.id",
+			types:    []string{"task", "bug"},
+			identity: identity,
 			want: []store.PropPredicate{
-				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+				{Property: "assignee", Op: store.PropEqual, Value: identity, Scalar: true},
 			},
 		},
 		{
-			name:  "a property missing on one type pushes nothing",
-			src:   "entity.count == 3 and entity.assignee == current_user.id",
-			types: []string{"task", "bug"},
-			me:    me,
+			name:     "a property missing on one type pushes nothing",
+			src:      "entity.count == 3 and entity.assignee == current_user.id",
+			types:    []string{"task", "bug"},
+			identity: identity,
 			want: []store.PropPredicate{
-				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+				{Property: "assignee", Op: store.PropEqual, Value: identity, Scalar: true},
 			},
 		},
 
 		// --- fail-closed and soundness ---
 		{
-			name:  "an empty identity pushes NOTHING, never an empty-string equality",
-			src:   "entity.assignee == current_user.id",
-			types: []string{"task"},
-			me:    "",
-			want:  nil,
+			name:     "an empty identity pushes NOTHING, never an empty-string equality",
+			src:      "entity.assignee == current_user.id",
+			types:    []string{"task"},
+			identity: "",
+			want:     nil,
 		},
 		{
-			name:  "an OR pushes nothing",
-			src:   "entity.assignee == current_user.id or entity.status == 'open'",
-			types: []string{"task"},
-			me:    me,
-			want:  nil,
+			name:     "an OR pushes nothing",
+			src:      "entity.assignee == current_user.id or entity.status == 'open'",
+			types:    []string{"task"},
+			identity: identity,
+			want:     nil,
 		},
 		{
-			name:  "the is_me sugar is not a pushable equality shape",
-			src:   "is_me(entity.assignee)",
-			types: []string{"task"},
-			me:    me,
-			want:  nil,
+			name:     "the is_current_user sugar is not a pushable equality shape",
+			src:      "is_current_user(entity.assignee)",
+			types:    []string{"task"},
+			identity: identity,
+			want:     nil,
 		},
 		{
-			name:  "current_user.tool is never pushed",
-			src:   "entity.status == current_user.tool",
-			types: []string{"task"},
-			me:    me,
-			want:  nil,
+			name:     "current_user.tool is never pushed",
+			src:      "entity.status == current_user.tool",
+			types:    []string{"task"},
+			identity: identity,
+			want:     nil,
 		},
 		{
 			// A list property cannot even be COMPARED (the type checker
-			// rejects it), so membership is spelled me_in — and a host
+			// rejects it), so membership is spelled has_current_user — and a host
 			// call is not an equality shape, so it pushes nothing.
-			name:  "list membership is not pushed",
-			src:   "me_in(entity.watchers)",
-			types: []string{"task"},
-			me:    me,
-			want:  nil,
+			name:     "list membership is not pushed",
+			src:      "has_current_user(entity.watchers)",
+			types:    []string{"task"},
+			identity: identity,
+			want:     nil,
 		},
 		{
-			name:  "no types pushes nothing",
-			src:   "entity.assignee == current_user.id",
-			types: nil,
-			me:    me,
-			want:  nil,
+			name:     "no types pushes nothing",
+			src:      "entity.assignee == current_user.id",
+			types:    nil,
+			identity: identity,
+			want:     nil,
 		},
 	}
 
@@ -134,7 +134,7 @@ func TestConditionPrefilters(t *testing.T) {
 			if err != nil {
 				t.Fatalf("compile %q: %v", tc.src, err)
 			}
-			got := queryplan.ConditionPrefilters(prog, meta, tc.types, tc.me)
+			got := queryplan.ConditionPrefilters(prog, meta, tc.types, tc.identity)
 			if len(got) != len(tc.want) {
 				t.Fatalf("got %d predicates %+v, want %d %+v", len(got), got, len(tc.want), tc.want)
 			}

--- a/internal/queryplan/conditionprefilter_test.go
+++ b/internal/queryplan/conditionprefilter_test.go
@@ -1,0 +1,165 @@
+package queryplan_test
+
+import (
+	"testing"
+
+	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
+	"github.com/Sourcehaven-BV/rela/internal/queryplan"
+	"github.com/Sourcehaven-BV/rela/internal/store"
+)
+
+func conditionMeta() *metamodel.Metamodel {
+	return &metamodel.Metamodel{
+		Entities: map[string]metamodel.EntityDef{
+			"task": {Properties: map[string]metamodel.PropertyDef{
+				"assignee": {Type: metamodel.PropertyTypeString},
+				"status":   {Type: metamodel.PropertyTypeString},
+				"count":    {Type: metamodel.PropertyTypeInteger},
+				"watchers": {Type: metamodel.PropertyTypeString, List: true},
+			}},
+			"bug": {Properties: map[string]metamodel.PropertyDef{
+				"assignee": {Type: metamodel.PropertyTypeString},
+				"status":   {Type: metamodel.PropertyTypeString},
+			}},
+		},
+	}
+}
+
+func TestConditionPrefilters(t *testing.T) {
+	meta := conditionMeta()
+	const me = "PERS-JV"
+
+	tests := []struct {
+		name  string
+		src   string
+		types []string
+		me    string
+		want  []store.PropPredicate
+	}{
+		{
+			name:  "current-user equality resolves to the identity",
+			src:   "entity.assignee == current_user.id",
+			types: []string{"task"},
+			me:    me,
+			want: []store.PropPredicate{
+				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+			},
+		},
+		{
+			name:  "literal and identity push together",
+			src:   "entity.status == 'open' and entity.assignee == current_user.id",
+			types: []string{"task"},
+			me:    me,
+			want: []store.PropPredicate{
+				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+				{Property: "status", Op: store.PropEqual, Value: "open", Scalar: true},
+			},
+		},
+		{
+			name:  "pushes only across types that all declare the property as a string",
+			src:   "entity.assignee == current_user.id",
+			types: []string{"task", "bug"},
+			me:    me,
+			want: []store.PropPredicate{
+				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+			},
+		},
+		{
+			name:  "a property missing on one type pushes nothing",
+			src:   "entity.count == 3 and entity.assignee == current_user.id",
+			types: []string{"task", "bug"},
+			me:    me,
+			want: []store.PropPredicate{
+				{Property: "assignee", Op: store.PropEqual, Value: me, Scalar: true},
+			},
+		},
+
+		// --- fail-closed and soundness ---
+		{
+			name:  "an empty identity pushes NOTHING, never an empty-string equality",
+			src:   "entity.assignee == current_user.id",
+			types: []string{"task"},
+			me:    "",
+			want:  nil,
+		},
+		{
+			name:  "an OR pushes nothing",
+			src:   "entity.assignee == current_user.id or entity.status == 'open'",
+			types: []string{"task"},
+			me:    me,
+			want:  nil,
+		},
+		{
+			name:  "the is_me sugar is not a pushable equality shape",
+			src:   "is_me(entity.assignee)",
+			types: []string{"task"},
+			me:    me,
+			want:  nil,
+		},
+		{
+			name:  "current_user.tool is never pushed",
+			src:   "entity.status == current_user.tool",
+			types: []string{"task"},
+			me:    me,
+			want:  nil,
+		},
+		{
+			// A list property cannot even be COMPARED (the type checker
+			// rejects it), so membership is spelled me_in — and a host
+			// call is not an equality shape, so it pushes nothing.
+			name:  "list membership is not pushed",
+			src:   "me_in(entity.watchers)",
+			types: []string{"task"},
+			me:    me,
+			want:  nil,
+		},
+		{
+			name:  "no types pushes nothing",
+			src:   "entity.assignee == current_user.id",
+			types: nil,
+			me:    me,
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := predicatefns.NewEvaluator(meta)
+			// Compile against the first named type; the condition must
+			// type-check on every type it will be evaluated against, which
+			// is the rule CompileNextActions already enforces.
+			compileType := "task"
+			prog, err := ev.CompileWithCurrentUser(compileType, tc.src)
+			if err != nil {
+				t.Fatalf("compile %q: %v", tc.src, err)
+			}
+			got := queryplan.ConditionPrefilters(prog, meta, tc.types, tc.me)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d predicates %+v, want %d %+v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("predicate %d: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestConditionPrefilters_NilInputs covers the degenerate cases at the
+// boundary rather than leaving them to panic in a handler.
+func TestConditionPrefilters_NilInputs(t *testing.T) {
+	meta := conditionMeta()
+	ev := predicatefns.NewEvaluator(meta)
+	prog, err := ev.CompileWithCurrentUser("task", "entity.assignee == current_user.id")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if got := queryplan.ConditionPrefilters(nil, meta, []string{"task"}, "x"); got != nil {
+		t.Fatalf("nil program: got %+v, want nil", got)
+	}
+	if got := queryplan.ConditionPrefilters(prog, nil, []string{"task"}, "x"); got != nil {
+		t.Fatalf("nil meta: got %+v, want nil", got)
+	}
+}

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -4,6 +4,7 @@ package queryplan
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -169,7 +170,11 @@ func staticIndexProps(
 		}
 	}
 	if condition != "" && ev != nil {
-		if prog, err := ev.CompileWithCurrentUser(sq.EntityTypes[0], condition); err == nil {
+		prog, err := ev.CompileWithCurrentUser(sq.EntityTypes[0], condition)
+		if err != nil {
+			slog.Warn("queryplan: next-action condition skipped for index derivation",
+				"type", sq.EntityTypes[0], "error", err)
+		} else {
 			props = append(props, ConditionIndexProperties(prog, meta, sq.EntityTypes)...)
 		}
 	}
@@ -227,8 +232,13 @@ func ConditionPrefilters(
 			}
 			value = identity
 		}
+		// Scalar opts into the indexable string-only comparison; a
+		// membership must keep the store's list reading. An empty value
+		// cannot reach here — an empty identity continued above and an
+		// empty literal is refused by ConstEqualities — so "is empty" is
+		// never what this predicate means.
 		pushed = append(pushed, store.PropPredicate{
-			Property: eq.Attribute, Op: store.PropEqual, Value: value, Scalar: !eq.List && value != "",
+			Property: eq.Attribute, Op: store.PropEqual, Value: value, Scalar: !eq.List,
 		})
 	}
 	return pushed

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -138,13 +138,14 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 //     store's string-form comparison cannot disagree with the
 //     metamodel-aware Go pass on a typed value.
 //
-// `me` is the current user's query identity. An EMPTY `me` pushes
-// nothing rather than pushing an empty-string equality: an unidentified
-// request must not silently pre-filter to the rows whose property is
-// unset. The Go pass fails that request closed on its own; this must not
-// quietly answer it first.
+// `identity` is the current user's query identity (see
+// predicatefns.QueryIdentity.ID). An EMPTY identity pushes nothing
+// rather than an empty-string equality: an unidentified request must not
+// silently pre-filter to the rows whose property is unset. The Go pass
+// fails that request closed on its own; this must not quietly answer it
+// first.
 func ConditionPrefilters(
-	prog *predicate.Program, meta *metamodel.Metamodel, types []string, me string,
+	prog *predicate.Program, meta *metamodel.Metamodel, types []string, identity string,
 ) []store.PropPredicate {
 	if prog == nil || meta == nil || len(types) == 0 {
 		return nil
@@ -157,10 +158,10 @@ func ConditionPrefilters(
 			// deliberately not pushable: it is diagnostic, never an
 			// authorization or membership input (see internal/affordances),
 			// and pushing it would invite exactly that use.
-			if eq.FromVar != predicatefns.FieldCurrentUserID || me == "" {
+			if eq.FromVar != predicatefns.FieldCurrentUserID || identity == "" {
 				continue
 			}
-			value = me
+			value = identity
 		}
 		if !stringComparableOnEveryType(meta, types, eq.Attribute) {
 			continue

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -50,13 +50,27 @@ func PushdownPrefilters(filters []*filter.Filter, meta *metamodel.Metamodel, typ
 }
 
 func stringComparableOnEveryType(meta *metamodel.Metamodel, types []string, prop string) bool {
+	return declaredOnEveryType(meta, types, prop, false)
+}
+
+// stringListOnEveryType is the list twin of stringComparableOnEveryType: the
+// property must be a LIST of strings on every type, so a membership predicate
+// compares element text the same way the Go pass does.
+func stringListOnEveryType(meta *metamodel.Metamodel, types []string, prop string) bool {
+	return declaredOnEveryType(meta, types, prop, true)
+}
+
+func declaredOnEveryType(meta *metamodel.Metamodel, types []string, prop string, list bool) bool {
+	if len(types) == 0 {
+		return false
+	}
 	for _, typ := range types {
 		def, ok := meta.GetEntityDef(typ)
 		if !ok {
 			return false
 		}
 		pd, ok := def.Properties[prop]
-		if !ok || pd.List || pd.Type != metamodel.PropertyTypeString {
+		if !ok || pd.List != list || pd.Type != metamodel.PropertyTypeString {
 			return false
 		}
 	}
@@ -69,38 +83,17 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 	if cfg == nil || meta == nil {
 		return nil
 	}
-	var queries []string
-	if cfg.Dashboard != nil {
-		for _, card := range cfg.Dashboard.Cards {
-			queries = append(queries, card.Query)
-		}
-	}
-	for _, src := range cfg.NextActions {
-		if src.Query != "" {
-			queries = append(queries, src.Query)
-		}
-		for _, offer := range src.Actions {
-			if offer.PickOne != nil {
-				queries = append(queries, offer.PickOne.Query)
-			}
-		}
-	}
-
+	var ev *predicatefns.Evaluator
 	byKey := make(map[string]store.DerivedObjectSpec)
-	for _, raw := range queries {
-		sq := searchparser.ParseQuery(raw)
+	for _, q := range staticQueries(cfg) {
+		sq := searchparser.ParseQuery(q.query)
 		if len(sq.ParseErrors) != 0 || len(sq.EntityTypes) != 1 || sq.HasFreeText() {
 			continue
 		}
-		pushed := PushdownPrefilters(sq.PropertyFilters, meta, sq.EntityTypes)
-		props := make([]string, 0, len(pushed))
-		for _, p := range pushed {
-			if p.Scalar {
-				props = append(props, p.Property)
-			}
+		if q.condition != "" && ev == nil {
+			ev = predicatefns.NewEvaluator(meta)
 		}
-		slices.Sort(props)
-		props = slices.Compact(props)
+		props := staticIndexProps(sq, q.condition, meta, ev)
 		if len(props) == 0 {
 			continue
 		}
@@ -119,6 +112,60 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 	return out
 }
 
+// staticQuery is one operator-declared query and, for a next-action source,
+// the condition that is pushed down beside it at runtime. The two are ANDed
+// by the store, so they share ONE composite index — the same shape the
+// runtime pushdown (dataentry's executeQuery with the condition prefilters
+// appended) actually probes.
+type staticQuery struct{ query, condition string }
+
+// staticQueries collects every query shape the config declares statically.
+func staticQueries(cfg *dataentryconfig.Config) []staticQuery {
+	var queries []staticQuery
+	if cfg.Dashboard != nil {
+		for _, card := range cfg.Dashboard.Cards {
+			queries = append(queries, staticQuery{query: card.Query})
+		}
+	}
+	for _, src := range cfg.NextActions {
+		if src.Query != "" {
+			queries = append(queries, staticQuery{query: src.Query, condition: src.Condition})
+		}
+		for _, offer := range src.Actions {
+			if offer.PickOne != nil {
+				queries = append(queries, staticQuery{query: offer.PickOne.Query})
+			}
+		}
+	}
+	return queries
+}
+
+// staticIndexProps returns the sorted, deduplicated index columns for one
+// static query: the query's scalar pushdown properties plus, when a condition
+// is present, its scalar pushdown properties ([ConditionIndexProperties]).
+//
+// A condition that does not compile contributes nothing, and that is not a
+// partial-set hazard: conditionlint refuses the same expression at load, so
+// no runtime query will ever probe for the index it would have described.
+func staticIndexProps(
+	sq *searchparser.SearchQuery, condition string, meta *metamodel.Metamodel, ev *predicatefns.Evaluator,
+) []string {
+	pushed := PushdownPrefilters(sq.PropertyFilters, meta, sq.EntityTypes)
+	props := make([]string, 0, len(pushed))
+	for _, p := range pushed {
+		if p.Scalar {
+			props = append(props, p.Property)
+		}
+	}
+	if condition != "" && ev != nil {
+		if prog, err := ev.CompileWithCurrentUser(sq.EntityTypes[0], condition); err == nil {
+			props = append(props, ConditionIndexProperties(prog, meta, sq.EntityTypes)...)
+		}
+	}
+	slices.Sort(props)
+	return slices.Compact(props)
+}
+
 // ConditionPrefilters returns the store-evaluable pre-filter subset of a
 // compiled predicate condition, resolving the current user's identity to
 // a literal.
@@ -131,12 +178,20 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 // Soundness rests on two independent gates:
 //
 //   - [predicate.Program.ConstEqualities] restricts the shape to
-//     top-level ANDed equalities against a request-constant, so a
-//     pushed predicate can never contradict the program.
-//   - stringComparableOnEveryType (shared with the filter path)
-//     restricts it to declared non-list string properties, so the
-//     store's string-form comparison cannot disagree with the
-//     metamodel-aware Go pass on a typed value.
+//     top-level ANDed equalities against a request-constant (a literal,
+//     current_user.id, or the is_current_user / has_current_user sugar),
+//     so a pushed predicate can never contradict the program.
+//   - The metamodel gate (shared with the filter path) restricts it to
+//     declared string properties — scalar for an equality, list-of-string
+//     for a membership — so the store's string-form comparison cannot
+//     disagree with the metamodel-aware Go pass on a typed value.
+//
+// A membership (`has_current_user(entity.watchers)`) lowers to a
+// NON-scalar [store.PropEqual], which every backend already defines as
+// "some element equals" for a list value (the multi-select rule pinned by
+// storetest's Props_value_shapes). It needs no new store operator, but it
+// is not indexable by the derived static-query index, which covers scalar
+// text only — see [ConditionIndexProperties].
 //
 // `identity` is the current user's query identity (see
 // predicatefns.QueryIdentity.ID). An EMPTY identity pushes nothing
@@ -147,28 +202,71 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 func ConditionPrefilters(
 	prog *predicate.Program, meta *metamodel.Metamodel, types []string, identity string,
 ) []store.PropPredicate {
-	if prog == nil || meta == nil || len(types) == 0 {
-		return nil
-	}
 	var pushed []store.PropPredicate
-	for _, eq := range prog.ConstEqualities(predicatefns.VarEntity, predicatefns.VarCurrentUser) {
+	for _, eq := range conditionEqualities(prog, meta, types) {
 		value := eq.Value
 		if eq.FromVar != "" {
-			// Only the identity field resolves to a value here. `tool` is
-			// deliberately not pushable: it is diagnostic, never an
-			// authorization or membership input (see internal/affordances),
-			// and pushing it would invite exactly that use.
-			if eq.FromVar != predicatefns.FieldCurrentUserID || identity == "" {
+			if identity == "" {
 				continue
 			}
 			value = identity
 		}
-		if !stringComparableOnEveryType(meta, types, eq.Attribute) {
-			continue
-		}
 		pushed = append(pushed, store.PropPredicate{
-			Property: eq.Attribute, Op: store.PropEqual, Value: value, Scalar: value != "",
+			Property: eq.Attribute, Op: store.PropEqual, Value: value, Scalar: !eq.List && value != "",
 		})
 	}
 	return pushed
+}
+
+// ConditionIndexProperties returns the properties of a compiled condition
+// that [ConditionPrefilters] would push as SCALAR equalities — the shape
+// the derived static-query index covers — regardless of what the identity
+// resolves to at request time.
+//
+// It is the index-inference half of the eligibility decision
+// ConditionPrefilters makes at runtime, and the two must not drift: an
+// index derived for a predicate that is never pushed is dead weight, and
+// a pushed predicate with no index is a sequential scan the operator was
+// promised would not happen. Both call conditionEqualities, so they
+// cannot disagree about which conjuncts qualify. Memberships are
+// excluded here because the composite btree over `properties ->> p` does
+// not serve a jsonb containment probe.
+func ConditionIndexProperties(prog *predicate.Program, meta *metamodel.Metamodel, types []string) []string {
+	var props []string
+	for _, eq := range conditionEqualities(prog, meta, types) {
+		if eq.List {
+			continue
+		}
+		props = append(props, eq.Attribute)
+	}
+	return props
+}
+
+// conditionEqualities is the shared eligibility core: the program's
+// request-constant equalities that ALSO pass the metamodel gate for every
+// type they will be evaluated against. Only the identity field of
+// current_user resolves — `tool` is deliberately not pushable: it is
+// diagnostic, never an authorization or membership input (see
+// internal/affordances), and pushing it would invite exactly that use.
+func conditionEqualities(
+	prog *predicate.Program, meta *metamodel.Metamodel, types []string,
+) []predicate.ConstEquality {
+	if prog == nil || meta == nil || len(types) == 0 {
+		return nil
+	}
+	var out []predicate.ConstEquality
+	for _, eq := range prog.ConstEqualities(predicatefns.CurrentUserPrefilterSpec()) {
+		if eq.FromVar != "" && eq.FromVar != predicatefns.FieldCurrentUserID {
+			continue
+		}
+		if eq.List {
+			if !stringListOnEveryType(meta, types, eq.Attribute) {
+				continue
+			}
+		} else if !stringComparableOnEveryType(meta, types, eq.Attribute) {
+			continue
+		}
+		out = append(out, eq)
+	}
+	return out
 }

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
+	"github.com/Sourcehaven-BV/rela/internal/predicate"
+	"github.com/Sourcehaven-BV/rela/internal/predicatefns"
 	"github.com/Sourcehaven-BV/rela/internal/search/searchparser"
 	"github.com/Sourcehaven-BV/rela/internal/store"
 )
@@ -115,4 +117,57 @@ func StaticIndexSpecs(cfg *dataentryconfig.Config, meta *metamodel.Metamodel) []
 		out = append(out, byKey[key])
 	}
 	return out
+}
+
+// ConditionPrefilters returns the store-evaluable pre-filter subset of a
+// compiled predicate condition, resolving the current user's identity to
+// a literal.
+//
+// It is the predicate-path twin of [PushdownPrefilters] and carries the
+// identical contract: the returned predicates are a PRE-FILTER only, and
+// the caller must still evaluate the whole program in Go. The store may
+// remove rows the Go pass would also have removed — never more.
+//
+// Soundness rests on two independent gates:
+//
+//   - [predicate.Program.ConstEqualities] restricts the shape to
+//     top-level ANDed equalities against a request-constant, so a
+//     pushed predicate can never contradict the program.
+//   - stringComparableOnEveryType (shared with the filter path)
+//     restricts it to declared non-list string properties, so the
+//     store's string-form comparison cannot disagree with the
+//     metamodel-aware Go pass on a typed value.
+//
+// `me` is the current user's query identity. An EMPTY `me` pushes
+// nothing rather than pushing an empty-string equality: an unidentified
+// request must not silently pre-filter to the rows whose property is
+// unset. The Go pass fails that request closed on its own; this must not
+// quietly answer it first.
+func ConditionPrefilters(
+	prog *predicate.Program, meta *metamodel.Metamodel, types []string, me string,
+) []store.PropPredicate {
+	if prog == nil || meta == nil || len(types) == 0 {
+		return nil
+	}
+	var pushed []store.PropPredicate
+	for _, eq := range prog.ConstEqualities(predicatefns.VarEntity, predicatefns.VarCurrentUser) {
+		value := eq.Value
+		if eq.FromVar != "" {
+			// Only the identity field resolves to a value here. `tool` is
+			// deliberately not pushable: it is diagnostic, never an
+			// authorization or membership input (see internal/affordances),
+			// and pushing it would invite exactly that use.
+			if eq.FromVar != predicatefns.FieldCurrentUserID || me == "" {
+				continue
+			}
+			value = me
+		}
+		if !stringComparableOnEveryType(meta, types, eq.Attribute) {
+			continue
+		}
+		pushed = append(pushed, store.PropPredicate{
+			Property: eq.Attribute, Op: store.PropEqual, Value: value, Scalar: value != "",
+		})
+	}
+	return pushed
 }

--- a/internal/queryplan/queryplan.go
+++ b/internal/queryplan/queryplan.go
@@ -3,11 +3,13 @@
 package queryplan
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Sourcehaven-BV/rela/internal/conditionlint"
 	"github.com/Sourcehaven-BV/rela/internal/dataentryconfig"
 	"github.com/Sourcehaven-BV/rela/internal/filter"
 	"github.com/Sourcehaven-BV/rela/internal/metamodel"
@@ -27,6 +29,13 @@ func LoadStaticIndexSpecs(data []byte, meta *metamodel.Metamodel) ([]store.Deriv
 	}
 	if err := dataentryconfig.ValidateConfig(data, &cfg, meta); err != nil {
 		return nil, err
+	}
+	// A next-action condition that does not compile is a load error on the
+	// server (projectsetup), so the desired set must be computed from the
+	// same gate here: `rela db reconcile` reading a config the server would
+	// refuse must not converge to an index shape the server never derives.
+	if _, problems := conditionlint.CompileNextActions(&cfg, meta); len(problems) > 0 {
+		return nil, fmt.Errorf("next-action condition: %s", problems[0])
 	}
 	return StaticIndexSpecs(&cfg, meta), nil
 }
@@ -144,9 +153,11 @@ func staticQueries(cfg *dataentryconfig.Config) []staticQuery {
 // static query: the query's scalar pushdown properties plus, when a condition
 // is present, its scalar pushdown properties ([ConditionIndexProperties]).
 //
-// A condition that does not compile contributes nothing, and that is not a
-// partial-set hazard: conditionlint refuses the same expression at load, so
-// no runtime query will ever probe for the index it would have described.
+// A condition that does not compile contributes nothing. Every production
+// entry point ([LoadStaticIndexSpecs], and the server's own load) has
+// already refused such a config through conditionlint, so this branch is
+// reachable only from a caller building a Config in code; skipping keeps it
+// non-destructive there rather than pretending to a guarantee.
 func staticIndexProps(
 	sq *searchparser.SearchQuery, condition string, meta *metamodel.Metamodel, ev *predicatefns.Evaluator,
 ) []string {
@@ -192,6 +203,11 @@ func staticIndexProps(
 // storetest's Props_value_shapes). It needs no new store operator, but it
 // is not indexable by the derived static-query index, which covers scalar
 // text only — see [ConditionIndexProperties].
+//
+// The metamodel gate is the one [PushdownPrefilters] uses, so enum-typed
+// (custom-type) properties are not pushed from either path even though the
+// predicate compiler treats them as strings. Widening that gate is a
+// shared decision for both pushdowns, not one to take here alone.
 //
 // `identity` is the current user's query identity (see
 // predicatefns.QueryIdentity.ID). An EMPTY identity pushes nothing

--- a/internal/queryplan/queryplan_test.go
+++ b/internal/queryplan/queryplan_test.go
@@ -110,3 +110,24 @@ func TestLoadStaticIndexSpecsRejectsIncompleteConfig(t *testing.T) {
 		t.Fatalf("LoadStaticIndexSpecs() = %#v, %v; want nil specs and an error", got, err)
 	}
 }
+
+// LoadStaticIndexSpecs must refuse a config whose next-action condition
+// does not compile, exactly as the server does at load — otherwise
+// `rela db reconcile` would converge to a desired set the server never
+// derives.
+func TestLoadStaticIndexSpecsRejectsBrokenCondition(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+next_action_bands:
+  - id: b
+next_actions:
+  s:
+    band: b
+    query: "type:task prop:status=open"
+    condition: "entity.nope == 1"
+    suggest: "x"
+`)
+	if _, err := LoadStaticIndexSpecs(data, testMeta()); err == nil {
+		t.Fatal("expected an error for a non-compiling condition")
+	}
+}

--- a/internal/queryplan/queryplan_test.go
+++ b/internal/queryplan/queryplan_test.go
@@ -46,6 +46,42 @@ func TestStaticIndexSpecsCollectsAndCanonicalizesStaticQueries(t *testing.T) {
 	}
 }
 
+// A next-action condition's pushable equalities join the query's in ONE
+// composite index, because the runtime pushes both into the same store
+// query. Memberships and unpushable shapes contribute no column, and a
+// condition that does not compile contributes nothing at all.
+func TestStaticIndexSpecsIncludeNextActionConditionEqualities(t *testing.T) {
+	t.Parallel()
+	cfg := &dataentryconfig.Config{
+		NextActions: map[string]dataentryconfig.NextActionSource{
+			"mine": {
+				Query:     "type:task prop:status=open",
+				Condition: "is_current_user(entity.owner) and contains(entity.tags, 'x')",
+			},
+			"watched": {
+				Query:     "type:task prop:status=open",
+				Condition: "has_current_user(entity.tags)",
+			},
+			"broken": {
+				Query:     "type:task prop:owner=alice",
+				Condition: "entity.nope == 1",
+			},
+			"ordered": {
+				Query:     "type:task",
+				Condition: "entity.count >= 3 and entity.owner == current_user.id",
+			},
+		},
+	}
+	want := []store.DerivedObjectSpec{
+		{Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"owner"}},
+		{Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"owner", "status"}},
+		{Kind: store.DerivedQueryIndex, Type: "task", Properties: []string{"status"}},
+	}
+	if got := StaticIndexSpecs(cfg, testMeta()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("StaticIndexSpecs() = %#v, want %#v", got, want)
+	}
+}
+
 func TestStaticIndexSpecsSkipsUnsupportedShapes(t *testing.T) {
 	t.Parallel()
 	queries := []string{

--- a/internal/store/graphquery.go
+++ b/internal/store/graphquery.go
@@ -88,7 +88,11 @@ type PropOp int
 
 const (
 	// PropEqual matches when the property equals Value. With an empty
-	// Value it means "is empty" — see [PropPredicate].
+	// Value it means "is empty" — see [PropPredicate]. Against a LIST value
+	// (multi-select) a non-scalar PropEqual is MEMBERSHIP: it matches when
+	// any element equals Value, which is how `has_current_user(entity.watchers)`
+	// lowers without a dedicated operator. [PropPredicate.Scalar] opts out
+	// of that reading.
 	PropEqual PropOp = iota
 	// PropNotEqual is the negation. With an empty Value it means "is not
 	// empty".

--- a/tickets/entities/docs-checklists/DOCS-IRYGXC.md
+++ b/tickets/entities/docs-checklists/DOCS-IRYGXC.md
@@ -1,0 +1,59 @@
+---
+id: DOCS-IRYGXC
+type: docs-checklist
+title: 'Documentation: current_user in the predicate language and next-action pushdown'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Code Documentation
+
+- [x] Exported symbols have godoc
+- [x] Non-obvious decisions explained at the call site
+
+The comments carry the *why*: `CurrentUserType` says why it is a record and not
+a string (operator `acl.yaml` passes it whole to `has_role`); `ErrNoCurrentUser`
+says why absence is an error and not an empty binding (an empty identity would
+match every unset property); `DeclareCurrentUser` says why it is separate from
+`Declare` (validation, scheduler and index derivation must keep it a compile
+error); `Program.ConstEqualities` states the three soundness restrictions and
+why each exists; `PrefilterSpec.ConstFuncs` names the caller's assertion the
+engine cannot verify; `ConditionPrefilterer` documents the raw-vs-redacted
+asymmetry and why it is sound; `nextActionRequestScope` explains stamp/principal
+agreement and names the ACL precedent; `bindingContext.identity` explains why
+the attribution placeholder is not a user; `store.PropEqual` names the
+list-membership reading a non-scalar equality has.
+
+## Project Documentation
+
+- [x] `docs/data-entry.md` — new "Per-user sources: `current_user`" subsection
+under the next-action `condition` reference: the three spellings, what
+`current_user.id` resolves to with and without a `user_entity_type`, the
+fail-closed refusal (`next_action_identity_required`), and what is pushed to the
+store versus evaluated in Go (including that membership is pushed but not
+indexed).
+- [x] Limitations documented, not just capabilities
+
+Stated limitations: `current_user.tool` is diagnostic only; anything under
+`or`/`not` or a typed comparison stays Go-side; a condition on a free-text query
+is refused at load; `where:` surfaces and the CLI are not covered
+([[TKT-ZQV9O5]]).
+
+## External Documentation
+
+- [x] ~~README updated~~ (N/A: no new binary, flag or command; a config-language
+addition documented in the data-entry reference.)
+- [x] ~~CHANGELOG~~ (N/A: the repo does not keep one; the ticket and commits
+carry the history.)
+
+## Cross-references
+
+- [x] `CLAUDE.md` — the "Derived static-query indexes" rule now states that a
+next-action `condition:` participates in both pushdown and index inference,
+which shapes are pushed, and why list membership derives no index (a GIN shape
+needs its own EXPLAIN test first). Added because the rule as written would
+otherwise be read as "query filters only".
+- [x] Field comment on `dataentryconfig.NextActionSource.Condition` updated so
+the select/refine split is described as a LANGUAGE split, not a "where work
+happens" split, and names the identity requirement.

--- a/tickets/entities/implementation-checklists/IMPL-69FYMO.md
+++ b/tickets/entities/implementation-checklists/IMPL-69FYMO.md
@@ -1,0 +1,44 @@
+---
+id: IMPL-69FYMO
+type: implementation-checklist
+title: 'Implementation: Predicate language: current_user with is_current_user/has_current_user sugar, pushed into next-action queries'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Development
+
+- [ ] Unit tests written for new code
+- [ ] Integration tests written (test full flow, not just units)
+- [ ] Happy path implemented
+- [ ] Edge cases from planning handled
+- [ ] Error handling in place (errors surfaced, not swallowed)
+
+## Test Quality
+
+- [ ] Using fixture builders or factories for test data
+- [ ] No hardcoded values in assertions when object is in scope
+- [ ] Only specifying values that matter for the test
+- [ ] Interpolated values constructed from objects, not hardcoded
+- [ ] Property comparisons use original object, not hardcoded strings
+
+## Manual Verification
+
+- [ ] Feature manually tested end-to-end
+- [ ] Each acceptance criterion verified with test scenario from planning
+- [ ] Edge cases manually verified
+
+**Verification Evidence:**
+<!-- Document what you tested and the results -->
+
+## Quality
+
+- [ ] Code follows project patterns (check similar code)
+- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+patterns extracted to a helper / constant / type where it sharpens the contract
+(don't extract for its own sake; CLAUDE.md "three similar lines is better than a
+premature abstraction" still holds)
+- [ ] No security issues introduced
+- [ ] No silent failures (errors logged AND returned)
+- [ ] No debug code left behind

--- a/tickets/entities/implementation-checklists/IMPL-69FYMO.md
+++ b/tickets/entities/implementation-checklists/IMPL-69FYMO.md
@@ -16,26 +16,31 @@ status: done
 - [x] Error handling in place (errors surfaced, not swallowed)
 
 Unit: `internal/predicate/prefilter_test.go` (ConstEqualities per shape,
-References/Functions), `internal/predicatefns/currentuser_test.go` +
-`evaluator_currentuser_test.go` (bind fail-closed, MatchesAs binds only when
-required, prefilter spec drift guard, empty identity never matches),
-`internal/queryplan/conditionprefilter_test.go`
-+ `queryplan_test.go` (lowering, index derivation, agreement, static specs,
-Load refuses a broken condition), `internal/conditionlint/nextaction_test.go`
-(user profile, identity contract, free-text refusal, Types),
+References/Functions, one expression per IR node type),
+`internal/predicatefns/currentuser_test.go` + `evaluator_currentuser_test.go`
+(bind fail-closed, MatchesAs binds only when required, prefilter spec drift
+guard incl. RequiresCurrentUser, empty identity never matches),
+`internal/queryplan/conditionprefilter_test.go` + `queryplan_test.go` (lowering,
+index derivation, agreement, static specs, Load refuses a broken condition),
+`internal/conditionlint/nextaction_test.go` (user profile, identity contract,
+free-text refusal, Types), `internal/nextaction/condition_test.go`
+(ErrIdentityRequired skips only that source; other errors propagate),
 `internal/appbuild/nextaction_matchers_test.go` (scope binder, agreement,
-mismatch refusal), `internal/affordances/currentuser_sugar_test.go` (sugar,
-unknown placeholder via `everyone`).
+conflict), `internal/affordances/currentuser_sugar_test.go` (sugar; unknown
+placeholder via `everyone`).
 
 Integration: `internal/dataentry/nextaction_condition_test.go` — pre-filter
 reaches the store while the Go pass stays authoritative; real
 `appbuild.NextActionMatchers` behind the HTTP handler for all three spellings
-across principals; unidentified request → `next_action_identity_required`;
-hidden property makes the condition false end to end.
+across principals; unidentified caller gets the identity-free source and null
+when only per-user sources exist; identity conflict →
+`next_action_identity_conflict` with no identity echoed; hidden property makes
+the condition false end to end.
 
-Errors: `ErrNoCurrentUser` → `nextaction.ErrIdentityRequired` → HTTP 500 with a
-named code and a WARN log; a non-compiling or free-text condition is a load
-error; a stamp disagreeing with the principal is refused.
+Errors: an unidentified caller's per-user source is SKIPPED with a WARN naming
+the source (never a placeholder match, never a failure of other sources); a
+stamp/principal conflict is refused whole with a named code; a non-compiling or
+free-text condition is a load error.
 
 ## Test Quality
 
@@ -47,7 +52,7 @@ error; a stamp disagreeing with the principal is refused.
 
 Fixtures: `seedAssignedTicket`, `withTicketAssignment`, `recordingMatcher`,
 `matcherFuncFor`, `scoped`, `prefilterEnv`/`fullSpec`,
-`matcherMeta`/`matcherCfg`.
+`matcherMeta`/`matcherCfg`, `matchIDs`.
 
 ## Manual Verification
 
@@ -62,7 +67,8 @@ Scratch project (`/tmp/rela-cu-verify`): `task` with `assignee` (string) and
 watchers [dave, alice], unassigned); one source `query: "type:task
 prop:status=open"`, `condition: "is_current_user(entity.assignee) or
 has_current_user(entity.watchers)"`. `rela-server -principal-header
-X-Forwarded-User`, `GET /api/v1/_next_action`:
+X-Forwarded-User`, `GET /api/v1/_next_action`, repeated on the final tree (after
+the code-review fixes):
 
 | principal | result |
 |---|---|
@@ -70,10 +76,10 @@ X-Forwarded-User`, `GET /api/v1/_next_action`:
 | bob | `T-bob` |
 | dave | `T-watched` (watcher) |
 | erin | `{"suggestion": null}` |
-| no header (placeholder principal) | HTTP 500 `next_action_identity_required`, WARN logged, no identity or entity data in the body |
+| no header (placeholder principal) | HTTP 200 `{"suggestion": null}`; WARN `nextaction: source skipped, its condition needs an identified principal source=assigned`; no identity or entity data in body or log |
 
 Gates on the final tree: full `./internal/... ./cmd/...` suite, golangci-lint,
-arch-lint, comment-lint, plimsoll, coverage floors — all pass.
+arch-lint, comment-lint, plimsoll, coverage floors (79.3%) — all pass.
 
 ## Quality
 
@@ -90,5 +96,6 @@ Patterns: consumer-side interfaces (`ConditionPrefilterer`,
 `NextActionRequestScope`, `PrincipalResolver`), optional capability by type
 assertion, belt-and-braces pushdown identical to `PushdownPrefilters`, shared
 eligibility core for pushdown and index inference, `principal.Unknown` replaces
-three bare literals. Security: design review RR-2ITZ84/RR-LD2B23 addressed
-(affordance placeholder identity; stamp/principal agreement).
+three bare literals, sugar bindings built once per binding context. Security:
+design review RR-2ITZ84/RR-LD2B23 addressed; code review's security pass found
+no issues.

--- a/tickets/entities/implementation-checklists/IMPL-69FYMO.md
+++ b/tickets/entities/implementation-checklists/IMPL-69FYMO.md
@@ -2,43 +2,93 @@
 id: IMPL-69FYMO
 type: implementation-checklist
 title: 'Implementation: Predicate language: current_user with is_current_user/has_current_user sugar, pushed into next-action queries'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Development
 
-- [ ] Unit tests written for new code
-- [ ] Integration tests written (test full flow, not just units)
-- [ ] Happy path implemented
-- [ ] Edge cases from planning handled
-- [ ] Error handling in place (errors surfaced, not swallowed)
+- [x] Unit tests written for new code
+- [x] Integration tests written (test full flow, not just units)
+- [x] Happy path implemented
+- [x] Edge cases from planning handled
+- [x] Error handling in place (errors surfaced, not swallowed)
+
+Unit: `internal/predicate/prefilter_test.go` (ConstEqualities per shape,
+References/Functions), `internal/predicatefns/currentuser_test.go` +
+`evaluator_currentuser_test.go` (bind fail-closed, MatchesAs binds only when
+required, prefilter spec drift guard, empty identity never matches),
+`internal/queryplan/conditionprefilter_test.go`
++ `queryplan_test.go` (lowering, index derivation, agreement, static specs,
+Load refuses a broken condition), `internal/conditionlint/nextaction_test.go`
+(user profile, identity contract, free-text refusal, Types),
+`internal/appbuild/nextaction_matchers_test.go` (scope binder, agreement,
+mismatch refusal), `internal/affordances/currentuser_sugar_test.go` (sugar,
+unknown placeholder via `everyone`).
+
+Integration: `internal/dataentry/nextaction_condition_test.go` — pre-filter
+reaches the store while the Go pass stays authoritative; real
+`appbuild.NextActionMatchers` behind the HTTP handler for all three spellings
+across principals; unidentified request → `next_action_identity_required`;
+hidden property makes the condition false end to end.
+
+Errors: `ErrNoCurrentUser` → `nextaction.ErrIdentityRequired` → HTTP 500 with a
+named code and a WARN log; a non-compiling or free-text condition is a load
+error; a stamp disagreeing with the principal is refused.
 
 ## Test Quality
 
-- [ ] Using fixture builders or factories for test data
-- [ ] No hardcoded values in assertions when object is in scope
-- [ ] Only specifying values that matter for the test
-- [ ] Interpolated values constructed from objects, not hardcoded
-- [ ] Property comparisons use original object, not hardcoded strings
+- [x] Using fixture builders or factories for test data
+- [x] No hardcoded values in assertions when object is in scope
+- [x] Only specifying values that matter for the test
+- [x] Interpolated values constructed from objects, not hardcoded
+- [x] Property comparisons use original object, not hardcoded strings
+
+Fixtures: `seedAssignedTicket`, `withTicketAssignment`, `recordingMatcher`,
+`matcherFuncFor`, `scoped`, `prefilterEnv`/`fullSpec`,
+`matcherMeta`/`matcherCfg`.
 
 ## Manual Verification
 
-- [ ] Feature manually tested end-to-end
-- [ ] Each acceptance criterion verified with test scenario from planning
-- [ ] Edge cases manually verified
+- [x] Feature manually tested end-to-end
+- [x] Each acceptance criterion verified with test scenario from planning
+- [x] Edge cases manually verified
 
 **Verification Evidence:**
-<!-- Document what you tested and the results -->
+
+Scratch project (`/tmp/rela-cu-verify`): `task` with `assignee` (string) and
+`watchers` (string list); four tasks (assigned to alice, to bob, to carol with
+watchers [dave, alice], unassigned); one source `query: "type:task
+prop:status=open"`, `condition: "is_current_user(entity.assignee) or
+has_current_user(entity.watchers)"`. `rela-server -principal-header
+X-Forwarded-User`, `GET /api/v1/_next_action`:
+
+| principal | result |
+|---|---|
+| alice | `T-watched` (eligible for both her own and the watched task; stable-random picked the latter) |
+| bob | `T-bob` |
+| dave | `T-watched` (watcher) |
+| erin | `{"suggestion": null}` |
+| no header (placeholder principal) | HTTP 500 `next_action_identity_required`, WARN logged, no identity or entity data in the body |
+
+Gates on the final tree: full `./internal/... ./cmd/...` suite, golangci-lint,
+arch-lint, comment-lint, plimsoll, coverage floors — all pass.
 
 ## Quality
 
-- [ ] Code follows project patterns (check similar code)
-- [ ] Checked for DRY opportunities — repeated literals, expressions, or
+- [x] Code follows project patterns (check similar code)
+- [x] Checked for DRY opportunities — repeated literals, expressions, or
 patterns extracted to a helper / constant / type where it sharpens the contract
 (don't extract for its own sake; CLAUDE.md "three similar lines is better than a
 premature abstraction" still holds)
-- [ ] No security issues introduced
-- [ ] No silent failures (errors logged AND returned)
-- [ ] No debug code left behind
+- [x] No security issues introduced
+- [x] No silent failures (errors logged AND returned)
+- [x] No debug code left behind
+
+Patterns: consumer-side interfaces (`ConditionPrefilterer`,
+`NextActionRequestScope`, `PrincipalResolver`), optional capability by type
+assertion, belt-and-braces pushdown identical to `PushdownPrefilters`, shared
+eligibility core for pushdown and index inference, `principal.Unknown` replaces
+three bare literals. Security: design review RR-2ITZ84/RR-LD2B23 addressed
+(affordance placeholder identity; stamp/principal agreement).

--- a/tickets/entities/planning-checklists/PLAN-J84R77.md
+++ b/tickets/entities/planning-checklists/PLAN-J84R77.md
@@ -1,0 +1,229 @@
+---
+id: PLAN-J84R77
+type: planning-checklist
+title: 'Planning: Predicate language: current_user with is_current_user/has_current_user sugar, pushed into next-action queries'
+status: done
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Understanding
+
+- [x] Problem/requirements clearly understood
+- [x] Scope defined (what's in/out documented below)
+- [x] Acceptance criteria documented with specific test scenarios
+
+**Scope:**
+
+IN: `current_user` record + `is_current_user`/`has_current_user` host functions
+in the predicate language (`internal/predicatefns`); fail-closed identity
+binding from a ctx-stamped `QueryIdentity`; IR accessor for request-constant
+equalities (`predicate.Program.ConstEqualities`); store pushdown + static-index
+derivation for next-action `condition:` (`internal/queryplan`); exposure on ACL
+affordance `when:` and next-action `condition:`; docs.
+
+OUT: `where:` surfaces (views/feeds/kanbans/CalDAV) and CLI `--filter` →
+[[TKT-ZQV9O5]]. Ordered-comparison pushdown (needs a store operator) → follow-up
+per [[RES-05JD73]]. GIN index for list membership. Wizard-form identity.
+State-machine/computed/validation/automation profiles deliberately do NOT
+declare `current_user` (no request principal, or persisted results).
+
+**Acceptance Criteria:**
+
+1. All three spellings compile and evaluate in the two exposed profiles;
+referencing them in a profile without a request is a compile error at load —
+`TestCurrentUser_EqualityAndSugar`, `TestCurrentUser_UndeclaredInStdlibProfile`.
+2. Absent/empty identity fails closed — `TestCurrentUser_BindFailsClosed`,
+`TestMatchesAs_IdentityBoundOnlyWhenNeeded`,
+`TestAffordances_CurrentUserSugar_UnknownPlaceholderNeverMatches`; empty
+identity pushes nothing — `TestConditionPrefilters` ("an empty identity pushes
+NOTHING").
+3. Only top-level AND equalities/memberships are pushed — `TestConstEqualities`
+(one case per refused shape, including the empty literal),
+`TestConditionPrefilters`.
+4. Pushdown and index inference agree — `TestConditionPrefilters_AgreesWithIndexProperties`.
+5. Two principals, one source, different entities — `TestNextAction_CurrentUserConditionEndToEnd`.
+6. Pre-filter actually reaches the store and the Go pass stays authoritative —
+`TestNextAction_ConditionPrefiltersReachTheStore`,
+`TestNextAction_HiddenPropertyMakesCurrentUserConditionFalse`.
+
+## Research
+
+- [x] ~~For larger features: run `/research` to create a structured research doc~~ (N/A: approach settled in-session against existing research; see below)
+- [x] Searched for existing libraries that solve this problem
+- [x] Checked codebase for similar patterns or reusable code
+- [x] Looked for reference implementations in other projects
+- [x] Reviewed relevant rela concepts for prior art
+
+**Research Doc:** N/A — [[RES-05JD73]] (pushing date conditions into the store)
+already covers the pushdown seam and constant-folding; this ticket takes its
+Step-1 shape for equalities only.
+
+**Existing Solutions:**
+
+- No library: the predicate language is rela's own sandboxed Lua-expression
+subset (gopher-lua parser). `in` is a reserved Lua keyword, so membership must
+be a host function, not an operator.
+- `internal/affordances/env.go` already declared a `current_user` RecordType
+`{id, tool}` for ACL `when:` — reused as the canonical type
+(`predicatefns.CurrentUserType`) rather than introducing a second shape.
+- `queryplan.PushdownPrefilters` + `dataentry.executeQuery` (helpers.go) are the
+existing belt-and-braces pushdown seam; `ConditionPrefilters` is its
+predicate-path twin with the identical contract.
+- `store.PropPredicate` non-scalar `PropEqual` already means "any element
+equals" for list values (pgstore `equalsCond`, `propmatch.Decide`, storetest
+`Props_value_shapes`) — so membership needs no new store operator.
+- Prior art on the "@me" idea elsewhere: Jira JQL `currentUser()`, GitHub
+`assignee:@me`. Both resolve at query time from the session, never at config
+load — same choice here.
+
+## Approach
+
+- [x] Technical approach chosen and documented
+- [x] Approach builds on existing patterns (not reinventing)
+- [x] Alternatives considered (document why rejected)
+- [x] Dependencies identified (packages, APIs, types)
+
+**Technical Approach:**
+
+1. `predicatefns/currentuser.go`: `CurrentUserType`, `QueryIdentity` + ctx
+stamp, `DeclareCurrentUser`/`DeclareCurrentUserFuncs`, `BindCurrentUser` (fail
+closed), `CurrentUserFuncs`/`CurrentUserBindings` (empty identity never
+matches), `ResolveQueryIdentity` (consumer-side `PrincipalResolver`),
+`CurrentUserPrefilterSpec`, `RequiresCurrentUser`.
+2. `predicatefns/evaluator.go`: `CompileWithCurrentUser`/`MatchesAs`; profile
+in the cache key; identity bound only when required.
+3. `predicate/program.go`: `References`, `Functions`; `inspect` refuses an
+unhandled node. `predicate/prefilter.go`: `ConstEqualities(PrefilterSpec)` over
+the top-level AND spine, recognising listed sugar functions (scalar → equality,
+list → membership); empty literal refused.
+4. `queryplan`: `ConditionPrefilters`, `ConditionIndexProperties`, shared
+`conditionEqualities` core; `StaticIndexSpecs` includes next-action conditions;
+`LoadStaticIndexSpecs` runs `conditionlint` so the CLI reconcile refuses what
+the server refuses.
+5. `conditionlint`: compile in the user profile, evaluate via `MatchesAs`,
+expose `Program(type)` and `Types()`; refuse a condition on a free-text query.
+6. `nextaction.CandidateFunc` gains the source id; `dataentry` declares
+`ConditionPrefilterer` + `NextActionRequestScope` (consumer-side) and threads
+prefilters through `executeQueryPrefiltered`; the handler applies the scope
+binder once per request. `appbuild.NextActionMatchers` wraps the matcher and
+supplies the scope binder (`nextActionRequestScope`, refusing a stamp that
+disagrees with the principal); `ErrNoCurrentUser` →
+`nextaction.ErrIdentityRequired` → HTTP `next_action_identity_required`.
+7. `affordances`: alias the record type, declare the sugar funcs, bind per loop;
+`passes` refuses a per-user clause for an unidentified caller.
+
+**Alternatives rejected:**
+
+- `@me` token in `internal/filter`: would give the filter DSL a second parser
+concern and no IR to push from; predicate is the converging dialect.
+- `current_user` as a bare string: breaks `has_role(current_user, ...)` in
+operator acl.yaml; relaxing `checkRelational` without touching `valuesEqual`
+would turn a loud compile error into a silent `false`.
+- A `PropContains` store operator: unnecessary — non-scalar `PropEqual` already
+has membership semantics on every backend.
+- Stamping identity in `dataentry`'s router: dataentry may not import
+`predicatefns` (arch-lint keeps the predicate engine above the app); the
+composition root supplies a scope binder the handler applies once. Converging on
+a router-boundary stamp is noted for [[TKT-ZQV9O5]].
+
+**Files to modify:** see the commits on `current-user-predicate`.
+
+## Security Considerations
+
+- [x] Input sources identified (user input, config, external APIs)
+- [x] Input validation approach defined (allowlist preferred over blocklist)
+- [x] Security-sensitive operations identified (file access, auth, crypto)
+- [x] Error handling doesn't leak sensitive information
+
+**Input Sources & Validation:**
+
+- Operator config (`condition:`, `when:`): compiled at load against a typed Env;
+unknown identifiers/functions are compile errors. Not a secret (config rule).
+- Request principal: already resolved by `resolvePrincipalEntity`; the scope
+binder reads it, never re-derives from headers. `unknown`/empty → no identity.
+- Entity data compared against the identity: read through the existing ACL read
+gate (`visibleListByTypes`), unchanged.
+
+**Security-Sensitive Operations:**
+
+- Identity binding fails closed (`ErrNoCurrentUser`); an empty identity is never
+bound on the query path and never matches on the affordance path; an affordance
+grant reading the current user is refused for an unidentified caller.
+- Pushdown is narrowing-only (the store may only remove rows the Go pass would
+remove); the authoritative Go pass still runs. Pre-filter and Go pass read one
+identity stamped once per request, so they cannot select different users' rows.
+- `current_user.tool` is never pushed and is documented as not an authorization
+input.
+- Error response names the misconfiguration (`next_action_identity_required`)
+without echoing the identity or any entity data.
+
+## Test Plan
+
+- [x] Test scenarios documented for each acceptance criterion
+- [x] Edge cases identified and documented
+- [x] Negative test cases defined (invalid input, error conditions)
+- [x] Integration test approach defined (not just unit tests)
+
+**Test Scenarios:** see Acceptance Criteria above (each names its test).
+
+**Edge Cases:**
+
+- Unset property with `is_current_user` → false, not error (Nil arg).
+- Empty list / bare scalar in a list property → membership semantics agree
+between `coerceList` and the store's non-scalar equality.
+- Same attribute constrained twice → reported once (result is a SUBSET).
+- Program compiled with `current_user` declared but not referenced → evaluates
+without an identity (`RequiresCurrentUser` false).
+- Stamped identity agreeing with the principal is honored; disagreeing is refused.
+- Hidden (`visible:`) property: pre-filter keeps the row, Go pass rejects it.
+
+**Negative Tests:**
+
+- `entity.watchers == current_user.id` (list vs string) → compile error.
+- `current_user` in a stdlib-only profile → compile error.
+- OR / NOT / `~=` / ordered / typed / field-to-field / empty literal → nothing pushed.
+- Free-text next-action query with a condition → load error.
+- Unidentified request on a per-user source → HTTP 500 with a named code.
+
+## Risk Assessment
+
+- [x] Technical risks assessed with mitigations
+- [x] Security risks assessed (see Security Considerations)
+- [x] Effort estimated (xs/s/m/l/xl)
+
+**Risks:**
+
+- Pushdown widening results → mitigated by the never-widen contract, per-shape
+refusal tests, and the authoritative Go pass.
+- Index inference drifting from pushdown → mitigated by a shared eligibility
+core and an agreement test.
+- `CandidateFunc` / `NextActionMatcherFunc` signature changes → all
+implementations updated; engine tests pass.
+- Cache-key collision between profiles → profile is part of the key; tested.
+
+Effort: m.
+
+## Documentation Planning
+
+- [x] User-facing docs identified (skip if internal refactor)
+- [x] Docs-checklist will be created when entering implementation
+
+**Documentation Impact:**
+
+- [x] docs/data-entry.md — "Per-user sources: `current_user`" under next-action
+`condition`
+- [x] CLAUDE.md — derived static-query index rule now covers conditions
+- [x] Field comment on `NextActionSource.Condition`; `store.PropEqual` doc names
+the list-membership reading
+- [x] ~~docs/metamodel.md~~ (N/A: no metamodel change)
+
+## Design Review
+
+- [x] Run `/design-review` before starting implementation
+- [x] All critical/significant findings addressed in plan
+
+**Design Review Findings:** RR-2ITZ84 (significant, addressed), RR-PDKNZG
+(significant, addressed), RR-A856MZ (significant, addressed), RR-LD2B23,
+RR-IZ9XNH, RR-JMHJJ5, RR-QBW3QO, RR-P1YQPB (minor, addressed), RR-3WKYQX,
+RR-KUXDQO (nit, addressed), RR-NDER2B (nit, deferred with reason).

--- a/tickets/entities/review-checklists/REV-JHH8AX.md
+++ b/tickets/entities/review-checklists/REV-JHH8AX.md
@@ -2,72 +2,92 @@
 id: REV-JHH8AX
 type: review-checklist
 title: 'Review: Predicate language: current_user with is_current_user/has_current_user sugar, pushed into next-action queries'
-status: in-progress
+status: done
 ---
 
 <!-- @managed: claude-workflow v1 -->
 
 ## Automated Checks
 
-- [ ] All tests pass (`just test`)
-- [ ] Lint clean (`just lint`)
-- [ ] Comment lint gate clean (`just comment-lint`)
-- [ ] Coverage maintained (`just coverage-check`)
+- [x] All tests pass (`just test`)
+- [x] Lint clean (`just lint`)
+- [x] Comment lint gate clean (`just comment-lint`)
+- [x] Coverage maintained (`just coverage-check`)
 
-**Comment findings.** `just comment-report` lists the advisory rules
-(duplication, nil-contract, param-contract, restatement). They are not a merge
-gate, but a finding your diff *introduces* should be fixed or suppressed — don't
-grow the backlog.
-
-Every rule is a heuristic over prose, so false positives are expected. To
-suppress one, prefer the inline form on the declaration line, which travels with
-the code and is reviewed in this diff:
-
-```go
-func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
-```
-
-Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
-same prose recurs across many sites. A reason is required either way — an
-unexplained suppression is a finding nobody can re-evaluate later.
+Full `./internal/... ./cmd/...` suite green; golangci-lint 0 issues; arch-lint,
+comment-lint (commented-code + doclink) and plimsoll clean; coverage floors
+satisfied at 79.3% total. One doclink finding introduced by the diff (a
+bracketed unexported method) was fixed, not suppressed.
 
 ## Code Review
 
-- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
-- [ ] All critical review-responses addressed
-- [ ] All significant review-responses addressed
-- [ ] Self-reviewed the diff for unrelated changes
+- [x] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [x] All critical review-responses addressed
+- [x] All significant review-responses addressed
+- [x] Self-reviewed the diff for unrelated changes
 
-**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
-RR-xxxx -->
+**Review Responses:**
+
+Design review (before implementation was accepted): RR-2ITZ84, RR-PDKNZG,
+RR-A856MZ (significant, addressed); RR-LD2B23, RR-IZ9XNH, RR-JMHJJ5, RR-QBW3QO,
+RR-P1YQPB (minor, addressed); RR-3WKYQX, RR-KUXDQO (nit, addressed); RR-NDER2B
+(nit, deferred with reason).
+
+Code review — cranky-code-reviewer: RR-635ZA0 (significant, addressed);
+RR-J1XD8R, RR-8JIICP, RR-COK0GT, RR-S7ESOF (minor, addressed); RR-P7424Q,
+RR-Z12KRD, RR-LT2O71, RR-1S9AX5, RR-2RD921 (nit, addressed). Code review —
+rela-security-reviewer: no findings at any severity; confirmed all four earlier
+security fixes complete; one below-threshold note (compare `Tool` as well as
+`ID()` once a boundary stamp exists) recorded on TKT-ZQV9O5.
+
+Self-review: the diff also renames three bare `"unknown"` literals to
+`principal.Unknown` (needed by the identity guard) and rebuilds the embedded
+frontend for the manual check (build artifact, gitignored). Nothing else
+unrelated.
 
 ## Acceptance Verification
 
-- [ ] Each acceptance criterion tested (reference planning checklist)
-- [ ] Test evidence documented in implementation checklist
+- [x] Each acceptance criterion tested (reference planning checklist)
+- [x] Test evidence documented in implementation checklist
 
 **Acceptance Status:**
-<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+1. Three spellings compile/evaluate in both exposed profiles; compile error in
+a request-less profile — PASS (`TestCurrentUser_EqualityAndSugar`,
+`TestCurrentUser_UndeclaredInStdlibProfile`).
+2. Absent/empty identity fails closed; empty identity pushes nothing — PASS
+(`TestCurrentUser_BindFailsClosed`, `TestMatchesAs_IdentityBoundOnlyWhenNeeded`,
+`TestAffordances_CurrentUserSugar_UnknownPlaceholderNeverMatches`,
+`TestCondition_IdentityRequiredSkipsOnlyThatSource`, `TestConditionPrefilters`
+empty-identity case).
+3. Only top-level AND equalities/memberships pushed — PASS
+(`TestConstEqualities`, `TestConditionPrefilters`).
+4. Pushdown and index inference agree — PASS
+(`TestConditionPrefilters_AgreesWithIndexProperties`).
+5. Two principals, different entities, end to end — PASS
+(`TestNextAction_CurrentUserConditionEndToEnd`; live-server table in
+IMPL-69FYMO).
+6. All gates green — PASS.
 
 ## Documentation (enhancements only)
 
-Skip this section for bugs and internal refactors.
+- [x] Docs-checklist created and linked via `has-docs`
+- [x] User-facing documentation updated
+- [x] Docs-checklist marked as done
 
-- [ ] Docs-checklist created and linked via `has-docs`
-- [ ] User-facing documentation updated
-- [ ] Docs-checklist marked as done
-
-**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+**Docs Checklist:** DOCS-IRYGXC
 
 ## Final Checks
 
-- [ ] Commit message explains the why, not just what
-- [ ] No TODOs or FIXMEs left unaddressed
-- [ ] Ready for another developer to use
+- [x] Commit message explains the why, not just what
+- [x] No TODOs or FIXMEs left unaddressed
+- [x] Ready for another developer to use
 
 ## Pull Request
 
-- [ ] Run `/pr` command to create PR and monitor CI
+- [x] ~~Run `/pr` command to create PR and monitor CI~~ (N/A here: `/pr` gates on
+this ticket being `done`, so it runs after this checklist closes — see the note
+below.)
 
 <!--
 Deliberately NOT tracked here: the PR URL and whether CI passed.

--- a/tickets/entities/review-checklists/REV-JHH8AX.md
+++ b/tickets/entities/review-checklists/REV-JHH8AX.md
@@ -1,0 +1,83 @@
+---
+id: REV-JHH8AX
+type: review-checklist
+title: 'Review: Predicate language: current_user with is_current_user/has_current_user sugar, pushed into next-action queries'
+status: in-progress
+---
+
+<!-- @managed: claude-workflow v1 -->
+
+## Automated Checks
+
+- [ ] All tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Comment lint gate clean (`just comment-lint`)
+- [ ] Coverage maintained (`just coverage-check`)
+
+**Comment findings.** `just comment-report` lists the advisory rules
+(duplication, nil-contract, param-contract, restatement). They are not a merge
+gate, but a finding your diff *introduces* should be fixed or suppressed — don't
+grow the backlog.
+
+Every rule is a heuristic over prose, so false positives are expected. To
+suppress one, prefer the inline form on the declaration line, which travels with
+the code and is reviewed in this diff:
+
+```go
+func f(p string) {} //commentlint:ignore param-contract  p is contained by Clone
+```
+
+Use `.commentlint.yml` (`ignore:` path globs, `allow-phrases:`) only when the
+same prose recurs across many sites. A reason is required either way — an
+unexplained suppression is a finding nobody can re-evaluate later.
+
+## Code Review
+
+- [ ] Run `/code-review` command (invokes cranky-code-reviewer agent)
+- [ ] All critical review-responses addressed
+- [ ] All significant review-responses addressed
+- [ ] Self-reviewed the diff for unrelated changes
+
+**Review Responses:** <!-- List IDs of review-response entities created, e.g.,
+RR-xxxx -->
+
+## Acceptance Verification
+
+- [ ] Each acceptance criterion tested (reference planning checklist)
+- [ ] Test evidence documented in implementation checklist
+
+**Acceptance Status:**
+<!-- For each acceptance criterion, state PASS/FAIL with evidence -->
+
+## Documentation (enhancements only)
+
+Skip this section for bugs and internal refactors.
+
+- [ ] Docs-checklist created and linked via `has-docs`
+- [ ] User-facing documentation updated
+- [ ] Docs-checklist marked as done
+
+**Docs Checklist:** <!-- e.g., DOCS-xxxx -->
+
+## Final Checks
+
+- [ ] Commit message explains the why, not just what
+- [ ] No TODOs or FIXMEs left unaddressed
+- [ ] Ready for another developer to use
+
+## Pull Request
+
+- [ ] Run `/pr` command to create PR and monitor CI
+
+<!--
+Deliberately NOT tracked here: the PR URL and whether CI passed.
+
+Both post-date this checklist. `/pr` requires the ticket to be `done` and
+validating clean before it opens the PR, and a `done` review-checklist may have
+no unchecked items — so an item asking for the PR URL can only be satisfied by a
+PR that does not exist yet. Checking it early would mean asserting "CI passed"
+before CI ran, which turns the checklist from evidence into a formality.
+
+GitHub records both authoritatively, and the branch and commit messages carry
+the ticket ID, so the ticket-to-PR link is recoverable without duplicating it
+here. See TKT-UFV01M. -->

--- a/tickets/entities/review-responses/RR-1S9AX5.md
+++ b/tickets/entities/review-responses/RR-1S9AX5.md
@@ -1,0 +1,9 @@
+---
+id: RR-1S9AX5
+type: review-response
+title: The 'falls back to the unpushed query' subtest asserted only a call count
+finding: The third subtest of TestNextAction_ConditionPrefiltersReachTheStore asserted Prefilters was called once — already established by the first subtest — and never checked a suggestion, so it would pass whether or not the empty pre-filter fell back correctly. The subtests also share one app and swap its matcher, which must stay sequential.
+severity: nit
+resolution: The subtest now asserts a suggestion is returned and is one of the two seeded candidates (both eligible when nothing is pushed and Match accepts all); a comment on the parent test says the subtests must not be parallelised.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2ITZ84.md
+++ b/tickets/entities/review-responses/RR-2ITZ84.md
@@ -1,0 +1,9 @@
+---
+id: RR-2ITZ84
+type: review-response
+title: 'Affordance when: bound the unknown placeholder as a real identity'
+finding: 'internal/affordances/bindings.go bound is_current_user/has_current_user (and current_user.id) from principal.From(ctx).User, which is the literal "unknown" placeholder for an unstamped or identity-less request. Affordance when: clauses gate visible:/readonly:/actions, so `is_current_user(entity.owner)` would grant to an anonymous caller for an entity whose owner literally holds "unknown". Reachable through the `everyone` role. The query path refuses exactly this state (ErrNoCurrentUser); the affordance path did not, while both were documented as one implementation. Raised independently by both the security and architecture reviewers.'
+severity: significant
+resolution: bindingContext.identity() maps principal.Unknown to ""; PolicyResolver.passes refuses any grant whose clause reads the current user (predicatefns.RequiresCurrentUser) when the identity is empty; predicatefns.CurrentUserBindings("") never matches as defence in depth. Pinned by TestAffordances_CurrentUserSugar_UnknownPlaceholderNeverMatches (everyone role, unknown and unstamped, all three spellings, including an empty owner) and TestCurrentUserBindings_EmptyIdentityNeverMatches.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-2RD921.md
+++ b/tickets/entities/review-responses/RR-2RD921.md
@@ -1,0 +1,9 @@
+---
+id: RR-2RD921
+type: review-response
+title: RequiresCurrentUser rebuilt the signature map per call
+finding: It called CurrentUserFuncs() — allocating the map and two FuncSig values — on every candidate in a resolve, for a property of the compiled program that never changes.
+severity: nit
+resolution: A package-level currentUserFuncNames set is consulted instead; the prefilter-spec drift test now also asserts RequiresCurrentUser recognises every declared sugar function so the set cannot lag a new declaration.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-3WKYQX.md
+++ b/tickets/entities/review-responses/RR-3WKYQX.md
@@ -1,0 +1,9 @@
+---
+id: RR-3WKYQX
+type: review-response
+title: ConditionPrefilterer contract omitted the raw-vs-redacted asymmetry
+finding: The pre-filter compares RAW store values while Match evaluates the field-REDACTED candidate (redactedForSuggestion). Sound today because redaction removes a property (binds Nil, every current-user form is false on Nil), so the Go pass is strictly narrower — but the contract prose described the two passes as seeing the same values.
+severity: nit
+resolution: ConditionPrefilterer's doc names the asymmetry and why it is sound; TestNextAction_HiddenPropertyMakesCurrentUserConditionFalse pins that a visible:-hidden assignee makes is_current_user non-matching end to end while the unhidden baseline fires.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-635ZA0.md
+++ b/tickets/entities/review-responses/RR-635ZA0.md
@@ -1,0 +1,9 @@
+---
+id: RR-635ZA0
+type: review-response
+title: One per-user source failed the whole next-action endpoint for unidentified callers, non-deterministically
+finding: ErrIdentityRequired propagated out of applyCondition through resolveBand and Resolve, so a single source with a current_user condition made GET /_next_action return 500 for every anonymous request — taking every other, resolvable source with it. Because Resolve short-circuits at the first band with a winner, whether the 500 fired depended on band order and on the caller, so the same config answered for one user and failed for another. The Condition field comment and docs/data-entry.md both claimed the SOURCE was refused, which is not what the code did.
+severity: significant
+resolution: 'nextaction.applyCondition treats ErrIdentityRequired as a per-source SKIP (no candidates, one WARN naming the source), the same shape as a source whose world the caller may not read; any other matcher error still propagates. The handler no longer has an ErrIdentityRequired arm. Docs and the field comment now describe the skip. Pinned by TestCondition_IdentityRequiredSkipsOnlyThatSource (engine: two bands, identity-free source still resolves, other errors propagate) and TestNextAction_CurrentUserConditionWithoutIdentitySkipsTheSource (HTTP: anonymous gets the identity-free source; only per-user sources → null, never 500). Manual live-server check repeated.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-8JIICP.md
+++ b/tickets/entities/review-responses/RR-8JIICP.md
@@ -1,0 +1,9 @@
+---
+id: RR-8JIICP
+type: review-response
+title: Condition pre-filter and query pushdown gate against two metamodel snapshots
+finding: nextActionEngine snapshots st.Meta for the condition prefilters and matchers, while executeQueryPrefiltered gates the query's own pushdown against the read bundle's metamodel resolved separately; a reload landing between them mixes snapshots within one request, against CLAUDE.md's capture-once rule.
+severity: minor
+resolution: 'Documented at nextActionCandidates'' meta parameter rather than threaded through queryService: the coherence that matters — the condition''s pre-filter and its authoritative Go pass sharing a snapshot — holds (both derive from st.Meta), each pushdown is coherent with its own pass, and a metamodel gate can only decline to push, never widen. Threading the bundle would touch the shared queryService for no soundness gain.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-A856MZ.md
+++ b/tickets/entities/review-responses/RR-A856MZ.md
@@ -1,0 +1,9 @@
+---
+id: RR-A856MZ
+type: review-response
+title: Free-text query branch is relevance-capped before the condition runs
+finding: 'executeQueryPrefiltered documented the free-text branch as equivalent, only unpushed. It is not: that branch caps at maxFreeTextSearchResults (and the searcher limit) BEFORE nextaction.applyCondition runs, so a per-user condition on a free-text next-action query could silently under-report — the same lossy shape the condition-before-cap rule in internal/nextaction exists to prevent.'
+severity: significant
+resolution: 'conditionlint.conditionEntityTypes now refuses a condition on a query with free text at load (after the no-type check), with a message pointing at prop: filters; TestCompileNextActions_RefusesFreeTextQuery. executeQueryPrefiltered''s comment states the cap and the refusal.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-COK0GT.md
+++ b/tickets/entities/review-responses/RR-COK0GT.md
@@ -1,0 +1,9 @@
+---
+id: RR-COK0GT
+type: review-response
+title: CurrentUserBindings allocated a map and two closures on every affordance grant evaluation
+finding: newBindings runs per grant per role per entity on the list-render read path and now called predicatefns.CurrentUserBindings(identity) each time — a fresh map plus two closures for a value constant across the whole bindingContext.
+severity: minor
+resolution: bindingContext gained a userFuncs field built once in bindingFor from bc.identity(); newBindings binds from it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-IZ9XNH.md
+++ b/tickets/entities/review-responses/RR-IZ9XNH.md
@@ -1,0 +1,9 @@
+---
+id: RR-IZ9XNH
+type: review-response
+title: ResolveQueryIdentity is documented as the single derivation point but has no production caller
+finding: predicatefns.ResolveQueryIdentity's doc claims it is where every transport derives the identity and that resolver errors must not degrade to the raw principal. Production uses appbuild.queryIdentityFor, which infers the resolution outcome from RawUser != User and inherits resolvePrincipalEntity's fail-open on a backend error (raw email compared against entity ids — matches nothing, narrowing).
+severity: minor
+resolution: 'Kept, since the boundary stamp in TKT-ZQV9O5 is its intended caller: ResolveQueryIdentity''s doc now says no boundary calls it yet and names that ticket; queryIdentityFor''s doc records the backend-error degradation (matches nothing, never widens) so the next reader does not assume the stronger contract.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-J1XD8R.md
+++ b/tickets/entities/review-responses/RR-J1XD8R.md
@@ -1,0 +1,9 @@
+---
+id: RR-J1XD8R
+type: review-response
+title: The identity-disagreement refusal rendered advice for a different problem
+finding: nextActionRequestScope wrapped the stamp-vs-principal disagreement in ErrIdentityRequired, so the handler emitted next_action_identity_required with the hint 'configure an identity source' — for a request that has TWO identities, not none. The test only asserted errors.Is, so nothing pinned the rendered message.
+severity: minor
+resolution: New sentinel nextaction.ErrIdentityConflict; the scope binder returns it directly; writeNextActionError maps it to next_action_identity_conflict with its own title and hint, echoing neither identity. TestNextActionRequestScope asserts the conflict is NOT an ErrIdentityRequired; TestNextAction_IdentityConflictIsNamed pins the HTTP code and that no identity is echoed.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-JMHJJ5.md
+++ b/tickets/entities/review-responses/RR-JMHJJ5.md
@@ -1,0 +1,9 @@
+---
+id: RR-JMHJJ5
+type: review-response
+title: RequiresCurrentUser would fail open on an IR node inspect() does not visit
+finding: Program.inspect's type switch had no exhaustiveness guard. A future node type carrying sub-expressions would be skipped, References()/Functions() would omit the variable, RequiresCurrentUser would return false and MatchesAs would skip the binding — surfacing as a generic 'binding not provided' eval error rather than ErrNoCurrentUser, bypassing the next_action_identity_required translation.
+severity: minor
+resolution: inspect now has a default arm that panics naming the unhandled node type, so adding a node without extending the dependency walk fails the first test that compiles it.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-KUXDQO.md
+++ b/tickets/entities/review-responses/RR-KUXDQO.md
@@ -1,0 +1,9 @@
+---
+id: RR-KUXDQO
+type: review-response
+title: nextActionPrefilters re-parsed the query per request and coupled type order to the matcher
+finding: dataentry re-ran searchparser.ParseQuery on every request only to recover EntityTypes that conditionlint had already parsed at compile time, and appbuild's Prefilters relied on types[0] matching the matcher's program map by unsorted parse order.
+severity: nit
+resolution: conditionlint.NextActionMatcher exposes Types() (sorted, the compiled types); ConditionPrefilterer.Prefilters(ctx, meta) takes no types and the matcher supplies its own. dataentry no longer imports searchparser in nextaction.go. TestNextActionMatcher_TypesAreTheCompiledTypes.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LD2B23.md
+++ b/tickets/entities/review-responses/RR-LD2B23.md
@@ -1,0 +1,9 @@
+---
+id: RR-LD2B23
+type: review-response
+title: A pre-stamped QueryIdentity silently overrode the request principal
+finding: appbuild's Match and Prefilters preferred an already-stamped QueryIdentity over the principal on the same ctx with no agreement check; the test even pinned bob's request selecting alice's rows. No production code stamps yet, so latent — but attachACLRequest refuses the analogous disagreement for ACL requests.
+severity: minor
+resolution: nextActionRequestScope errors (wrapped nextaction.ErrIdentityRequired) when a stamped identity and the request principal name different users; agreeing stamps and stamp-only contexts are honored. TestNextActionRequestScope pins all four cases.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-LT2O71.md
+++ b/tickets/entities/review-responses/RR-LT2O71.md
@@ -1,0 +1,9 @@
+---
+id: RR-LT2O71
+type: review-response
+title: ConditionPrefilters derived Scalar from a condition no reachable input exercised
+finding: 'Scalar: !eq.List && value != "" — the value check was dead for both branches (empty identity continues earlier; empty literal refused by ConstEqualities), so it read as if empty values were expected.'
+severity: nit
+resolution: 'Simplified to Scalar: !eq.List with a comment recording why an empty value cannot reach the predicate.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-NDER2B.md
+++ b/tickets/entities/review-responses/RR-NDER2B.md
@@ -1,0 +1,9 @@
+---
+id: RR-NDER2B
+type: review-response
+title: Enum-typed string properties are silently unpushable
+finding: declaredOnEveryType requires PropertyType string exactly, while the predicate compiler maps custom enum-like types to StringType. `entity.status == 'open'` on an enum status compiles and evaluates but is never pushed and derives no index, with no diagnostic — status-shaped enums are the most common next-action conjunct.
+severity: nit
+reason: The gate is shared with the pre-existing filter-path pushdown (queryplan.PushdownPrefilters), which has the same exclusion; widening it changes what dashboards and scope navigation push too and needs the enum-vs-store string-form question answered once for both. Documented on ConditionPrefilters as deliberately out of scope; to be taken as its own change.
+status: deferred
+---

--- a/tickets/entities/review-responses/RR-P1YQPB.md
+++ b/tickets/entities/review-responses/RR-P1YQPB.md
@@ -1,0 +1,9 @@
+---
+id: RR-P1YQPB
+type: review-response
+title: ConstEqualities reported an empty-string literal whose store meaning differs from the Go pass
+finding: '`entity.assignee == ''''` lowered to PropPredicate{Value: ""}, which every backend reads as ''is empty'' (absent, null, empty list), while the Go pass reads Nil == String("") as false. Direction safe (store keeps a superset) but two operators of one expression disagreed on the unset population, with no test.'
+severity: minor
+resolution: constEqualityFrom refuses an empty literal (pushes nothing), with the reason in a comment; TestConstEqualities gained the case.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-P7424Q.md
+++ b/tickets/entities/review-responses/RR-P7424Q.md
@@ -1,0 +1,9 @@
+---
+id: RR-P7424Q
+type: review-response
+title: staticIndexProps silently swallowed a condition compile error
+finding: The branch is unreachable from every production entry point after RR-QBW3QO, but an in-code Config caller would get a silently query-only index with no signal.
+severity: nit
+resolution: The error is now logged at WARN with the entity type before the condition's columns are skipped.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-PDKNZG.md
+++ b/tickets/entities/review-responses/RR-PDKNZG.md
@@ -1,0 +1,9 @@
+---
+id: RR-PDKNZG
+type: review-response
+title: Identity was derived and re-stamped per candidate, not once per request
+finding: WithQueryIdentity's godoc and the ticket say the identity is stamped once per request by the wiring site, never derived per row. As built, appbuild's nextActionMatcher.Match derived it (QueryIdentityFrom -> queryIdentityFor -> context.WithValue) on every call, and nextaction.applyCondition calls Match once per candidate. Cheap only because the derivation skips the ACL resolver; the planned convergence on ResolveQueryIdentity would have made it one store lookup per row.
+severity: significant
+resolution: The NextActionMatcherFunc seam now also returns a per-request scope binder (dataentry.NextActionRequestScope). handleV1NextActionGet applies it to the request ctx once before eng.Resolve; appbuild's Match and Prefilters only read predicatefns.QueryIdentityFrom and never derive. TestNextActionMatchers_PrefiltersAndMatchShareTheIdentity asserts an unscoped ctx with a principal yields no identity.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-QBW3QO.md
+++ b/tickets/entities/review-responses/RR-QBW3QO.md
@@ -1,0 +1,9 @@
+---
+id: RR-QBW3QO
+type: review-response
+title: rela db reconcile could derive an index shape the server never derives
+finding: staticIndexProps justified skipping a non-compiling condition with 'conditionlint refuses it at load', but queryplan.LoadStaticIndexSpecs (the CLI's `rela db reconcile` path) ran only dataentryconfig.ValidateConfig, never conditionlint. A broken condition would converge to the query-only index while the server refuses the config.
+severity: minor
+resolution: 'LoadStaticIndexSpecs runs conditionlint.CompileNextActions and returns an error on any problem (arch-lint: queryplan may depend on conditionlint); TestLoadStaticIndexSpecsRejectsBrokenCondition. staticIndexProps''s comment narrowed to the in-code Config case.'
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-S7ESOF.md
+++ b/tickets/entities/review-responses/RR-S7ESOF.md
@@ -1,0 +1,9 @@
+---
+id: RR-S7ESOF
+type: review-response
+title: inspect's exhaustiveness guard had no test
+finding: 'The default: panic in Program.inspect is correct, but no test compiled one expression per sealed node type, so relational, concat, arithmetic, unary-minus and table-argument nodes were reached incidentally at best and a new node type could still land untested.'
+severity: minor
+resolution: TestProgram_InspectCoversEveryNodeType compiles one expression per node type (bool profile for const/var/attr/relational/logical/not/call/table-arg; ValueProfile for arithmetic, unary minus and concatenation) and reads References/Functions on each.
+status: addressed
+---

--- a/tickets/entities/review-responses/RR-Z12KRD.md
+++ b/tickets/entities/review-responses/RR-Z12KRD.md
@@ -1,0 +1,9 @@
+---
+id: RR-Z12KRD
+type: review-response
+title: Handler prelude obscured the scope-then-resolve control flow
+finding: handleV1NextActionGet declared err up front, conditionally assigned it from the scope binder, then guarded Resolve behind if err == nil with sug/found in a separate var block — four statements to say 'if scoping fails, skip resolving'.
+severity: nit
+resolution: 'Rewritten as an early return: scope, on error writeNextActionError and return; then Resolve. The error mapping is a free function (writeNextActionError) shared by both sites, since App is at its plimsoll cap.'
+status: addressed
+---

--- a/tickets/entities/tickets/TKT-OIRBFH.md
+++ b/tickets/entities/tickets/TKT-OIRBFH.md
@@ -5,7 +5,7 @@ title: 'Predicate language: current_user with is_current_user/has_current_user s
 kind: enhancement
 priority: medium
 effort: m
-status: review
+status: done
 ---
 
 ## Problem
@@ -112,10 +112,10 @@ disagrees with it; matchers and pre-filters only read what it stamped.
 - A per-user condition for an unidentified caller (unstamped, or the `unknown`
 placeholder — now `principal.Unknown`) makes that SOURCE contribute nothing,
 with a WARN naming it: `nextaction.ErrIdentityRequired` is a per-source skip in
-the engine, never a match against a placeholder and never a failure of the
-other sources (code review RR-635ZA0). A request carrying two DISAGREEING
-identities — a boundary stamp and a principal naming different users — is
-refused whole with `next_action_identity_conflict` (`nextaction.ErrIdentityConflict`).
+the engine, never a match against a placeholder and never a failure of the other
+sources (code review RR-635ZA0). A request carrying two DISAGREEING identities —
+a boundary stamp and a principal naming different users — is refused whole with
+`next_action_identity_conflict` (`nextaction.ErrIdentityConflict`).
 
 ### Deliberately not exposed
 
@@ -130,8 +130,8 @@ not a graph identity — revisit with [[TKT-ZQV9O5]]).
 `has_current_user(entity.xs)` compile and evaluate in affordance `when:` and
 next-action `condition:`; referencing them in a validation rule is a load error.
 2. An absent/empty identity fails closed (`ErrNoCurrentUser`; affordance grant
-refused; next-action source skipped, other sources unaffected); pushdown with
-an empty identity pushes nothing.
+refused; next-action source skipped, other sources unaffected); pushdown with an
+empty identity pushes nothing.
 3. Equality and membership conjuncts under a top-level `and` reach the store as
 pre-filters; `or`/`not`/typed comparisons do not (tests per restriction).
 4. Pushed scalar equalities and derived index columns agree (drift test).

--- a/tickets/entities/tickets/TKT-OIRBFH.md
+++ b/tickets/entities/tickets/TKT-OIRBFH.md
@@ -5,7 +5,7 @@ title: 'Predicate language: current_user with is_current_user/has_current_user s
 kind: enhancement
 priority: medium
 effort: m
-status: in-progress
+status: review
 ---
 
 ## Problem
@@ -49,13 +49,14 @@ affordance profile, so `has_role(current_user, entity, "editor")` in existing
 - Two host functions, because Lua reserves `in` and lists cannot be compared:
 `is_current_user(entity.assignee)` (string equality; an unset property is "not
 me", never an error) and `has_current_user(entity.watchers)` (list membership).
+Bound with an empty identity they never match.
 - `DeclareCurrentUser` is deliberately **separate from `Declare`**: validation,
 the scheduler and index derivation compile with no request in sight, and
 referencing `current_user` there must stay a compile error at load.
 - Identity is a `QueryIdentity{EntityID, Raw, Tool}` stamped on ctx once per
-request by the wiring site (`WithQueryIdentity` / `ResolveQueryIdentity`), never
-derived per row. `ID()` prefers the resolved user-entity id (so it compares
-against a property holding an entity id) and falls back to the raw principal.
+request by the wiring site (`WithQueryIdentity`), never derived per row. `ID()`
+prefers the resolved user-entity id (so it compares against a property holding
+an entity id) and falls back to the raw principal.
 - **Fail closed**: `BindCurrentUser` returns `ErrNoCurrentUser` for an absent or
 empty identity. An empty identity would match every unset property — the worst
 version of getting this wrong.
@@ -63,16 +64,17 @@ version of getting this wrong.
 from `Compile` / `Matches`, and the profile is part of the program cache key.
 `MatchesAs` binds the identity only when `RequiresCurrentUser(prog)` is true, so
 one request-scoped profile serves conditions with and without an identity
-clause.
+clause. `Program.References`/`Functions` back that test; `inspect` refuses an
+unhandled node type so a future node cannot make it fail open.
 
 ### Pushdown (`internal/predicate/prefilter.go`, `internal/queryplan`)
 
 - `Program.ConstEqualities(PrefilterSpec)` walks the **top-level AND spine
-only** and reports attribute-vs-request-constant equalities: string literals,
-`current_user.id`, and the two sugar functions (listed by the caller in
-`PrefilterSpec.ConstFuncs`; a list-typed argument is reported with `List:
-true`). `or`, `not`, inequality, ordered and typed comparisons push nothing —
-each restriction has a test asserting nothing is pushed.
+only** and reports attribute-vs-request-constant equalities: non-empty string
+literals, `current_user.id`, and the two sugar functions (listed by the caller
+in `PrefilterSpec.ConstFuncs`; a list-typed argument is reported with `List:
+true`). `or`, `not`, inequality, ordered and typed comparisons and the empty
+literal push nothing — each restriction has a test asserting nothing is pushed.
 - `queryplan.ConditionPrefilters` lowers those to `store.PropPredicate` behind
 the same metamodel gate the filter pushdown uses (string on every type; list of
 strings for membership). Membership lowers to a **non-scalar `PropEqual`**,
@@ -81,28 +83,39 @@ rule pinned by storetest) — **no store contract change was needed.**
 - `queryplan.ConditionIndexProperties` is the index-inference half; both call
 one eligibility core so they cannot drift (test pins agreement).
 `StaticIndexSpecs` now includes a next-action source's condition, so query and
-condition equalities derive **one composite index**. Membership derives no index
-(the btree over `->>` does not serve jsonb containment; a GIN shape needs its
-own EXPLAIN test first).
+condition equalities derive **one composite index**; `LoadStaticIndexSpecs` runs
+`conditionlint` so `rela db reconcile` refuses exactly the configs the server
+refuses. Membership derives no index (the btree over `->>` does not serve jsonb
+containment; a GIN shape needs its own EXPLAIN test first).
 - `current_user.tool` is never pushed: diagnostic, never a membership input.
 
 ### Surfaces
 
 - **ACL affordance `when:`** (`internal/affordances`): the sugar functions are
 declared beside the existing `current_user` record; `userRecordType` now aliases
-`predicatefns.CurrentUserType` (drift guard test).
+`predicatefns.CurrentUserType` (drift guard test). An unidentified caller
+(unstamped, or the `unknown` placeholder — reachable only through the `everyone`
+role) binds NO identity, and a `when:` clause that reads the current user is
+refused for them rather than evaluated against a placeholder.
 - **Next-action `condition:`**: `conditionlint` compiles in the request-scoped
-profile and evaluates via `MatchesAs`. `nextaction.CandidateFunc` now receives
-the source id; `dataentry` looks up the matcher and, through a consumer-side
-`ConditionPrefilterer` capability, ANDs the condition's store-safe conjuncts
-into the candidate query (`executeQueryPrefiltered`). The Go pass stays
-authoritative. The composition-root matcher (`appbuild.NextActionMatchers`)
-derives the identity from the request principal through ONE function used by
-both `Match` and `Prefilters`.
-- A per-user condition on an unidentified request (unstamped, or the `unknown`
-placeholder — now `principal.Unknown`) is refused:
-`nextaction.ErrIdentityRequired` maps to HTTP 500
-`next_action_identity_required`, never "matches nothing".
+profile (refusing a free-text query, whose relevance cap would make the
+condition lossy) and evaluates via `MatchesAs`. `nextaction.CandidateFunc` now
+receives the source id; `dataentry` looks up the matcher and, through a
+consumer-side `ConditionPrefilterer` capability, ANDs the condition's store-safe
+conjuncts into the candidate query (`executeQueryPrefiltered`). The Go pass
+stays authoritative (it also sees the field-REDACTED candidate, so it is
+strictly narrower than the raw-value pre-filter). The composition root
+(`appbuild.NextActionMatchers`) supplies both the matchers and a per-request
+scope binder (`dataentry.NextActionRequestScope`) that derives the identity from
+the resolved principal ONCE per request and refuses a boundary stamp that
+disagrees with it; matchers and pre-filters only read what it stamped.
+- A per-user condition for an unidentified caller (unstamped, or the `unknown`
+placeholder — now `principal.Unknown`) makes that SOURCE contribute nothing,
+with a WARN naming it: `nextaction.ErrIdentityRequired` is a per-source skip in
+the engine, never a match against a placeholder and never a failure of the
+other sources (code review RR-635ZA0). A request carrying two DISAGREEING
+identities — a boundary stamp and a principal naming different users — is
+refused whole with `next_action_identity_conflict` (`nextaction.ErrIdentityConflict`).
 
 ### Deliberately not exposed
 
@@ -116,22 +129,26 @@ not a graph identity — revisit with [[TKT-ZQV9O5]]).
 1. `entity.x == current_user.id`, `is_current_user(entity.x)` and
 `has_current_user(entity.xs)` compile and evaluate in affordance `when:` and
 next-action `condition:`; referencing them in a validation rule is a load error.
-2. An absent/empty identity fails closed (`ErrNoCurrentUser`); pushdown with an
-empty identity pushes nothing.
+2. An absent/empty identity fails closed (`ErrNoCurrentUser`; affordance grant
+refused; next-action source skipped, other sources unaffected); pushdown with
+an empty identity pushes nothing.
 3. Equality and membership conjuncts under a top-level `and` reach the store as
 pre-filters; `or`/`not`/typed comparisons do not (tests per restriction).
 4. Pushed scalar equalities and derived index columns agree (drift test).
 5. End to end: two principals hitting one next-action source are offered
-different entities (`TestNextAction_CurrentUserConditionEndToEnd`).
+different entities (`TestNextAction_CurrentUserConditionEndToEnd`; verified
+manually against a live `rela-server`, see the implementation checklist).
 6. Full suite, golangci-lint, arch-lint, comment-lint, plimsoll, coverage floors
 green.
 
 ## Follow-ups
 
-- [[TKT-ZQV9O5]] — `where:` surfaces (views, feeds, kanbans, CalDAV) and CLI.
+- [[TKT-ZQV9O5]] — `where:` surfaces (views, feeds, kanbans, CalDAV) and CLI;
+converge on a router-boundary identity stamp via `ResolveQueryIdentity`.
 - Ordered pushdown (`due <= today() + 7`): `today()` folds to a constant, but
 `store.PropOp` has no ordered operator. Needs `PropLessEqual`/`PropGreaterEqual`
 across fs/mem/sqlite/pg + storetest + EXPLAIN test. See [[RES-05JD73]].
 - GIN index shape for list membership, with its own EXPLAIN test.
+- Enum-typed properties are not pushed by either pushdown (RR-NDER2B, deferred).
 - Wizard-form conditions: the SPA passes an empty `current_user: {}`
 (`DynamicForm.vue`); the client-side engine has no identity yet.

--- a/tickets/entities/tickets/TKT-OIRBFH.md
+++ b/tickets/entities/tickets/TKT-OIRBFH.md
@@ -1,55 +1,137 @@
 ---
 id: TKT-OIRBFH
 type: ticket
-title: 'Filter language: a token for the requesting principal (@me)'
+title: 'Predicate language: current_user with is_current_user/has_current_user sugar, pushed into next-action queries'
 kind: enhancement
 priority: medium
 effort: m
-status: backlog
+status: in-progress
 ---
 
 ## Problem
 
-There is no way to write "the things assigned to me". `internal/filter` has no
-principal awareness — no token resolves to the requesting user — so a `where:`
-clause cannot reference them. The motivating case is a CalDAV "My tasks"
-collection, but the gap is general: ICS feeds, list views and kanbans all take
-`where:` clauses and all have the same hole.
+There is no way to write "the things assigned to me". Neither condition dialect
+knew the requesting principal: `internal/filter` had no token for it, and the
+predicate language (`internal/predicate` + `internal/predicatefns`) declared no
+`current_user` outside the ACL affordance profile. So a next-action
+`condition:`, a view or feed `where:`, or a CalDAV collection could not select
+per caller. The motivating case is a personal inbox ("tickets assigned to me
+that are stale"); the gap is general.
 
-## Proposal
+## Scope decision (this ticket)
 
-A token in the filter language that resolves to the request's principal:
+Originally framed as an `@me` token in the **filter** language. Redirected to
+the **predicate** language, for two reasons:
 
-```yaml
-    where: ["assignee = @me"]
-```
+- The predicate engine is the condition/policy dialect the codebase is
+converging on (CLAUDE.md: "New condition/`when:`-style code evaluates through
+`predicate`"), and it already has a typed `current_user` record in the ACL
+affordance profile. Adding the same identity there gives one spelling across
+`when:` clauses and query conditions.
+- A predicate `Program` exposes its IR, so a request-constant equality can be
+lowered to a store predicate (pushdown) without a second parser.
 
-Resolved at match time from `principal.Principal` on the context, not
-substituted into the config at load — the same config is evaluated per request
-and must yield different results per caller.
+The operator writing the condition is not the "me" being selected, so the
+identity is named `current_user`, not `@me`.
 
-## Design questions
+This ticket delivers the **language feature and its first query surface**.
+Exposing it on `where:` (views, feeds, kanbans) and CalDAV is the next step and
+is split into [[TKT-ZQV9O5]].
 
-- **What does `@me` compare against?** `Principal.User()` is a string identity
-from the upstream assertion. If `assignee` holds an entity id (a `person`
-entity) rather than that string, the token needs a resolution step — probably a
-configured mapping from principal to entity, which is a design decision in
-itself and may deserve its own ticket.
-- **Unauthenticated / system principals.** `@me` with a zero principal must not
-silently match everything. Fail closed: match nothing, and say so in the config
-docs.
-- **Caching.** Anything that memoizes filter results per collection (the CalDAV
-ctag path renders per request today, but that may change) must key on the
-principal once results become principal-dependent. Getting this wrong leaks one
-user's view to another — worth an explicit test.
-- **Does the ACL already cover it?** Where visibility is already gated by
-assignee, a plain collection IS "my stuff" without any new token. Check whether
-the motivating deployments need this at all before building it.
+## What was built
 
-## Acceptance criteria
+### Language (`internal/predicatefns`)
 
-1. `@me` resolves to the requesting principal in any `where:` clause.
-2. A zero/unknown principal matches NOTHING (fail closed), with a test.
-3. Two principals hitting one CalDAV collection see different resources.
-4. Works identically in `feeds:`, `views:` and `caldav:` — it is a filter
-feature, not a CalDAV one.
+- `current_user` is a **record** `{id, tool}` (`CurrentUserType`), matching the
+affordance profile, so `has_role(current_user, entity, "editor")` in existing
+`acl.yaml` keeps type-checking. Records cannot be compared with `==`, so
+`entity.assignee == current_user.id` is the equality form.
+- Two host functions, because Lua reserves `in` and lists cannot be compared:
+`is_current_user(entity.assignee)` (string equality; an unset property is "not
+me", never an error) and `has_current_user(entity.watchers)` (list membership).
+- `DeclareCurrentUser` is deliberately **separate from `Declare`**: validation,
+the scheduler and index derivation compile with no request in sight, and
+referencing `current_user` there must stay a compile error at load.
+- Identity is a `QueryIdentity{EntityID, Raw, Tool}` stamped on ctx once per
+request by the wiring site (`WithQueryIdentity` / `ResolveQueryIdentity`), never
+derived per row. `ID()` prefers the resolved user-entity id (so it compares
+against a property holding an entity id) and falls back to the raw principal.
+- **Fail closed**: `BindCurrentUser` returns `ErrNoCurrentUser` for an absent or
+empty identity. An empty identity would match every unset property — the worst
+version of getting this wrong.
+- `Evaluator.CompileWithCurrentUser` / `MatchesAs` are distinct entry points
+from `Compile` / `Matches`, and the profile is part of the program cache key.
+`MatchesAs` binds the identity only when `RequiresCurrentUser(prog)` is true, so
+one request-scoped profile serves conditions with and without an identity
+clause.
+
+### Pushdown (`internal/predicate/prefilter.go`, `internal/queryplan`)
+
+- `Program.ConstEqualities(PrefilterSpec)` walks the **top-level AND spine
+only** and reports attribute-vs-request-constant equalities: string literals,
+`current_user.id`, and the two sugar functions (listed by the caller in
+`PrefilterSpec.ConstFuncs`; a list-typed argument is reported with `List:
+true`). `or`, `not`, inequality, ordered and typed comparisons push nothing —
+each restriction has a test asserting nothing is pushed.
+- `queryplan.ConditionPrefilters` lowers those to `store.PropPredicate` behind
+the same metamodel gate the filter pushdown uses (string on every type; list of
+strings for membership). Membership lowers to a **non-scalar `PropEqual`**,
+which every backend already defines as "some element equals" (the multi-select
+rule pinned by storetest) — **no store contract change was needed.**
+- `queryplan.ConditionIndexProperties` is the index-inference half; both call
+one eligibility core so they cannot drift (test pins agreement).
+`StaticIndexSpecs` now includes a next-action source's condition, so query and
+condition equalities derive **one composite index**. Membership derives no index
+(the btree over `->>` does not serve jsonb containment; a GIN shape needs its
+own EXPLAIN test first).
+- `current_user.tool` is never pushed: diagnostic, never a membership input.
+
+### Surfaces
+
+- **ACL affordance `when:`** (`internal/affordances`): the sugar functions are
+declared beside the existing `current_user` record; `userRecordType` now aliases
+`predicatefns.CurrentUserType` (drift guard test).
+- **Next-action `condition:`**: `conditionlint` compiles in the request-scoped
+profile and evaluates via `MatchesAs`. `nextaction.CandidateFunc` now receives
+the source id; `dataentry` looks up the matcher and, through a consumer-side
+`ConditionPrefilterer` capability, ANDs the condition's store-safe conjuncts
+into the candidate query (`executeQueryPrefiltered`). The Go pass stays
+authoritative. The composition-root matcher (`appbuild.NextActionMatchers`)
+derives the identity from the request principal through ONE function used by
+both `Match` and `Prefilters`.
+- A per-user condition on an unidentified request (unstamped, or the `unknown`
+placeholder — now `principal.Unknown`) is refused:
+`nextaction.ErrIdentityRequired` maps to HTTP 500
+`next_action_identity_required`, never "matches nothing".
+
+### Deliberately not exposed
+
+State-machine `When:` (no request principal on the write path), computed
+properties (persisted), validation (`context.Background()`), automation (stored
+effects + transport-dependent principal), CLI `--filter` (principal is `$USER`,
+not a graph identity — revisit with [[TKT-ZQV9O5]]).
+
+## Acceptance
+
+1. `entity.x == current_user.id`, `is_current_user(entity.x)` and
+`has_current_user(entity.xs)` compile and evaluate in affordance `when:` and
+next-action `condition:`; referencing them in a validation rule is a load error.
+2. An absent/empty identity fails closed (`ErrNoCurrentUser`); pushdown with an
+empty identity pushes nothing.
+3. Equality and membership conjuncts under a top-level `and` reach the store as
+pre-filters; `or`/`not`/typed comparisons do not (tests per restriction).
+4. Pushed scalar equalities and derived index columns agree (drift test).
+5. End to end: two principals hitting one next-action source are offered
+different entities (`TestNextAction_CurrentUserConditionEndToEnd`).
+6. Full suite, golangci-lint, arch-lint, comment-lint, plimsoll, coverage floors
+green.
+
+## Follow-ups
+
+- [[TKT-ZQV9O5]] — `where:` surfaces (views, feeds, kanbans, CalDAV) and CLI.
+- Ordered pushdown (`due <= today() + 7`): `today()` folds to a constant, but
+`store.PropOp` has no ordered operator. Needs `PropLessEqual`/`PropGreaterEqual`
+across fs/mem/sqlite/pg + storetest + EXPLAIN test. See [[RES-05JD73]].
+- GIN index shape for list membership, with its own EXPLAIN test.
+- Wizard-form conditions: the SPA passes an empty `current_user: {}`
+(`DynamicForm.vue`); the client-side engine has no identity yet.

--- a/tickets/entities/tickets/TKT-ZQV9O5.md
+++ b/tickets/entities/tickets/TKT-ZQV9O5.md
@@ -37,8 +37,13 @@ condition that does not compile is a load error.
 - Stamp the identity once per request at the router boundary
 (`predicatefns.ResolveQueryIdentity` + `WithQueryIdentity`, after
 `resolvePrincipalEntity`), so every surface shares one derivation. The
-next-action adapter in `appbuild` currently derives it from the principal
-itself; converge on the boundary stamp.
+next-action path currently derives it in a per-request scope binder supplied by
+`appbuild` (`nextActionRequestScope`); converge on the boundary stamp and reduce
+the binder to the agreement check. When doing so, compare `Tool` as well as
+`ID()` in that check — today only the id is compared, which is fine while
+nothing stamps upstream, but a boundary stamp with a divergent tool would bind
+`current_user.tool` from the stamp (security review note on TKT-OIRBFH; `tool`
+is diagnostic and never pushed, so no exposure today).
 - Push `queryplan.ConditionPrefilters` into the list/feed query where the path
 already goes through `visibleListByTypes`, and include the condition in
 `StaticIndexSpecs` for the surfaces that are static.
@@ -57,6 +62,9 @@ keep `current_user` undeclared on the CLI and say so.
 - **Wizard forms.** The SPA's client-side condition engine passes
 `current_user: {}`; decide whether the server supplies the identity to the form
 context or the namespace stays server-only.
+- **Free-text queries.** Next actions refuse a `condition:` on a free-text
+query because the relevance cap runs before the condition. A view or feed
+`where:` is not capped the same way; confirm before allowing the combination.
 
 ## Acceptance
 

--- a/tickets/entities/tickets/TKT-ZQV9O5.md
+++ b/tickets/entities/tickets/TKT-ZQV9O5.md
@@ -1,0 +1,67 @@
+---
+id: TKT-ZQV9O5
+type: ticket
+title: 'Expose current_user on where: surfaces (views, feeds, kanbans, CalDAV) and the CLI'
+kind: enhancement
+priority: medium
+effort: m
+status: backlog
+---
+
+## Problem
+
+[[TKT-OIRBFH]] added `current_user` (with `is_current_user` /
+`has_current_user`) to the predicate language and exposed it on ACL affordance
+`when:` clauses and next-action `condition:`, with store pushdown. The `where:`
+surfaces still cannot select per caller: view/list `where:`, feed `where:`,
+kanbans and CalDAV collections all evaluate `internal/filter` clauses with no
+principal awareness. The motivating case from the original ticket — a CalDAV "My
+tasks" collection — is therefore still open.
+
+## Proposal
+
+Add a `condition:` key beside `where:` on the surfaces that take one (views,
+lists, feeds, kanbans, `caldav:` collections), in predicate syntax, ANDed with
+`where:`. Same two-key rule as next actions and automations: the dialects
+overlap without erroring, so a sniffing heuristic would guess quietly.
+
+```yaml
+caldav:
+  my-tasks:
+    where: ["type = task", "status != done"]
+    condition: "is_current_user(entity.assignee) or has_current_user(entity.watchers)"
+```
+
+- Compile once at config load with `Evaluator.CompileWithCurrentUser`; a
+condition that does not compile is a load error.
+- Stamp the identity once per request at the router boundary
+(`predicatefns.ResolveQueryIdentity` + `WithQueryIdentity`, after
+`resolvePrincipalEntity`), so every surface shares one derivation. The
+next-action adapter in `appbuild` currently derives it from the principal
+itself; converge on the boundary stamp.
+- Push `queryplan.ConditionPrefilters` into the list/feed query where the path
+already goes through `visibleListByTypes`, and include the condition in
+`StaticIndexSpecs` for the surfaces that are static.
+- Fail closed everywhere: an unidentified request on a per-user surface is a
+named error, never an empty or everyone's result.
+
+## Design questions
+
+- **Caching keyed on principal.** Anything memoizing filter results per
+collection (CalDAV ctag, rendered feeds) must key on the identity once results
+are principal-dependent; a cross-principal cache leaks one user's view to
+another. Explicit test.
+- **CLI `--filter`.** The CLI principal is `$USER`, not a graph identity. Either
+resolve through the ACL policy's `principal_property` lookup when one exists, or
+keep `current_user` undeclared on the CLI and say so.
+- **Wizard forms.** The SPA's client-side condition engine passes
+`current_user: {}`; decide whether the server supplies the identity to the form
+context or the namespace stays server-only.
+
+## Acceptance
+
+1. `condition:` with `current_user` works identically on views, feeds and
+`caldav:` collections.
+2. Two principals hitting one CalDAV collection see different resources.
+3. A zero/unknown principal on a per-user surface fails closed, with a test.
+4. Any per-collection cache is keyed on the identity, with a test.

--- a/tickets/relations/TKT-OIRBFH--has-docs--DOCS-IRYGXC.md
+++ b/tickets/relations/TKT-OIRBFH--has-docs--DOCS-IRYGXC.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-docs
+to: DOCS-IRYGXC
+---

--- a/tickets/relations/TKT-OIRBFH--has-implementation--IMPL-69FYMO.md
+++ b/tickets/relations/TKT-OIRBFH--has-implementation--IMPL-69FYMO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-implementation
+to: IMPL-69FYMO
+---

--- a/tickets/relations/TKT-OIRBFH--has-planning--PLAN-J84R77.md
+++ b/tickets/relations/TKT-OIRBFH--has-planning--PLAN-J84R77.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-planning
+to: PLAN-J84R77
+---

--- a/tickets/relations/TKT-OIRBFH--has-review--REV-JHH8AX.md
+++ b/tickets/relations/TKT-OIRBFH--has-review--REV-JHH8AX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review
+to: REV-JHH8AX
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-1S9AX5.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-1S9AX5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-1S9AX5
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-2ITZ84.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-2ITZ84.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-2ITZ84
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-2RD921.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-2RD921.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-2RD921
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-3WKYQX.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-3WKYQX.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-3WKYQX
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-635ZA0.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-635ZA0.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-635ZA0
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-8JIICP.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-8JIICP.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-8JIICP
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-A856MZ.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-A856MZ.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-A856MZ
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-COK0GT.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-COK0GT.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-COK0GT
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-IZ9XNH.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-IZ9XNH.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-IZ9XNH
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-J1XD8R.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-J1XD8R.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-J1XD8R
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-JMHJJ5.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-JMHJJ5.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-JMHJJ5
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-KUXDQO.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-KUXDQO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-KUXDQO
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-LD2B23.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-LD2B23.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-LD2B23
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-LT2O71.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-LT2O71.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-LT2O71
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-NDER2B.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-NDER2B.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-NDER2B
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-P1YQPB.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-P1YQPB.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-P1YQPB
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-P7424Q.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-P7424Q.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-P7424Q
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-PDKNZG.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-PDKNZG.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-PDKNZG
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-QBW3QO.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-QBW3QO.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-QBW3QO
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-S7ESOF.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-S7ESOF.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-S7ESOF
+---

--- a/tickets/relations/TKT-OIRBFH--has-review-response--RR-Z12KRD.md
+++ b/tickets/relations/TKT-OIRBFH--has-review-response--RR-Z12KRD.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: has-review-response
+to: RR-Z12KRD
+---

--- a/tickets/relations/TKT-OIRBFH--implements--FEAT-79DTF9.md
+++ b/tickets/relations/TKT-OIRBFH--implements--FEAT-79DTF9.md
@@ -1,0 +1,5 @@
+---
+from: TKT-OIRBFH
+relation: implements
+to: FEAT-79DTF9
+---

--- a/tickets/relations/TKT-ZQV9O5--affects--authorization.md
+++ b/tickets/relations/TKT-ZQV9O5--affects--authorization.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZQV9O5
+relation: affects
+to: authorization
+---

--- a/tickets/relations/TKT-ZQV9O5--affects--views.md
+++ b/tickets/relations/TKT-ZQV9O5--affects--views.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZQV9O5
+relation: affects
+to: views
+---

--- a/tickets/relations/TKT-ZQV9O5--implements--FEAT-OT4361.md
+++ b/tickets/relations/TKT-ZQV9O5--implements--FEAT-OT4361.md
@@ -1,0 +1,5 @@
+---
+from: TKT-ZQV9O5
+relation: implements
+to: FEAT-OT4361
+---


### PR DESCRIPTION
Ticket: TKT-OIRBFH (follow-up: TKT-ZQV9O5)

## What

Adds the requesting principal to the predicate language and pushes it into store queries.

- `current_user` record (`{id, tool}`) plus `is_current_user(x)` (string equality) and `has_current_user(xs)` (list membership) in `internal/predicatefns`. Declared separately from the stdlib so validation, scheduler and index derivation keep it a compile error.
- Fail-closed identity: a `QueryIdentity` stamped once per request; an absent or empty identity is `ErrNoCurrentUser`, never an empty-string match.
- Pushdown: `predicate.Program.ConstEqualities` reports request-constant equalities on the top-level AND spine; `queryplan.ConditionPrefilters` lowers them to `store.PropPredicate` behind the same metamodel gate as the filter pushdown. Membership lowers to the store's existing non-scalar `PropEqual` (multi-select rule), so no store contract change. `StaticIndexSpecs` includes next-action conditions; pushdown and index inference share one eligibility core.
- Surfaces: ACL affordance `when:` and next-action `condition:`. `nextaction.CandidateFunc` gains the source id; dataentry threads condition prefilters into the candidate query through a consumer-side `ConditionPrefilterer`; `appbuild` supplies matchers plus a per-request scope binder.
- `where:` surfaces (views, feeds, kanbans, CalDAV) and the CLI are TKT-ZQV9O5.

## Behaviour worth knowing

- An unidentified caller's per-user next-action source contributes nothing (one WARN naming the source); other sources are unaffected.
- Affordance `when:` clauses reading `current_user` are refused for the `unknown` placeholder and unstamped callers.
- A boundary-stamped identity disagreeing with the request principal is refused (`next_action_identity_conflict`).
- A `condition:` on a free-text next-action query is a load error (relevance cap runs before the condition).
- `rela db reconcile` compiles conditions, so it refuses what the server refuses.
- `principal.Unknown` names the placeholder previously spelled as three bare literals.

## Review

Design review (architecture + security) and code review (cranky + security) run through the ticket workflow: 21 review-responses, 20 addressed, 1 nit deferred (enum-typed properties not pushed by either pushdown, shared gate). Security pass on the final code: no findings.

## Verification

Full suite, golangci-lint, arch-lint, comment-lint, plimsoll, coverage floors green. Manually verified against a live `rela-server` with `-principal-header`: alice/bob/dave receive their own or watched tasks, erin nothing, an unidentified request gets `{"suggestion": null}` with the WARN.

https://claude.ai/code/session_014C5aENjid9zgXz1ZcUUnbN
